### PR TITLE
Add Gaussian process noise to CartPole and Mountain Car state transitions

### DIFF
--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
@@ -47,9 +47,10 @@ class CartPolePOMDPMetrics(Enum):
 class CartPoleStateTransition(StateTransitionModel):
     """Physics-based state transition model for CartPole POMDP.
 
-    This model implements the classical cart-pole dynamics with deterministic
-    physics simulation. The cart experiences forces that affect both cart
-    acceleration and pole angular acceleration through coupled equations of motion.
+    This model implements the classical cart-pole dynamics with Gaussian
+    process noise. The cart experiences forces that affect both cart
+    acceleration and pole angular acceleration through coupled equations
+    of motion, with additive Normal noise on the resulting next state.
 
     Attributes:
         state: Current state [cart_position, cart_velocity, pole_angle, pole_velocity]
@@ -66,11 +67,14 @@ class CartPoleStateTransition(StateTransitionModel):
     Example:
         >>> import numpy as np
         >>> np.random.seed(42)  # For reproducible results
+        >>> from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
         >>> # Define initial state [position, velocity, angle, angular_velocity]
         >>> state = np.array([0.0, 0.0, 0.1, 0.0])
         >>> action = 1  # Apply right force
 
-        >>> # Create transition model with physics parameters
+        >>> # Create transition model with physics parameters and noise
+        >>> state_transition_cov = np.diag([1e-4, 1e-4, 2.5e-5, 1e-4])
+        >>> state_transition_dist = CovarianceParameterizedMultivariateNormal(state_transition_cov)
         >>> transition = CartPoleStateTransition(
         ...     state=state,
         ...     action=action,
@@ -81,7 +85,8 @@ class CartPoleStateTransition(StateTransitionModel):
         ...     length=0.5,
         ...     kinematics_integrator="euler",
         ...     tau=0.02,
-        ...     masspole=0.1
+        ...     masspole=0.1,
+        ...     state_transition_dist=state_transition_dist
         ... )
 
         >>> # Simulate physics step
@@ -104,6 +109,7 @@ class CartPoleStateTransition(StateTransitionModel):
         kinematics_integrator: str,
         tau: float,
         masspole: float,
+        state_transition_dist: CovarianceParameterizedMultivariateNormal,
     ):
         super().__init__(state, action)
 
@@ -115,8 +121,14 @@ class CartPoleStateTransition(StateTransitionModel):
         self.kinematics_integrator = kinematics_integrator
         self.tau = tau
         self.masspole = masspole
+        self._state_transition_dist = state_transition_dist
 
     def sample(self, n_samples: int = 1) -> List[np.ndarray]:
+        deterministic_next_state = self._compute_deterministic_next_state()
+        noise_samples = self._state_transition_dist.sample(np.zeros(4), n_samples=n_samples)
+        return [deterministic_next_state + noise_samples[i] for i in range(n_samples)]
+
+    def _compute_deterministic_next_state(self) -> np.ndarray:
         x, x_dot, theta, theta_dot = self.state
         force = self.force_mag if self.action == 1 else -self.force_mag
         costheta = math.cos(theta)
@@ -141,17 +153,12 @@ class CartPoleStateTransition(StateTransitionModel):
             theta_dot = theta_dot + self.tau * thetaacc
             theta = theta + self.tau * theta_dot
 
-        next_state = np.array([x, x_dot, theta, theta_dot])
-        return [next_state] * n_samples
+        return np.array([x, x_dot, theta, theta_dot])
 
     def probability(self, values: List[np.ndarray]) -> np.ndarray:
-        # Deterministic transition - probability is 1.0 for the exact next state, 0.0 otherwise
-        result = np.zeros(len(values))
-        expected_next_state = self.sample()[0]  # Get the deterministic next state
-        for i, value in enumerate(values):
-            if np.array_equal(value, expected_next_state):
-                result[i] = 1.0
-        return result
+        deterministic_next_state = self._compute_deterministic_next_state()
+        values_array = np.array(values)
+        return self._state_transition_dist.pdf(values_array, deterministic_next_state)
 
 
 class CartPoleObservation(ObservationModel):
@@ -297,10 +304,13 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
         False
     """
 
