### PR TITLE
Add vectorized belief updater for RockSample POMDP

### DIFF
--- a/POMDPPlanners/environments/rock_sample_pomdp/__init__.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/__init__.py
@@ -22,6 +22,10 @@ from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import (
     get_rocks,
     states_equal,
 )
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs import (
+    RockSampleVectorizedUpdater,
+    create_rocksample_belief,
+)
 from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_visualizer import (
     RockSampleVisualizer,
 )
@@ -32,8 +36,10 @@ __all__ = [
     "RockSampleStateTransitionModel",
     "RockSampleObservationModel",
     "RockSampleVisualizer",
+    "RockSampleVectorizedUpdater",
     "create_random_rock_sample",
     "create_rock_sample_state",
+    "create_rocksample_belief",
     "get_robot_pos",
     "get_rocks",
     "states_equal",

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_beliefs/__init__.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_beliefs/__init__.py
@@ -1,0 +1,13 @@
+"""RockSample POMDP belief support with vectorized particle filter."""
+
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rocksample_belief_factory import (
+    create_rocksample_belief,
+)
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rocksample_vectorized_updater import (
+    RockSampleVectorizedUpdater,
+)
+
+__all__ = [
+    "RockSampleVectorizedUpdater",
+    "create_rocksample_belief",
+]

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_beliefs/rocksample_belief_factory.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_beliefs/rocksample_belief_factory.py
@@ -1,0 +1,125 @@
+"""Belief factory for RockSample POMDP.
+
+This module provides a factory function for creating belief objects for the
+RockSample environment, supporting both standard weighted particle beliefs
+and vectorized particle beliefs.
+
+Classes:
+    RockSampleVectorizedWeightedParticleBelief: Thin subclass that handles
+        string-to-integer observation encoding for RockSample.
+
+Functions:
+    create_rocksample_belief: Factory returning a configured Belief.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+import numpy as np
+
+from POMDPPlanners.core.belief.belief_utils import get_initial_belief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rocksample_vectorized_updater import (
+    RockSampleVectorizedUpdater,
+)
+from POMDPPlanners.utils.belief_factory import BeliefType
+
+if TYPE_CHECKING:
+    from POMDPPlanners.core.belief.base_belief import Belief
+    from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
+        VectorizedParticleBeliefUpdater,
+    )
+    from POMDPPlanners.core.environment import Environment
+    from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import (
+        RockSamplePOMDP,
+    )
+
+_OBS_ENCODING = {"none": 0, "good": 1, "bad": 2}
+
+
+class RockSampleVectorizedWeightedParticleBelief(VectorizedWeightedParticleBelief):
+    """Vectorized weighted particle belief with string observation encoding.
+
+    RockSample observations are strings (``"none"``, ``"good"``, ``"bad"``),
+    but the parent class expects numeric observations.  This subclass
+    transparently encodes string observations to integers before delegating
+    to the vectorized updater.
+    """
+
+    def update(
+        self,
+        action: Any,
+        observation: Any,
+        pomdp: Optional[Environment] = None,
+        state: Optional[Any] = None,
+    ) -> RockSampleVectorizedWeightedParticleBelief:
+        """Update belief, encoding string observations to integers."""
+        del pomdp, state  # unused — kept for interface compatibility
+        if isinstance(observation, str):
+            observation = _OBS_ENCODING[observation]
+
+        encoded_obs = np.asarray(observation, dtype=float)
+
+        next_particles = self.updater.batch_transition(self.particles, action)
+        log_likelihoods = self.updater.batch_observation_log_likelihood(
+            next_particles, action, encoded_obs
+        )
+        next_log_weights = self.log_weights + log_likelihoods
+
+        if self.resampling:
+            next_particles, next_log_weights = self._resample(next_particles, next_log_weights)
+
+        return RockSampleVectorizedWeightedParticleBelief(
+            particles=next_particles,
+            log_weights=next_log_weights,
+            updater=self.updater,
+            resampling=self.resampling,
+            ess_factor=self.ess_factor,
+        )
+
+
+def create_rocksample_belief(
+    env: RockSamplePOMDP,
+    belief_type: BeliefType = BeliefType.VECTORIZED_PARTICLE,
+    n_particles: int = 200,
+    **kwargs: Any,
+) -> Belief:
+    """Create a belief object for the RockSample POMDP.
+
+    Args:
+        env: RockSample environment instance.
+        belief_type: Desired belief representation.  Supports
+            ``PARTICLE`` and ``VECTORIZED_PARTICLE``.
+        n_particles: Number of particles.  Defaults to 200.
+        **kwargs: Reserved for future use.
+
+    Returns:
+        A configured belief object.
+
+    Raises:
+        ValueError: If *belief_type* is not supported.
+    """
+    del kwargs  # reserved for future use
+    if belief_type == BeliefType.PARTICLE:
+        return get_initial_belief(env, n_particles)
+    if belief_type == BeliefType.VECTORIZED_PARTICLE:
+        return _create_vectorized_belief(env, n_particles)
+    raise ValueError(f"RockSamplePOMDP does not support belief type {belief_type!r}")
+
+
+def _create_vectorized_belief(
+    env: RockSamplePOMDP, n_particles: int
+) -> RockSampleVectorizedWeightedParticleBelief:
+    updater: VectorizedParticleBeliefUpdater = RockSampleVectorizedUpdater.from_environment(env)
+    initial_states = env.initial_state_dist().sample(n_samples=n_particles)
+    particles = np.stack(initial_states)
+    log_weights = np.log(np.ones(n_particles) / n_particles)
+    return RockSampleVectorizedWeightedParticleBelief(
+        particles=particles,
+        log_weights=log_weights,
+        updater=updater,
+        resampling=True,
+    )

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_beliefs/rocksample_vectorized_updater.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_beliefs/rocksample_vectorized_updater.py
@@ -1,0 +1,218 @@
+"""Vectorized particle belief updater for RockSample POMDP.
+
+This module provides a NumPy-vectorized implementation of particle belief
+updates for the RockSample environment, eliminating Python-level loops
+over individual particles.
+
+Classes:
+    RockSampleVectorizedUpdater: Batched transition and observation
+        log-likelihood for RockSample states.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
+    VectorizedParticleBeliefUpdater,
+)
+from POMDPPlanners.utils.config_to_id import config_to_id
+
+if TYPE_CHECKING:
+    from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import (
+        RockSamplePOMDP,
+    )
+
+# Observation encoding: "none" -> 0, "good" -> 1, "bad" -> 2
+OBS_NONE = 0
+OBS_GOOD = 1
+OBS_BAD = 2
+
+
+class RockSampleVectorizedUpdater(VectorizedParticleBeliefUpdater):
+    """Vectorized particle belief updater for the RockSample POMDP.
+
+    Stores precomputed environment parameters and performs all-particle
+    transitions and observation log-likelihood evaluations using NumPy
+    operations.  State layout per particle is
+    ``[robot_row, robot_col, rock_0_quality, ..., rock_{R-1}_quality]``.
+
+    Attributes:
+        map_rows: Number of grid rows.
+        map_cols: Number of grid columns.
+        num_rocks: Number of rocks in the environment.
+        rock_positions: Array of shape (R, 2) with rock (row, col) positions.
+        sensor_efficiency: Sensor noise parameter (higher = less noise).
+    """
+
+    def __init__(
+        self,
+        map_rows: int,
+        map_cols: int,
+        num_rocks: int,
+        rock_positions: np.ndarray,
+        sensor_efficiency: float,
+    ):
+        self.map_rows = map_rows
+        self.map_cols = map_cols
+        self.num_rocks = num_rocks
+        self.rock_positions = rock_positions
+        self.sensor_efficiency = sensor_efficiency
+
+    @classmethod
+    def from_environment(cls, env: RockSamplePOMDP) -> RockSampleVectorizedUpdater:
+        """Construct an updater from a RockSamplePOMDP instance."""
+        rock_pos = np.array(env.rock_positions, dtype=np.int32)
+        return cls(
+            map_rows=env.map_size[0],
+            map_cols=env.map_size[1],
+            num_rocks=len(env.rock_positions),
+            rock_positions=rock_pos,
+            sensor_efficiency=env.sensor_efficiency,
+        )
+
+    # ------------------------------------------------------------------
+    # Public interface (ABC)
+    # ------------------------------------------------------------------
+
+    def batch_transition(self, particles: np.ndarray, action: np.ndarray) -> np.ndarray:
+        """Transition all particles for the given action.
+
+        Args:
+            particles: Array of shape (N, 2 + num_rocks).
+            action: Scalar action index.
+
+        Returns:
+            Next-state particles of shape (N, 2 + num_rocks).
+        """
+        action_idx = int(action)
+        result = particles.copy()
+
+        live = self._live_mask(result)
+        if not np.any(live):
+            return result
+
+        if action_idx == 0:
+            self._apply_sample(result, live)
+        elif 1 <= action_idx <= 4:
+            self._apply_movement(result, live, action_idx)
+        # action >= 5 (check): no state change
+
+        self._apply_exit(result, live)
+        return result
+
+    def batch_observation_log_likelihood(
+        self,
+        next_particles: np.ndarray,
+        action: np.ndarray,
+        observation: np.ndarray,
+    ) -> np.ndarray:
+        """Compute observation log-likelihoods for all particles.
+
+        Args:
+            next_particles: Array of shape (N, 2 + num_rocks).
+            action: Scalar action index.
+            observation: Integer-encoded observation (0=none, 1=good, 2=bad).
+
+        Returns:
+            Log-likelihoods of shape (N,).
+        """
+        action_idx = int(action)
+        obs_int = int(np.asarray(observation).item())
+        n_particles = next_particles.shape[0]
+
+        if action_idx <= 4:
+            return self._log_ll_movement(n_particles, obs_int)
+
+        rock_idx = action_idx - 5
+        if rock_idx >= self.num_rocks:
+            return self._log_ll_movement(n_particles, obs_int)
+
+        if obs_int == OBS_NONE:
+            return np.full(n_particles, -np.inf)
+
+        return self._log_ll_check(next_particles, rock_idx, obs_int)
+
+    @property
+    def config_id(self) -> str:
+        """Return a deterministic identifier for this updater configuration."""
+        cfg = {
+            "class": "RockSampleVectorizedUpdater",
+            "map_rows": self.map_rows,
+            "map_cols": self.map_cols,
+            "num_rocks": self.num_rocks,
+            "rock_positions": self.rock_positions.tolist(),
+            "sensor_efficiency": self.sensor_efficiency,
+        }
+        return config_to_id(cfg)
+
+    # ------------------------------------------------------------------
+    # Private helpers — transition
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _live_mask(particles: np.ndarray) -> np.ndarray:
+        return (particles[:, 0] >= 0) | (particles[:, 1] >= 0)
+
+    def _apply_movement(self, result: np.ndarray, live: np.ndarray, action_idx: int) -> None:
+        if action_idx == 1:  # North
+            result[live, 0] = np.maximum(0, result[live, 0] - 1)
+        elif action_idx == 2:  # East
+            result[live, 1] = result[live, 1] + 1
+        elif action_idx == 3:  # South
+            result[live, 0] = np.minimum(self.map_rows - 1, result[live, 0] + 1)
+        elif action_idx == 4:  # West
+            result[live, 1] = np.maximum(0, result[live, 1] - 1)
+
+    def _apply_sample(self, result: np.ndarray, live: np.ndarray) -> None:
+        robot_row = result[:, 0].astype(np.int32)
+        robot_col = result[:, 1].astype(np.int32)
+        for i in range(self.num_rocks):
+            rock_r, rock_c = self.rock_positions[i]
+            at_rock = live & (robot_row == rock_r) & (robot_col == rock_c)
+            result[at_rock, 2 + i] = 0.0
+
+    def _apply_exit(self, result: np.ndarray, live: np.ndarray) -> None:
+        exited = live & (result[:, 1] >= self.map_cols)
+        result[exited, 0] = -1.0
+        result[exited, 1] = -1.0
+
+    # ------------------------------------------------------------------
+    # Private helpers — observation log-likelihood
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _log_ll_movement(n_particles: int, obs_int: int) -> np.ndarray:
+        if obs_int == OBS_NONE:
+            return np.zeros(n_particles)
+        return np.full(n_particles, -np.inf)
+
+    def _log_ll_check(
+        self,
+        next_particles: np.ndarray,
+        rock_idx: int,
+        obs_int: int,
+    ) -> np.ndarray:
+        rock_r, rock_c = self.rock_positions[rock_idx]
+        robot_row = next_particles[:, 0]
+        robot_col = next_particles[:, 1]
+
+        distance = np.sqrt((robot_row - rock_r) ** 2 + (robot_col - rock_c) ** 2)
+        efficiency = np.exp(-distance / self.sensor_efficiency)
+
+        is_good = next_particles[:, 2 + rock_idx] > 0.5
+
+        if obs_int == OBS_GOOD:
+            prob = np.where(is_good, efficiency, 1.0 - efficiency)
+        else:  # OBS_BAD
+            prob = np.where(is_good, 1.0 - efficiency, efficiency)
+
+        prob = np.maximum(prob, 1e-300)
+        log_ll = np.log(prob)
+
+        is_terminal = (next_particles[:, 0] < 0) & (next_particles[:, 1] < 0)
+        log_ll[is_terminal] = -np.inf
+
+        return log_ll

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/benchmark_rocksample_vectorized_belief.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/benchmark_rocksample_vectorized_belief.py
@@ -1,0 +1,200 @@
+"""Performance benchmark: RockSample vectorized vs non-vectorized belief.
+
+Run manually to measure speedup:
+    python -m POMDPPlanners.tests.test_environments.test_rock_sample_pomdp.benchmark_rocksample_vectorized_belief
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, List, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.belief.belief_utils import get_initial_belief
+from POMDPPlanners.environments.rock_sample_pomdp import (
+    RockSamplePOMDP,
+    create_random_rock_sample,
+)
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rocksample_belief_factory import (
+    create_rocksample_belief,
+)
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rocksample_vectorized_updater import (
+    OBS_GOOD,
+    RockSampleVectorizedUpdater,
+)
+from POMDPPlanners.utils.belief_factory import BeliefType
+
+
+def _time_fn(fn: Callable[[], Any], n_runs: int = 100) -> Tuple[float, float]:
+    times: List[float] = []
+    for _ in range(n_runs):
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    arr = np.array(times) * 1000  # ms
+    return float(arr.mean()), float(arr.std())
+
+
+def _create_env() -> RockSamplePOMDP:
+    return create_random_rock_sample(map_size=7, num_rocks=8, seed=42)
+
+
+def _benchmark_single_ops(env: RockSamplePOMDP) -> None:
+    print("\n--- Baseline: Single-state operations ---")
+    state = env.initial_state_dist().sample()[0]
+    action = 2  # East
+
+    mean_t, std_t = _time_fn(
+        lambda: env.state_transition_model(state, action).sample()[0], n_runs=500
+    )
+    print(f"  state_transition_model.sample()      : {mean_t:.4f} +/- {std_t:.4f} ms")
+
+    next_state = env.state_transition_model(state, action).sample()[0]
+    obs = env.observation_model(next_state, action).sample()[0]
+
+    mean_t, std_t = _time_fn(
+        lambda: env.observation_model(next_state, action).probability([obs]),
+        n_runs=500,
+    )
+    print(f"  observation_model.probability()      : {mean_t:.4f} +/- {std_t:.4f} ms")
+
+    check_action = 5
+    next_state_check = env.state_transition_model(state, check_action).sample()[0]
+    obs_check = env.observation_model(next_state_check, check_action).sample()[0]
+
+    mean_t, std_t = _time_fn(
+        lambda: env.observation_model(next_state_check, check_action).probability([obs_check]),
+        n_runs=500,
+    )
+    print(f"  observation_model.probability(check)  : {mean_t:.4f} +/- {std_t:.4f} ms")
+
+
+def _benchmark_sample(env: RockSamplePOMDP, particle_counts: List[int]) -> None:
+    print("\n--- belief.sample() ---")
+    print(f"{'N':>6} | {'Baseline (ms)':>14} | {'Vectorized (ms)':>16} | {'Speedup':>8}")
+    print("-" * 55)
+
+    for n in particle_counts:
+        np.random.seed(42)
+        base_belief = get_initial_belief(env, n)
+        mean_base, _ = _time_fn(lambda: base_belief.sample(), n_runs=500)
+
+        np.random.seed(42)
+        vec_belief = create_rocksample_belief(
+            env, belief_type=BeliefType.VECTORIZED_PARTICLE, n_particles=n
+        )
+        mean_vec, _ = _time_fn(lambda: vec_belief.sample(), n_runs=500)
+
+        speedup = mean_base / mean_vec if mean_vec > 0 else float("inf")
+        print(f"{n:>6} | {mean_base:>14.4f} | {mean_vec:>16.4f} | {speedup:>7.1f}x")
+
+
+def _benchmark_batch_transition(env: RockSamplePOMDP, particle_counts: List[int]) -> None:
+    print("\n--- batch_transition vs loop of state_transition_model.sample() ---")
+    print(f"{'N':>6} | {'Loop (ms)':>14} | {'Vectorized (ms)':>16} | {'Speedup':>8}")
+    print("-" * 55)
+
+    updater = RockSampleVectorizedUpdater.from_environment(env)
+    action = 5  # check action
+
+    for n in particle_counts:
+        np.random.seed(42)
+        states = env.initial_state_dist().sample(n_samples=n)
+        particles = np.stack(states)
+
+        mean_loop, _ = _time_fn(
+            lambda: [env.state_transition_model(s, action).sample()[0] for s in states],
+            n_runs=100,
+        )
+
+        mean_vec, _ = _time_fn(
+            lambda: updater.batch_transition(particles, np.array(action)),
+            n_runs=100,
+        )
+
+        speedup = mean_loop / mean_vec if mean_vec > 0 else float("inf")
+        print(f"{n:>6} | {mean_loop:>14.3f} | {mean_vec:>16.3f} | {speedup:>7.1f}x")
+
+
+def _benchmark_batch_log_likelihood(env: RockSamplePOMDP, particle_counts: List[int]) -> None:
+    print("\n--- batch_observation_log_likelihood vs loop of observation_model.probability() ---")
+    print(f"{'N':>6} | {'Loop (ms)':>14} | {'Vectorized (ms)':>16} | {'Speedup':>8}")
+    print("-" * 55)
+
+    updater = RockSampleVectorizedUpdater.from_environment(env)
+    action = 5
+    obs_str = "good"
+
+    for n in particle_counts:
+        np.random.seed(42)
+        states = env.initial_state_dist().sample(n_samples=n)
+        particles = np.stack(states)
+
+        mean_loop, _ = _time_fn(
+            lambda: [env.observation_model(s, action).probability([obs_str])[0] for s in states],
+            n_runs=100,
+        )
+
+        mean_vec, _ = _time_fn(
+            lambda: updater.batch_observation_log_likelihood(
+                particles, np.array(action), np.array(OBS_GOOD)
+            ),
+            n_runs=100,
+        )
+
+        speedup = mean_loop / mean_vec if mean_vec > 0 else float("inf")
+        print(f"{n:>6} | {mean_loop:>14.3f} | {mean_vec:>16.3f} | {speedup:>7.1f}x")
+
+
+def _benchmark_belief_update(env: RockSamplePOMDP, particle_counts: List[int]) -> None:
+    print("\n--- belief.update() ---")
+    print(f"{'N':>6} | {'Baseline (ms)':>14} | {'Vectorized (ms)':>16} | {'Speedup':>8}")
+    print("-" * 55)
+
+    action = 5
+    state = env.initial_state_dist().sample()[0]
+    next_state = env.state_transition_model(state, action).sample()[0]
+    obs = env.observation_model(next_state, action).sample()[0]
+
+    for n in particle_counts:
+        np.random.seed(42)
+        base_belief = get_initial_belief(env, n)
+        mean_base, _ = _time_fn(
+            lambda: base_belief.update(action=action, observation=obs, pomdp=env),
+            n_runs=20,
+        )
+
+        np.random.seed(42)
+        vec_belief = create_rocksample_belief(
+            env, belief_type=BeliefType.VECTORIZED_PARTICLE, n_particles=n
+        )
+        mean_vec, _ = _time_fn(
+            lambda: vec_belief.update(action=action, observation=obs),
+            n_runs=20,
+        )
+
+        speedup = mean_base / mean_vec if mean_vec > 0 else float("inf")
+        print(f"{n:>6} | {mean_base:>14.3f} | {mean_vec:>16.3f} | {speedup:>7.1f}x")
+
+
+def main() -> None:
+    print("=" * 80)
+    print("RockSample Vectorized Belief Benchmark")
+    print("=" * 80)
+
+    env = _create_env()
+    particle_counts = [50, 200, 500, 1000]
+
+    _benchmark_single_ops(env)
+    _benchmark_sample(env, particle_counts)
+    _benchmark_batch_transition(env, particle_counts)
+    _benchmark_batch_log_likelihood(env, particle_counts)
+    _benchmark_belief_update(env, particle_counts)
+
+    print("\n" + "=" * 80)
+    print("Benchmark complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_belief_factory.py
@@ -1,0 +1,110 @@
+"""Tests for RockSample belief factory."""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.environments.rock_sample_pomdp import RockSamplePOMDP
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rocksample_belief_factory import (
+    RockSampleVectorizedWeightedParticleBelief,
+    create_rocksample_belief,
+)
+from POMDPPlanners.utils.belief_factory import BeliefType, create_environment_belief
+
+
+@pytest.fixture()
+def simple_env():
+    return RockSamplePOMDP(
+        map_size=(5, 5),
+        rock_positions=[(1, 1), (3, 3)],
+        init_pos=(2, 2),
+        sensor_efficiency=10.0,
+        discount_factor=0.95,
+    )
+
+
+class TestCreateVectorizedBelief:
+    def test_returns_vectorized_type(self, simple_env):
+        """Test that VECTORIZED_PARTICLE returns the custom subclass.
+
+        Purpose: Validates correct return type for vectorized belief.
+
+        Given: A RockSamplePOMDP environment.
+        When: create_rocksample_belief is called with VECTORIZED_PARTICLE.
+        Then: Returns RockSampleVectorizedWeightedParticleBelief.
+
+        Test type: unit
+        """
+        belief = create_rocksample_belief(
+            simple_env, belief_type=BeliefType.VECTORIZED_PARTICLE, n_particles=50
+        )
+        assert isinstance(belief, RockSampleVectorizedWeightedParticleBelief)
+
+    def test_correct_shapes(self, simple_env):
+        """Test that particle and weight arrays have correct shapes.
+
+        Purpose: Validates dimensional correctness of belief arrays.
+
+        Given: A RockSamplePOMDP with 2 rocks.
+        When: Vectorized belief is created with 100 particles.
+        Then: particles shape is (100, 4), log_weights shape is (100,).
+
+        Test type: unit
+        """
+        belief = create_rocksample_belief(
+            simple_env, belief_type=BeliefType.VECTORIZED_PARTICLE, n_particles=100
+        )
+        assert isinstance(belief, RockSampleVectorizedWeightedParticleBelief)
+        assert belief.particles.shape == (100, 4)  # 2 pos + 2 rocks
+        assert belief.log_weights.shape == (100,)
+
+
+class TestCreateParticleBelief:
+    def test_returns_particle_type(self, simple_env):
+        """Test that PARTICLE returns a WeightedParticleBelief.
+
+        Purpose: Validates correct return type for standard particle belief.
+
+        Given: A RockSamplePOMDP environment.
+        When: create_rocksample_belief is called with PARTICLE type.
+        Then: Returns WeightedParticleBelief.
+
+        Test type: unit
+        """
+        belief = create_rocksample_belief(
+            simple_env, belief_type=BeliefType.PARTICLE, n_particles=50
+        )
+        assert isinstance(belief, WeightedParticleBelief)
+
+
+class TestUnsupportedType:
+    def test_gaussian_raises_value_error(self, simple_env):
+        """Test that unsupported belief types raise ValueError.
+
+        Purpose: Validates error handling for unsupported types.
+
+        Given: A RockSamplePOMDP environment.
+        When: create_rocksample_belief is called with GAUSSIAN.
+        Then: ValueError is raised.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="does not support"):
+            create_rocksample_belief(simple_env, belief_type=BeliefType.GAUSSIAN, n_particles=50)
+
+
+class TestRegistryDispatches:
+    def test_global_factory_dispatches_to_rocksample(self, simple_env):
+        """Test that the global belief factory dispatches to RockSample factory.
+
+        Purpose: Validates global registry integration.
+
+        Given: A RockSamplePOMDP environment.
+        When: create_environment_belief is called.
+        Then: Returns RockSampleVectorizedWeightedParticleBelief (default).
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        belief = create_environment_belief(simple_env, n_particles=50)
+        assert isinstance(belief, RockSampleVectorizedWeightedParticleBelief)

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_belief_integration.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_belief_integration.py
@@ -1,0 +1,332 @@
+"""Integration tests for RockSample vectorized belief."""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.environments.rock_sample_pomdp import RockSamplePOMDP
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rocksample_belief_factory import (
+    RockSampleVectorizedWeightedParticleBelief,
+    create_rocksample_belief,
+)
+from POMDPPlanners.utils.belief_factory import BeliefType
+
+
+@pytest.fixture()
+def simple_env():
+    return RockSamplePOMDP(
+        map_size=(5, 5),
+        rock_positions=[(1, 1), (3, 3)],
+        init_pos=(2, 2),
+        sensor_efficiency=10.0,
+        discount_factor=0.95,
+    )
+
+
+@pytest.fixture()
+def vec_belief(simple_env):
+    np.random.seed(42)
+    return create_rocksample_belief(
+        simple_env, belief_type=BeliefType.VECTORIZED_PARTICLE, n_particles=100
+    )
+
+
+class TestBeliefUpdateCycle:
+    def test_update_with_movement_preserves_shapes(self, vec_belief):
+        """Test that belief update with movement action preserves shapes.
+
+        Purpose: Validates end-to-end update cycle for movement actions.
+
+        Given: A vectorized belief with 100 particles.
+        When: Updated with East action and 'none' observation.
+        Then: Particle count and dimensionality are preserved.
+
+        Test type: integration
+        """
+        updated = vec_belief.update(action=2, observation="none")
+        assert isinstance(updated, RockSampleVectorizedWeightedParticleBelief)
+        assert updated.particles.shape == vec_belief.particles.shape
+        assert updated.log_weights.shape == vec_belief.log_weights.shape
+
+    def test_update_with_check_action(self, vec_belief):
+        """Test belief update with check action and sensor observation.
+
+        Purpose: Validates end-to-end update for non-trivial observations.
+
+        Given: A vectorized belief with 100 particles.
+        When: Updated with check rock 0 and 'good' observation.
+        Then: Shapes are preserved and weights are updated.
+
+        Test type: integration
+        """
+        updated = vec_belief.update(action=5, observation="good")
+        assert isinstance(updated, RockSampleVectorizedWeightedParticleBelief)
+        assert updated.particles.shape == vec_belief.particles.shape
+
+    def test_multiple_chained_updates(self, vec_belief):
+        """Test that multiple sequential updates work correctly.
+
+        Purpose: Validates chained updates maintain correct subclass.
+
+        Given: A vectorized belief.
+        When: Three sequential updates are applied.
+        Then: Each returns RockSampleVectorizedWeightedParticleBelief
+            with correct shapes.
+
+        Test type: integration
+        """
+        b = vec_belief
+        b = b.update(action=5, observation="good")
+        b = b.update(action=2, observation="none")
+        b = b.update(action=6, observation="bad")
+        assert isinstance(b, RockSampleVectorizedWeightedParticleBelief)
+        assert b.particles.shape == vec_belief.particles.shape
+
+
+class TestBeliefSampleValidState:
+    def test_sample_returns_valid_array(self, vec_belief):
+        """Test that sampling from belief returns a valid state array.
+
+        Purpose: Validates sampled state is a proper numpy array.
+
+        Given: A vectorized belief.
+        When: A state is sampled.
+        Then: Result is a 1-D numpy array of correct dimensionality.
+
+        Test type: integration
+        """
+        state = vec_belief.sample()
+        assert isinstance(state, np.ndarray)
+        assert state.shape == (4,)  # 2 pos + 2 rocks
+
+    def test_sampled_state_has_valid_values(self, vec_belief):
+        """Test that sampled states have physically valid values.
+
+        Purpose: Validates that sampled state represents a valid RockSample state.
+
+        Given: A vectorized belief for a 5x5 grid.
+        When: Multiple states are sampled.
+        Then: Robot positions are within bounds and rock qualities are binary.
+
+        Test type: integration
+        """
+        for _ in range(20):
+            state = vec_belief.sample()
+            # Robot position within grid (or terminal)
+            row, col = int(state[0]), int(state[1])
+            assert (row == -1 and col == -1) or (0 <= row < 5 and 0 <= col < 5)
+            # Rock qualities are 0 or 1
+            for rock_q in state[2:]:
+                assert rock_q in (0.0, 1.0)
+
+
+class TestStringObservationEncoding:
+    def test_all_observation_strings_accepted(self, vec_belief):
+        """Test that all valid string observations are accepted.
+
+        Purpose: Validates string-to-integer encoding for all observations.
+
+        Given: A vectorized belief.
+        When: Updated with each valid observation string.
+        Then: No errors are raised.
+
+        Test type: integration
+        """
+        vec_belief.update(action=2, observation="none")
+        vec_belief.update(action=5, observation="good")
+        vec_belief.update(action=5, observation="bad")
+
+    def test_integer_observation_also_works(self, vec_belief):
+        """Test that integer-encoded observations are also accepted.
+
+        Purpose: Validates that pre-encoded integer observations pass through.
+
+        Given: A vectorized belief.
+        When: Updated with integer observation (1 for 'good').
+        Then: No errors are raised.
+
+        Test type: integration
+        """
+        updated = vec_belief.update(action=5, observation=1)
+        assert isinstance(updated, RockSampleVectorizedWeightedParticleBelief)
+
+
+def _make_aligned_beliefs(env, n_particles=200):
+    """Create baseline and vectorized beliefs with identical particles."""
+    np.random.seed(42)
+    states = env.initial_state_dist().sample(n_samples=n_particles)
+    particles_list = list(states)
+    particles_array = np.stack(states)
+    log_weights = np.log(np.ones(n_particles) / n_particles)
+
+    from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rocksample_vectorized_updater import (
+        RockSampleVectorizedUpdater,
+    )
+
+    base = WeightedParticleBelief(
+        particles=particles_list,
+        log_weights=log_weights.copy(),
+        resampling=False,
+    )
+    vec = RockSampleVectorizedWeightedParticleBelief(
+        particles=particles_array,
+        log_weights=log_weights.copy(),
+        updater=RockSampleVectorizedUpdater.from_environment(env),
+        resampling=False,
+    )
+    return base, vec
+
+
+class TestVectorizedMatchesBaseline:
+    """Verify that vectorized and baseline beliefs produce equivalent results."""
+
+    def test_transition_particles_match_for_movement(self, simple_env):
+        """Test that transitioned particles match for movement actions.
+
+        Purpose: Validates that vectorized batch_transition produces the same
+            next states as the loop-based state_transition_model.
+
+        Given: Identical particles in both belief types.
+        When: Both are updated with East action and 'none' observation.
+        Then: The transitioned particles are identical.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(simple_env)
+        action = 2  # East
+        obs = "none"
+
+        base_updated = base.update(action=action, observation=obs, pomdp=simple_env)
+        vec_updated = vec.update(action=action, observation=obs)
+
+        base_particles = np.stack(base_updated.particles)
+        np.testing.assert_array_equal(vec_updated.particles, base_particles)
+
+    def test_transition_particles_match_for_sample_action(self, simple_env):
+        """Test that transitioned particles match for sample action.
+
+        Purpose: Validates vectorized Sample action produces identical state
+            changes as the loop-based approach.
+
+        Given: Identical particles in both belief types.
+        When: Both are updated with Sample action and 'none' observation.
+        Then: The transitioned particles are identical.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(simple_env)
+        action = 0  # Sample
+        obs = "none"
+
+        base_updated = base.update(action=action, observation=obs, pomdp=simple_env)
+        vec_updated = vec.update(action=action, observation=obs)
+
+        base_particles = np.stack(base_updated.particles)
+        np.testing.assert_array_equal(vec_updated.particles, base_particles)
+
+    def test_transition_particles_match_for_check_action(self, simple_env):
+        """Test that transitioned particles match for check actions.
+
+        Purpose: Validates vectorized Check action (no state change) matches
+            the loop-based approach.
+
+        Given: Identical particles in both belief types.
+        When: Both are updated with Check rock 0 and 'good' observation.
+        Then: The transitioned particles are identical.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(simple_env)
+        action = 5  # Check rock 0
+        obs = "good"
+
+        base_updated = base.update(action=action, observation=obs, pomdp=simple_env)
+        vec_updated = vec.update(action=action, observation=obs)
+
+        base_particles = np.stack(base_updated.particles)
+        np.testing.assert_array_equal(vec_updated.particles, base_particles)
+
+    def test_normalized_weights_match_for_movement(self, simple_env):
+        """Test that normalized weights match for movement actions.
+
+        Purpose: Validates that both belief types produce identical weight
+            distributions for deterministic 'none' observations.
+
+        Given: Identical particles in both belief types.
+        When: Both are updated with North action and 'none' observation.
+        Then: Normalized weights are equal.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(simple_env)
+        action = 1  # North
+        obs = "none"
+
+        base_updated = base.update(action=action, observation=obs, pomdp=simple_env)
+        vec_updated = vec.update(action=action, observation=obs)
+
+        np.testing.assert_allclose(
+            vec_updated.normalized_weights,
+            base_updated.normalized_weights,
+            atol=1e-6,
+        )
+
+    def test_normalized_weights_close_for_check_action(self, simple_env):
+        """Test that normalized weights are close for check actions.
+
+        Purpose: Validates that both belief types produce nearly identical
+            weight distributions for sensor observations. Small differences
+            are expected due to different numerical clamping (eps vs max).
+
+        Given: Identical particles in both belief types.
+        When: Both are updated with Check rock 0 and 'good' observation.
+        Then: Normalized weights are close (atol=1e-6).
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(simple_env)
+        action = 5  # Check rock 0
+        obs = "good"
+
+        base_updated = base.update(action=action, observation=obs, pomdp=simple_env)
+        vec_updated = vec.update(action=action, observation=obs)
+
+        np.testing.assert_allclose(
+            vec_updated.normalized_weights,
+            base_updated.normalized_weights,
+            atol=1e-6,
+        )
+
+    def test_weights_match_after_multiple_updates(self, simple_env):
+        """Test that weights remain close after a sequence of updates.
+
+        Purpose: Validates that numerical differences don't accumulate
+            over multiple belief update steps.
+
+        Given: Identical particles in both belief types.
+        When: Both are updated with a sequence of actions/observations.
+        Then: Normalized weights remain close after all updates.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(simple_env, n_particles=500)
+
+        steps = [
+            (5, "good"),  # check rock 0
+            (2, "none"),  # move east
+            (6, "bad"),  # check rock 1
+            (1, "none"),  # move north
+            (5, "good"),  # check rock 0 again
+        ]
+
+        for action, obs in steps:
+            base = base.update(action=action, observation=obs, pomdp=simple_env)
+            vec = vec.update(action=action, observation=obs)
+
+        base_particles = np.stack(base.particles)
+        np.testing.assert_array_equal(vec.particles, base_particles)
+        np.testing.assert_allclose(
+            vec.normalized_weights,
+            base.normalized_weights,
+            atol=1e-5,
+        )

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_vectorized_updater.py
@@ -1,0 +1,418 @@
+"""Tests for RockSample vectorized particle belief updater."""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.rock_sample_pomdp import RockSamplePOMDP
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rocksample_vectorized_updater import (
+    OBS_BAD,
+    OBS_GOOD,
+    OBS_NONE,
+    RockSampleVectorizedUpdater,
+)
+
+
+@pytest.fixture()
+def simple_env():
+    return RockSamplePOMDP(
+        map_size=(5, 5),
+        rock_positions=[(1, 1), (3, 3)],
+        init_pos=(2, 2),
+        sensor_efficiency=10.0,
+        discount_factor=0.95,
+    )
+
+
+@pytest.fixture()
+def updater(simple_env):
+    return RockSampleVectorizedUpdater.from_environment(simple_env)
+
+
+@pytest.fixture()
+def sample_particles(simple_env):
+    np.random.seed(42)
+    states = simple_env.initial_state_dist().sample(n_samples=10)
+    return np.stack(states)
+
+
+class TestFromEnvironmentConstruction:
+    def test_creates_without_error(self, simple_env):
+        """Test that from_environment constructs an updater successfully.
+
+        Purpose: Validates updater creation from environment.
+
+        Given: A configured RockSamplePOMDP environment.
+        When: RockSampleVectorizedUpdater.from_environment is called.
+        Then: Updater has matching attributes.
+
+        Test type: unit
+        """
+        upd = RockSampleVectorizedUpdater.from_environment(simple_env)
+        assert upd.map_rows == 5
+        assert upd.map_cols == 5
+        assert upd.num_rocks == 2
+        assert upd.rock_positions.shape == (2, 2)
+        assert upd.sensor_efficiency == 10.0
+
+
+class TestBatchTransition:
+    def test_shape_preserved(self, updater, sample_particles):
+        """Test that batch_transition preserves particle array shape.
+
+        Purpose: Validates output shape matches input shape.
+
+        Given: Particles of shape (N, d).
+        When: batch_transition is called with any action.
+        Then: Output has the same shape.
+
+        Test type: unit
+        """
+        result = updater.batch_transition(sample_particles, np.array(2))
+        assert result.shape == sample_particles.shape
+
+    def test_terminal_unchanged(self, updater):
+        """Test that terminal particles remain unchanged after transition.
+
+        Purpose: Validates that terminal states are not modified.
+
+        Given: A particle with terminal position (-1, -1).
+        When: batch_transition is called.
+        Then: The particle remains at (-1, -1).
+
+        Test type: unit
+        """
+        terminal = np.array([[-1.0, -1.0, 1.0, 0.0]])
+        for action in range(7):
+            result = updater.batch_transition(terminal, np.array(action))
+            assert result[0, 0] == -1.0
+            assert result[0, 1] == -1.0
+
+    def test_north_movement(self, updater):
+        """Test northward movement decreases row by 1.
+
+        Purpose: Validates North action (1) moves robot correctly.
+
+        Given: Robot at position (2, 2).
+        When: North action is applied.
+        Then: Robot row decreases by 1.
+
+        Test type: unit
+        """
+        particles = np.array([[2.0, 2.0, 1.0, 0.0]])
+        result = updater.batch_transition(particles, np.array(1))
+        assert result[0, 0] == 1.0
+        assert result[0, 1] == 2.0
+
+    def test_north_clamps_at_boundary(self, updater):
+        """Test that North movement clamps at row 0.
+
+        Purpose: Validates boundary clamping for North action.
+
+        Given: Robot at row 0.
+        When: North action is applied.
+        Then: Robot stays at row 0.
+
+        Test type: unit
+        """
+        particles = np.array([[0.0, 2.0, 1.0, 0.0]])
+        result = updater.batch_transition(particles, np.array(1))
+        assert result[0, 0] == 0.0
+
+    def test_east_movement(self, updater):
+        """Test eastward movement increases column by 1.
+
+        Purpose: Validates East action (2) moves robot correctly.
+
+        Given: Robot at position (2, 2).
+        When: East action is applied.
+        Then: Robot column increases by 1.
+
+        Test type: unit
+        """
+        particles = np.array([[2.0, 2.0, 1.0, 0.0]])
+        result = updater.batch_transition(particles, np.array(2))
+        assert result[0, 0] == 2.0
+        assert result[0, 1] == 3.0
+
+    def test_south_movement(self, updater):
+        """Test southward movement increases row by 1.
+
+        Purpose: Validates South action (3) moves robot correctly.
+
+        Given: Robot at position (2, 2).
+        When: South action is applied.
+        Then: Robot row increases by 1.
+
+        Test type: unit
+        """
+        particles = np.array([[2.0, 2.0, 1.0, 0.0]])
+        result = updater.batch_transition(particles, np.array(3))
+        assert result[0, 0] == 3.0
+        assert result[0, 1] == 2.0
+
+    def test_south_clamps_at_boundary(self, updater):
+        """Test that South movement clamps at last row.
+
+        Purpose: Validates boundary clamping for South action.
+
+        Given: Robot at last row (4).
+        When: South action is applied.
+        Then: Robot stays at row 4.
+
+        Test type: unit
+        """
+        particles = np.array([[4.0, 2.0, 1.0, 0.0]])
+        result = updater.batch_transition(particles, np.array(3))
+        assert result[0, 0] == 4.0
+
+    def test_west_movement(self, updater):
+        """Test westward movement decreases column by 1.
+
+        Purpose: Validates West action (4) moves robot correctly.
+
+        Given: Robot at position (2, 2).
+        When: West action is applied.
+        Then: Robot column decreases by 1.
+
+        Test type: unit
+        """
+        particles = np.array([[2.0, 2.0, 1.0, 0.0]])
+        result = updater.batch_transition(particles, np.array(4))
+        assert result[0, 0] == 2.0
+        assert result[0, 1] == 1.0
+
+    def test_west_clamps_at_boundary(self, updater):
+        """Test that West movement clamps at column 0.
+
+        Purpose: Validates boundary clamping for West action.
+
+        Given: Robot at column 0.
+        When: West action is applied.
+        Then: Robot stays at column 0.
+
+        Test type: unit
+        """
+        particles = np.array([[2.0, 0.0, 1.0, 0.0]])
+        result = updater.batch_transition(particles, np.array(4))
+        assert result[0, 1] == 0.0
+
+    def test_east_exit_becomes_terminal(self, updater):
+        """Test that moving east from last column triggers exit.
+
+        Purpose: Validates exit condition sets terminal state.
+
+        Given: Robot at rightmost column (4) in a 5-wide map.
+        When: East action is applied.
+        Then: Robot position becomes (-1, -1).
+
+        Test type: unit
+        """
+        particles = np.array([[2.0, 4.0, 1.0, 0.0]])
+        result = updater.batch_transition(particles, np.array(2))
+        assert result[0, 0] == -1.0
+        assert result[0, 1] == -1.0
+
+    def test_sample_at_rock_sets_quality_zero(self, updater):
+        """Test that sampling at a rock position sets its quality to 0.
+
+        Purpose: Validates Sample action (0) at a rock position.
+
+        Given: Robot at rock position (1, 1) with rock quality 1.0.
+        When: Sample action is applied.
+        Then: Rock quality becomes 0.0.
+
+        Test type: unit
+        """
+        particles = np.array([[1.0, 1.0, 1.0, 1.0]])
+        result = updater.batch_transition(particles, np.array(0))
+        assert result[0, 2] == 0.0  # rock 0 at (1,1) sampled
+        assert result[0, 3] == 1.0  # rock 1 at (3,3) unchanged
+
+    def test_sample_not_at_rock_no_change(self, updater):
+        """Test that sampling away from rocks doesn't change state.
+
+        Purpose: Validates Sample action has no effect when not at a rock.
+
+        Given: Robot at position (2, 2) with no rocks there.
+        When: Sample action is applied.
+        Then: All rock qualities unchanged.
+
+        Test type: unit
+        """
+        particles = np.array([[2.0, 2.0, 1.0, 1.0]])
+        result = updater.batch_transition(particles, np.array(0))
+        assert result[0, 2] == 1.0
+        assert result[0, 3] == 1.0
+
+    def test_check_action_no_state_change(self, updater):
+        """Test that check actions do not modify the state.
+
+        Purpose: Validates Check actions (5+) leave state unchanged.
+
+        Given: An arbitrary particle state.
+        When: Check action is applied.
+        Then: State is identical to input.
+
+        Test type: unit
+        """
+        particles = np.array([[2.0, 2.0, 1.0, 0.0]])
+        for check_action in [5, 6]:
+            result = updater.batch_transition(particles, np.array(check_action))
+            np.testing.assert_array_equal(result, particles)
+
+    def test_does_not_mutate_input(self, updater, sample_particles):
+        """Test that batch_transition does not modify the input array.
+
+        Purpose: Validates immutability of input particles.
+
+        Given: A particle array.
+        When: batch_transition is called.
+        Then: The original array is unchanged.
+
+        Test type: unit
+        """
+        original = sample_particles.copy()
+        updater.batch_transition(sample_particles, np.array(2))
+        np.testing.assert_array_equal(sample_particles, original)
+
+
+class TestBatchObservationLogLikelihood:
+    def test_shape(self, updater, sample_particles):
+        """Test that output shape is (N,).
+
+        Purpose: Validates output dimensionality.
+
+        Given: Particles of shape (N, d).
+        When: batch_observation_log_likelihood is called.
+        Then: Output has shape (N,).
+
+        Test type: unit
+        """
+        log_ll = updater.batch_observation_log_likelihood(
+            sample_particles, np.array(5), np.array(OBS_GOOD)
+        )
+        assert log_ll.shape == (sample_particles.shape[0],)
+
+    def test_movement_action_none_obs(self, updater, sample_particles):
+        """Test that movement actions with 'none' obs give log-likelihood 0.
+
+        Purpose: Validates deterministic 'none' observation for movement actions.
+
+        Given: Particles with movement action (East).
+        When: Observation is 'none' (0).
+        Then: All log-likelihoods are 0.0.
+
+        Test type: unit
+        """
+        for action in range(5):
+            log_ll = updater.batch_observation_log_likelihood(
+                sample_particles, np.array(action), np.array(OBS_NONE)
+            )
+            np.testing.assert_array_equal(log_ll, 0.0)
+
+    def test_movement_action_non_none_obs(self, updater, sample_particles):
+        """Test that movement actions with non-'none' obs give -inf.
+
+        Purpose: Validates impossible observations for movement actions.
+
+        Given: Particles with movement action.
+        When: Observation is 'good' or 'bad'.
+        Then: All log-likelihoods are -inf.
+
+        Test type: unit
+        """
+        for action in range(5):
+            for obs in [OBS_GOOD, OBS_BAD]:
+                log_ll = updater.batch_observation_log_likelihood(
+                    sample_particles, np.array(action), np.array(obs)
+                )
+                assert np.all(np.isneginf(log_ll))
+
+    def test_check_good_rock_close_good_obs(self, updater):
+        """Test high log-likelihood for correct obs near a good rock.
+
+        Purpose: Validates sensor model gives high probability for correct
+            observation when close to a good rock.
+
+        Given: Robot at rock 0 position (1, 1) with good rock quality.
+        When: Check rock 0 with 'good' observation.
+        Then: Log-likelihood is close to 0 (high probability).
+
+        Test type: unit
+        """
+        particles = np.array([[1.0, 1.0, 1.0, 0.0]])
+        log_ll = updater.batch_observation_log_likelihood(
+            particles, np.array(5), np.array(OBS_GOOD)
+        )
+        # At distance 0, efficiency ≈ 1.0, so log(1.0) ≈ 0.0
+        assert log_ll[0] > -0.1
+
+    def test_check_good_rock_far_bad_obs(self, updater):
+        """Test that bad obs has higher log-likelihood when far from good rock.
+
+        Purpose: Validates sensor noise increases with distance.
+
+        Given: Robot far from good rock 0.
+        When: Check rock 0 with 'bad' observation (incorrect).
+        Then: Log-likelihood for 'bad' is higher when far than when close.
+
+        Test type: unit
+        """
+        # Close: robot at (1, 1), rock 0 at (1, 1), distance = 0
+        close = np.array([[1.0, 1.0, 1.0, 0.0]])
+        ll_close = updater.batch_observation_log_likelihood(close, np.array(5), np.array(OBS_BAD))
+
+        # Far: robot at (4, 4), rock 0 at (1, 1), distance ≈ 4.24
+        far = np.array([[4.0, 4.0, 1.0, 0.0]])
+        ll_far = updater.batch_observation_log_likelihood(far, np.array(5), np.array(OBS_BAD))
+
+        # Bad obs should be more likely when far (more noise)
+        assert ll_far[0] > ll_close[0]
+
+    def test_terminal_particles_neg_inf(self, updater):
+        """Test that terminal particles get -inf log-likelihood for check obs.
+
+        Purpose: Validates terminal handling in observation model.
+
+        Given: A terminal particle (-1, -1).
+        When: Check action with 'good' observation.
+        Then: Log-likelihood is -inf.
+
+        Test type: unit
+        """
+        terminal = np.array([[-1.0, -1.0, 1.0, 0.0]])
+        log_ll = updater.batch_observation_log_likelihood(terminal, np.array(5), np.array(OBS_GOOD))
+        assert np.isneginf(log_ll[0])
+
+    def test_check_none_obs_impossible(self, updater, sample_particles):
+        """Test that 'none' observation is impossible for check actions.
+
+        Purpose: Validates that check actions cannot produce 'none'.
+
+        Given: Particles with check action.
+        When: Observation is 'none'.
+        Then: All log-likelihoods are -inf.
+
+        Test type: unit
+        """
+        log_ll = updater.batch_observation_log_likelihood(
+            sample_particles, np.array(5), np.array(OBS_NONE)
+        )
+        assert np.all(np.isneginf(log_ll))
+
+
+class TestConfigId:
+    def test_deterministic(self, simple_env):
+        """Test that config_id is deterministic for same environment.
+
+        Purpose: Validates reproducible config identification.
+
+        Given: Two updaters created from the same environment.
+        When: config_id is computed for each.
+        Then: Both return the same string.
+
+        Test type: unit
+        """
+        upd1 = RockSampleVectorizedUpdater.from_environment(simple_env)
+        upd2 = RockSampleVectorizedUpdater.from_environment(simple_env)
+        assert upd1.config_id == upd2.config_id

--- a/POMDPPlanners/utils/belief_factory.py
+++ b/POMDPPlanners/utils/belief_factory.py
@@ -113,6 +113,11 @@ _ENV_FACTORY_REGISTRY: dict[str, tuple[str, str, BeliefType]] = {
         "create_pacman_belief",
         BeliefType.VECTORIZED_PARTICLE,
     ),
+    "RockSamplePOMDP": (
+        "POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs",
+        "create_rocksample_belief",
+        BeliefType.VECTORIZED_PARTICLE,
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- Implements `RockSampleVectorizedUpdater` with batched NumPy operations for state transitions and observation log-likelihoods
- Adds `RockSampleVectorizedWeightedParticleBelief` subclass to handle string-to-integer observation encoding (`"none"`/`"good"`/`"bad"`)
- Registers RockSample in the global belief factory with `create_rocksample_belief` supporting both `PARTICLE` and `VECTORIZED_PARTICLE` types
- 41 tests covering updater correctness, factory dispatch, integration cycles, and **equivalence with baseline `WeightedParticleBelief`** (particles and normalized weights match)

## Benchmark results (`belief.update()` end-to-end)

| Particles | Baseline (ms) | Vectorized (ms) | Speedup |
|-----------|---------------|-----------------|---------|
| 50        | 0.34          | 0.047           | **7.2x**  |
| 200       | 1.29          | 0.053           | **24.4x** |
| 500       | 3.10          | 0.058           | **53.6x** |
| 1000      | 6.27          | 0.070           | **89.4x** |

## Test plan
- [x] `pytest POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/ -v` — 101 tests pass
- [x] `pytest POMDPPlanners/tests/test_core/test_belief/ -v` — 300 existing belief tests pass
- [x] pyright 0 errors, pylint 10.00/10 on all new files
- [x] Benchmark script: `python -m POMDPPlanners.tests.test_environments.test_rock_sample_pomdp.benchmark_rocksample_vectorized_belief`