### PR TITLE
Add episode-level parallelization option for hyperparameter tuning

### DIFF
--- a/POMDPPlanners/core/simulation/__init__.py
+++ b/POMDPPlanners/core/simulation/__init__.py
@@ -8,6 +8,7 @@ from POMDPPlanners.core.simulation.hyperparameter_tuning import (
     CategoricalHyperParameter,
     HyperParameterFeature,
     NumericalHyperParameter,
+    ParallelizationLevel,
 )
 from POMDPPlanners.core.simulation.metrics import MetricValue
 from POMDPPlanners.core.simulation.simulation_configs import (
@@ -27,6 +28,7 @@ __all__ = [
     "CategoricalHyperParameter",
     "NumericalHyperParameter",
     "HyperParameterFeature",
+    "ParallelizationLevel",
     "MetricValue",
     "EnvironmentRunParams",
     "HyperParameterRunParams",

--- a/POMDPPlanners/core/simulation/hyperparameter_tuning.py
+++ b/POMDPPlanners/core/simulation/hyperparameter_tuning.py
@@ -77,6 +77,20 @@ class HyperParameterOptimizationDirection(Enum):
     MINIMIZE = "minimize"
 
 
+class ParallelizationLevel(Enum):
+    """Level at which parallelization is applied during hyperparameter tuning.
+
+    Attributes:
+        OPTUNA_TRIALS: Parallelize across Optuna trials. Multiple trials run
+            concurrently while episodes within each trial run sequentially.
+        EPISODES: Parallelize across episodes within each trial. Optuna trials
+            run sequentially while episodes within each trial run concurrently.
+    """
+
+    OPTUNA_TRIALS = "optuna_trials"
+    EPISODES = "episodes"
+
+
 @dataclass(frozen=True)
 class HyperParamPlannerConfig:
     policy_cls: Type["Policy"]

--- a/POMDPPlanners/simulations/hyper_parameter_tuning_simulations.py
+++ b/POMDPPlanners/simulations/hyper_parameter_tuning_simulations.py
@@ -132,6 +132,7 @@ from POMDPPlanners.core.simulation import (
 from POMDPPlanners.core.simulation.hyperparameter_tuning import (
     HyperParameterRunParams,
     OptimizedPolicyResult,
+    ParallelizationLevel,
 )
 from POMDPPlanners.simulations.simulations_deployment.task_manager_configs import (
     JoblibConfig,
@@ -244,6 +245,7 @@ class HyperParameterOptimizer:
         alpha: float = 0.05,
         mlflow_tracking_uri: Optional[Path] = None,
         use_queue_logger: bool = False,
+        parallelization_level: ParallelizationLevel = ParallelizationLevel.OPTUNA_TRIALS,
     ):
         """Initialize the hyperparameter optimizer.
 
@@ -272,6 +274,10 @@ class HyperParameterOptimizer:
                 If provided, must be a Path object pointing to the desired MLflow
                 tracking directory on the local filesystem.
             use_queue_logger: Whether to use queue-based logging. Defaults to True.
+            parallelization_level: Controls where parallelization is applied.
+                OPTUNA_TRIALS (default) parallelizes across Optuna trials while
+                running episodes sequentially. EPISODES parallelizes across
+                episodes within each trial while running trials sequentially.
         Raises:
             TypeError: If cache_dir_path is not a Path object
         """
@@ -282,6 +288,7 @@ class HyperParameterOptimizer:
         self.confidence_interval_level = confidence_interval_level
         self.alpha = alpha
         self.use_queue_logger = use_queue_logger
+        self.parallelization_level = parallelization_level
         # Set up MLFlow tracking
         if mlflow_tracking_uri is None:
             # Use local file storage in cache_dir_path/mlruns
@@ -352,6 +359,7 @@ class HyperParameterOptimizer:
                 n_jobs=self.n_jobs,
                 confidence_interval_level=self.confidence_interval_level,
                 alpha=self.alpha,
+                parallelization_level=self.parallelization_level,
             )
             tasks.append(task)
             task_identifiers.append(task.get_config_id())

--- a/POMDPPlanners/simulations/simulation_apis/dask_simulations_api.py
+++ b/POMDPPlanners/simulations/simulation_apis/dask_simulations_api.py
@@ -10,6 +10,7 @@ from POMDPPlanners.core.simulation.hyperparameter_tuning import (
     HyperParameterRunParams,
     HyperParamPlannerConfigGenerator,
     OptimizedPolicyResult,
+    ParallelizationLevel,
 )
 from POMDPPlanners.simulations.workflows.hyperparameter_tuning_evaluation_workflows import (
     OptimizationEvaluationDaskWorkflow,
@@ -331,6 +332,7 @@ class DaskSimulationsAPI(SimulationsAPIInterface):
         confidence_interval_level: float = 0.95,
         alpha: float = 0.05,
         use_queue_logger: bool = False,
+        parallelization_level: ParallelizationLevel = ParallelizationLevel.OPTUNA_TRIALS,
         scheduler_address: Optional[str] = None,
         cache_size: int = int(2e9),
     ) -> List[OptimizedPolicyResult]:
@@ -394,6 +396,7 @@ class DaskSimulationsAPI(SimulationsAPIInterface):
             confidence_interval_level=confidence_interval_level,
             alpha=alpha,
             use_queue_logger=use_queue_logger,
+            parallelization_level=parallelization_level,
         )
 
         try:

--- a/POMDPPlanners/simulations/simulation_apis/local_simulations_api.py
+++ b/POMDPPlanners/simulations/simulation_apis/local_simulations_api.py
@@ -11,6 +11,7 @@ from POMDPPlanners.core.simulation.hyperparameter_tuning import (
     HyperParameterRunParams,
     HyperParamPlannerConfigGenerator,
     OptimizedPolicyResult,
+    ParallelizationLevel,
 )
 from POMDPPlanners.simulations.workflows.planner_evaluation_workflow import (
     PlannerEvaluationLocalWorkflow,
@@ -453,6 +454,7 @@ class LocalSimulationsAPI(SimulationsAPIInterface):
         confidence_interval_level: float = 0.95,
         alpha: float = 0.05,
         use_queue_logger: bool = False,
+        parallelization_level: ParallelizationLevel = ParallelizationLevel.OPTUNA_TRIALS,
     ) -> List[OptimizedPolicyResult]:
         """Run hyperparameter optimization for POMDP policies using Optuna.
 
@@ -490,6 +492,10 @@ class LocalSimulationsAPI(SimulationsAPIInterface):
                 Defaults to 0.05 for 5% significance level.
             use_queue_logger: Whether to use queue-based logging for distributed
                 execution scenarios. Defaults to False for local execution.
+            parallelization_level: Controls where parallelization is applied.
+                OPTUNA_TRIALS (default) parallelizes across Optuna trials while
+                running episodes sequentially. EPISODES parallelizes across
+                episodes within each trial while running trials sequentially.
 
         Returns:
             List[OptimizedPolicyResult]: List of optimization results, each containing
@@ -604,6 +610,7 @@ class LocalSimulationsAPI(SimulationsAPIInterface):
             task_manager_config=task_manager_config,
             confidence_interval_level=confidence_interval_level,
             alpha=alpha,
+            parallelization_level=parallelization_level,
             use_queue_logger=use_queue_logger,
         )
 

--- a/POMDPPlanners/simulations/simulation_apis/pbs_simulations_api.py
+++ b/POMDPPlanners/simulations/simulation_apis/pbs_simulations_api.py
@@ -10,6 +10,7 @@ from POMDPPlanners.core.simulation.hyperparameter_tuning import (
     HyperParameterRunParams,
     HyperParamPlannerConfigGenerator,
     OptimizedPolicyResult,
+    ParallelizationLevel,
 )
 from POMDPPlanners.simulations.workflows.hyperparameter_tuning_evaluation_workflows import (
     OptimizationEvaluationPBSWorkflow,
@@ -371,6 +372,7 @@ class PBSSimulationsAPI(SimulationsAPIInterface):
         confidence_interval_level: float = 0.95,
         alpha: float = 0.05,
         use_queue_logger: bool = False,
+        parallelization_level: ParallelizationLevel = ParallelizationLevel.OPTUNA_TRIALS,
     ) -> List[OptimizedPolicyResult]:
         """Run hyperparameter optimization for POMDP policies using Optuna on PBS cluster.
 
@@ -426,6 +428,7 @@ class PBSSimulationsAPI(SimulationsAPIInterface):
             confidence_interval_level=confidence_interval_level,
             alpha=alpha,
             use_queue_logger=use_queue_logger,
+            parallelization_level=parallelization_level,
         )
 
         self.logger.info("Running PBS cluster hyperparameter optimization")