+    DEFAULT_STATE_TRANSITION_COV = np.diag([1e-4, 1e-4, 2.5e-5, 1e-4])
+
     def __init__(
         self,
         discount_factor: float,
         noise_cov: NDArray[np.floating[Any]],
+        state_transition_cov: Optional[NDArray[np.floating[Any]]] = None,
         name: str = "CartPolePOMDP",
         output_dir: Optional[Path] = None,
         debug: bool = False,
@@ -309,6 +319,14 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
         # Set all configuration parameters first
         self.noise_cov = noise_cov
         self._obs_dist = CovarianceParameterizedMultivariateNormal(noise_cov)
+        self.state_transition_cov = (
+            state_transition_cov
+            if state_transition_cov is not None
+            else self.DEFAULT_STATE_TRANSITION_COV
+        )
+        self._state_transition_dist = CovarianceParameterizedMultivariateNormal(
+            self.state_transition_cov
+        )
         self.gravity = 9.8
         self.masscart = 1.0
         self.masspole = 0.1
@@ -355,6 +373,7 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
             kinematics_integrator=self.kinematics_integrator,
             tau=self.tau,
             masspole=self.masspole,
+            state_transition_dist=self._state_transition_dist,
         )
 
     def observation_model(self, next_state: np.ndarray, action: int) -> ObservationModel:

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
@@ -27,6 +27,7 @@ from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import matplotlib
 import numpy as np
