### PR TITLE
Add vectorized belief support for PacMan POMDP

### DIFF
--- a/POMDPPlanners/environments/pacman_pomdp/__init__.py
+++ b/POMDPPlanners/environments/pacman_pomdp/__init__.py
@@ -7,11 +7,17 @@ from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import (
     PacManStateTransitionModel,
     create_simple_maze_pacman,
 )
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs import (
+    PacManVectorizedUpdater,
+    create_pacman_belief,
+)
 
 __all__ = [
     "PacManPOMDP",
     "PacManState",
     "PacManStateTransitionModel",
     "PacManObservationModel",
+    "PacManVectorizedUpdater",
+    "create_pacman_belief",
     "create_simple_maze_pacman",
 ]

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -863,10 +863,123 @@ class PacManPOMDP(DiscreteActionsEnvironment):
         # Initialize ghost patrol directions for patrol strategy
         self._ghost_patrol_directions: Dict[int, int] = {}
 
+        # Precompute array state layout for vectorized belief support
+        self._all_pellet_positions = tuple(self.initial_pellets)
+        self._num_initial_pellets = len(self._all_pellet_positions)
+        self._pellet_to_index = {pos: i for i, pos in enumerate(self._all_pellet_positions)}
+
+        self._idx_pac_row = 0
+        self._idx_pac_col = 1
+        self._idx_ghosts_start = 2
+        self._idx_ghosts_end = 2 + 2 * self.num_ghosts
+        self._idx_pellets_start = self._idx_ghosts_end
+        self._idx_pellets_end = self._idx_pellets_start + self._num_initial_pellets
+        self._idx_score = self._idx_pellets_end
+        self._idx_terminal = self._idx_pellets_end + 1
+        self._state_dim = self._idx_terminal + 1
+        self._cached_neighbor_table: Optional[np.ndarray] = None
+
     @property
     def initial_ghost_pos(self) -> Tuple[int, int]:
         """Backward compatibility: returns first ghost position."""
         return self.initial_ghost_positions[0] if self.initial_ghost_positions else (0, 0)
+
+    # ------------------------------------------------------------------
+    # Array state conversion (for vectorized belief support)
+    # ------------------------------------------------------------------
+
+    def state_to_array(self, state: PacManState) -> np.ndarray:
+        """Convert a PacManState to a fixed-size numpy array.
+
+        The array layout is:
+        ``[pac_row, pac_col, g0_row, g0_col, ..., pellet_mask[0..P-1], score, terminal]``
+
+        Args:
+            state: A PacManState instance.
+
+        Returns:
+            1-D float array of shape ``(self._state_dim,)``.
+        """
+        arr = np.zeros(self._state_dim, dtype=np.float64)
+        arr[self._idx_pac_row] = state.pacman_pos[0]
+        arr[self._idx_pac_col] = state.pacman_pos[1]
+        for g, gpos in enumerate(state.ghost_positions):
+            arr[self._idx_ghosts_start + 2 * g] = gpos[0]
+            arr[self._idx_ghosts_start + 2 * g + 1] = gpos[1]
+        pellet_set = set(state.pellets)
+        for pos, idx in self._pellet_to_index.items():
+            if pos in pellet_set:
+                arr[self._idx_pellets_start + idx] = 1.0
+        arr[self._idx_score] = state.score
+        arr[self._idx_terminal] = 1.0 if state.terminal else 0.0
+        return arr
+
+    def array_to_state(self, arr: np.ndarray) -> PacManState:
+        """Convert a numpy array back to a PacManState.
+
+        Args:
+            arr: 1-D array of shape ``(self._state_dim,)`` produced by
+                :meth:`state_to_array`.
+
+        Returns:
+            Reconstructed PacManState.
+        """
+        pacman_pos = (int(arr[self._idx_pac_row]), int(arr[self._idx_pac_col]))
+        ghost_positions = tuple(
+            (
+                int(arr[self._idx_ghosts_start + 2 * g]),
+                int(arr[self._idx_ghosts_start + 2 * g + 1]),
+            )
+            for g in range(self.num_ghosts)
+        )
+        pellets = tuple(
+            pos
+            for pos, idx in self._pellet_to_index.items()
+            if arr[self._idx_pellets_start + idx] > 0.5
+        )
+        score = float(arr[self._idx_score])
+        terminal = arr[self._idx_terminal] > 0.5
+        return PacManState(
+            pacman_pos=pacman_pos,
+            ghost_positions=ghost_positions,
+            pellets=pellets,
+            score=score,
+            terminal=terminal,
+        )
+
+    def states_to_array(self, states: List[PacManState]) -> np.ndarray:
+        """Batch-convert a list of PacManState to a 2-D numpy array.
+
+        Args:
+            states: List of PacManState instances.
+
+        Returns:
+            Array of shape ``(len(states), self._state_dim)``.
+        """
+        return np.array([self.state_to_array(s) for s in states])
+
+    def observation_to_array(self, obs: Tuple[Tuple[int, int], ...]) -> np.ndarray:
+        """Convert a PacMan observation tuple to a flat numpy array.
+
+        Args:
+            obs: Observation as tuple of ghost (row, col) positions.
+
+        Returns:
+            1-D array of shape ``(2 * num_ghosts,)``.
+        """
+        return np.array([coord for gpos in obs for coord in gpos], dtype=np.float64)
+
+    def array_to_observation(self, arr: np.ndarray) -> Tuple[Tuple[int, int], ...]:
+        """Convert a flat numpy array back to a PacMan observation tuple.
+
+        Args:
+            arr: 1-D array of shape ``(2 * num_ghosts,)``.
+
+        Returns:
+            Observation as tuple of (row, col) tuples.
+        """
+        flat = arr.ravel()
+        return tuple((int(flat[2 * g]), int(flat[2 * g + 1])) for g in range(self.num_ghosts))
 
     def _generate_ghost_positions(self, num_ghosts: int) -> List[Tuple[int, int]]:
         """Generate ghost starting positions automatically."""
@@ -1001,6 +1114,90 @@ class PacManPOMDP(DiscreteActionsEnvironment):
             total_reward += self.win_reward
 
         return total_reward
