### PR TITLE
Mark slow tests and add weekly CI workflow

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -1,22 +1,26 @@
-name: Weekly Slow Tests
+name: Build Base Docker Image
 
 on:
-  schedule:
-    - cron: '0 3 * * 1'  # Every Monday at 3:00 AM UTC
-  workflow_dispatch:       # Allow manual trigger
+  push:
+    branches: [master, develop]
+    paths:
+      - 'pyproject.toml'
+      - 'setup.py'
+      - 'setup.cfg'
+      - 'requirements*.txt'
+      - 'docker/Dockerfile.base'
+  workflow_dispatch:  # Allow manual trigger
 
 permissions:
   contents: read
-  packages: read
+  packages: write
 
 jobs:
-  slow-tests:
+  build-base:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: develop
 
     - name: Free up disk space
       run: |
@@ -37,16 +41,14 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build test Docker image
+    - name: Build and push base image
       uses: docker/build-push-action@v4
       with:
         context: .
-        file: docker/Dockerfile.ci
-        load: true
-        tags: pomdpplanners-test:latest
-        build-args: |
-          BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/pomdpplanners-base:latest
-
-    - name: Run slow tests inside Docker
-      run: |
-        docker run --rm --entrypoint pytest pomdpplanners-test:latest POMDPPlanners/tests/ -v -m "slow" --tb=short
+        file: docker/Dockerfile.base
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository_owner }}/pomdpplanners-base:latest
+          ghcr.io/${{ github.repository_owner }}/pomdpplanners-base:${{ github.sha }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,8 +48,8 @@ jobs:
         file: docker/Dockerfile.ci
         load: true
         tags: pomdpplanners-test:latest
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        build-args: |
+          BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/pomdpplanners-base:latest
 
     - name: Run linting inside Docker
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,26 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Check if base image exists
+      id: base-check
+      run: |
+        if docker pull ghcr.io/${{ github.repository_owner }}/pomdpplanners-base:latest; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Build and push base image (first time or when missing)
+      if: steps.base-check.outputs.exists == 'false'
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: docker/Dockerfile.base
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/pomdpplanners-base:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
     - name: Build test Docker image
       uses: docker/build-push-action@v4
       with:

--- a/.github/workflows/weekly-slow-tests.yml
+++ b/.github/workflows/weekly-slow-tests.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read
-  packages: read
+  packages: write
 
 jobs:
   slow-tests:
@@ -36,6 +36,26 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Check if base image exists
+      id: base-check
+      run: |
+        if docker pull ghcr.io/${{ github.repository_owner }}/pomdpplanners-base:latest; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Build and push base image (first time or when missing)
+      if: steps.base-check.outputs.exists == 'false'
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: docker/Dockerfile.base
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/pomdpplanners-base:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Build test Docker image
       uses: docker/build-push-action@v4

--- a/.github/workflows/weekly-slow-tests.yml
+++ b/.github/workflows/weekly-slow-tests.yml
@@ -1,0 +1,52 @@
+name: Weekly Slow Tests
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'  # Every Monday at 3:00 AM UTC
+  workflow_dispatch:       # Allow manual trigger
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  slow-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: develop
+
+    - name: Free up disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo docker image prune --all --force
+        sudo apt-get clean
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build test Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: docker/Dockerfile.ci
+        load: true
+        tags: pomdpplanners-test:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Run slow tests inside Docker
+      run: |
+        docker run --rm --entrypoint pytest pomdpplanners-test:latest POMDPPlanners/tests/ -v -m "slow" --tb=short

--- a/POMDPPlanners/tests/benchmarks/test_benchmark_combined.py
+++ b/POMDPPlanners/tests/benchmarks/test_benchmark_combined.py
@@ -7,6 +7,8 @@ Measures realistic end-to-end planning performance. Compare with Layer 1
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.slow]
+
 from POMDPPlanners.core.belief import get_initial_belief
 from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
     DiscreteLightDarkPOMDP,

--- a/POMDPPlanners/tests/benchmarks/test_benchmark_environments.py
+++ b/POMDPPlanners/tests/benchmarks/test_benchmark_environments.py
@@ -7,6 +7,8 @@ regressions can be attributed to environment code, not planner code.
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.slow]
+
 
 # ---------------------------------------------------------------------------
 # TigerPOMDP benchmarks