+from numpy.typing import NDArray
 
 from POMDPPlanners.core.distributions import Distribution
 from POMDPPlanners.core.environment import (
@@ -52,13 +53,18 @@ class MountainCarPOMDPMetrics(Enum):
 class MountainCarTransition(StateTransitionModel):
     """Physics-based state transition model for Mountain Car POMDP.
 
-    This model implements the deterministic physics of a car on a sinusoidal
-    hill surface. The car's velocity is affected by both the applied action
-    (engine force) and gravitational force that depends on the slope of the hill.
+    This model implements the physics of a car on a sinusoidal hill surface
+    with additive Gaussian process noise. The car's velocity is affected by
+    both the applied action (engine force) and gravitational force that depends
+    on the slope of the hill.
 
     The physics equations are:
     - velocity += action * power + cos(3 * position) * (-gravity)
     - position += velocity
+
+    After computing the deterministic next state, Normal noise is sampled
+    from the provided distribution and added. The result is then clipped
+    to respect position and velocity bounds.
 
     Attributes:
         state: Current state (position, velocity) tuple
@@ -74,12 +80,15 @@ class MountainCarTransition(StateTransitionModel):
 
             >>> import numpy as np
             >>> np.random.seed(42)  # For reproducible results
+            >>> from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
             >>>
             >>> # Define car state: position=-0.5 (in valley), velocity=0.0
             >>> state = (-0.5, 0.0)
             >>> action = 1  # Accelerate right/forward
             >>>
-            >>> # Create transition model
+            >>> # Create transition model with noise
+            >>> state_transition_cov = np.diag([2.5e-5, 1e-6])
+            >>> state_transition_dist = CovarianceParameterizedMultivariateNormal(state_transition_cov)
             >>> transition = MountainCarTransition(
             ...     state=state,
             ...     action=action,
@@ -87,15 +96,15 @@ class MountainCarTransition(StateTransitionModel):
             ...     gravity=0.0025,
             ...     max_speed=0.07,
             ...     min_position=-1.2,
-            ...     max_position=0.6
+            ...     max_position=0.6,
+            ...     state_transition_dist=state_transition_dist
             ... )
             >>>
             >>> # Simulate physics step
             >>> next_state = transition.sample()[0]
-            >>> # Returns new [position, velocity] with physics applied
-            >>> new_pos, new_vel = next_state
-            >>> print(f"New position: {new_pos:.3f}, New velocity: {new_vel:.3f}")
-            New position: -0.499, New velocity: 0.001
+            >>> # Returns new [position, velocity] with physics and noise applied
+            >>> len(next_state) == 2
+            True
     """
 
     def __init__(
@@ -107,6 +116,7 @@ class MountainCarTransition(StateTransitionModel):
         max_speed: float,
         min_position: float,
         max_position: float,
+        state_transition_dist: CovarianceParameterizedMultivariateNormal,
     ):
         super().__init__(state, action)
 
@@ -115,8 +125,19 @@ class MountainCarTransition(StateTransitionModel):
         self.max_speed = max_speed
         self.min_position = min_position
         self.max_position = max_position
+        self._state_transition_dist = state_transition_dist
 
     def sample(self, n_samples: int = 1) -> List[np.ndarray]:
+        deterministic_next_state = self._compute_deterministic_next_state()
+        noise_samples = self._state_transition_dist.sample(np.zeros(2), n_samples=n_samples)
+        results = []
+        for i in range(n_samples):
+            noisy_state = deterministic_next_state + noise_samples[i]
+            noisy_state = self._clip_state(noisy_state)
+            results.append(noisy_state)
+        return results
+
+    def _compute_deterministic_next_state(self) -> np.ndarray:
         position, velocity = self.state
         v = velocity + self.action * self.power + np.cos(3 * position) * (-self.gravity)
         v = np.clip(v, -self.max_speed, self.max_speed)
@@ -124,16 +145,20 @@ class MountainCarTransition(StateTransitionModel):
         p = np.clip(p, self.min_position, self.max_position)
         if p == self.min_position and v < 0:
             v = 0
-        next_state = np.array([p, v])
-        return [next_state] * n_samples
+        return np.array([p, v])
+
+    def _clip_state(self, state: np.ndarray) -> np.ndarray:
+        p, v = state
+        v = np.clip(v, -self.max_speed, self.max_speed)
+        p = np.clip(p, self.min_position, self.max_position)
+        if p == self.min_position and v < 0:
+            v = 0
+        return np.array([p, v])
 
     def probability(self, values: List[np.ndarray]) -> np.ndarray:
-        result = np.zeros(len(values))
-        expected_next_state = self.sample()[0]
-        for i, value in enumerate(values):
-            if np.array_equal(value, expected_next_state):
-                result[i] = 1.0
-        return result
+        deterministic_next_state = self._compute_deterministic_next_state()
+        values_array = np.array(values)
+        return self._state_transition_dist.pdf(values_array, deterministic_next_state)
 
 
 class MountainCarObservation(ObservationModel):
@@ -240,9 +265,12 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
         False
     """
 
+    DEFAULT_STATE_TRANSITION_COV = np.diag([2.5e-5, 1e-6])
+
     def __init__(
         self,
         discount_factor: float,
+        state_transition_cov: Optional[NDArray[np.floating[Any]]] = None,
         name: str = "MountainCarPOMDP",
         output_dir: Optional[Path] = None,
         debug: bool = False,
@@ -267,6 +295,16 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
 
         # Pre-compute Cholesky decomposition for efficient sampling and PDF
         self._obs_dist = CovarianceParameterizedMultivariateNormal(self.cov_matrix)
+
+        # State transition noise
+        self.state_transition_cov = (
+            state_transition_cov
+            if state_transition_cov is not None
+            else self.DEFAULT_STATE_TRANSITION_COV
+        )
+        self._state_transition_dist = CovarianceParameterizedMultivariateNormal(
+            self.state_transition_cov
+        )
 
         space_info = SpaceInfo(
             action_space=SpaceType.DISCRETE,  # Action space is [-1, 0, 1]
@@ -293,6 +331,7 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
             max_speed=self.max_speed,
             min_position=self.min_position,
             max_position=self.max_position,
+            state_transition_dist=self._state_transition_dist,
         )
 
     def observation_model(self, next_state: Tuple[float, float], action: int) -> ObservationModel:

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
@@ -294,6 +294,101 @@ def test_state_transition_model(base_cartpole_environment):
     assert next_state.shape == (4,)
 
 
+def test_state_transition_produces_varying_samples(base_cartpole_environment):
+    """Test that state transition with noise produces varying samples.
+
+    Purpose: Validates that the stochastic state transition model produces
+    different samples due to Gaussian process noise
+
+    Given: A CartPolePOMDP environment and initial state [0.0, 0.0, 0.1, 0.0] with action 1
+    When: Multiple samples are drawn from the state transition model
+    Then: Not all samples are identical, confirming stochastic behavior
+
+    Test type: unit
+    """
+    state = np.array([0.0, 0.0, 0.1, 0.0])
+    action = 1
+    transition = base_cartpole_environment.state_transition_model(state, action)
+    samples = transition.sample(n_samples=50)
+
+    assert len(samples) == 50
+    assert all(s.shape == (4,) for s in samples)
+
+    # With noise, samples should not all be identical
+    sample_array = np.array(samples)
+    assert not np.all(
+        sample_array == sample_array[0]
+    ), "All samples are identical — noise is not being applied"
+
+
+def test_state_transition_noise_magnitude(base_cartpole_environment):
+    """Test that state transition noise magnitude is reasonable.
+
+    Purpose: Validates that noisy samples cluster around the deterministic next state
+
+    Given: A CartPolePOMDP environment with default noise covariance
+    When: Many samples are drawn from the state transition model
+    Then: Sample mean is close to deterministic next state and standard deviations
+    match the expected noise levels from the covariance matrix
+
+    Test type: unit
+    """
+    state = np.array([0.0, 0.0, 0.1, 0.0])
+    action = 1
+    transition = base_cartpole_environment.state_transition_model(state, action)
+    samples = np.array(transition.sample(n_samples=5000))
+
+    # The mean of many samples should be close to the deterministic next state
+    # pylint: disable=protected-access
+    deterministic = transition._compute_deterministic_next_state()
+    sample_mean = samples.mean(axis=0)
+    np.testing.assert_allclose(sample_mean, deterministic, atol=0.01)
+
+    # Standard deviations should roughly match sqrt of diagonal of cov matrix
+    expected_std = np.sqrt(np.diag(base_cartpole_environment.state_transition_cov))
+    sample_std = samples.std(axis=0)
+    np.testing.assert_allclose(sample_std, expected_std, rtol=0.3)
+
+
+def test_state_transition_default_covariance():
+    """Test that default state transition covariance is used when not specified.
+
+    Purpose: Validates that CartPolePOMDP uses the default state transition
+    covariance matrix when none is provided
+
+    Given: A CartPolePOMDP environment created without explicit state_transition_cov
+    When: The state_transition_cov attribute is checked
+    Then: It matches the class-level DEFAULT_STATE_TRANSITION_COV
+
+    Test type: unit
+    """
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1)
+    np.testing.assert_array_equal(
+        env.state_transition_cov, CartPolePOMDP.DEFAULT_STATE_TRANSITION_COV
+    )
+
+
+def test_state_transition_custom_covariance():
+    """Test that custom state transition covariance is applied correctly.
+
+    Purpose: Validates that a custom state transition covariance matrix is
+    stored and used when explicitly provided
+
+    Given: A CartPolePOMDP environment created with a custom state_transition_cov
+    When: The state_transition_cov attribute is checked
+    Then: It matches the custom covariance matrix provided at construction
+
+    Test type: unit
+    """
+    custom_cov = np.diag([1e-3, 1e-3, 1e-4, 1e-3])
+    env = CartPolePOMDP(
+        discount_factor=0.95,
+        noise_cov=np.eye(4) * 0.1,
+        state_transition_cov=custom_cov,
+    )
+    np.testing.assert_array_equal(env.state_transition_cov, custom_cov)
+
+
 def test_observation_model(base_cartpole_environment):
     """Test observation model.
 

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py
@@ -254,14 +254,14 @@ class TestConfigId:
 
 class TestEquivalenceWithPerParticleLoop:
     def test_batch_transition_matches_per_particle_loop(self, env, updater):
-        """Test vectorized batch_transition matches per-particle state_transition_model.
+        """Test vectorized batch_transition matches per-particle deterministic physics.
 
-        Purpose: Verifies that batch_transition produces the same results as calling
-                 the environment's state_transition_model per particle.
+        Purpose: Verifies that batch_transition produces the same deterministic
+                 next states as the environment's state_transition_model physics.
 
         Given: A set of particles, an action, and a fixed random seed.
-        When: batch_transition is called, and the same transitions are computed
-              per-particle using the environment's state_transition_model.
+        When: batch_transition is called, and the same deterministic transitions
+              are computed per-particle using the environment's state_transition_model.
         Then: Results match within floating-point tolerance.
 
         Test type: integration
@@ -275,8 +275,8 @@ class TestEquivalenceWithPerParticleLoop:
 
         per_particle_result = np.empty_like(particles)
         for i in range(n):
-            next_state = env.state_transition_model(state=particles[i], action=action).sample()[0]
-            per_particle_result[i] = next_state
+            transition = env.state_transition_model(state=particles[i], action=action)
+            per_particle_result[i] = transition._compute_deterministic_next_state()
 
         np.testing.assert_allclose(vectorized_result, per_particle_result, atol=1e-10)
 

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_gaussian_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_gaussian_beliefs.py
@@ -87,13 +87,13 @@ class TestFactoryDispatch:
 
 class TestEKFFunctions:
     def test_ekf_transition_fn_matches_environment(self, env, initial_cov):
-        """Test that the EKF transition function matches CartPole physics.
+        """Test that the EKF transition function matches CartPole deterministic physics.
 
         Purpose: Validates that the EKF transition function produces the
-                 same next state as the environment's state transition model.
+                 same deterministic next state as the environment's physics.
 
         Given: An EKF-based belief and a known state-action pair.
-        When: transition_fn is called and compared to environment transition.
+        When: transition_fn is called and compared to deterministic environment transition.
         Then: Results match.
 
         Test type: unit
@@ -108,7 +108,8 @@ class TestEKFFunctions:
 
         state = np.array([0.01, -0.02, 0.03, -0.01])
         for action_val in [0, 1]:
-            env_next = env.state_transition_model(state, action_val).sample()[0]
+            transition = env.state_transition_model(state, action_val)
+            env_next = transition._compute_deterministic_next_state()
             ekf_next = updater.transition_fn(state, np.array([float(action_val)]))
             np.testing.assert_allclose(ekf_next, env_next, atol=1e-12)
 
@@ -199,13 +200,14 @@ class TestEKFFunctions:
 
 class TestUKFFunctions:
     def test_ukf_transition_fn_matches_environment(self, env, initial_cov):
-        """Test that the UKF transition function matches CartPole physics.
+        """Test that the UKF transition function matches CartPole deterministic physics.
 
-        Purpose: Validates UKF transition function equivalence with environment.
+        Purpose: Validates UKF transition function equivalence with environment
+                 deterministic physics.
 
         Given: A UKF-based belief and a known state-action pair.
         When: transition_fn is called.
-        Then: Result matches the environment's state_transition_model output.
+        Then: Result matches the environment's deterministic transition output.
 
         Test type: unit
         """
@@ -219,7 +221,8 @@ class TestUKFFunctions:
 
         state = np.array([0.01, -0.02, 0.03, -0.01])
         for action_val in [0, 1]:
-            env_next = env.state_transition_model(state, action_val).sample()[0]
+            transition = env.state_transition_model(state, action_val)
+            env_next = transition._compute_deterministic_next_state()
             ukf_next = updater.transition_fn(state, np.array([float(action_val)]))
             np.testing.assert_allclose(ukf_next, env_next, atol=1e-12)
 

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
@@ -79,6 +79,97 @@ def test_state_transition_model(base_mountain_car_environment):
     assert new_state.shape == (2,)
 
 
+def test_state_transition_produces_varying_samples(base_mountain_car_environment):
+    """Test that state transition with noise produces varying samples.
+
+    Purpose: Validates that the stochastic state transition model produces
+    different samples due to Gaussian process noise
+
+    Given: A MountainCarPOMDP environment and initial state [-0.5, 0.0] with action 1
+    When: Multiple samples are drawn from the state transition model
+    Then: Not all samples are identical, confirming stochastic behavior
+
+    Test type: unit
+    """
+    state = np.array([-0.5, 0.0])
+    action = 1
+    transition = base_mountain_car_environment.state_transition_model(state, action)
+    samples = transition.sample(n_samples=50)
+
+    assert len(samples) == 50
+    assert all(s.shape == (2,) for s in samples)
+
+    sample_array = np.array(samples)
+    assert not np.all(
+        sample_array == sample_array[0]
+    ), "All samples are identical — noise is not being applied"
+
+
+def test_state_transition_noise_magnitude(base_mountain_car_environment):
+    """Test that state transition noise magnitude is reasonable.
+
+    Purpose: Validates that noisy samples cluster around the deterministic next state
+
+    Given: A MountainCarPOMDP environment with default noise covariance
+    When: Many samples are drawn from the state transition model
+    Then: Sample mean is close to deterministic next state and standard deviations
+    match the expected noise levels from the covariance matrix
+
+    Test type: unit
+    """
+    state = np.array([-0.5, 0.0])
+    action = 1
+    transition = base_mountain_car_environment.state_transition_model(state, action)
+    samples = np.array(transition.sample(n_samples=5000))
+
+    # pylint: disable=protected-access
+    deterministic = transition._compute_deterministic_next_state()
+    sample_mean = samples.mean(axis=0)
+    np.testing.assert_allclose(sample_mean, deterministic, atol=0.005)
+
+    expected_std = np.sqrt(np.diag(base_mountain_car_environment.state_transition_cov))
+    sample_std = samples.std(axis=0)
+    np.testing.assert_allclose(sample_std, expected_std, rtol=0.3)
+
+
+def test_state_transition_default_covariance():
+    """Test that default state transition covariance is used when not specified.
+
+    Purpose: Validates that MountainCarPOMDP uses the default state transition
+    covariance matrix when none is provided
+
+    Given: A MountainCarPOMDP environment created without explicit state_transition_cov
+    When: The state_transition_cov attribute is checked
+    Then: It matches the class-level DEFAULT_STATE_TRANSITION_COV
+
+    Test type: unit
+    """
+    env = MountainCarPOMDP(discount_factor=0.95)
+    np.testing.assert_array_equal(
+        env.state_transition_cov, MountainCarPOMDP.DEFAULT_STATE_TRANSITION_COV
+    )
+
+
+def test_state_transition_custom_covariance():
+    """Test that custom state transition covariance is applied correctly.
+
+    Purpose: Validates that a custom state transition covariance matrix is
+    stored and used when explicitly provided
+
+    Given: A MountainCarPOMDP environment created with a custom state_transition_cov
+    When: The state_transition_cov attribute is checked
+    Then: It matches the custom covariance matrix provided at construction
+
+    Test type: unit
+    """
+    custom_cov = np.diag([1e-4, 1e-5])
+    env = MountainCarPOMDP(
+        discount_factor=0.95,
+        state_transition_cov=custom_cov,
+    )
+    np.testing.assert_array_equal(env.state_transition_cov, custom_cov)
+
+
 def test_observation_model(base_mountain_car_environment):
     """Test observation model with noise addition.
 

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
@@ -277,14 +277,14 @@ class TestConfigId:
 
 class TestEquivalenceWithPerParticleLoop:
     def test_batch_transition_matches_per_particle_loop(self, env, updater):
-        """Test vectorized batch_transition matches per-particle state_transition_model.
+        """Test vectorized batch_transition matches per-particle deterministic physics.
 
-        Purpose: Verifies that batch_transition produces the same results as calling
-                 the environment's state_transition_model per particle.
+        Purpose: Verifies that batch_transition produces the same deterministic
+                 next states as the environment's state_transition_model physics.
 
         Given: A set of particles, an action, and a fixed random seed.
-        When: batch_transition is called, and the same transitions are computed
-              per-particle using the environment's state_transition_model.
+        When: batch_transition is called, and the same deterministic transitions
+              are computed per-particle using the environment's state_transition_model.
         Then: Results match within floating-point tolerance.
 
         Test type: integration
@@ -303,10 +303,8 @@ class TestEquivalenceWithPerParticleLoop:
 
         per_particle_result = np.empty_like(particles)
         for i in range(n):
-            next_state = env.state_transition_model(
-                state=tuple(particles[i]), action=action
-            ).sample()[0]
-            per_particle_result[i] = next_state
+            transition = env.state_transition_model(state=tuple(particles[i]), action=action)
+            per_particle_result[i] = transition._compute_deterministic_next_state()
 
         np.testing.assert_allclose(vectorized_result, per_particle_result, atol=1e-10)
 

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_gaussian_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_gaussian_beliefs.py
@@ -86,13 +86,13 @@ class TestFactoryDispatch:
 
 class TestEKFFunctions:
     def test_ekf_transition_fn_matches_environment(self, env, initial_cov):
-        """Test that the EKF transition function matches Mountain Car physics.
+        """Test that the EKF transition function matches Mountain Car deterministic physics.
 
         Purpose: Validates that the EKF transition function produces the
-                 same next state as the environment's state transition model.
+                 same deterministic next state as the environment's physics.
 
         Given: An EKF-based belief and a known state-action pair.
-        When: transition_fn is called and compared to environment transition.
+        When: transition_fn is called and compared to deterministic environment transition.
         Then: Results match.
 
         Test type: unit
@@ -107,7 +107,8 @@ class TestEKFFunctions:
 
         state = np.array([-0.5, 0.01])
         for action_val in [-1, 0, 1]:
-            env_next = env.state_transition_model(tuple(state), action_val).sample()[0]
+            transition = env.state_transition_model(tuple(state), action_val)
+            env_next = transition._compute_deterministic_next_state()
             ekf_next = updater.transition_fn(state, np.array([float(action_val)]))
             np.testing.assert_allclose(ekf_next, env_next, atol=1e-12)
 
@@ -200,13 +201,14 @@ class TestEKFFunctions:
 
 class TestUKFFunctions:
     def test_ukf_transition_fn_matches_environment(self, env, initial_cov):
-        """Test that the UKF transition function matches Mountain Car physics.
+        """Test that the UKF transition function matches Mountain Car deterministic physics.
 
-        Purpose: Validates UKF transition function equivalence with environment.
+        Purpose: Validates UKF transition function equivalence with environment
+                 deterministic physics.
 
         Given: A UKF-based belief and a known state-action pair.
         When: transition_fn is called.
-        Then: Result matches the environment's state_transition_model output.
+        Then: Result matches the environment's deterministic transition output.
 
         Test type: unit
         """
@@ -220,7 +222,8 @@ class TestUKFFunctions:
 
         state = np.array([-0.5, 0.01])
         for action_val in [-1, 0, 1]:
-            env_next = env.state_transition_model(tuple(state), action_val).sample()[0]
+            transition = env.state_transition_model(tuple(state), action_val)
+            env_next = transition._compute_deterministic_next_state()
             ukf_next = updater.transition_fn(state, np.array([float(action_val)]))
             np.testing.assert_allclose(ukf_next, env_next, atol=1e-12)
 

--- a/POMDPPlanners/tests/test_interfaces/test_state_transition_models.py
+++ b/POMDPPlanners/tests/test_interfaces/test_state_transition_models.py
@@ -416,25 +416,24 @@ class TestCartPolePOMDPProbability:
     """Test probability method for CartPole POMDP."""
 
     def test_cartpole_transition_probability(self):
-        """Test CartPole POMDP probability method with physics-based transition.
+        """Test CartPole POMDP probability() returns valid continuous PDF values.
 
-        Purpose: Validates that probability() method matches empirical distribution
+        Purpose: Validates that probability() method returns valid PDF values
+        for the stochastic state transition with Gaussian process noise
 
         Given: CartPole POMDP with basic configuration and action
-        When: Comparing computed probabilities to empirical sampling
-        Then: Probabilities match within tolerance and are properly normalized
+        When: PDF values are computed for sampled next states
+        Then: PDF values are non-negative, deterministic, and higher for
+        states closer to the deterministic next state
 
         Test type: unit
         """
         noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
         pomdp = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
 
-        # Get initial state
         initial_state = pomdp.initial_state_dist().sample()[0]
-
-        # Get a valid action
         actions = pomdp.get_actions()
-        action = actions[0]  # Left force
+        action = actions[0]
 
         transition = CartPoleStateTransition(
             state=initial_state,
@@ -447,38 +446,44 @@ class TestCartPolePOMDPProbability:
             kinematics_integrator=pomdp.kinematics_integrator,
             tau=pomdp.tau,
             masspole=pomdp.masspole,
-        )
-        results = validate_probability_matches_empirical_distribution(
-            transition, num_samples=1000, max_js_divergence=0.01
+            state_transition_dist=pomdp._state_transition_dist,  # pylint: disable=protected-access
         )
 
-        assert results["probabilities_normalized"]
-        assert results["distance"] < 0.01  # Should be nearly perfect (deterministic)
-        assert results["num_unique_states"] == 1  # Deterministic transition
+        samples = transition.sample(n_samples=100)
+        pdf_values = transition.probability(samples)
+
+        assert np.all(pdf_values >= 0), "PDF values must be non-negative"
+        assert np.allclose(pdf_values, transition.probability(samples)), "PDF must be deterministic"
+
+        # pylint: disable=protected-access
+        det_state = transition._compute_deterministic_next_state()
+        close_state = det_state + np.array([0.001, 0.001, 0.001, 0.001])
+        far_state = det_state + np.array([1.0, 1.0, 1.0, 1.0])
+        probs = transition.probability([close_state, far_state])
+        assert probs[0] > probs[1], "Closer states should have higher PDF"
 
 
 class TestMountainCarPOMDPProbability:
     """Test probability method for Mountain Car POMDP."""
 
     def test_mountain_car_transition_probability(self):
-        """Test Mountain Car POMDP probability method with physics-based transition.
+        """Test Mountain Car POMDP probability() returns valid continuous PDF values.
 
-        Purpose: Validates that probability() method matches empirical distribution
+        Purpose: Validates that probability() method returns valid PDF values
+        for the stochastic state transition with Gaussian process noise
 
         Given: Mountain Car POMDP with basic configuration and action
-        When: Comparing computed probabilities to empirical sampling
-        Then: Probabilities match within tolerance and are properly normalized
+        When: PDF values are computed for sampled next states
+        Then: PDF values are non-negative, deterministic, and higher for
+        states closer to the deterministic next state
 
         Test type: unit
         """
         pomdp = MountainCarPOMDP(discount_factor=0.95)
 
-        # Get initial state
         initial_state = pomdp.initial_state_dist().sample()[0]
-
-        # Get a valid action
         actions = pomdp.get_actions()
-        action = actions[0]  # Reverse
+        action = actions[0]
 
         transition = MountainCarTransition(
             state=initial_state,
@@ -488,14 +493,21 @@ class TestMountainCarPOMDPProbability:
             max_speed=pomdp.max_speed,
             min_position=pomdp.min_position,
             max_position=pomdp.max_position,
-        )
-        results = validate_probability_matches_empirical_distribution(
-            transition, num_samples=1000, max_js_divergence=0.01
+            state_transition_dist=pomdp._state_transition_dist,  # pylint: disable=protected-access
         )
 
-        assert results["probabilities_normalized"]
-        assert results["distance"] < 0.01  # Should be nearly perfect (deterministic)
-        assert results["num_unique_states"] == 1  # Deterministic transition
+        samples = transition.sample(n_samples=100)
+        pdf_values = transition.probability(samples)
+
+        assert np.all(pdf_values >= 0), "PDF values must be non-negative"
+        assert np.allclose(pdf_values, transition.probability(samples)), "PDF must be deterministic"
+
+        # pylint: disable=protected-access
+        det_state = transition._compute_deterministic_next_state()
+        close_state = det_state + np.array([0.0001, 0.0001])
+        far_state = det_state + np.array([0.5, 0.05])
+        probs = transition.probability([close_state, far_state])
+        assert probs[0] > probs[1], "Closer states should have higher PDF"
 
 
 class TestSafetyAntVelocityPOMDPProbability:


### PR DESCRIPTION
## Summary
- Add configurable Gaussian process noise to `CartPoleStateTransition` and `MountainCarTransition` models, following the existing pattern from `ContinuousPushStateTransitionModel`
- CartPole default covariance: `diag([1e-4, 1e-4, 2.5e-5, 1e-4])` — small noise relative to the narrow stability region
- Mountain Car default covariance: `diag([2.5e-5, 1e-6])` — small noise relative to the tiny velocity range
- Updated `probability()` methods to return PDF values via `CovarianceParameterizedMultivariateNormal`
- Added tests for stochastic behavior, noise magnitude, default/custom covariance

## Test plan
- [x] All existing CartPole and Mountain Car tests pass
- [x] New tests verify samples vary (noise is applied)
- [x] New tests verify noise magnitude matches covariance matrix
- [x] New tests verify default and custom covariance usage
- [x] State transition model interface tests updated for continuous PDF validation
- [x] Pyright: 0 errors, 0 warnings
- [x] Pylint: no new issues