--- a/POMDPPlanners/simulations/simulation_apis/simulations_api_interface.py
+++ b/POMDPPlanners/simulations/simulation_apis/simulations_api_interface.py
@@ -18,6 +18,7 @@ from POMDPPlanners.core.simulation.hyperparameter_tuning import (
     HyperParameterRunParams,
     HyperParamPlannerConfigGenerator,
     OptimizedPolicyResult,
+    ParallelizationLevel,
 )
 
 
@@ -163,6 +164,7 @@ class SimulationsAPIInterface(ABC):
         confidence_interval_level: float = 0.95,
         alpha: float = 0.05,
         use_queue_logger: bool = False,
+        parallelization_level: ParallelizationLevel = ParallelizationLevel.OPTUNA_TRIALS,
     ) -> List[OptimizedPolicyResult]:
         """Run hyperparameter optimization for POMDP policies using Optuna.
 
@@ -200,6 +202,10 @@ class SimulationsAPIInterface(ABC):
                 Defaults to 0.05 for 5% significance level.
             use_queue_logger: Whether to use queue-based logging for distributed
                 execution scenarios. Defaults to False for local execution.
+            parallelization_level: Controls where parallelization is applied.
+                OPTUNA_TRIALS (default) parallelizes across Optuna trials while
+                running episodes sequentially. EPISODES parallelizes across
+                episodes within each trial while running trials sequentially.
 
         Returns:
             List[OptimizedPolicyResult]: List of optimization results, each containing

--- a/POMDPPlanners/simulations/simulations_deployment/tasks/hyper_parameter_tuning_simulation_task.py
+++ b/POMDPPlanners/simulations/simulations_deployment/tasks/hyper_parameter_tuning_simulation_task.py
@@ -136,6 +136,12 @@ class HyperParameterTuningSimulationTask(SimulationTask):
         self.console_output = console_output
         self.n_jobs = n_jobs
         self.parallelization_level = parallelization_level
+        self.optuna_n_jobs = (
+            n_jobs if parallelization_level == ParallelizationLevel.OPTUNA_TRIALS else 1
+        )
+        self.episode_n_jobs = (
+            n_jobs if parallelization_level == ParallelizationLevel.EPISODES else 1
+        )
         self.confidence_interval_level = confidence_interval_level
         self.alpha = alpha
         self.seed = seed
@@ -361,13 +367,8 @@ class HyperParameterTuningSimulationTask(SimulationTask):
             objective_function = self._create_optuna_objective_function()
 
             # Execute the optimization study
-            optuna_n_jobs = (
-                self.n_jobs
-                if self.parallelization_level == ParallelizationLevel.OPTUNA_TRIALS
-                else 1
-            )
             study = self._execute_optimization_study(
-                objective_function, n_trials=self.n_trials, n_jobs=optuna_n_jobs
+                objective_function, n_trials=self.n_trials, n_jobs=self.optuna_n_jobs
             )
 
             # Calculate optimization time
@@ -968,14 +969,11 @@ class HyperParameterTuningSimulationTask(SimulationTask):
         ]
 
         # Use simulator's direct parallel execution method to avoid MLflow experiment creation
-        episode_n_jobs = (
-            self.n_jobs if self.parallelization_level == ParallelizationLevel.EPISODES else 1
-        )
         results = self.simulator.simulate_multiple_environments_and_policies_parallel(
             environment_run_params=env_run_params,
             alpha=self.alpha,  # Default alpha for intermediate results
             confidence_interval_level=self.confidence_interval_level,
-            n_jobs=episode_n_jobs,
+            n_jobs=self.episode_n_jobs,
         )
 
         # Extract histories from results

--- a/POMDPPlanners/simulations/simulations_deployment/tasks/hyper_parameter_tuning_simulation_task.py
+++ b/POMDPPlanners/simulations/simulations_deployment/tasks/hyper_parameter_tuning_simulation_task.py
@@ -23,6 +23,7 @@ from POMDPPlanners.core.simulation import (
 from POMDPPlanners.core.simulation.hyperparameter_tuning import (
     HyperParameterOptimizationDirection,
     OptimizedPolicyResult,
+    ParallelizationLevel,
 )
 from POMDPPlanners.core.simulation.simulation_configs import EnvironmentRunParams
 from POMDPPlanners.simulations.simulation_statistics import (
@@ -56,6 +57,7 @@ class HyperParameterTuningSimulationTask(SimulationTask):
         debug: bool = False,
         console_output: bool = True,
         n_jobs: int = 1,
+        parallelization_level: ParallelizationLevel = ParallelizationLevel.OPTUNA_TRIALS,
         confidence_interval_level: float = 0.95,
         alpha: float = 0.1,
         seed: int = 42,
@@ -80,6 +82,10 @@ class HyperParameterTuningSimulationTask(SimulationTask):
             debug: Whether to enable debug logging
             console_output: Whether to enable console output
             n_jobs: Number of parallel jobs
+            parallelization_level: Controls where parallelization is applied.
+                OPTUNA_TRIALS (default) parallelizes across Optuna trials while
+                running episodes sequentially. EPISODES parallelizes across
+                episodes within each trial while running trials sequentially.
             confidence_interval_level: Confidence interval level (0-1)
             alpha: Alpha parameter for statistics (0-1)
             seed: Random seed for reproducibility
@@ -108,6 +114,7 @@ class HyperParameterTuningSimulationTask(SimulationTask):
             debug=debug,
             console_output=console_output,
             n_jobs=n_jobs,
+            parallelization_level=parallelization_level,
             confidence_interval_level=confidence_interval_level,
             alpha=alpha,
             seed=seed,
@@ -128,6 +135,7 @@ class HyperParameterTuningSimulationTask(SimulationTask):
         self.debug = debug
         self.console_output = console_output
         self.n_jobs = n_jobs
+        self.parallelization_level = parallelization_level
         self.confidence_interval_level = confidence_interval_level
         self.alpha = alpha
         self.seed = seed
@@ -169,6 +177,7 @@ class HyperParameterTuningSimulationTask(SimulationTask):
         debug: bool,
         console_output: bool,
         n_jobs: int,
+        parallelization_level: ParallelizationLevel,
         confidence_interval_level: float,
         alpha: float,
         seed: int,
@@ -255,6 +264,11 @@ class HyperParameterTuningSimulationTask(SimulationTask):
             raise ValueError("n_trials must be a positive integer")
         if not isinstance(n_jobs, int) or (n_jobs <= 0 and n_jobs != -1):
             raise ValueError("n_jobs must be a positive integer or -1 (for all cores)")
+        if not isinstance(parallelization_level, ParallelizationLevel):
+            raise TypeError(
+                f"parallelization_level must be a ParallelizationLevel instance, "
+                f"got {type(parallelization_level)}"
+            )
         if not isinstance(seed, int):
             raise TypeError("seed must be an integer")
 
@@ -347,8 +361,13 @@ class HyperParameterTuningSimulationTask(SimulationTask):
             objective_function = self._create_optuna_objective_function()
 
             # Execute the optimization study
+            optuna_n_jobs = (
+                self.n_jobs
+                if self.parallelization_level == ParallelizationLevel.OPTUNA_TRIALS
+                else 1
+            )
             study = self._execute_optimization_study(
-                objective_function, n_trials=self.n_trials, n_jobs=self.n_jobs
+                objective_function, n_trials=self.n_trials, n_jobs=optuna_n_jobs
             )
 
             # Calculate optimization time
@@ -949,11 +968,14 @@ class HyperParameterTuningSimulationTask(SimulationTask):
         ]
 
         # Use simulator's direct parallel execution method to avoid MLflow experiment creation
+        episode_n_jobs = (
+            self.n_jobs if self.parallelization_level == ParallelizationLevel.EPISODES else 1
+        )
         results = self.simulator.simulate_multiple_environments_and_policies_parallel(
             environment_run_params=env_run_params,
             alpha=self.alpha,  # Default alpha for intermediate results
             confidence_interval_level=self.confidence_interval_level,
-            n_jobs=1,
+            n_jobs=episode_n_jobs,
         )
 
         # Extract histories from results
@@ -979,6 +1001,7 @@ class HyperParameterTuningSimulationTask(SimulationTask):
                 for param_name, direction in self.parameters_to_optimize
             ],
             "n_trials": self.n_trials,
+            "parallelization_level": self.parallelization_level.value,
             "seed": self.seed,
             "use_queue_logger": self.use_queue_logger,
             "training_hyper_parameters": list(self.training_hyper_parameters),

--- a/POMDPPlanners/tests/test_core/test_hyper_parameter_tuning.py
+++ b/POMDPPlanners/tests/test_core/test_hyper_parameter_tuning.py
@@ -1751,3 +1751,72 @@ class TestOptimizedPolicyResultValidation:
         assert len(result.optimized_metric_values) == 2
         assert result.optimized_metric_values["average_return"] == 42.5
         assert result.optimized_metric_values["return_cvar"] == 38.2
+
+
+# ===== ParallelizationLevel Tests =====
+
+from POMDPPlanners.core.simulation.hyperparameter_tuning import ParallelizationLevel
+
+
+class TestParallelizationLevelEnum:
+    """Tests for the ParallelizationLevel enum."""
+
+    def test_enum_values(self):
+        """Test ParallelizationLevel enum values.
+
+        Purpose: Validates enum has correct string values
+
+        Given: The ParallelizationLevel enum
+        When: Accessing enum values
+        Then: OPTUNA_TRIALS is "optuna_trials" and EPISODES is "episodes"
+
+        Test type: unit
+        """
+        assert ParallelizationLevel.OPTUNA_TRIALS.value == "optuna_trials"
+        assert ParallelizationLevel.EPISODES.value == "episodes"
+
+    def test_enum_members(self):
+        """Test ParallelizationLevel has exactly two members.
+
+        Purpose: Validates enum membership
+
+        Given: The ParallelizationLevel enum
+        When: Listing all members
+        Then: There are exactly two members
+
+        Test type: unit
+        """
+        members = list(ParallelizationLevel)
+        assert len(members) == 2
+        assert ParallelizationLevel.OPTUNA_TRIALS in members
+        assert ParallelizationLevel.EPISODES in members
+
+    def test_enum_from_value(self):
+        """Test ParallelizationLevel can be constructed from string values.
+
+        Purpose: Validates enum can be created from string values
+
+        Given: String values matching enum values
+        When: Constructing enum instances from strings
+        Then: Correct enum members are returned
+
+        Test type: unit
+        """
+        assert ParallelizationLevel("optuna_trials") == ParallelizationLevel.OPTUNA_TRIALS
+        assert ParallelizationLevel("episodes") == ParallelizationLevel.EPISODES
+
+    def test_enum_invalid_value_raises_error(self):
+        """Test that invalid string raises ValueError.
+
+        Purpose: Validates that invalid values are rejected
+
+        Given: An invalid string value
+        When: Constructing a ParallelizationLevel from it
+        Then: ValueError is raised
+
+        Test type: unit
+        """
+        import pytest
+
+        with pytest.raises(ValueError):
+            ParallelizationLevel("invalid")

--- a/POMDPPlanners/tests/test_simulations/test_hyper_parameter_tuning_simulations.py
+++ b/POMDPPlanners/tests/test_simulations/test_hyper_parameter_tuning_simulations.py
@@ -1535,7 +1535,6 @@ class TestHyperParameterOptimizerWithTaskManagerConfigs:
             # (e.g., PBS not available, which is expected in CI/CD)
             error_str = str(e).lower()
             if "pbs" in error_str or "qsub" in error_str or "scheduler" in error_str:
-
                 warnings.warn(
                     f"PBS cluster creation skipped - PBS environment not available: {e}",
                     UserWarning,
@@ -1586,7 +1585,6 @@ class TestHyperParameterOptimizerWithTaskManagerConfigs:
             # Handle PBS environment not being available
             error_str = str(e).lower()
             if "pbs" in error_str or "qsub" in error_str or "scheduler" in error_str:
-
                 warnings.warn(
                     f"PBS cluster creation skipped - PBS environment not available: {e}",
                     UserWarning,
@@ -2814,3 +2812,80 @@ class TestSingleEnvironmentOptimizationSmoke:
         optimizer = HyperParameterOptimizer(cache_dir_path=temp_cache_dir)
         result = optimizer.optimize([config])
         assert isinstance(result, list)
+
+
+# ===== ParallelizationLevel Tests =====
+
+from POMDPPlanners.core.simulation.hyperparameter_tuning import ParallelizationLevel
+
+
+class TestHyperParameterOptimizerParallelizationLevel:
+    """Tests for ParallelizationLevel parameter in HyperParameterOptimizer."""
+
+    def test_default_parallelization_level(self, temp_cache_dir):
+        """Test that default parallelization_level is OPTUNA_TRIALS.
+
+        Purpose: Validates backward compatibility of optimizer default
+
+        Given: An optimizer created without specifying parallelization_level
+        When: The optimizer is instantiated
+        Then: parallelization_level defaults to OPTUNA_TRIALS
+
+        Test type: unit
+        """
+        optimizer = HyperParameterOptimizer(cache_dir_path=temp_cache_dir)
+        assert optimizer.parallelization_level == ParallelizationLevel.OPTUNA_TRIALS
+
+    def test_custom_parallelization_level(self, temp_cache_dir):
+        """Test setting EPISODES parallelization_level on optimizer.
+
+        Purpose: Validates that EPISODES can be set on the optimizer
+
+        Given: An optimizer created with parallelization_level=EPISODES
+        When: The optimizer is instantiated
+        Then: parallelization_level is EPISODES
+
+        Test type: unit
+        """
+        optimizer = HyperParameterOptimizer(
+            cache_dir_path=temp_cache_dir,
+            parallelization_level=ParallelizationLevel.EPISODES,
+        )
+        assert optimizer.parallelization_level == ParallelizationLevel.EPISODES
+
+    def test_parallelization_level_passed_to_tasks(self, temp_cache_dir, sample_configs):
+        """Test that parallelization_level is threaded through to created tasks.
+
+        Purpose: Validates that the optimizer passes parallelization_level to tasks
+
+        Given: An optimizer with parallelization_level=EPISODES and sample configs
+        When: _create_tasks is called
+        Then: Each created task has parallelization_level=EPISODES
+
+        Test type: unit
+        """
+        optimizer = HyperParameterOptimizer(
+            cache_dir_path=temp_cache_dir,
+            parallelization_level=ParallelizationLevel.EPISODES,
+        )
+        tasks, _ = optimizer._create_tasks(sample_configs)
+
+        for task in tasks:
+            assert task.parallelization_level == ParallelizationLevel.EPISODES
+
+    def test_default_parallelization_level_passed_to_tasks(self, temp_cache_dir, sample_configs):
+        """Test that default parallelization_level is threaded through to tasks.
+
+        Purpose: Validates that the default OPTUNA_TRIALS is passed to tasks
+
+        Given: An optimizer with default parallelization_level and sample configs
+        When: _create_tasks is called
+        Then: Each created task has parallelization_level=OPTUNA_TRIALS
+
+        Test type: unit
+        """
+        optimizer = HyperParameterOptimizer(cache_dir_path=temp_cache_dir)
+        tasks, _ = optimizer._create_tasks(sample_configs)
+
+        for task in tasks:
+            assert task.parallelization_level == ParallelizationLevel.OPTUNA_TRIALS

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_hyper_parameter_tuning_simulation_task.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_hyper_parameter_tuning_simulation_task.py
@@ -1834,3 +1834,221 @@ def test_cache_survives_task_recreation(environment, hyper_parameters, temp_cach
     assert "average_return" in result2.optimized_metric_values
     assert isinstance(result1.optimized_metric_values["average_return"], float)
     assert isinstance(result2.optimized_metric_values["average_return"], float)
+
+
+# ===== ParallelizationLevel Tests =====
+
+from POMDPPlanners.core.simulation.hyperparameter_tuning import ParallelizationLevel
+
+
+class TestParallelizationLevel:
+    """Tests for the ParallelizationLevel parameter in HyperParameterTuningSimulationTask."""
+
+    def test_default_parallelization_level_is_optuna_trials(
+        self, environment, hyper_parameters, temp_cache_dir
+    ):
+        """Test that default parallelization_level is OPTUNA_TRIALS.
+
+        Purpose: Validates backward compatibility — default is OPTUNA_TRIALS
+
+        Given: A task created without specifying parallelization_level
+        When: The task is instantiated
+        Then: parallelization_level defaults to OPTUNA_TRIALS
+
+        Test type: unit
+        """
+        belief = create_test_belief(environment)
+        task = HyperParameterTuningSimulationTask(
+            environment=environment,
+            belief=belief,
+            policy_cls=SparseSamplingDiscreteActionsPlanner,
+            hyper_parameters=hyper_parameters,
+            constant_parameters={},
+            num_episodes=2,
+            num_steps=3,
+            parameters_to_optimize=[
+                ("average_return", HyperParameterOptimizationDirection.MAXIMIZE)
+            ],
+            cache_dir=temp_cache_dir,
+            n_jobs=2,
+        )
+        assert task.parallelization_level == ParallelizationLevel.OPTUNA_TRIALS
+
+    def test_explicit_optuna_trials_parallelization(
+        self, environment, hyper_parameters, temp_cache_dir
+    ):
+        """Test explicit OPTUNA_TRIALS parallelization_level.
+
+        Purpose: Validates that OPTUNA_TRIALS can be set explicitly
+
+        Given: A task created with parallelization_level=OPTUNA_TRIALS
+        When: The task is instantiated
+        Then: parallelization_level is OPTUNA_TRIALS
+
+        Test type: unit
+        """
+        belief = create_test_belief(environment)
+        task = HyperParameterTuningSimulationTask(
+            environment=environment,
+            belief=belief,
+            policy_cls=SparseSamplingDiscreteActionsPlanner,
+            hyper_parameters=hyper_parameters,
+            constant_parameters={},
+            num_episodes=2,
+            num_steps=3,
+            parameters_to_optimize=[
+                ("average_return", HyperParameterOptimizationDirection.MAXIMIZE)
+            ],
+            cache_dir=temp_cache_dir,
+            n_jobs=2,
+            parallelization_level=ParallelizationLevel.OPTUNA_TRIALS,
+        )
+        assert task.parallelization_level == ParallelizationLevel.OPTUNA_TRIALS
+
+    def test_episodes_parallelization(self, environment, hyper_parameters, temp_cache_dir):
+        """Test EPISODES parallelization_level.
+
+        Purpose: Validates that EPISODES parallelization_level can be set
+
+        Given: A task created with parallelization_level=EPISODES
+        When: The task is instantiated
+        Then: parallelization_level is EPISODES
+
+        Test type: unit
+        """
+        belief = create_test_belief(environment)
+        task = HyperParameterTuningSimulationTask(
+            environment=environment,
+            belief=belief,
+            policy_cls=SparseSamplingDiscreteActionsPlanner,
+            hyper_parameters=hyper_parameters,
+            constant_parameters={},
+            num_episodes=2,
+            num_steps=3,
+            parameters_to_optimize=[
+                ("average_return", HyperParameterOptimizationDirection.MAXIMIZE)
+            ],
+            cache_dir=temp_cache_dir,
+            n_jobs=2,
+            parallelization_level=ParallelizationLevel.EPISODES,
+        )
+        assert task.parallelization_level == ParallelizationLevel.EPISODES
+
+    def test_invalid_parallelization_level_raises_type_error(
+        self, environment, hyper_parameters, temp_cache_dir
+    ):
+        """Test that invalid parallelization_level raises TypeError.
+
+        Purpose: Validates input validation for parallelization_level
+
+        Given: An invalid value for parallelization_level (a string)
+        When: HyperParameterTuningSimulationTask is created with the invalid value
+        Then: TypeError is raised
+
+        Test type: unit
+        """
+        belief = create_test_belief(environment)
+        with pytest.raises(TypeError, match="parallelization_level must be a ParallelizationLevel"):
+            HyperParameterTuningSimulationTask(
+                environment=environment,
+                belief=belief,
+                policy_cls=SparseSamplingDiscreteActionsPlanner,
+                hyper_parameters=hyper_parameters,
+                constant_parameters={},
+                num_episodes=2,
+                num_steps=3,
+                parameters_to_optimize=[
+                    ("average_return", HyperParameterOptimizationDirection.MAXIMIZE)
+                ],
+                cache_dir=temp_cache_dir,
+                n_jobs=2,
+                parallelization_level="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_to_dict_includes_parallelization_level(
+        self, environment, hyper_parameters, temp_cache_dir
+    ):
+        """Test that to_dict includes parallelization_level.
+
+        Purpose: Validates that parallelization_level is included in serialized dict
+
+        Given: Tasks with different parallelization levels
+        When: to_dict() is called on each task
+        Then: The dict includes the parallelization_level value as a string
+
+        Test type: unit
+        """
+        belief = create_test_belief(environment)
+        task_optuna = HyperParameterTuningSimulationTask(
+            environment=environment,
+            belief=belief,
+            policy_cls=SparseSamplingDiscreteActionsPlanner,
+            hyper_parameters=hyper_parameters,
+            constant_parameters={},
+            num_episodes=2,
+            num_steps=3,
+            parameters_to_optimize=[
+                ("average_return", HyperParameterOptimizationDirection.MAXIMIZE)
+            ],
+            cache_dir=temp_cache_dir,
+            parallelization_level=ParallelizationLevel.OPTUNA_TRIALS,
+        )
+        task_episodes = HyperParameterTuningSimulationTask(
+            environment=environment,
+            belief=belief,
+            policy_cls=SparseSamplingDiscreteActionsPlanner,
+            hyper_parameters=hyper_parameters,
+            constant_parameters={},
+            num_episodes=2,
+            num_steps=3,
+            parameters_to_optimize=[
+                ("average_return", HyperParameterOptimizationDirection.MAXIMIZE)
+            ],
+            cache_dir=temp_cache_dir,
+            parallelization_level=ParallelizationLevel.EPISODES,
+        )
+
+        dict_optuna = task_optuna.to_dict()
+        dict_episodes = task_episodes.to_dict()
+
+        assert dict_optuna["parallelization_level"] == "optuna_trials"
+        assert dict_episodes["parallelization_level"] == "episodes"
+
+    def test_different_parallelization_levels_produce_different_config_ids(
+        self, environment, hyper_parameters, temp_cache_dir
+    ):
+        """Test that different parallelization levels produce different config IDs.
+
+        Purpose: Validates that cache keys differ by parallelization level
+
+        Given: Two tasks identical except for parallelization_level
+        When: get_config_id() is called on each
+        Then: The config IDs are different
+
+        Test type: unit
+        """
+        belief = create_test_belief(environment)
+        common_params = dict(
+            environment=environment,
+            belief=belief,
+            policy_cls=SparseSamplingDiscreteActionsPlanner,
+            hyper_parameters=hyper_parameters,
+            constant_parameters={},
+            num_episodes=2,
+            num_steps=3,
+            parameters_to_optimize=[
+                ("average_return", HyperParameterOptimizationDirection.MAXIMIZE)
+            ],
+            cache_dir=temp_cache_dir,
+            n_jobs=2,
+        )
+        task_optuna = HyperParameterTuningSimulationTask(
+            **common_params,
+            parallelization_level=ParallelizationLevel.OPTUNA_TRIALS,
+        )
+        task_episodes = HyperParameterTuningSimulationTask(
+            **common_params,
+            parallelization_level=ParallelizationLevel.EPISODES,
+        )
+
+        assert task_optuna.get_config_id() != task_episodes.get_config_id()


### PR DESCRIPTION
## Summary
- Adds a `ParallelizationLevel` enum (`OPTUNA_TRIALS`, `EPISODES`) that controls where `n_jobs` parallelization is applied during hyperparameter tuning
- `OPTUNA_TRIALS` (default): multiple Optuna trials run in parallel, episodes run sequentially — preserves existing behavior
- `EPISODES`: Optuna trials run sequentially, episodes within each trial run in parallel
- Parameter is threaded through the full API chain: `SimulationsAPIInterface` → `LocalSimulationsAPI` / `PBSSimulationsAPI` / `DaskSimulationsAPI` → `HyperParameterOptimizer` → `HyperParameterTuningSimulationTask`

## Test plan
- [x] 4 enum tests (values, members, from_value, invalid)
- [x] 6 task-level tests (default, explicit, episodes, invalid type, to_dict, config_id differentiation)
- [x] 4 optimizer-level tests (default, custom, threading to tasks)
- [x] All existing tests pass with no regressions
- [x] Pyright: 0 errors on all source files
- [x] Pylint: 9.94/10 on source files (no new issues)
- [x] Pre-commit hooks (black, pylint, pyright) pass