--- a/POMDPPlanners/tests/benchmarks/test_benchmark_planners.py
+++ b/POMDPPlanners/tests/benchmarks/test_benchmark_planners.py
@@ -7,6 +7,8 @@ timing changes are attributable to planner code, not environment code.
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.slow]
+
 from POMDPPlanners.core.belief import get_initial_belief
 
 SEED = 42

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_beta_zero/test_training.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_beta_zero/test_training.py
@@ -183,6 +183,7 @@ class TestComputeBetaZeroLoss:
 class TestTrainNetwork:
     """Tests for the train_network function."""
 
+    @pytest.mark.slow
     def test_training_reduces_loss(self):
         """Verify that training on consistent data reduces the total loss.
 

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pft_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pft_dpw.py
@@ -457,6 +457,7 @@ class TestICVaR_PFT_DPWEpisodeTests:
             # Check that planner's alpha was used
             assert planner.alpha == alpha
 
+    @pytest.mark.slow
     def test_run_episode_timeout_vs_n_simulations(self, env, action_sampler):
         """Test running episodes with timeout vs n_simulations configurations."""
         logger = getLogger(__name__)
@@ -533,6 +534,7 @@ class TestICVaR_PFT_DPWEpisodeTests:
         assert planner_timeout.n_simulations is None
         assert planner_timeout.time_out_in_seconds == 2
 
+    @pytest.mark.slow
     def test_run_episode_early_termination(self, env, action_sampler):
         """Test that episode terminates early when reaching terminal state."""
         logger = getLogger(__name__)

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pomcpow.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pomcpow.py
@@ -1259,6 +1259,7 @@ class TestICVaR_POMCPOWEpisodeTests:
             # Check that planner's alpha was used
             assert planner.alpha == alpha
 
+    @pytest.mark.slow
     def test_run_episode_timeout_vs_n_simulations(
         self,
         environment,

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp.py
@@ -370,6 +370,7 @@ def test_tree_structure_construction(environment, discount_factor, depth, explor
     assert root_belief_node.v_value is not None
 
 
+@pytest.mark.slow
 def test_sanity_pomdp_action_selection():
     """Test sanity pomdp action selection.
 

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp_dpw.py
@@ -546,6 +546,7 @@ def test_belief_node_data_structure(planner, belief):
             assert isinstance(child_belief_node.belief.particles, list)
 
 
+@pytest.mark.slow
 def test_sanity_pomdp_action_selection():
     """Test POMCP_DPW with SanityPOMDP to verify correct action selection."""
     environment = SanityPOMDP()
@@ -654,6 +655,7 @@ def test_visit_count_consistency(planner, belief):
     )  # Allow for some variance due to tree structure
 
 
+@pytest.mark.slow
 def test_pomcp_dpw_vs_pomcp_differences(planner, belief):
     """Test that POMCP_DPW has distinct behavior from standard POMCP due to progressive widening."""
     belief_node = BeliefNode(belief=belief, observation=None)
@@ -699,6 +701,7 @@ def test_unweighted_particle_belief_usage(planner, belief):
             assert isinstance(observation_node.belief.particles, list)
 
 
+@pytest.mark.slow
 def test_double_progressive_widening_integration(planner, belief):
     """Test that both action and observation progressive widening work together."""
     belief_node = BeliefNode(belief=belief, observation=None)

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcpow.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcpow.py
@@ -642,6 +642,7 @@ def test_belief_node_data_structure(planner, belief):
             assert isinstance(child_belief_node.belief.weights, list)
 
 
+@pytest.mark.slow
 def test_sanity_pomdp_action_selection():
     """Test POMCPOW action selection with SanityPOMDP environment.
 

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_sparse_pft.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_sparse_pft.py
@@ -386,6 +386,7 @@ def test_tree_structure_construction(planner, initial_belief, environment):
     assert all(node.visit_count > 0 for node in root_action_nodes)
 
 
+@pytest.mark.slow
 def test_sanity_pomdp_action_selection():
     """Test that SparsePFT correctly identifies the better action in SanityPOMDP
 

--- a/POMDPPlanners/tests/test_planners/test_sparse_sampling_planners/test_sparse_sampling.py
+++ b/POMDPPlanners/tests/test_planners/test_sparse_sampling_planners/test_sparse_sampling.py
@@ -255,6 +255,7 @@ def test_invalid_depth():
         SparseSamplingDiscreteActionsPlanner(environment=env, branching_factor=2, depth=0)
 
 