+
+    def reward_batch(  # type: ignore[override]
+        self, states: Union[np.ndarray, Sequence[Any]], action: int
+    ) -> np.ndarray:
+        """Calculate rewards for a batch of states.
+
+        Accepts either a 2-D numpy array of shape ``(N, state_dim)``
+        (vectorized path) or a sequence of PacManState objects (falls back
+        to the loop-based default).
+
+        Computes deterministic reward components only: step penalty, pellet
+        collection, and win bonus. Ghost collision penalty is excluded because
+        it depends on stochastic ghost movement.
+
+        Args:
+            states: Array of shape ``(N, state_dim)`` or sequence of states.
+            action: Discrete action index (0-3).
+
+        Returns:
+            1-D array of reward values with shape ``(N,)``.
+        """
+        states_arr = np.asarray(states)
+        if states_arr.dtype.kind == "f":
+            if states_arr.ndim == 1:
+                states_arr = states_arr.reshape(1, -1)
+            return self._compute_reward_batch(states_arr, action)
+        # Fallback for PacManState sequences (non-vectorized beliefs)
+        return np.array([self.reward(states[i], action) for i in range(len(states))])
+
+    def _compute_reward_batch(self, states_arr: np.ndarray, action: int) -> np.ndarray:
+        terminal = states_arr[:, self._idx_terminal] > 0.5
+        rewards = np.where(terminal, 0.0, self.step_penalty)
+
+        new_pac_rows, new_pac_cols = self._batch_move_pacman(states_arr, action)
+        pellet_collected, all_collected = self._batch_check_pellets(
+            states_arr, new_pac_rows, new_pac_cols
+        )
+        rewards += np.where(~terminal & pellet_collected, self.pellet_reward, 0.0)
+        rewards += np.where(~terminal & all_collected, self.win_reward, 0.0)
+        return rewards
+
+    def _batch_move_pacman(
+        self, states_arr: np.ndarray, action: int
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        pac_rows = states_arr[:, self._idx_pac_row].astype(np.int32)
+        pac_cols = states_arr[:, self._idx_pac_col].astype(np.int32)
+        table = self._get_neighbor_table()
+        new_positions = table[pac_rows, pac_cols, action]
+        return new_positions[:, 0], new_positions[:, 1]
+
+    def _batch_check_pellets(
+        self,
+        states_arr: np.ndarray,
+        pac_rows: np.ndarray,
+        pac_cols: np.ndarray,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        n = states_arr.shape[0]
+        pellet_mask = states_arr[:, self._idx_pellets_start : self._idx_pellets_end]
+        pellet_pos = np.array(self._all_pellet_positions, dtype=np.int32)
+
+        if len(pellet_pos) == 0:
+            return np.zeros(n, dtype=bool), np.ones(n, dtype=bool)
+
+        # Check if new pacman position matches any active pellet
+        row_match = pac_rows[:, None] == pellet_pos[None, :, 0]
+        col_match = pac_cols[:, None] == pellet_pos[None, :, 1]
+        pos_match = row_match & col_match
+        active_match = pos_match & (pellet_mask > 0.5)
+        collected = active_match.any(axis=1)
+
+        remaining_after = pellet_mask.sum(axis=1) - collected.astype(np.float64)
+        all_collected = collected & (remaining_after < 0.5)
+        return collected, all_collected
+
+    def _get_neighbor_table(self) -> np.ndarray:
+        if self._cached_neighbor_table is None:
+            from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_grid_utils import (  # pylint: disable=import-outside-toplevel
+                precompute_neighbor_table,
+                precompute_valid_cell_mask,
+            )
+
+            valid_mask = precompute_valid_cell_mask(self.maze_size, self.walls)
+            self._cached_neighbor_table = precompute_neighbor_table(self.maze_size, valid_mask)
+        return self._cached_neighbor_table
 
     def is_terminal(self, state: PacManState) -> bool:
         """Check if state is terminal."""

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -1082,16 +1082,22 @@ class PacManPOMDP(DiscreteActionsEnvironment):
         """Get all available actions."""
         return list(range(len(self.action_names)))
 
-    def state_transition_model(self, state: PacManState, action: int) -> PacManStateTransitionModel:
+    def _ensure_pacman_state(self, state: Any) -> PacManState:
+        if isinstance(state, np.ndarray):
+            return self.array_to_state(state)
+        return state
+
+    def state_transition_model(self, state: Any, action: int) -> PacManStateTransitionModel:
         """Get state transition model."""
-        return PacManStateTransitionModel(state, action, self)
+        return PacManStateTransitionModel(self._ensure_pacman_state(state), action, self)
 
-    def observation_model(self, next_state: PacManState, action: int) -> PacManObservationModel:
+    def observation_model(self, next_state: Any, action: int) -> PacManObservationModel:
         """Get observation model."""
-        return PacManObservationModel(next_state, action, self)
+        return PacManObservationModel(self._ensure_pacman_state(next_state), action, self)
 
-    def reward(self, state: PacManState, action: int) -> float:
+    def reward(self, state: Any, action: int) -> float:
         """Calculate immediate reward."""
+        state = self._ensure_pacman_state(state)
         if state.terminal:
             return 0.0  # No reward for terminal states
 
@@ -1199,8 +1205,9 @@ class PacManPOMDP(DiscreteActionsEnvironment):
             self._cached_neighbor_table = precompute_neighbor_table(self.maze_size, valid_mask)
         return self._cached_neighbor_table
 
-    def is_terminal(self, state: PacManState) -> bool:
+    def is_terminal(self, state: Any) -> bool:
         """Check if state is terminal."""
+        state = self._ensure_pacman_state(state)
         return state.terminal
 
     def initial_state_dist(self) -> DiscreteDistribution:

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_beliefs/__init__.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_beliefs/__init__.py
@@ -1,0 +1,23 @@
+"""PacMan POMDP belief support with vectorized particle filter.
+
+This package provides vectorized belief updater, grid utilities,
+and a belief factory for the PacMan POMDP environment.
+
+Classes:
+    PacManVectorizedUpdater: Batched updater for PacMan POMDP.
+
+Functions:
+    create_pacman_belief: Factory producing a configured belief for PacManPOMDP.
+"""
+
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_belief_factory import (
+    create_pacman_belief,
+)
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_vectorized_updater import (
+    PacManVectorizedUpdater,
+)
+
+__all__ = [
+    "PacManVectorizedUpdater",
+    "create_pacman_belief",
+]

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_beliefs/pacman_belief_factory.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_beliefs/pacman_belief_factory.py
@@ -1,0 +1,83 @@
+"""Belief factory for the PacMan POMDP.
+
+This module provides a factory function that creates ready-to-use belief
+objects for the PacMan POMDP, supporting both standard weighted particle
+beliefs and vectorized particle beliefs.
+
+Functions:
+    create_pacman_belief: Factory producing a configured belief for PacManPOMDP.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from POMDPPlanners.core.belief.belief_utils import get_initial_belief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_vectorized_updater import (
+    PacManVectorizedUpdater,
+)
+from POMDPPlanners.utils.belief_factory import BeliefType
+
+if TYPE_CHECKING:
+    from POMDPPlanners.core.belief.base_belief import Belief
+    from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import PacManPOMDP
+
+_SUPPORTED_TYPES = {BeliefType.PARTICLE, BeliefType.VECTORIZED_PARTICLE}
+_DEFAULT_TYPE = BeliefType.VECTORIZED_PARTICLE
+
+
+def create_pacman_belief(
+    env: "PacManPOMDP",
+    belief_type: BeliefType = _DEFAULT_TYPE,
+    n_particles: int = 200,
+    **kwargs: Any,  # pylint: disable=unused-argument
+) -> "Belief":
+    """Create a ready-to-use belief for the PacMan POMDP.
+
+    Args:
+        env: PacManPOMDP environment instance.
+        belief_type: Desired belief representation.
+            Defaults to ``BeliefType.VECTORIZED_PARTICLE``.
+        n_particles: Number of particles. Defaults to 200.
+        **kwargs: Extra arguments (reserved for future use).
+
+    Returns:
+        A configured :class:`Belief` object.
+
+    Raises:
+        ValueError: If *belief_type* is not supported.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(42)
+        >>> from POMDPPlanners.environments.pacman_pomdp import PacManPOMDP
+        >>> env = PacManPOMDP(discount_factor=0.95)
+        >>> belief = create_pacman_belief(env, n_particles=50)
+        >>> belief.sample().shape[0] > 0
+        True
+    """
+    del kwargs  # reserved for future use
+    if belief_type not in _SUPPORTED_TYPES:
+        raise ValueError(
+            f"PacManPOMDP does not support {belief_type}. " f"Supported: {_SUPPORTED_TYPES}"
+        )
+    if belief_type == BeliefType.PARTICLE:
+        return _create_particle_belief(env, n_particles)
+    return _create_vectorized_belief(env, n_particles)
+
+
+def _create_particle_belief(env: "PacManPOMDP", n_particles: int) -> "Belief":
+    return get_initial_belief(env, n_particles)
+
+
+def _create_vectorized_belief(env: "PacManPOMDP", n_particles: int) -> "Belief":
+    updater = PacManVectorizedUpdater.from_environment(env)
+    initial_states = env.initial_state_dist().sample(n_samples=n_particles)
+    particles = env.states_to_array(initial_states)
+    log_weights = np.log(np.ones(n_particles) / n_particles)
+    return VectorizedWeightedParticleBelief(particles, log_weights, updater)

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_beliefs/pacman_grid_utils.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_beliefs/pacman_grid_utils.py
@@ -1,0 +1,120 @@
+"""Precomputed grid navigation tables for vectorized PacMan operations.
+
+This module provides utility functions that precompute lookup tables for
+maze navigation, enabling O(1) position lookups via NumPy fancy indexing
+instead of per-particle Python branching.
+
+Functions:
+    precompute_valid_cell_mask: Boolean grid marking non-wall cells.
+    precompute_neighbor_table: Result position for each cell and move.
+    precompute_neighbor_validity: Boolean mask of valid moves per cell.
+"""
+
+from typing import Set, Tuple
+
+import numpy as np
+
+# Move indices: 0=North, 1=East, 2=South, 3=West, 4=Stay
+_DIRECTION_OFFSETS = np.array(
+    [
+        [-1, 0],  # North
+        [0, 1],  # East
+        [1, 0],  # South
+        [0, -1],  # West
+        [0, 0],  # Stay
+    ],
+    dtype=np.int32,
+)
+
+NUM_MOVES = 5
+
+
+def precompute_valid_cell_mask(
+    maze_size: Tuple[int, int],
+    walls: Set[Tuple[int, int]],
+) -> np.ndarray:
+    """Create boolean grid where True means the cell is not a wall.
+
+    Args:
+        maze_size: Grid dimensions as (rows, cols).
+        walls: Set of wall positions as (row, col) tuples.
+
+    Returns:
+        Boolean array of shape ``(rows, cols)``.
+    """
+    rows, cols = maze_size
+    mask = np.ones((rows, cols), dtype=bool)
+    for r, c in walls:
+        if 0 <= r < rows and 0 <= c < cols:
+            mask[r, c] = False
+    return mask
+
+
+def precompute_neighbor_table(
+    maze_size: Tuple[int, int],
+    valid_cell_mask: np.ndarray,
+) -> np.ndarray:
+    """Precompute resulting position for each cell and each of 5 moves.
+
+    For each cell and move direction, stores the resulting position.
+    If the move would go out of bounds or into a wall, the position
+    stays the same (i.e., the agent does not move).
+
+    Args:
+        maze_size: Grid dimensions as (rows, cols).
+        valid_cell_mask: Boolean array of shape ``(rows, cols)``
+            from :func:`precompute_valid_cell_mask`.
+
+    Returns:
+        Integer array of shape ``(rows, cols, 5, 2)`` where
+        ``result[r, c, move_idx]`` gives ``[new_row, new_col]``.
+    """
+    rows, cols = maze_size
+    table = np.zeros((rows, cols, NUM_MOVES, 2), dtype=np.int32)
+
+    for r in range(rows):
+        for c in range(cols):
+            for m in range(NUM_MOVES):
+                nr = r + _DIRECTION_OFFSETS[m, 0]
+                nc = c + _DIRECTION_OFFSETS[m, 1]
+                if 0 <= nr < rows and 0 <= nc < cols and valid_cell_mask[nr, nc]:
+                    table[r, c, m, 0] = nr
+                    table[r, c, m, 1] = nc
+                else:
+                    table[r, c, m, 0] = r
+                    table[r, c, m, 1] = c
+    return table
+
+
+def precompute_neighbor_validity(
+    maze_size: Tuple[int, int],
+    valid_cell_mask: np.ndarray,
+) -> np.ndarray:
+    """Precompute which moves are valid from each cell.
+
+    A move is valid if the resulting position is in-bounds and not a wall.
+    The stay move (index 4) is always valid.
+
+    Args:
+        maze_size: Grid dimensions as (rows, cols).
+        valid_cell_mask: Boolean array of shape ``(rows, cols)``.
+
+    Returns:
+        Boolean array of shape ``(rows, cols, 5)`` where
+        ``result[r, c, move_idx]`` is True if the move leads to a valid cell.
+    """
+    rows, cols = maze_size
+    validity = np.zeros((rows, cols, NUM_MOVES), dtype=bool)
+
+    for r in range(rows):
+        for c in range(cols):
+            for m in range(NUM_MOVES):
+                nr = r + _DIRECTION_OFFSETS[m, 0]
+                nc = c + _DIRECTION_OFFSETS[m, 1]
+                if 0 <= nr < rows and 0 <= nc < cols and valid_cell_mask[nr, nc]:
+                    validity[r, c, m] = True
+                else:
+                    validity[r, c, m] = False
+            # Stay is always valid
+            validity[r, c, 4] = True
+    return validity

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_beliefs/pacman_vectorized_updater.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_beliefs/pacman_vectorized_updater.py
@@ -1,0 +1,439 @@
+"""Vectorized particle belief updater for the PacMan POMDP.
+
+This module implements a concrete
+:class:`~POMDPPlanners.core.belief.vectorized_particle_belief_updater.VectorizedParticleBeliefUpdater`
+that performs batched state transitions and observation log-likelihood
+evaluations for the PacMan environment, replacing per-particle Python loops
+with NumPy array operations.
+
+Classes:
+    PacManVectorizedUpdater: Batched updater for the PacMan POMDP.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
+    VectorizedParticleBeliefUpdater,
+)
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_grid_utils import (
+    precompute_neighbor_table,
+    precompute_neighbor_validity,
+    precompute_valid_cell_mask,
+)
+from POMDPPlanners.utils.config_to_id import config_to_id
+
+if TYPE_CHECKING:
+    from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import PacManPOMDP
+
+
+class PacManVectorizedUpdater(VectorizedParticleBeliefUpdater):
+    """Vectorized particle belief updater for PacMan POMDP.
+
+    Performs all-particle transitions and observation log-likelihood
+    evaluations using vectorized NumPy operations. Ghost movement uses
+    batched softmax sampling, and collision/pellet logic operates on
+    the full particle array at once.
+
+    Attributes:
+        maze_size: Grid dimensions (rows, cols).
+        num_ghosts: Number of ghosts.
+        num_pellets: Number of initial pellets.
+        state_dim: Dimensionality of the array state.
+        ghost_aggressiveness: Softmax temperature for ghost pursuit.
+        ghost_coordination: Ghost coordination mode.
+        ghost_strategies: Per-ghost strategy list.
+        observation_noise_factor: Multiplier for observation noise.
+        max_observation_noise: Maximum observation noise std.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        maze_size: Tuple[int, int],
+        num_ghosts: int,
+        num_pellets: int,
+        state_dim: int,
+        neighbor_table: np.ndarray,
+        neighbor_validity: np.ndarray,
+        pellet_positions: np.ndarray,
+        ghost_aggressiveness: float,
+        ghost_coordination: str,
+        ghost_strategies: List[str],
+        observation_noise_factor: float,
+        max_observation_noise: float,
+        idx_pac_row: int,
+        idx_pac_col: int,
+        idx_ghosts_start: int,
+        idx_pellets_start: int,
+        idx_pellets_end: int,
+        idx_score: int,
+        idx_terminal: int,
+    ):
+        self.maze_size = maze_size
+        self.num_ghosts = num_ghosts
+        self.num_pellets = num_pellets
+        self.state_dim = state_dim
+        self.neighbor_table = neighbor_table
+        self.neighbor_validity = neighbor_validity
+        self.pellet_positions = pellet_positions
+        self.ghost_aggressiveness = ghost_aggressiveness
+        self.ghost_coordination = ghost_coordination
+        self.ghost_strategies = ghost_strategies
+        self.observation_noise_factor = observation_noise_factor
+        self.max_observation_noise = max_observation_noise
+        self._idx_pac_row = idx_pac_row
+        self._idx_pac_col = idx_pac_col
+        self._idx_ghosts_start = idx_ghosts_start
+        self._idx_pellets_start = idx_pellets_start
+        self._idx_pellets_end = idx_pellets_end
+        self._idx_score = idx_score
+        self._idx_terminal = idx_terminal
+
+    @classmethod
+    def from_environment(cls, env: "PacManPOMDP") -> "PacManVectorizedUpdater":
+        """Construct an updater from a PacManPOMDP instance.
+
+        Args:
+            env: Environment to extract parameters from.
+
+        Returns:
+            A new ``PacManVectorizedUpdater`` instance.
+        """
+        valid_mask = precompute_valid_cell_mask(env.maze_size, env.walls)
+        neighbor_table = precompute_neighbor_table(env.maze_size, valid_mask)
+        neighbor_valid = precompute_neighbor_validity(env.maze_size, valid_mask)
+        pellet_pos = np.array(
+            env._all_pellet_positions, dtype=np.int32  # pylint: disable=protected-access
+        ).reshape(-1, 2)
+
+        return cls(
+            maze_size=env.maze_size,
+            num_ghosts=env.num_ghosts,
+            num_pellets=env._num_initial_pellets,  # pylint: disable=protected-access
+            state_dim=env._state_dim,  # pylint: disable=protected-access
+            neighbor_table=neighbor_table,
+            neighbor_validity=neighbor_valid,
+            pellet_positions=pellet_pos,
+            ghost_aggressiveness=env.ghost_aggressiveness,
+            ghost_coordination=env.ghost_coordination,
+            ghost_strategies=env.ghost_strategies,
+            observation_noise_factor=env.observation_noise_factor,
+            max_observation_noise=env.max_observation_noise,
+            idx_pac_row=env._idx_pac_row,  # pylint: disable=protected-access
+            idx_pac_col=env._idx_pac_col,  # pylint: disable=protected-access
+            idx_ghosts_start=env._idx_ghosts_start,  # pylint: disable=protected-access
+            idx_pellets_start=env._idx_pellets_start,  # pylint: disable=protected-access
+            idx_pellets_end=env._idx_pellets_end,  # pylint: disable=protected-access
+            idx_score=env._idx_score,  # pylint: disable=protected-access
+            idx_terminal=env._idx_terminal,  # pylint: disable=protected-access
+        )
+
+    # ------------------------------------------------------------------
+    # VectorizedParticleBeliefUpdater interface
+    # ------------------------------------------------------------------
+
+    def batch_transition(  # pylint: disable=arguments-renamed
+        self, particles: np.ndarray, action: np.ndarray
+    ) -> np.ndarray:
+        action_idx = int(action)
+        result = particles.copy()
+        is_terminal = result[:, self._idx_terminal] > 0.5
+
+        if np.all(is_terminal):
+            return result
+
+        live = ~is_terminal
+        self._apply_pacman_movement(result, action_idx, live)
+        self._apply_ghost_movement(result, live)
+        self._apply_collisions_and_pellets(result, live)
+        return result
+
+    def batch_observation_log_likelihood(
+        self,
+        next_particles: np.ndarray,
+        action: np.ndarray,  # pylint: disable=unused-argument
+        observation: np.ndarray,
+    ) -> np.ndarray:
+        del action  # observation likelihood is action-independent for PacMan
+        observation = np.asarray(observation, dtype=np.float64).ravel()
+        n = next_particles.shape[0]
+        is_terminal = next_particles[:, self._idx_terminal] > 0.5
+        obs_is_terminal = np.all(observation < -0.5)
+
+        log_ll = np.full(n, -np.inf)
+
+        if obs_is_terminal:
+            log_ll[is_terminal] = 0.0
+            return log_ll
+
+        log_ll[is_terminal] = -np.inf
+        live = ~is_terminal
+        if not np.any(live):
+            return log_ll
+
+        log_ll[live] = self._compute_live_observation_log_ll(next_particles[live], observation)
+        return log_ll
+
+    @property
+    def config_id(self) -> str:
+        config_dict = {
+            "class": "PacManVectorizedUpdater",
+            "maze_size": list(self.maze_size),
+            "num_ghosts": self.num_ghosts,
+            "num_pellets": self.num_pellets,
+            "ghost_aggressiveness": self.ghost_aggressiveness,
+            "ghost_coordination": self.ghost_coordination,
+            "ghost_strategies": self.ghost_strategies,
+            "observation_noise_factor": self.observation_noise_factor,
+            "max_observation_noise": self.max_observation_noise,
+        }
+        return config_to_id(config_dict)
+
+    # ------------------------------------------------------------------
+    # Transition helpers
+    # ------------------------------------------------------------------
+
+    def _apply_pacman_movement(self, result: np.ndarray, action_idx: int, live: np.ndarray) -> None:
+        pac_r = result[live, self._idx_pac_row].astype(np.int32)
+        pac_c = result[live, self._idx_pac_col].astype(np.int32)
+        new_pos = self.neighbor_table[pac_r, pac_c, action_idx]
+        result[live, self._idx_pac_row] = new_pos[:, 0]
+        result[live, self._idx_pac_col] = new_pos[:, 1]
+
+    def _apply_ghost_movement(self, result: np.ndarray, live: np.ndarray) -> None:
+        for g in range(self.num_ghosts):
+            g_row_idx = self._idx_ghosts_start + 2 * g
+            g_col_idx = self._idx_ghosts_start + 2 * g + 1
+            g_rows = result[live, g_row_idx].astype(np.int32)
+            g_cols = result[live, g_col_idx].astype(np.int32)
+            pac_r = result[live, self._idx_pac_row].astype(np.int32)
+            pac_c = result[live, self._idx_pac_col].astype(np.int32)
+
+            strategy = self._get_ghost_strategy(g)
+            if strategy == "aggressive":
+                new_r, new_c = self._batch_move_aggressive(g_rows, g_cols, pac_r, pac_c)
+            elif strategy == "patrol":
+                new_r, new_c = self._batch_move_patrol(g_rows, g_cols)
+            elif strategy == "ambush":
+                new_r, new_c = self._batch_move_ambush(g_rows, g_cols, pac_r, pac_c)
+            else:
+                new_r, new_c = self._batch_move_aggressive(g_rows, g_cols, pac_r, pac_c)
+
+            result[live, g_row_idx] = new_r
+            result[live, g_col_idx] = new_c
+
+    def _get_ghost_strategy(self, ghost_id: int) -> str:
+        if self.ghost_coordination == "coordinated":
+            return "coordinated"
+        if self.ghost_coordination == "mixed":
+            return "aggressive" if ghost_id % 2 == 0 else "patrol"
+        if ghost_id < len(self.ghost_strategies):
+            return self.ghost_strategies[ghost_id]
+        return "aggressive"
+
+    def _batch_move_aggressive(
+        self,
+        g_rows: np.ndarray,
+        g_cols: np.ndarray,
+        pac_r: np.ndarray,
+        pac_c: np.ndarray,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        return self._batch_softmax_move_toward(
+            g_rows, g_cols, pac_r, pac_c, self.ghost_aggressiveness
+        )
+
+    def _batch_softmax_move_toward(
+        self,
+        g_rows: np.ndarray,
+        g_cols: np.ndarray,
+        target_r: np.ndarray,
+        target_c: np.ndarray,
+        temperature: float,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        n = len(g_rows)
+        # For each of 5 moves, compute resulting positions
+        # neighbor_table shape: (rows, cols, 5, 2)
+        all_next = self.neighbor_table[g_rows, g_cols]  # (n, 5, 2)
+        valid = self.neighbor_validity[g_rows, g_cols]  # (n, 5)
+
+        # Manhattan distance to target for each move
+        dist: np.ndarray = np.abs(
+            all_next[:, :, 0].astype(np.float64) - target_r[:, None].astype(np.float64)
+        ) + np.abs(
+            all_next[:, :, 1].astype(np.float64) - target_c[:, None].astype(np.float64)
+        )  # (n, 5)
+
+        # Softmax scores: negative distance / temperature
+        scores: np.ndarray = np.where(valid, -dist / temperature, -1e9)  # type: ignore[operator]
+        scores_max = scores.max(axis=1, keepdims=True)  # pylint: disable=unexpected-keyword-arg
+        exp_scores = np.exp(scores - scores_max)
+        exp_scores = np.where(valid, exp_scores, 0.0)
+        probs = exp_scores / exp_scores.sum(axis=1, keepdims=True)
+
+        # Sample using cumulative probability
+        cum_probs = np.cumsum(probs, axis=1)
+        u = np.random.random(n)[:, None]
+        chosen = (u < cum_probs).argmax(axis=1)
+
+        new_r = all_next[np.arange(n), chosen, 0]
+        new_c = all_next[np.arange(n), chosen, 1]
+        return new_r.astype(np.float64), new_c.astype(np.float64)
+
+    def _batch_move_patrol(
+        self, g_rows: np.ndarray, g_cols: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        n = len(g_rows)
+        valid = self.neighbor_validity[g_rows, g_cols]  # (n, 5)
+        # Uniform random over valid moves
+        probs = np.where(valid, 1.0, 0.0)
+        probs = probs / probs.sum(axis=1, keepdims=True)
+        cum_probs = np.cumsum(probs, axis=1)
+        u = np.random.random(n)[:, None]
+        chosen = (u < cum_probs).argmax(axis=1)
+
+        all_next = self.neighbor_table[g_rows, g_cols]  # (n, 5, 2)
+        new_r = all_next[np.arange(n), chosen, 0]
+        new_c = all_next[np.arange(n), chosen, 1]
+        return new_r.astype(np.float64), new_c.astype(np.float64)
+
+    def _batch_move_ambush(
+        self,
+        g_rows: np.ndarray,
+        g_cols: np.ndarray,
+        pac_r: np.ndarray,
+        pac_c: np.ndarray,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        n = len(g_rows)
+        all_next = self.neighbor_table[g_rows, g_cols]  # (n, 5, 2)
+        valid = self.neighbor_validity[g_rows, g_cols]  # (n, 5)
+
+        # Prefer positions 2-4 tiles from pacman
+        dist: np.ndarray = np.abs(
+            all_next[:, :, 0].astype(np.float64) - pac_r[:, None].astype(np.float64)
+        ) + np.abs(all_next[:, :, 1].astype(np.float64) - pac_c[:, None].astype(np.float64))
+        in_range = (dist >= 2) & (dist <= 4)
+        scores: np.ndarray = np.where(in_range, -dist, -(dist + 10))  # type: ignore[operator]
+        scores = np.where(valid, scores, -1e9)
+
+        # Deterministic: pick best move
+        chosen = scores.argmax(axis=1)
+        new_r = all_next[np.arange(n), chosen, 0]
+        new_c = all_next[np.arange(n), chosen, 1]
+        return new_r.astype(np.float64), new_c.astype(np.float64)
+
+    def _apply_collisions_and_pellets(self, result: np.ndarray, live: np.ndarray) -> None:
+        live_idx = np.where(live)[0]
+        pac_r = result[live_idx, self._idx_pac_row].astype(np.int32)
+        pac_c = result[live_idx, self._idx_pac_col].astype(np.int32)
+
+        # Check ghost collisions
+        collision = self._check_ghost_collisions(result, live_idx, pac_r, pac_c)
+        result[live_idx[collision], self._idx_terminal] = 1.0
+
+        # Check pellet collection (only for non-collision particles)
+        not_collided = ~collision
+        self._collect_pellets(
+            result, live_idx[not_collided], pac_r[not_collided], pac_c[not_collided]
+        )
+
+        # Check win condition
+        self._check_win_condition(result, live_idx[not_collided])
+
+    def _check_ghost_collisions(
+        self,
+        result: np.ndarray,
+        live_idx: np.ndarray,
+        pac_r: np.ndarray,
+        pac_c: np.ndarray,
+    ) -> np.ndarray:
+        collision = np.zeros(len(live_idx), dtype=bool)
+        for g in range(self.num_ghosts):
+            g_row_idx = self._idx_ghosts_start + 2 * g
+            g_col_idx = self._idx_ghosts_start + 2 * g + 1
+            g_r = result[live_idx, g_row_idx].astype(np.int32)
+            g_c = result[live_idx, g_col_idx].astype(np.int32)
+            collision |= (pac_r == g_r) & (pac_c == g_c)
+        return collision
+
+    def _collect_pellets(
+        self,
+        result: np.ndarray,
+        idx: np.ndarray,
+        pac_r: np.ndarray,
+        pac_c: np.ndarray,
+    ) -> None:
+        if len(idx) == 0 or self.num_pellets == 0:
+            return
+        pellet_pos = self.pellet_positions  # (P, 2)
+        for p in range(self.num_pellets):
+            p_col_idx = self._idx_pellets_start + p
+            on_pellet = (pac_r == pellet_pos[p, 0]) & (pac_c == pellet_pos[p, 1])
+            active = result[idx, p_col_idx] > 0.5
+            collected = on_pellet & active
+            result[idx[collected], p_col_idx] = 0.0
+            result[idx[collected], self._idx_score] += 1.0
+
+    def _check_win_condition(self, result: np.ndarray, idx: np.ndarray) -> None:
+        if len(idx) == 0 or self.num_pellets == 0:
+            return
+        pellet_mask = result[idx, self._idx_pellets_start : self._idx_pellets_end]
+        all_collected = pellet_mask.sum(axis=1) < 0.5
+        result[idx[all_collected], self._idx_terminal] = 1.0
+
+    # ------------------------------------------------------------------
+    # Observation log-likelihood helpers
+    # ------------------------------------------------------------------
+
+    def _compute_live_observation_log_ll(
+        self, particles: np.ndarray, observation: np.ndarray
+    ) -> np.ndarray:
+        pac_r = particles[:, self._idx_pac_row]
+        pac_c = particles[:, self._idx_pac_col]
+        total_log_ll = np.zeros(particles.shape[0])
+
+        for g in range(self.num_ghosts):
+            g_row_idx = self._idx_ghosts_start + 2 * g
+            g_col_idx = self._idx_ghosts_start + 2 * g + 1
+            true_g_r = particles[:, g_row_idx]
+            true_g_c = particles[:, g_col_idx]
+
+            obs_g_r = observation[2 * g]
+            obs_g_c = observation[2 * g + 1]
+
+            log_ll_g = self._ghost_observation_log_likelihood(
+                true_g_r, true_g_c, pac_r, pac_c, obs_g_r, obs_g_c
+            )
+            total_log_ll += log_ll_g
+
+        return total_log_ll
+
+    def _ghost_observation_log_likelihood(
+        self,
+        true_g_r: np.ndarray,
+        true_g_c: np.ndarray,
+        pac_r: np.ndarray,
+        pac_c: np.ndarray,
+        obs_g_r: float,
+        obs_g_c: float,
+    ) -> np.ndarray:
+        manhattan_dist = np.abs(true_g_r - pac_r) + np.abs(true_g_c - pac_c)
+        noise_std = np.minimum(
+            manhattan_dist * self.observation_noise_factor,
+            self.max_observation_noise,
+        )
+        noise_std = np.maximum(noise_std, 1e-6)
+        variance = noise_std**2
+
+        row_diff = obs_g_r - true_g_r
+        col_diff = obs_g_c - true_g_c
+        dist_sq = row_diff**2 + col_diff**2
+
+        # Isotropic 2D Gaussian log-PDF
+        log_norm = -np.log(2.0 * np.pi * variance)
+        log_prob = log_norm - dist_sq / (2.0 * variance)
+        return log_prob

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
@@ -1883,3 +1883,241 @@ class TestMultiGhostFeatures:
 
         assert pomdp_legacy.num_ghosts == 1
         assert pomdp_legacy.initial_ghost_positions == [(4, 4)]
+
+
+# ---------------------------------------------------------------------------
+# Array state conversion tests
+# ---------------------------------------------------------------------------
+
+
+class TestStateToArrayConversion:
+    """Tests for state_to_array and array_to_state conversion methods."""
+
+    @pytest.fixture()
+    def env(self):
+        return PacManPOMDP(
+            maze_size=(5, 5),
+            walls={(2, 2)},
+            initial_pellets=[(1, 1), (3, 3)],
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(4, 4)],
+            discount_factor=0.95,
+        )
+
+    def test_state_to_array_shape(self, env):
+        """Test that state_to_array returns correct shape.
+
+        Purpose: Validates output shape equals env._state_dim.
+
+        Given: A PacManState from the initial distribution.
+        When: state_to_array is called.
+        Then: Output is 1-D with length state_dim.
+
+        Test type: unit
+        """
+        state = env.initial_state_dist().sample()[0]
+        arr = env.state_to_array(state)
+        assert arr.shape == (env._state_dim,)
+
+    def test_roundtrip(self, env):
+        """Test that state -> array -> state roundtrip preserves the state.
+
+        Purpose: Validates lossless conversion.
+
+        Given: Various PacManStates (initial, mid-game, terminal).
+        When: state_to_array then array_to_state is applied.
+        Then: The reconstructed state equals the original.
+
+        Test type: unit
+        """
+        initial_state = env.initial_state_dist().sample()[0]
+        roundtripped = env.array_to_state(env.state_to_array(initial_state))
+        assert roundtripped == initial_state
+
+        mid_state = PacManState(
+            pacman_pos=(1, 1),
+            ghost_positions=((3, 3),),
+            pellets=((3, 3),),  # One pellet eaten
+            score=10,
+            terminal=False,
+        )
+        roundtripped = env.array_to_state(env.state_to_array(mid_state))
+        assert roundtripped.pacman_pos == mid_state.pacman_pos
+        assert roundtripped.ghost_positions == mid_state.ghost_positions
+        assert roundtripped.score == mid_state.score
+        assert roundtripped.terminal == mid_state.terminal
+
+    def test_pellet_bitmask(self, env):
+        """Test pellet bitmask encoding.
+
+        Purpose: Validates eaten pellets produce 0s, remaining produce 1s.
+
+        Given: A state with one pellet eaten.
+        When: state_to_array is called.
+        Then: Bitmask has 0 for eaten pellet and 1 for remaining.
+
+        Test type: unit
+        """
+        # All pellets present
+        full_state = PacManState(
+            pacman_pos=(0, 0),
+            ghost_positions=((4, 4),),
+            pellets=((1, 1), (3, 3)),
+            score=0,
+            terminal=False,
+        )
+        arr = env.state_to_array(full_state)
+        assert arr[env._idx_pellets_start] == 1.0
+        assert arr[env._idx_pellets_start + 1] == 1.0
+
+        # One pellet eaten
+        partial_state = PacManState(
+            pacman_pos=(0, 0),
+            ghost_positions=((4, 4),),
+            pellets=((3, 3),),
+            score=10,
+            terminal=False,
+        )
+        arr = env.state_to_array(partial_state)
+        assert arr[env._idx_pellets_start] == 0.0  # (1,1) eaten
+        assert arr[env._idx_pellets_start + 1] == 1.0  # (3,3) remains
+
+    def test_terminal_flag(self, env):
+        """Test terminal flag encoding.
+
+        Purpose: Validates terminal=True produces 1 in array.
+
+        Given: A terminal PacManState.
+        When: state_to_array is called.
+        Then: Terminal index is 1.0.
+
+        Test type: unit
+        """
+        state = PacManState(
+            pacman_pos=(0, 0),
+            ghost_positions=((0, 0),),
+            pellets=((1, 1), (3, 3)),
+            score=0,
+            terminal=True,
+        )
+        arr = env.state_to_array(state)
+        assert arr[env._idx_terminal] == 1.0
+
+    def test_states_to_array_batch(self, env):
+        """Test batch conversion matches individual conversions.
+
+        Purpose: Validates batch and individual conversions agree.
+
+        Given: Multiple PacManStates.
+        When: states_to_array is called.
+        Then: Each row matches individual state_to_array output.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        states = env.initial_state_dist().sample(n_samples=5)
+        batch = env.states_to_array(states)
+        assert batch.shape == (5, env._state_dim)
+        for i, s in enumerate(states):
+            np.testing.assert_array_equal(batch[i], env.state_to_array(s))
+
+
+class TestRewardBatch:
+    """Tests for vectorized reward_batch on PacManPOMDP."""
+
+    @pytest.fixture()
+    def env(self):
+        return PacManPOMDP(
+            maze_size=(5, 5),
+            walls={(2, 2)},
+            initial_pellets=[(1, 1), (3, 3)],
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(4, 4)],
+            discount_factor=0.95,
+        )
+
+    def test_shape(self, env):
+        """Test reward_batch output shape.
+
+        Purpose: Validates output shape is (N,).
+
+        Given: 5 array-encoded states.
+        When: reward_batch is called.
+        Then: Output has shape (5,).
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        states = env.initial_state_dist().sample(n_samples=5)
+        arr = env.states_to_array(states)
+        rewards = env.reward_batch(arr, 2)
+        assert rewards.shape == (5,)
+
+    def test_terminal_zero(self, env):
+        """Test that terminal states return 0 reward.
+
+        Purpose: Validates terminal state reward is zero.
+
+        Given: A terminal PacManState encoded as array.
+        When: reward_batch is called.
+        Then: Reward is 0.0.
+
+        Test type: unit
+        """
+        state = PacManState(
+            pacman_pos=(0, 0),
+            ghost_positions=((0, 0),),
+            pellets=((1, 1), (3, 3)),
+            score=0,
+            terminal=True,
+        )
+        arr = env.state_to_array(state).reshape(1, -1)
+        rewards = env.reward_batch(arr, 2)
+        assert rewards[0] == 0.0
+
+    def test_step_penalty_included(self, env):
+        """Test that non-terminal non-event states include step penalty.
+
+        Purpose: Validates base step penalty is applied.
+
+        Given: A non-terminal state far from pellets and ghosts.
+        When: reward_batch is called with an action that doesn't collect pellets.
+        Then: Reward equals step_penalty.
+
+        Test type: unit
+        """
+        state = PacManState(
+            pacman_pos=(0, 0),
+            ghost_positions=((4, 4),),
+            pellets=((3, 3),),
+            score=0,
+            terminal=False,
+        )
+        arr = env.state_to_array(state).reshape(1, -1)
+        # Move South from (0,0) to (1,0) - no pellet there
+        rewards = env.reward_batch(arr, 2)
+        assert rewards[0] == env.step_penalty
+
+    def test_pellet_collection_reward(self, env):
+        """Test that pellet collection adds pellet_reward.
+
+        Purpose: Validates pellet collection reward component.
+
+        Given: PacMan at (1,0) with pellet at (1,1).
+        When: Action East moves PacMan onto the pellet.
+        Then: Reward includes step_penalty + pellet_reward.
+
+        Test type: unit
+        """
+        state = PacManState(
+            pacman_pos=(1, 0),
+            ghost_positions=((4, 4),),
+            pellets=((1, 1), (3, 3)),
+            score=0,
+            terminal=False,
+        )
+        arr = env.state_to_array(state).reshape(1, -1)
+        rewards = env.reward_batch(arr, 1)  # East -> (1,1)
+        assert rewards[0] == env.step_penalty + env.pellet_reward

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/__init__.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for PacMan POMDP belief support."""

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/benchmark_pacman_vectorized_belief.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/benchmark_pacman_vectorized_belief.py
@@ -1,0 +1,191 @@
+"""Performance benchmark: PacMan vectorized vs non-vectorized belief.
+
+Run manually to measure speedup:
+    python -m POMDPPlanners.tests.test_environments.test_pacman_pomdp_beliefs.benchmark_pacman_vectorized_belief
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, List, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.belief.belief_utils import get_initial_belief
+from POMDPPlanners.core.cost import belief_expectation_reward
+from POMDPPlanners.environments.pacman_pomdp import PacManPOMDP
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_belief_factory import (
+    create_pacman_belief,
+)
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_vectorized_updater import (
+    PacManVectorizedUpdater,
+)
+from POMDPPlanners.utils.belief_factory import BeliefType
+
+
+def _time_fn(fn: Callable[[], Any], n_runs: int = 100) -> Tuple[float, float]:
+    times: List[float] = []
+    for _ in range(n_runs):
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    arr = np.array(times) * 1000  # ms
+    return float(arr.mean()), float(arr.std())
+
+
+def _create_env() -> PacManPOMDP:
+    return PacManPOMDP(
+        maze_size=(7, 7),
+        num_ghosts=2,
+        ghost_coordination="independent",
+        ghost_aggressiveness=2.0,
+        discount_factor=0.95,
+    )
+
+
+def _benchmark_single_ops(env: PacManPOMDP) -> None:
+    print("\n--- Baseline: Single-state operations ---")
+    state = env.initial_state_dist().sample()[0]
+    action = 2
+
+    mean_t, std_t = _time_fn(
+        lambda: env.state_transition_model(state, action).sample()[0], n_runs=500
+    )
+    print(f"  state_transition_model.sample()     : {mean_t:.4f} +/- {std_t:.4f} ms")
+
+    next_state = env.state_transition_model(state, action).sample()[0]
+    obs = env.observation_model(next_state, action).sample()[0]
+
+    mean_t, std_t = _time_fn(
+        lambda: env.observation_model(next_state, action).probability([obs]), n_runs=500
+    )
+    print(f"  observation_model.probability()     : {mean_t:.4f} +/- {std_t:.4f} ms")
+
+
+def _benchmark_belief_update(env: PacManPOMDP, particle_counts: List[int]) -> None:
+    print("\n--- Belief Update ---")
+    print(f"{'N':>6} | {'Baseline (ms)':>14} | {'Vectorized (ms)':>16} | {'Speedup':>8}")
+    print("-" * 55)
+
+    action = 2
+    state = env.initial_state_dist().sample()[0]
+    next_state = env.state_transition_model(state, action).sample()[0]
+    obs = env.observation_model(next_state, action).sample()[0]
+    obs_arr = env.observation_to_array(obs)
+
+    for n in particle_counts:
+        # Baseline: WeightedParticleBelief
+        np.random.seed(42)
+        base_belief = get_initial_belief(env, n)
+        mean_base, _ = _time_fn(
+            lambda: base_belief.update(action=action, observation=obs, pomdp=env),
+            n_runs=20,
+        )
+
+        # Vectorized
+        np.random.seed(42)
+        vec_belief = create_pacman_belief(
+            env, belief_type=BeliefType.VECTORIZED_PARTICLE, n_particles=n
+        )
+        mean_vec, _ = _time_fn(
+            lambda: vec_belief.update(action=action, observation=obs_arr, pomdp=env),
+            n_runs=20,
+        )
+
+        speedup = mean_base / mean_vec if mean_vec > 0 else float("inf")
+        print(f"{n:>6} | {mean_base:>14.3f} | {mean_vec:>16.3f} | {speedup:>7.1f}x")
+
+
+def _benchmark_reward_batch(env: PacManPOMDP, particle_counts: List[int]) -> None:
+    print("\n--- reward_batch ---")
+    print(f"{'N':>6} | {'Loop (ms)':>14} | {'Vectorized (ms)':>16} | {'Speedup':>8}")
+    print("-" * 55)
+
+    action = 2
+
+    for n in particle_counts:
+        np.random.seed(42)
+        states = env.initial_state_dist().sample(n_samples=n)
+        arr = env.states_to_array(states)
+
+        # Baseline: loop
+        mean_base, _ = _time_fn(
+            lambda: np.array([env.reward(states[i], action) for i in range(n)]),
+            n_runs=20,
+        )
+
+        # Vectorized
+        mean_vec, _ = _time_fn(lambda: env.reward_batch(arr, action), n_runs=100)
+
+        speedup = mean_base / mean_vec if mean_vec > 0 else float("inf")
+        print(f"{n:>6} | {mean_base:>14.3f} | {mean_vec:>16.3f} | {speedup:>7.1f}x")
+
+
+def _benchmark_belief_expectation_reward(env: PacManPOMDP, particle_counts: List[int]) -> None:
+    print("\n--- belief_expectation_reward ---")
+    print(f"{'N':>6} | {'Baseline (ms)':>14} | {'Vectorized (ms)':>16} | {'Speedup':>8}")
+    print("-" * 55)
+
+    action = 2
+
+    for n in particle_counts:
+        # Baseline
+        np.random.seed(42)
+        base_belief = get_initial_belief(env, n)
+        mean_base, _ = _time_fn(
+            lambda: belief_expectation_reward(belief=base_belief, action=action, env=env),
+            n_runs=50,
+        )
+
+        # Vectorized
+        np.random.seed(42)
+        vec_belief = create_pacman_belief(
+            env, belief_type=BeliefType.VECTORIZED_PARTICLE, n_particles=n
+        )
+        mean_vec, _ = _time_fn(
+            lambda vb=vec_belief: belief_expectation_reward(belief=vb, action=action, env=env),
+            n_runs=50,
+        )
+
+        speedup = mean_base / mean_vec if mean_vec > 0 else float("inf")
+        print(f"{n:>6} | {mean_base:>14.3f} | {mean_vec:>16.3f} | {speedup:>7.1f}x")
+
+
+def _benchmark_batch_transition(env: PacManPOMDP, particle_counts: List[int]) -> None:
+    print("\n--- batch_transition ---")
+    updater = PacManVectorizedUpdater.from_environment(env)
+    print(f"{'N':>6} | {'Vectorized (ms)':>16}")
+    print("-" * 26)
+
+    action = 2
+    for n in particle_counts:
+        np.random.seed(42)
+        states = env.initial_state_dist().sample(n_samples=n)
+        arr = env.states_to_array(states)
+        mean_t, _ = _time_fn(
+            lambda a=arr: updater.batch_transition(a, np.array(action)),  # type: ignore[arg-type]
+            n_runs=100,
+        )
+        print(f"{n:>6} | {mean_t:>16.3f}")
+
+
+def main() -> None:
+    print("=" * 55)
+    print("PacMan Vectorized Belief Benchmark")
+    print("=" * 55)
+
+    env = _create_env()
+    particle_counts = [50, 200, 500, 1000]
+
+    _benchmark_single_ops(env)
+    _benchmark_batch_transition(env, particle_counts)
+    _benchmark_reward_batch(env, particle_counts)
+    _benchmark_belief_expectation_reward(env, particle_counts)
+    _benchmark_belief_update(env, particle_counts)
+
+    print("\n" + "=" * 55)
+    print("Benchmark complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_belief_factory.py
@@ -1,0 +1,111 @@
+"""Tests for PacMan belief factory."""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.environments.pacman_pomdp import PacManPOMDP
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_belief_factory import (
+    create_pacman_belief,
+)
+from POMDPPlanners.utils.belief_factory import BeliefType, create_environment_belief
+
+
+@pytest.fixture()
+def env():
+    return PacManPOMDP(
+        maze_size=(5, 5),
+        walls={(2, 2)},
+        initial_pellets=[(1, 1), (3, 3)],
+        initial_pacman_pos=(0, 0),
+        num_ghosts=1,
+        initial_ghost_positions=[(4, 4)],
+        discount_factor=0.95,
+    )
+
+
+class TestCreateVectorizedBelief:
+    def test_returns_vectorized_type(self, env):
+        """Test that vectorized belief type is returned.
+
+        Purpose: Validates factory creates VectorizedWeightedParticleBelief.
+
+        Given: A PacManPOMDP environment.
+        When: create_pacman_belief is called with VECTORIZED_PARTICLE type.
+        Then: A VectorizedWeightedParticleBelief is returned.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        belief = create_pacman_belief(env, n_particles=50)
+        assert isinstance(belief, VectorizedWeightedParticleBelief)
+
+    def test_correct_shapes(self, env):
+        """Test that vectorized belief has correct particle shapes.
+
+        Purpose: Validates particle array dimensions.
+
+        Given: A PacManPOMDP environment.
+        When: Vectorized belief is created with 50 particles.
+        Then: Particles shape is (50, state_dim).
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        belief = create_pacman_belief(env, n_particles=50)
+        assert isinstance(belief, VectorizedWeightedParticleBelief)
+        assert belief.particles.shape == (50, env._state_dim)  # pylint: disable=protected-access
+        assert belief.log_weights.shape == (50,)
+
+
+class TestCreateParticleBelief:
+    def test_returns_particle_type(self, env):
+        """Test that particle belief type is returned.
+
+        Purpose: Validates factory creates WeightedParticleBelief for PARTICLE type.
+
+        Given: A PacManPOMDP environment.
+        When: create_pacman_belief is called with PARTICLE type.
+        Then: A WeightedParticleBelief is returned.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        belief = create_pacman_belief(env, belief_type=BeliefType.PARTICLE, n_particles=50)
+        assert isinstance(belief, WeightedParticleBelief)
+
+
+class TestUnsupportedType:
+    def test_gaussian_raises_value_error(self, env):
+        """Test that unsupported belief type raises ValueError.
+
+        Purpose: Validates error handling for unsupported types.
+
+        Given: A PacManPOMDP environment.
+        When: create_pacman_belief is called with GAUSSIAN type.
+        Then: ValueError is raised.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="does not support"):
+            create_pacman_belief(env, belief_type=BeliefType.GAUSSIAN)
+
+
+class TestRegistryDispatches:
+    def test_create_environment_belief_works(self, env):
+        """Test that the global factory dispatches to PacMan factory.
+
+        Purpose: Validates registry-based dispatch.
+
+        Given: A PacManPOMDP environment registered in the factory.
+        When: create_environment_belief is called.
+        Then: A VectorizedWeightedParticleBelief is returned.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        belief = create_environment_belief(env, n_particles=50)
+        assert isinstance(belief, VectorizedWeightedParticleBelief)

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_belief_integration.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_belief_integration.py
@@ -1,0 +1,94 @@
+"""Integration tests for PacMan vectorized belief."""
+
+# pylint: disable=protected-access
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.core.cost import belief_expectation_reward
+from POMDPPlanners.environments.pacman_pomdp import PacManPOMDP
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_belief_factory import (
+    create_pacman_belief,
+)
+from POMDPPlanners.utils.belief_factory import BeliefType
+
+
+@pytest.fixture()
+def env():
+    return PacManPOMDP(
+        maze_size=(5, 5),
+        walls={(2, 2)},
+        initial_pellets=[(1, 1), (3, 3)],
+        initial_pacman_pos=(0, 0),
+        num_ghosts=1,
+        initial_ghost_positions=[(4, 4)],
+        discount_factor=0.95,
+    )
+
+
+class TestBeliefUpdateCycle:
+    def test_update_preserves_shapes(self, env):
+        """Test that belief update preserves particle array shapes.
+
+        Purpose: Validates belief update cycle with vectorized belief.
+
+        Given: A vectorized belief with 50 particles.
+        When: update is called with an action and observation.
+        Then: Updated belief has same particle count and state dim.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        belief = create_pacman_belief(
+            env, belief_type=BeliefType.VECTORIZED_PARTICLE, n_particles=50
+        )
+        action = 2  # South
+        obs = np.array([4.0, 4.0])  # Observed ghost at (4,4)
+        updated = belief.update(action=action, observation=obs, pomdp=env)
+        assert isinstance(updated, VectorizedWeightedParticleBelief)
+        assert updated.particles.shape == (50, env._state_dim)
+        assert updated.log_weights.shape == (50,)
+
+
+class TestBeliefSampleValidState:
+    def test_sample_converts_to_valid_state(self, env):
+        """Test that sampled array state converts to valid PacManState.
+
+        Purpose: Validates end-to-end sample -> state conversion.
+
+        Given: A vectorized belief created from the environment.
+        When: A state is sampled and converted to PacManState.
+        Then: The PacManState has valid fields.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        belief = create_pacman_belief(env, n_particles=50)
+        arr = belief.sample()
+        state = env.array_to_state(arr)
+        assert isinstance(state.pacman_pos, tuple)
+        assert len(state.pacman_pos) == 2
+        assert isinstance(state.ghost_positions, tuple)
+        assert len(state.ghost_positions) == env.num_ghosts
+
+
+class TestBeliefExpectationReward:
+    def test_returns_float(self, env):
+        """Test that belief_expectation_reward returns a float.
+
+        Purpose: Validates reward expectation computation with vectorized belief.
+
+        Given: A vectorized belief and a PacManPOMDP environment.
+        When: belief_expectation_reward is called.
+        Then: A finite float is returned.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        belief = create_pacman_belief(env, n_particles=50)
+        reward = belief_expectation_reward(belief=belief, action=2, env=env)
+        assert isinstance(reward, float)
+        assert np.isfinite(reward)

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_grid_utils.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_grid_utils.py
@@ -1,0 +1,140 @@
+"""Tests for PacMan grid navigation utility functions."""
+
+import numpy as np
+
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_grid_utils import (
+    precompute_neighbor_table,
+    precompute_neighbor_validity,
+    precompute_valid_cell_mask,
+)
+
+
+def _small_maze():
+    maze_size = (5, 5)
+    walls = {(1, 1), (2, 2)}
+    return maze_size, walls
+
+
+class TestValidCellMask:
+    def test_excludes_walls(self):
+        """Test that wall cells are marked False in the mask.
+
+        Purpose: Validates wall cells are excluded from valid mask.
+
+        Given: A 5x5 maze with walls at (1,1) and (2,2).
+        When: precompute_valid_cell_mask is called.
+        Then: Wall positions are False, others are True.
+
+        Test type: unit
+        """
+        maze_size, walls = _small_maze()
+        mask = precompute_valid_cell_mask(maze_size, walls)
+        assert mask.shape == (5, 5)
+        assert not mask[1, 1]
+        assert not mask[2, 2]
+        assert mask[0, 0]
+        assert mask[4, 4]
+
+    def test_shape(self):
+        """Test output shape matches maze dimensions.
+
+        Purpose: Validates output shape correctness.
+
+        Given: A 5x5 maze.
+        When: precompute_valid_cell_mask is called.
+        Then: Output shape is (5, 5).
+
+        Test type: unit
+        """
+        maze_size, walls = _small_maze()
+        mask = precompute_valid_cell_mask(maze_size, walls)
+        assert mask.shape == maze_size
+
+
+class TestNeighborTable:
+    def test_wall_blocked_move_stays(self):
+        """Test that moving into a wall keeps position unchanged.
+
+        Purpose: Validates wall collision handling in neighbor table.
+
+        Given: A 5x5 maze with a wall at (1,1).
+        When: Looking up a move from (1,0) East (which would go to (1,1)).
+        Then: The result position stays at (1,0).
+
+        Test type: unit
+        """
+        maze_size, walls = _small_maze()
+        mask = precompute_valid_cell_mask(maze_size, walls)
+        table = precompute_neighbor_table(maze_size, mask)
+        # Move East from (1,0) -> should hit wall at (1,1), stay at (1,0)
+        result = table[1, 0, 1]  # East
+        assert result[0] == 1 and result[1] == 0
+
+    def test_valid_move_updates_position(self):
+        """Test that a valid move correctly updates position.
+
+        Purpose: Validates position update for valid moves.
+
+        Given: A 5x5 maze.
+        When: Moving South from (0,0).
+        Then: Position updates to (1,0).
+
+        Test type: unit
+        """
+        maze_size, walls = _small_maze()
+        mask = precompute_valid_cell_mask(maze_size, walls)
+        table = precompute_neighbor_table(maze_size, mask)
+        # Move South from (0,0) -> goes to (1,0) which is valid
+        result = table[0, 0, 2]  # South
+        assert result[0] == 1 and result[1] == 0
+
+    def test_out_of_bounds_stays(self):
+        """Test that moving out of bounds keeps position unchanged.
+
+        Purpose: Validates boundary handling.
+
+        Given: A 5x5 maze.
+        When: Moving North from (0,0) which would go out of bounds.
+        Then: Position stays at (0,0).
+
+        Test type: unit
+        """
+        maze_size, walls = _small_maze()
+        mask = precompute_valid_cell_mask(maze_size, walls)
+        table = precompute_neighbor_table(maze_size, mask)
+        result = table[0, 0, 0]  # North from (0,0)
+        assert result[0] == 0 and result[1] == 0
+
+
+class TestNeighborValidity:
+    def test_stay_always_valid(self):
+        """Test that the stay move is always valid.
+
+        Purpose: Validates that move index 4 (stay) is always True.
+
+        Given: A 5x5 maze.
+        When: Checking validity of stay move for all cells.
+        Then: Stay move (index 4) is True everywhere.
+
+        Test type: unit
+        """
+        maze_size, walls = _small_maze()
+        mask = precompute_valid_cell_mask(maze_size, walls)
+        validity = precompute_neighbor_validity(maze_size, mask)
+        assert np.all(validity[:, :, 4])
+
+    def test_wall_blocked_move_invalid(self):
+        """Test that moves into walls are marked invalid.
+
+        Purpose: Validates wall-blocked moves are False.
+
+        Given: A 5x5 maze with a wall at (1,1).
+        When: Checking East move from (1,0).
+        Then: East move is invalid.
+
+        Test type: unit
+        """
+        maze_size, walls = _small_maze()
+        mask = precompute_valid_cell_mask(maze_size, walls)
+        validity = precompute_neighbor_validity(maze_size, mask)
+        assert not validity[1, 0, 1]  # East from (1,0) -> wall at (1,1)

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_vectorized_updater.py
@@ -1,0 +1,266 @@
+"""Tests for PacMan vectorized particle belief updater."""
+
+# pylint: disable=protected-access
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.pacman_pomdp import PacManPOMDP, PacManState
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_vectorized_updater import (
+    PacManVectorizedUpdater,
+)
+
+
+@pytest.fixture()
+def simple_env():
+    return PacManPOMDP(
+        maze_size=(5, 5),
+        walls={(2, 2)},
+        initial_pellets=[(1, 1), (3, 3)],
+        initial_pacman_pos=(0, 0),
+        num_ghosts=1,
+        initial_ghost_positions=[(4, 4)],
+        ghost_aggressiveness=2.0,
+        ghost_coordination="independent",
+        discount_factor=0.95,
+    )
+
+
+@pytest.fixture()
+def updater(simple_env):
+    return PacManVectorizedUpdater.from_environment(simple_env)
+
+
+@pytest.fixture()
+def sample_particles(simple_env):
+    np.random.seed(42)
+    states = simple_env.initial_state_dist().sample(n_samples=10)
+    return simple_env.states_to_array(states)
+
+
+class TestFromEnvironmentConstruction:
+    def test_creates_without_error(self, simple_env):
+        """Test that from_environment constructs an updater successfully.
+
+        Purpose: Validates updater creation from environment.
+
+        Given: A configured PacManPOMDP environment.
+        When: PacManVectorizedUpdater.from_environment is called.
+        Then: An updater instance is created without errors.
+
+        Test type: unit
+        """
+        updater = PacManVectorizedUpdater.from_environment(simple_env)
+        assert updater.maze_size == (5, 5)
+        assert updater.num_ghosts == 1
+        assert updater.num_pellets == 2
+        assert updater.state_dim == simple_env._state_dim
+
+
+class TestBatchTransition:
+    def test_shape_preserved(self, updater, sample_particles):
+        """Test that batch_transition preserves particle array shape.
+
+        Purpose: Validates output shape matches input shape.
+
+        Given: Particles array of shape (10, d).
+        When: batch_transition is called with action 2 (South).
+        Then: Output shape is (10, d).
+
+        Test type: unit
+        """
+        result = updater.batch_transition(sample_particles, 2)
+        assert result.shape == sample_particles.shape
+
+    def test_terminal_unchanged(self, updater, simple_env):
+        """Test that terminal particles remain unchanged after transition.
+
+        Purpose: Validates terminal particle preservation.
+
+        Given: A particle array where some particles are terminal.
+        When: batch_transition is called.
+        Then: Terminal particles are identical to input.
+
+        Test type: unit
+        """
+        state = PacManState(
+            pacman_pos=(0, 0),
+            ghost_positions=((4, 4),),
+            pellets=((1, 1), (3, 3)),
+            score=0,
+            terminal=True,
+        )
+        arr = simple_env.state_to_array(state).reshape(1, -1)
+        result = updater.batch_transition(arr, 2)
+        np.testing.assert_array_equal(result, arr)
+
+    def test_pacman_moves_correctly(self, updater, simple_env):
+        """Test that PacMan moves to correct position on valid move.
+
+        Purpose: Validates pacman movement direction.
+
+        Given: PacMan at (0,0) in a 5x5 maze.
+        When: Action South (2) is applied.
+        Then: PacMan moves to (1,0).
+
+        Test type: unit
+        """
+        state = PacManState(
+            pacman_pos=(0, 0),
+            ghost_positions=((4, 4),),
+            pellets=((1, 1), (3, 3)),
+            score=0,
+            terminal=False,
+        )
+        np.random.seed(42)
+        arr = simple_env.state_to_array(state).reshape(1, -1)
+        result = updater.batch_transition(arr, 2)  # South
+        assert result[0, updater._idx_pac_row] == 1
+        assert result[0, updater._idx_pac_col] == 0
+
+    def test_pellet_collection(self, updater, simple_env):
+        """Test that pellet bitmask flips and score increments on collection.
+
+        Purpose: Validates pellet collection mechanics.
+
+        Given: PacMan at (1,0) with pellet at (1,1).
+        When: Action East (1) moves PacMan onto the pellet.
+        Then: Pellet bitmask flips to 0 and score increments.
+
+        Test type: unit
+        """
+        state = PacManState(
+            pacman_pos=(1, 0),
+            ghost_positions=((4, 4),),
+            pellets=((1, 1), (3, 3)),
+            score=0,
+            terminal=False,
+        )
+        np.random.seed(42)
+        arr = simple_env.state_to_array(state).reshape(1, -1)
+        result = updater.batch_transition(arr, 1)  # East -> (1,1)
+        # Pellet at index 0 ((1,1)) should be collected
+        assert result[0, updater._idx_pellets_start] == 0.0
+        assert result[0, updater._idx_score] > arr[0, updater._idx_score]
+
+    def test_ghost_collision_sets_terminal(self, updater, simple_env):
+        """Test that ghost collision sets terminal flag.
+
+        Purpose: Validates collision detection in vectorized transition.
+
+        Given: PacMan at (3,4) with ghost at (4,4).
+        When: Action South (2) moves PacMan to ghost position.
+        Then: Terminal flag is set to 1.
+
+        Test type: unit
+        """
+        state = PacManState(
+            pacman_pos=(3, 4),
+            ghost_positions=((4, 4),),
+            pellets=((1, 1), (3, 3)),
+            score=0,
+            terminal=False,
+        )
+        np.random.seed(123)
+        arr = simple_env.state_to_array(state).reshape(1, -1)
+        # Move south to (4,4) where ghost might be
+        result = updater.batch_transition(arr, 2)
+        # PacMan should be at (4,4)
+        assert result[0, updater._idx_pac_row] == 4
+        assert result[0, updater._idx_pac_col] == 4
+        # If ghost stayed at (4,4), should be terminal
+        ghost_r = result[0, updater._idx_ghosts_start]
+        ghost_c = result[0, updater._idx_ghosts_start + 1]
+        if ghost_r == 4 and ghost_c == 4:
+            assert result[0, updater._idx_terminal] == 1.0
+
+
+class TestBatchObservationLogLikelihood:
+    def test_shape(self, updater, sample_particles):
+        """Test output shape of batch_observation_log_likelihood.
+
+        Purpose: Validates output shape is (N,).
+
+        Given: 10 particles and an observation.
+        When: batch_observation_log_likelihood is called.
+        Then: Output shape is (10,).
+
+        Test type: unit
+        """
+        obs = np.array([4.0, 4.0])
+        ll = updater.batch_observation_log_likelihood(sample_particles, 0, obs)
+        assert ll.shape == (10,)
+
+    def test_terminal_observation(self, updater, simple_env):
+        """Test terminal particle handling in log-likelihood.
+
+        Purpose: Validates terminal particles get correct log-likelihood.
+
+        Given: A terminal particle and a terminal observation (-1, -1).
+        When: batch_observation_log_likelihood is called.
+        Then: Terminal particle gets 0.0 log-likelihood.
+
+        Test type: unit
+        """
+        state = PacManState(
+            pacman_pos=(0, 0),
+            ghost_positions=((4, 4),),
+            pellets=(),
+            score=20,
+            terminal=True,
+        )
+        arr = simple_env.state_to_array(state).reshape(1, -1)
+        obs = np.array([-1.0, -1.0])
+        ll = updater.batch_observation_log_likelihood(arr, 0, obs)
+        assert ll[0] == 0.0
+
+    def test_closer_ghost_higher_precision(self, updater, simple_env):
+        """Test that closer ghosts yield higher log-likelihood for accurate obs.
+
+        Purpose: Validates distance-dependent observation noise.
+
+        Given: Two particles — one with ghost close to PacMan, one far.
+        When: Observation matches the true ghost position exactly.
+        Then: Close-ghost particle has higher log-likelihood.
+
+        Test type: unit
+        """
+        close_state = PacManState(
+            pacman_pos=(0, 0),
+            ghost_positions=((0, 1),),
+            pellets=((1, 1), (3, 3)),
+            score=0,
+            terminal=False,
+        )
+        far_state = PacManState(
+            pacman_pos=(0, 0),
+            ghost_positions=((4, 4),),
+            pellets=((1, 1), (3, 3)),
+            score=0,
+            terminal=False,
+        )
+        close_arr = simple_env.state_to_array(close_state).reshape(1, -1)
+        far_arr = simple_env.state_to_array(far_state).reshape(1, -1)
+        particles = np.vstack([close_arr, far_arr])
+
+        # Observation matches close ghost exactly
+        obs = np.array([0.0, 1.0])
+        ll = updater.batch_observation_log_likelihood(particles, 0, obs)
+        assert ll[0] > ll[1]
+
+
+class TestConfigId:
+    def test_deterministic(self, simple_env):
+        """Test that config_id is deterministic.
+
+        Purpose: Validates reproducible config_id generation.
+
+        Given: Two updaters from the same environment.
+        When: config_id is accessed.
+        Then: Both return the same string.
+
+        Test type: unit
+        """
+        u1 = PacManVectorizedUpdater.from_environment(simple_env)
+        u2 = PacManVectorizedUpdater.from_environment(simple_env)
+        assert u1.config_id == u2.config_id

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_task_managers.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_task_managers.py
@@ -310,7 +310,18 @@ def test_joblib_task_manager_cache(cache_db, environment, policy):
             # If we can't clear the cache, log a warning but continue with the test
             warnings.warn("Could not clear cache due to file being in use, continuing with test")
 
-        result3, ids3 = task_manager.run_tasks([task], [task_identifier])
+        # Create a fresh task because cleanup() nullifies environment/policy/belief
+        # on the original task object after the first run
+        task_fresh = EpisodeSimulationTask(
+            environment=environment,
+            policy=policy,
+            initial_belief=create_test_belief(),
+            num_steps=2,
+            episode_id=1,
+            seed=42,
+            console_output=False,
+        )
+        result3, ids3 = task_manager.run_tasks([task_fresh], [task_identifier])
 
         # Compare main fields again
         assert result1[0].discount_factor == result3[0].discount_factor

--- a/POMDPPlanners/utils/belief_factory.py
+++ b/POMDPPlanners/utils/belief_factory.py
@@ -108,6 +108,11 @@ _ENV_FACTORY_REGISTRY: dict[str, tuple[str, str, BeliefType]] = {
         "create_continuous_push_belief",
         BeliefType.VECTORIZED_PARTICLE,
     ),
+    "PacManPOMDP": (
+        "POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs",
+        "create_pacman_belief",
+        BeliefType.VECTORIZED_PARTICLE,
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- Restructure PacMan state as a fixed-size numpy array (pellet bitmask instead of variable-length tuple) to enable `VectorizedWeightedParticleBelief`
- Implement `PacManVectorizedUpdater` with batched state transition (softmax ghost movement), observation log-likelihood, and `reward_batch`
- Add belief factory, registry entry, precomputed grid navigation tables, and 34 new tests + benchmark script
- Fix pre-existing `test_joblib_task_manager_cache` failure (task object reuse after cleanup nullified attributes)

## Benchmark Results (7x7 maze, 2 ghosts)

| Operation | N=200 Baseline | N=200 Vectorized | Speedup |
|---|---|---|---|
| Belief update | 20.4 ms | 0.53 ms | **38x** |
| reward_batch | 22.0 ms | 0.07 ms | **312x** |
| belief_expectation_reward | 18.5 ms | 0.08 ms | **242x** |

At N=1000: belief update **84x**, reward_batch **650x**.

## Test plan
- [x] All 34 new tests pass (grid utils, updater, factory, integration)
- [x] All 63 PacMan tests pass (no regressions)
- [x] Full test suite: 2705 passed, 0 failed
- [x] Pyright: 0 errors, Pylint: 10.00/10 on new files
- [x] Doctests pass
- [x] Benchmark script runnable via `python -m POMDPPlanners.tests.test_environments.test_pacman_pomdp_beliefs.benchmark_pacman_vectorized_belief`

🤖 Generated with [Claude Code](https://claude.com/claude-code)