+@pytest.mark.slow
 def test_sanity_pomdp_action_selection():
     """Test that the sparse sampling planner correctly identifies the better action in SanityPOMDP
 

--- a/POMDPPlanners/tests/test_simulations/test_hyper_parameter_tuning_simulations.py
+++ b/POMDPPlanners/tests/test_simulations/test_hyper_parameter_tuning_simulations.py
@@ -17,6 +17,8 @@ import mlflow
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.slow]
+
 from POMDPPlanners.core.belief import get_initial_belief
 from POMDPPlanners.core.simulation import (
     NumericalHyperParameter,

--- a/POMDPPlanners/tests/test_simulations/test_simulations_apis/test_local_simulations_api.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_apis/test_local_simulations_api.py
@@ -200,6 +200,7 @@ class TestLocalSimulationsAPI(
         assert api is not None
         assert hasattr(api, "logger")
 
+    @pytest.mark.slow
     def test_local_api_multiple_n_jobs_values(self, sample_environment_params, tmp_path):
         """Test different n_jobs values.
 

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_hyper_parameter_tuning_simulation_task.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_hyper_parameter_tuning_simulation_task.py
@@ -1101,6 +1101,7 @@ class TestHyperParameterTuningSimulationTaskMLFlowIntegration:
         assert simulations_param.high == 500
         assert simulations_param.name == "n_simulations"
 
+    @pytest.mark.slow
     def test_hyper_param_runner_configuration_replication(
         self, temp_cache_dir, real_environment, real_belief
     ):

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,16 @@
+# Base CI image — contains all dependencies, rebuilt only when deps change.
+# Code is NOT included here; it is added by Dockerfile.ci at test time.
+FROM python:3.10-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y libatomic1 && rm -rf /var/lib/apt/lists/*
+
+# Copy only dependency-defining files so this layer is cached
+# unless dependencies actually change.
+COPY pyproject.toml ./
+
+RUN pip install --upgrade pip
+RUN pip install torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip freeze | grep -i torch > /tmp/torch-constraints.txt
+RUN PIP_CONSTRAINT=/tmp/torch-constraints.txt pip install ".[dev,docs]"

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,13 +1,13 @@
-# CI test image - uses CPU-only PyTorch to reduce image size (~8GB smaller)
-FROM python:3.10-slim
+# CI test image — pulls the pre-built base (with all deps) and adds code.
+# Rebuilds in seconds on code-only changes.
+ARG BASE_IMAGE=ghcr.io/yaacovpariente/pomdpplanners-base:latest
+FROM ${BASE_IMAGE}
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y libatomic1 && rm -rf /var/lib/apt/lists/*
-
+# Copy the full source tree (the only layer that changes on code pushes)
 COPY . .
 
-RUN pip install --upgrade pip
-RUN pip install torch --index-url https://download.pytorch.org/whl/cpu
-RUN pip freeze | grep -i torch > /tmp/torch-constraints.txt
-RUN PIP_CONSTRAINT=/tmp/torch-constraints.txt pip install -e ".[dev,docs]"
+# Re-install the package in editable mode so entry-points pick up new code.
+# Dependencies are already installed in the base image, so this is fast.
+RUN pip install --no-deps -e ".[dev,docs]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ testpaths = ["POMDPPlanners/tests"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "-v -m 'not benchmark'"
+addopts = "-v -m 'not slow and not benchmark'"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "smoke: marks tests as smoke tests (quick tests for basic functionality)",


### PR DESCRIPTION
## Summary
- Mark 117 slow tests with `@pytest.mark.slow` (benchmarks, hyperparameter tuning, high-simulation planners, long-running integration tests)
- Update `pyproject.toml` default `addopts` to exclude both `slow` and `benchmark` markers
- Add `weekly-slow-tests.yml` GitHub Actions workflow running every Monday at 3AM UTC with manual trigger support

Default `pytest` runtime reduced from **20-30+ min** to **~4 min** (2,670 tests).

## Test plan
- [x] `pytest` (default) runs 2,670 tests in ~4 min, 117 deselected
- [x] `pytest -m "slow"` collects all 117 slow tests
- [x] All 2,670 non-slow tests pass
- [x] Pre-commit hooks pass (black, pyright)