### PR TITLE
Add shared vectorized vs non-vectorized belief comparison tests

### DIFF
--- a/POMDPPlanners/tests/test_core/test_belief/vectorized_updater_test_utils.py
+++ b/POMDPPlanners/tests/test_core/test_belief/vectorized_updater_test_utils.py
@@ -1,0 +1,160 @@
+"""Shared test utilities for comparing vectorized vs per-particle belief updates.
+
+This module provides reusable assertion functions that verify vectorized
+batch operations (batch_transition, batch_observation_log_likelihood) produce
+the same results as the equivalent per-particle loop through the environment's
+state_transition_model and observation_model.
+
+Functions:
+    assert_batch_transition_matches_loop: Compare batch_transition vs per-particle transitions.
+    assert_batch_obs_log_likelihood_matches_loop: Compare batch log-likelihoods vs per-particle.
+"""
+
+from typing import Any, Callable, Optional
+
+import numpy as np
+
+from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
+    VectorizedParticleBeliefUpdater,
+)
+
+
+def assert_batch_transition_matches_loop(
+    updater: VectorizedParticleBeliefUpdater,
+    particles: np.ndarray,
+    action: Any,
+    per_particle_transition_fn: Callable[[np.ndarray, Any], np.ndarray],
+    atol: float = 1e-10,
+    seed: Optional[int] = None,
+    err_msg: str = "",
+) -> None:
+    """Assert that batch_transition matches a per-particle transition loop.
+
+    Args:
+        updater: Vectorized updater to test.
+        particles: Particle array of shape (N, d).
+        action: Action to apply.
+        per_particle_transition_fn: Callable(particle_1d, action) -> next_state_1d
+            that wraps the environment's per-particle transition logic.
+        atol: Absolute tolerance for comparison.
+        seed: If provided, seeds np.random before each path so stochastic
+            transitions consume the same random sequence.
+        err_msg: Optional message appended on failure.
+    """
+    vectorized_result = _run_vectorized_transition(updater, particles, action, seed)
+    per_particle_result = _run_per_particle_transition(
+        particles, action, per_particle_transition_fn, seed
+    )
+    np.testing.assert_allclose(vectorized_result, per_particle_result, atol=atol, err_msg=err_msg)
+
+
+def assert_batch_obs_log_likelihood_matches_loop(
+    updater: VectorizedParticleBeliefUpdater,
+    particles: np.ndarray,
+    action: Any,
+    observation: Any,
+    per_particle_ll_fn: Callable[[np.ndarray, Any, Any], float],
+    atol: float = 1e-10,
+    compare_mode: str = "absolute",
+    err_msg: str = "",
+) -> None:
+    """Assert that batch_observation_log_likelihood matches a per-particle loop.
+
+    Args:
+        updater: Vectorized updater to test.
+        particles: Particle array of shape (N, d).
+        action: Action used for the observation model.
+        observation: Observation value.
+        per_particle_ll_fn: Callable(particle_1d, action, observation) -> float
+            that wraps the environment's per-particle log-likelihood logic.
+        atol: Absolute tolerance for comparison.
+        compare_mode: ``"absolute"`` for direct comparison, or
+            ``"pairwise_diff"`` to compare ``ll - ll[0]`` (for environments
+            whose per-particle path omits a normalisation constant).
+        err_msg: Optional message appended on failure.
+
+    Raises:
+        ValueError: If compare_mode is not ``"absolute"`` or ``"pairwise_diff"``.
+    """
+    if compare_mode not in ("absolute", "pairwise_diff"):
+        raise ValueError(f"Unknown compare_mode: {compare_mode!r}")
+
+    vectorized_ll = updater.batch_observation_log_likelihood(particles, action, observation)
+    per_particle_ll = _build_per_particle_log_likelihoods(
+        particles, action, observation, per_particle_ll_fn
+    )
+
+    if compare_mode == "absolute":
+        _assert_log_likelihoods_absolute(vectorized_ll, per_particle_ll, atol, err_msg)
+    else:
+        _assert_log_likelihoods_pairwise_diff(vectorized_ll, per_particle_ll, atol, err_msg)
+
+
+# ------------------------------------------------------------------
+# Internal helpers
+# ------------------------------------------------------------------
+
+
+def _run_vectorized_transition(
+    updater: VectorizedParticleBeliefUpdater,
+    particles: np.ndarray,
+    action: Any,
+    seed: Optional[int],
+) -> np.ndarray:
+    if seed is not None:
+        np.random.seed(seed)
+    return updater.batch_transition(particles, action)
+
+
+def _run_per_particle_transition(
+    particles: np.ndarray,
+    action: Any,
+    per_particle_fn: Callable[[np.ndarray, Any], np.ndarray],
+    seed: Optional[int],
+) -> np.ndarray:
+    if seed is not None:
+        np.random.seed(seed)
+    n = len(particles)
+    result = np.empty_like(particles)
+    for i in range(n):
+        result[i] = per_particle_fn(particles[i], action)
+    return result
+
+
+def _build_per_particle_log_likelihoods(
+    particles: np.ndarray,
+    action: Any,
+    observation: Any,
+    per_particle_ll_fn: Callable[[np.ndarray, Any, Any], float],
+) -> np.ndarray:
+    n = len(particles)
+    result = np.empty(n)
+    for i in range(n):
+        result[i] = per_particle_ll_fn(particles[i], action, observation)
+    return result
+
+
+def _assert_log_likelihoods_absolute(
+    vectorized_ll: np.ndarray,
+    per_particle_ll: np.ndarray,
+    atol: float,
+    err_msg: str,
+) -> None:
+    finite_mask = np.isfinite(per_particle_ll)
+    np.testing.assert_allclose(
+        vectorized_ll[finite_mask],
+        per_particle_ll[finite_mask],
+        atol=atol,
+        err_msg=err_msg,
+    )
+
+
+def _assert_log_likelihoods_pairwise_diff(
+    vectorized_ll: np.ndarray,
+    per_particle_ll: np.ndarray,
+    atol: float,
+    err_msg: str,
+) -> None:
+    vectorized_diff = vectorized_ll - vectorized_ll[0]
+    per_particle_diff = per_particle_ll - per_particle_ll[0]
+    np.testing.assert_allclose(vectorized_diff, per_particle_diff, atol=atol, err_msg=err_msg)

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py
@@ -12,6 +12,10 @@ from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
 from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp_beliefs import (
     CartPoleVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
+    assert_batch_obs_log_likelihood_matches_loop,
+    assert_batch_transition_matches_loop,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -267,18 +271,18 @@ class TestEquivalenceWithPerParticleLoop:
         Test type: integration
         """
         np.random.seed(123)
-        n = 50
-        particles = np.random.uniform(-0.05, 0.05, (n, 4))
-        action = 1
+        particles = np.random.uniform(-0.05, 0.05, (50, 4))
 
-        vectorized_result = updater.batch_transition(particles, action)
+        def per_particle_fn(particle, action):
+            transition = env.state_transition_model(state=particle, action=action)
+            return transition._compute_deterministic_next_state()
 
-        per_particle_result = np.empty_like(particles)
-        for i in range(n):
-            transition = env.state_transition_model(state=particles[i], action=action)
-            per_particle_result[i] = transition._compute_deterministic_next_state()
-
-        np.testing.assert_allclose(vectorized_result, per_particle_result, atol=1e-10)
+        assert_batch_transition_matches_loop(
+            updater=updater,
+            particles=particles,
+            action=1,
+            per_particle_transition_fn=per_particle_fn,
+        )
 
     def test_batch_observation_log_likelihood_matches_per_particle_loop(self, env, updater):
         """Test vectorized log-likelihood matches per-particle observation_model.probability.
@@ -294,17 +298,17 @@ class TestEquivalenceWithPerParticleLoop:
         Test type: integration
         """
         np.random.seed(42)
-        n = 50
-        action = 1
+        particles = np.random.uniform(-0.05, 0.05, (50, 4))
         observation = np.array([0.01, 0.0, 0.02, 0.0])
-        particles = np.random.uniform(-0.05, 0.05, (n, 4))
 
-        vectorized_ll = updater.batch_observation_log_likelihood(particles, action, observation)
+        def per_particle_ll_fn(particle, action, obs):
+            obs_model = env.observation_model(next_state=particle, action=action)
+            return np.log(obs_model.probability([obs])[0])
 
-        per_particle_ll = np.empty(n)
-        for i in range(n):
-            obs_model = env.observation_model(next_state=particles[i], action=action)
-            prob = obs_model.probability([observation])[0]
-            per_particle_ll[i] = np.log(prob)
-
-        np.testing.assert_allclose(vectorized_ll, per_particle_ll, atol=1e-10)
+        assert_batch_obs_log_likelihood_matches_loop(
+            updater=updater,
+            particles=particles,
+            action=1,
+            observation=observation,
+            per_particle_ll_fn=per_particle_ll_fn,
+        )

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_continuous_laser_tag_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_continuous_laser_tag_vectorized_updater.py
@@ -14,6 +14,9 @@ from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_pomdp impor
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_beliefs.continuous_laser_tag_vectorized_updater import (
     ContinuousLaserTagVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
+    assert_batch_obs_log_likelihood_matches_loop,
+)
 
 
 @pytest.fixture
@@ -260,6 +263,105 @@ class TestBatchObservationLogLikelihood:
         action = np.array([1.0, 0.0, 0.0])
         ll = updater.batch_observation_log_likelihood(particles, action, obs)
         assert np.all(np.isfinite(ll))
+
+
+# ---------------------------------------------------------------------------
+# Equivalence test: vectorized vs per-particle loop
+# ---------------------------------------------------------------------------
+
+
+class TestEquivalenceWithPerParticleLoop:
+    def test_batch_transition_matches_per_particle_loop(self, env, updater):
+        """Test vectorized batch_transition matches per-particle state_transition_model.
+
+        Purpose: Verifies that batch_transition produces the same results as
+                 calling the environment's state_transition_model per particle.
+                 Because the vectorized path batches robot noise then opponent
+                 noise (different RNG order from the per-particle path which
+                 interleaves them), we compare each particle individually with
+                 its own seed.
+
+        Given: A set of non-terminal continuous-space particles.
+        When: For each particle, batch_transition is called on a single
+              particle, and the per-particle state_transition_model is called
+              with the same seed.
+        Then: Results match within floating-point tolerance.
+
+        Test type: integration
+        """
+        np.random.seed(123)
+        n = 30
+        particles = np.column_stack(
+            [
+                np.random.rand(n) * 10,
+                np.random.rand(n) * 6,
+                np.random.rand(n) * 10,
+                np.random.rand(n) * 6,
+                np.zeros(n),
+            ]
+        )
+        action = np.array([1.0, 0.5, 0.0])
+
+        for i in range(n):
+            single = particles[i : i + 1]
+
+            np.random.seed(1000 + i)
+            vec_result = updater.batch_transition(single, action)
+
+            np.random.seed(1000 + i)
+            scalar_result = env.state_transition_model(state=particles[i], action=action).sample()[
+                0
+            ]
+
+            np.testing.assert_allclose(
+                vec_result[0],
+                scalar_result,
+                atol=1e-10,
+                err_msg=f"Mismatch for particle {i}",
+            )
+
+    def test_batch_obs_log_likelihood_matches_per_particle_loop(self, env, updater):
+        """Test vectorized log-likelihood matches per-particle observation_model.probability.
+
+        Purpose: Verifies that batch_observation_log_likelihood matches the
+                 per-particle log(observation_model.probability) from the
+                 environment.
+
+        Given: A set of non-terminal particles and a valid observation.
+        When: batch_observation_log_likelihood is called, and per-particle
+              log-probabilities are computed.
+        Then: Results match within floating-point tolerance.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        n = 30
+        particles = np.column_stack(
+            [
+                np.random.rand(n) * 10,
+                np.random.rand(n) * 6,
+                np.random.rand(n) * 10,
+                np.random.rand(n) * 6,
+                np.zeros(n),
+            ]
+        )
+        obs = np.random.rand(8) * 5
+        action = np.array([1.0, 0.0, 0.0])
+
+        def per_particle_ll_fn(particle, act, observation):
+            obs_model = env.observation_model(next_state=particle, action=act)
+            prob = obs_model.probability([observation])[0]
+            if prob > 0:
+                return np.log(prob)
+            return -np.inf
+
+        assert_batch_obs_log_likelihood_matches_loop(
+            updater=updater,
+            particles=particles,
+            action=action,
+            observation=obs,
+            per_particle_ll_fn=per_particle_ll_fn,
+        )
 
 
 class TestConfigId:

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_laser_tag_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_laser_tag_vectorized_updater.py
@@ -18,6 +18,9 @@ from POMDPPlanners.environments.laser_tag_pomdp import LaserTagPOMDP
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_beliefs import (
     LaserTagVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
+    assert_batch_obs_log_likelihood_matches_loop,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -452,10 +455,13 @@ class TestEquivalenceWithPerParticleLoop:
 
         Purpose: Verifies that robot movement (deterministic part) in
                  batch_transition matches the per-particle loop exactly.
+                 Only robot positions (columns 0:2) are compared because
+                 opponent movement uses different RNG primitives between
+                 the vectorized and per-particle paths.
 
         Given: A set of non-terminal particles with transition_error_prob=0.
         When: batch_transition is called and the per-particle loop is run.
-        Then: Robot positions match exactly.
+        Then: Robot positions match exactly for all 5 actions.
 
         Test type: integration
         """
@@ -480,7 +486,6 @@ class TestEquivalenceWithPerParticleLoop:
                 ).sample()[0]
                 per_particle[i] = next_state
 
-            # Robot positions should match exactly
             np.testing.assert_array_equal(
                 vectorized[:, :2],
                 per_particle[:, :2],
@@ -545,30 +550,22 @@ class TestEquivalenceWithPerParticleLoop:
                 op = valid_positions[np.random.randint(len(valid_positions))]
             particles[i] = [rp[0], rp[1], op[0], op[1], 0.0]
 
-        # Use a representative observation
         obs_tuple = (1.5, 2.0, 1.0, 2.5, 1.5, 1.0, 2.0, 1.5)
         obs_array = np.array(obs_tuple, dtype=float)
 
-        vectorized_ll = updater_no_walls.batch_observation_log_likelihood(
-            particles, action=0, observation=obs_array
-        )
-
-        per_particle_ll = np.empty(n)
-        for i in range(n):
-            obs_model = env_no_walls.observation_model(next_state=particles[i], action=0)
+        def per_particle_ll_fn(particle, action, _observation):
+            obs_model = env_no_walls.observation_model(next_state=particle, action=action)
             prob = obs_model.probability([obs_tuple])[0]
             if prob > 0:
-                per_particle_ll[i] = np.log(prob)
-            else:
-                per_particle_ll[i] = -np.inf
+                return np.log(prob)
+            return -np.inf
 
-        # Both should be finite for non-terminal particles with
-        # reasonable observations
-        finite_mask = np.isfinite(per_particle_ll)
-        np.testing.assert_allclose(
-            vectorized_ll[finite_mask],
-            per_particle_ll[finite_mask],
-            atol=1e-10,
+        assert_batch_obs_log_likelihood_matches_loop(
+            updater=updater_no_walls,
+            particles=particles,
+            action=0,
+            observation=obs_array,
+            per_particle_ll_fn=per_particle_ll_fn,
         )
 
     def test_terminal_observation_equivalence(self, env_no_walls, updater_no_walls):

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_continuous_light_dark_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_continuous_light_dark_vectorized_updater.py
@@ -15,6 +15,10 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import (
     ContinuousLightDarkVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
+    assert_batch_obs_log_likelihood_matches_loop,
+    assert_batch_transition_matches_loop,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -227,24 +231,20 @@ class TestEquivalenceWithPerParticleLoop:
 
         Test type: integration
         """
-        n = 50
+        np.random.seed(123)
+        particles = np.random.rand(50, 2) * 10
         action = np.array([1.0, 0.5])
 
-        np.random.seed(123)
-        particles = np.random.rand(n, 2) * 10
+        def per_particle_fn(particle, act):
+            return env.state_transition_model(state=particle, action=act).sample()[0]
 
-        # Vectorized path
-        np.random.seed(999)
-        vectorized_result = updater.batch_transition(particles, action)
-
-        # Per-particle path: use the same noise generation logic
-        np.random.seed(999)
-        per_particle_result = np.empty_like(particles)
-        for i in range(n):
-            next_state = env.state_transition_model(state=particles[i], action=action).sample()[0]
-            per_particle_result[i] = next_state
-
-        np.testing.assert_allclose(vectorized_result, per_particle_result, atol=1e-10)
+        assert_batch_transition_matches_loop(
+            updater=updater,
+            particles=particles,
+            action=action,
+            per_particle_transition_fn=per_particle_fn,
+            seed=999,
+        )
 
     def test_batch_observation_log_likelihood_matches_per_particle_loop(self, env, updater):
         """Test vectorized log-likelihood matches per-particle log_pdf computation.
@@ -261,23 +261,21 @@ class TestEquivalenceWithPerParticleLoop:
         Test type: integration
         """
         np.random.seed(42)
-        n = 50
-        action = np.array([1.0, 0.0])
+        particles = np.random.rand(50, 2) * 10
         observation = np.array([5.0, 5.0])
-        particles = np.random.rand(n, 2) * 10
+        action = np.array([1.0, 0.0])
 
-        # Vectorized path
-        vectorized_ll = updater.batch_observation_log_likelihood(particles, action, observation)
+        def per_particle_ll_fn(particle, act, obs):
+            obs_model = env.observation_model(next_state=particle, action=act)
+            return obs_model._active_dist.log_pdf(np.array([obs]), particle)[0]
 
-        # Per-particle path: use log_pdf directly to avoid exp→log underflow
-        per_particle_ll = np.empty(n)
-        for i in range(n):
-            obs_model = env.observation_model(next_state=particles[i], action=action)
-            per_particle_ll[i] = obs_model._active_dist.log_pdf(
-                np.array([observation]), particles[i]
-            )[0]
-
-        np.testing.assert_allclose(vectorized_ll, per_particle_ll, atol=1e-10)
+        assert_batch_obs_log_likelihood_matches_loop(
+            updater=updater,
+            particles=particles,
+            action=action,
+            observation=observation,
+            per_particle_ll_fn=per_particle_ll_fn,
+        )
 
     def test_full_update_equivalence(self, env, updater):
         """Test that a full vectorized update matches WeightedParticleBelief._update_weights.

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
@@ -12,6 +12,10 @@ from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP
 from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp_beliefs import (
     MountainCarVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
+    assert_batch_obs_log_likelihood_matches_loop,
+    assert_batch_transition_matches_loop,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -290,23 +294,23 @@ class TestEquivalenceWithPerParticleLoop:
         Test type: integration
         """
         np.random.seed(123)
-        n = 50
         particles = np.column_stack(
             [
-                np.random.uniform(-0.6, -0.4, n),
-                np.random.uniform(-0.02, 0.02, n),
+                np.random.uniform(-0.6, -0.4, 50),
+                np.random.uniform(-0.02, 0.02, 50),
             ]
         )
-        action = 1
 
-        vectorized_result = updater.batch_transition(particles, action)
+        def per_particle_fn(particle, action):
+            transition = env.state_transition_model(state=tuple(particle), action=action)
+            return transition._compute_deterministic_next_state()
 
-        per_particle_result = np.empty_like(particles)
-        for i in range(n):
-            transition = env.state_transition_model(state=tuple(particles[i]), action=action)
-            per_particle_result[i] = transition._compute_deterministic_next_state()
-
-        np.testing.assert_allclose(vectorized_result, per_particle_result, atol=1e-10)
+        assert_batch_transition_matches_loop(
+            updater=updater,
+            particles=particles,
+            action=1,
+            per_particle_transition_fn=per_particle_fn,
+        )
 
     def test_batch_observation_log_likelihood_matches_per_particle_loop(self, env, updater):
         """Test vectorized log-likelihood matches per-particle observation_model.probability.
@@ -322,22 +326,22 @@ class TestEquivalenceWithPerParticleLoop:
         Test type: integration
         """
         np.random.seed(42)
-        n = 50
-        action = 0
-        observation = np.array([-0.5, 0.0])
         particles = np.column_stack(
             [
-                np.random.uniform(-0.6, -0.4, n),
-                np.random.uniform(-0.02, 0.02, n),
+                np.random.uniform(-0.6, -0.4, 50),
+                np.random.uniform(-0.02, 0.02, 50),
             ]
         )
+        observation = np.array([-0.5, 0.0])
 
-        vectorized_ll = updater.batch_observation_log_likelihood(particles, action, observation)
+        def per_particle_ll_fn(particle, action, obs):
+            obs_model = env.observation_model(next_state=tuple(particle), action=action)
+            return np.log(obs_model.probability([obs])[0])
 
-        per_particle_ll = np.empty(n)
-        for i in range(n):
-            obs_model = env.observation_model(next_state=tuple(particles[i]), action=action)
-            prob = obs_model.probability([observation])[0]
-            per_particle_ll[i] = np.log(prob)
-
-        np.testing.assert_allclose(vectorized_ll, per_particle_ll, atol=1e-10)
+        assert_batch_obs_log_likelihood_matches_loop(
+            updater=updater,
+            particles=particles,
+            action=0,
+            observation=observation,
+            per_particle_ll_fn=per_particle_ll_fn,
+        )

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_vectorized_updater.py
@@ -9,6 +9,10 @@ from POMDPPlanners.environments.pacman_pomdp import PacManPOMDP, PacManState
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_vectorized_updater import (
     PacManVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
+    assert_batch_obs_log_likelihood_matches_loop,
+    assert_batch_transition_matches_loop,
+)
 
 
 @pytest.fixture()
@@ -247,6 +251,81 @@ class TestBatchObservationLogLikelihood:
         obs = np.array([0.0, 1.0])
         ll = updater.batch_observation_log_likelihood(particles, 0, obs)
         assert ll[0] > ll[1]
+
+
+# ---------------------------------------------------------------------------
+# Equivalence test: vectorized vs per-particle loop
+# ---------------------------------------------------------------------------
+
+
+class TestEquivalenceWithPerParticleLoop:
+    def test_batch_transition_matches_per_particle_loop(self, simple_env, updater):
+        """Test vectorized batch_transition matches per-particle state_transition_model.
+
+        Purpose: Verifies that batch_transition produces the same results as
+                 calling the environment's state_transition_model per particle
+                 with the same random seed.
+
+        Given: A set of particles sampled from the initial distribution.
+        When: batch_transition is called, and the same transitions are computed
+              per-particle using the environment's state_transition_model.
+        Then: Results match within floating-point tolerance.
+
+        Test type: integration
+        """
+        np.random.seed(123)
+        states = simple_env.initial_state_dist().sample(n_samples=20)
+        particles = simple_env.states_to_array(states)
+
+        def per_particle_fn(particle, action):
+            next_state = simple_env.state_transition_model(state=particle, action=action).sample()[
+                0
+            ]
+            return simple_env.state_to_array(next_state)
+
+        for action in range(4):
+            assert_batch_transition_matches_loop(
+                updater=updater,
+                particles=particles,
+                action=action,
+                per_particle_transition_fn=per_particle_fn,
+                seed=999,
+                err_msg=f"Mismatch for action {action}",
+            )
+
+    def test_batch_obs_log_likelihood_matches_per_particle_loop(self, simple_env, updater):
+        """Test vectorized log-likelihood matches per-particle observation_model.probability.
+
+        Purpose: Verifies that batch_observation_log_likelihood matches the
+                 per-particle observation probability from the environment.
+
+        Given: A set of particles and a ghost observation.
+        When: batch_observation_log_likelihood is called, and per-particle
+              log(observation_model.probability) is computed.
+        Then: Results match within floating-point tolerance.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        states = simple_env.initial_state_dist().sample(n_samples=20)
+        particles = simple_env.states_to_array(states)
+        obs_array = np.array([3.0, 3.0])
+        obs_tuple = ((3, 3),)
+
+        def per_particle_ll_fn(particle, action, _observation):
+            obs_model = simple_env.observation_model(next_state=particle, action=action)
+            prob = obs_model.probability([obs_tuple])[0]
+            if prob > 0:
+                return np.log(prob)
+            return -np.inf
+
+        assert_batch_obs_log_likelihood_matches_loop(
+            updater=updater,
+            particles=particles,
+            action=0,
+            observation=obs_array,
+            per_particle_ll_fn=per_particle_ll_fn,
+        )
 
 
 class TestConfigId:

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_continuous_push_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_continuous_push_vectorized_updater.py
@@ -15,6 +15,10 @@ from POMDPPlanners.environments.push_pomdp.continuous_push_pomdp import (
 from POMDPPlanners.environments.push_pomdp.push_pomdp_beliefs.continuous_push_vectorized_updater import (
     ContinuousPushVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
+    assert_batch_obs_log_likelihood_matches_loop,
+    assert_batch_transition_matches_loop,
+)
 
 
 class TestContinuousPushVectorizedUpdater:
@@ -135,6 +139,77 @@ class TestContinuousPushVectorizedUpdater:
         )
         updater2 = ContinuousPushVectorizedUpdater.from_environment(env2)
         assert self.updater.config_id == updater2.config_id
+
+    def test_batch_transition_matches_per_particle_loop(self):
+        """Test vectorized batch_transition matches per-particle state_transition_model.
+
+        Purpose: Verifies that batch_transition produces the same results as
+                 calling the environment's state_transition_model per particle
+                 with the same random seed.
+
+        Given: A set of particles with varied positions and a continuous action.
+        When: batch_transition is called, and the same transitions are
+              computed per-particle via state_transition_model.
+        Then: Results match within floating-point tolerance.
+
+        Test type: integration
+        """
+        np.random.seed(123)
+        n = 30
+        particles = np.random.uniform(0.5, 3.5, (n, 6))
+        particles[:, 4:6] = [3.5, 3.5]
+        action = np.array([0.5, 0.3])
+
+        def per_particle_fn(particle, act):
+            return self.env.state_transition_model(state=particle, action=act).sample()[0]
+
+        assert_batch_transition_matches_loop(
+            updater=self.updater,
+            particles=particles,
+            action=action,
+            per_particle_transition_fn=per_particle_fn,
+            seed=999,
+        )
+
+    def test_batch_obs_log_likelihood_matches_per_particle_loop(self):
+        """Test vectorized log-likelihood matches per-particle observation_model.probability.
+
+        Purpose: Verifies that batch_observation_log_likelihood matches the
+                 per-particle log(observation_model.probability) from the
+                 environment.
+
+        Given: A set of particles with object positions near the observation.
+        When: batch_observation_log_likelihood is called, and per-particle
+              log-probabilities are computed.
+        Then: Results match within floating-point tolerance.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        n = 30
+        base_obj = np.array([2.0, 2.0])
+        particles = np.empty((n, 6))
+        particles[:, :2] = np.random.uniform(0.5, 3.5, (n, 2))
+        particles[:, 2:4] = base_obj + np.random.normal(0, 0.05, (n, 2))
+        particles[:, 4:6] = [3.5, 3.5]
+        observation = particles[0].copy()
+        observation[2:4] = base_obj + 0.02
+        action = np.array([0.5, 0.0])
+
+        def per_particle_ll_fn(particle, act, obs):
+            obs_model = self.env.observation_model(next_state=particle, action=act)
+            prob = obs_model.probability([obs])[0]
+            if prob > 0:
+                return np.log(prob)
+            return -np.inf
+
+        assert_batch_obs_log_likelihood_matches_loop(
+            updater=self.updater,
+            particles=particles,
+            action=action,
+            observation=observation,
+            per_particle_ll_fn=per_particle_ll_fn,
+        )
 
     def test_from_environment_discrete(self):
         """Test from_environment with discrete-action environment.

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_push_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_push_vectorized_updater.py
@@ -12,6 +12,10 @@ from POMDPPlanners.environments.push_pomdp import PushPOMDP
 from POMDPPlanners.environments.push_pomdp.push_pomdp_beliefs import (
     PushVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
+    assert_batch_obs_log_likelihood_matches_loop,
+    assert_batch_transition_matches_loop,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -437,32 +441,28 @@ class TestEquivalenceWithPerParticleLoop:
         Given: A set of particles, an integer action index, and transition_error_prob=0.
         When: batch_transition is called and the same transitions are computed
               per-particle using the environment's state_transition_model
-              (mapping int→string action).
+              (mapping int to string action).
         Then: Results match within floating-point tolerance.
 
         Test type: integration
         """
         np.random.seed(123)
-        n = 50
-        particles = np.random.uniform(1, 8, (n, 6))
-        # Fix target position columns to be consistent
+        particles = np.random.uniform(1, 8, (50, 6))
         particles[:, 4:6] = [9.0, 9.0]
 
         for action_idx in range(4):
-            vectorized_result = updater_no_obstacles.batch_transition(particles, action=action_idx)
-
-            per_particle_result = np.empty_like(particles)
             action_str = ACTION_STRINGS[action_idx]
-            for i in range(n):
-                next_state = env_no_obstacles.state_transition_model(
-                    state=particles[i], action=action_str
-                ).sample()[0]
-                per_particle_result[i] = next_state
 
-            np.testing.assert_allclose(
-                vectorized_result,
-                per_particle_result,
-                atol=1e-10,
+            def per_particle_fn(particle, _action, _str=action_str):
+                return env_no_obstacles.state_transition_model(
+                    state=particle, action=_str
+                ).sample()[0]
+
+            assert_batch_transition_matches_loop(
+                updater=updater_no_obstacles,
+                particles=particles,
+                action=action_idx,
+                per_particle_transition_fn=per_particle_fn,
                 err_msg=f"Mismatch for action {action_idx} ({action_str})",
             )
 
@@ -483,34 +483,29 @@ class TestEquivalenceWithPerParticleLoop:
         Test type: integration
         """
         np.random.seed(42)
-        n = 50
         action_idx = 2
         action_str = ACTION_STRINGS[action_idx]
 
-        # Keep object positions close to avoid underflow: the env computes
-        # exp(…) then we take log, which fails when exp underflows to 0.
         base_obj = np.array([4.0, 4.0])
-        particles = np.empty((n, 6))
-        particles[:, :2] = np.random.uniform(1, 8, (n, 2))
-        particles[:, 2:4] = base_obj + np.random.normal(0, 0.05, (n, 2))
+        particles = np.empty((50, 6))
+        particles[:, :2] = np.random.uniform(1, 8, (50, 2))
+        particles[:, 2:4] = base_obj + np.random.normal(0, 0.05, (50, 2))
         particles[:, 4:6] = [9.0, 9.0]
 
         observation = particles[0].copy()
         observation[2:4] = base_obj + 0.02
 
-        vectorized_ll = updater_no_obstacles.batch_observation_log_likelihood(
-            particles, action=action_idx, observation=observation
+        def per_particle_ll_fn(particle, _action, obs):
+            obs_model = env_no_obstacles.observation_model(next_state=particle, action=action_str)
+            return np.log(obs_model.probability([obs])[0])
+
+        assert_batch_obs_log_likelihood_matches_loop(
+            updater=updater_no_obstacles,
+            particles=particles,
+            action=action_idx,
+            observation=observation,
+            per_particle_ll_fn=per_particle_ll_fn,
         )
-
-        per_particle_ll = np.empty(n)
-        for i in range(n):
-            obs_model = env_no_obstacles.observation_model(
-                next_state=particles[i], action=action_str
-            )
-            prob = obs_model.probability([observation])[0]
-            per_particle_ll[i] = np.log(prob)
-
-        np.testing.assert_allclose(vectorized_ll, per_particle_ll, atol=1e-10)
 
     def test_batch_transition_with_obstacles_matches_per_particle(self, env, updater):
         """Test vectorized transition with obstacles matches per-particle loop.
@@ -525,24 +520,19 @@ class TestEquivalenceWithPerParticleLoop:
         Test type: integration
         """
         np.random.seed(77)
-        n = 50
-        particles = np.random.uniform(0, 9, (n, 6))
+        particles = np.random.uniform(0, 9, (50, 6))
         particles[:, 4:6] = [9.0, 9.0]
 
         for action_idx in range(4):
-            vectorized_result = updater.batch_transition(particles, action=action_idx)
-
-            per_particle_result = np.empty_like(particles)
             action_str = ACTION_STRINGS[action_idx]
-            for i in range(n):
-                next_state = env.state_transition_model(
-                    state=particles[i], action=action_str
-                ).sample()[0]
-                per_particle_result[i] = next_state
 
-            np.testing.assert_allclose(
-                vectorized_result,
-                per_particle_result,
-                atol=1e-10,
+            def per_particle_fn(particle, _action, _str=action_str):
+                return env.state_transition_model(state=particle, action=_str).sample()[0]
+
+            assert_batch_transition_matches_loop(
+                updater=updater,
+                particles=particles,
+                action=action_idx,
+                per_particle_transition_fn=per_particle_fn,
                 err_msg=f"Obstacle mismatch for action {action_idx} ({action_str})",
             )

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_vectorized_updater.py
@@ -10,6 +10,10 @@ from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rock
     OBS_NONE,
     RockSampleVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
+    assert_batch_obs_log_likelihood_matches_loop,
+    assert_batch_transition_matches_loop,
+)
 
 
 @pytest.fixture()
@@ -399,6 +403,85 @@ class TestBatchObservationLogLikelihood:
             sample_particles, np.array(5), np.array(OBS_NONE)
         )
         assert np.all(np.isneginf(log_ll))
+
+
+# ---------------------------------------------------------------------------
+# Equivalence test: vectorized vs per-particle loop
+# ---------------------------------------------------------------------------
+
+
+class TestEquivalenceWithPerParticleLoop:
+    def test_batch_transition_matches_per_particle_loop(self, simple_env, updater):
+        """Test vectorized batch_transition matches per-particle state_transition_model.
+
+        Purpose: Verifies that batch_transition produces the same results as
+                 calling the environment's state_transition_model per particle.
+
+        Given: A set of particles sampled from the initial distribution.
+        When: batch_transition is called for movement, sample, and check actions,
+              and the same transitions are computed per-particle.
+        Then: Results match exactly (deterministic transitions).
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        states = simple_env.initial_state_dist().sample(n_samples=50)
+        particles = np.stack(states)
+
+        def per_particle_fn(particle, action):
+            return simple_env.state_transition_model(state=particle, action=action).sample()[0]
+
+        for action in [0, 1, 2, 3, 4, 5, 6]:  # Sample, N, E, S, W, Check0, Check1
+            assert_batch_transition_matches_loop(
+                updater=updater,
+                particles=particles,
+                action=action,
+                per_particle_transition_fn=per_particle_fn,
+                err_msg=f"Mismatch for action {action}",
+            )
+
+    def test_batch_obs_log_likelihood_matches_per_particle_loop(self, simple_env, updater):
+        """Test vectorized log-likelihood matches per-particle observation_model.probability.
+
+        Purpose: Verifies that batch_observation_log_likelihood matches the
+                 per-particle observation probability from the environment.
+
+        Given: A set of particles and a sensor observation.
+        When: batch_observation_log_likelihood is called, and per-particle
+              log(observation_model.probability) is computed.
+        Then: Results match within floating-point tolerance.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        states = simple_env.initial_state_dist().sample(n_samples=50)
+        particles = np.stack(states)
+
+        def per_particle_ll_fn(particle, action, obs):
+            obs_model = simple_env.observation_model(next_state=particle, action=action)
+            obs_str = {OBS_NONE: "none", OBS_GOOD: "good", OBS_BAD: "bad"}[int(obs)]
+            prob = obs_model.probability([obs_str])[0]
+            if prob > 0:
+                return np.log(prob)
+            return -np.inf
+
+        # Check rock 0 with "good" observation
+        assert_batch_obs_log_likelihood_matches_loop(
+            updater=updater,
+            particles=particles,
+            action=5,
+            observation=np.array(OBS_GOOD),
+            per_particle_ll_fn=per_particle_ll_fn,
+        )
+
+        # Check rock 1 with "bad" observation
+        assert_batch_obs_log_likelihood_matches_loop(
+            updater=updater,
+            particles=particles,
+            action=6,
+            observation=np.array(OBS_BAD),
+            per_particle_ll_fn=per_particle_ll_fn,
+        )
 
 
 class TestConfigId:

--- a/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp_beliefs/test_safety_ant_velocity_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp_beliefs/test_safety_ant_velocity_vectorized_updater.py
@@ -14,6 +14,10 @@ from POMDPPlanners.environments.safety_ant_velocity_pomdp import (
 from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_pomdp_beliefs import (
     SafetyAntVelocityVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
+    assert_batch_obs_log_likelihood_matches_loop,
+    assert_batch_transition_matches_loop,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -301,27 +305,23 @@ class TestEquivalenceWithPerParticleLoop:
         Test type: integration
         """
         np.random.seed(123)
-        n = 50
         particles = np.column_stack(
             [
-                np.random.uniform(-1, 1, (n, 2)),
-                np.random.uniform(-0.5, 0.5, (n, 2)),
+                np.random.uniform(-1, 1, (50, 2)),
+                np.random.uniform(-0.5, 0.5, (50, 2)),
             ]
         )
-        action = 2
 
-        # Vectorized path
-        np.random.seed(999)
-        vectorized_result = updater.batch_transition(particles, action)
+        def per_particle_fn(particle, action):
+            return env.state_transition_model(state=particle, action=action).sample()[0]
 
-        # Per-particle path: same random seed, same noise sequence
-        np.random.seed(999)
-        per_particle_result = np.empty_like(particles)
-        for i in range(n):
-            next_state = env.state_transition_model(state=particles[i], action=action).sample()[0]
-            per_particle_result[i] = next_state
-
-        np.testing.assert_allclose(vectorized_result, per_particle_result, atol=1e-10)
+        assert_batch_transition_matches_loop(
+            updater=updater,
+            particles=particles,
+            action=2,
+            per_particle_transition_fn=per_particle_fn,
+            seed=999,
+        )
 
     def test_batch_observation_log_likelihood_matches_per_particle_loop(self, env, updater):
         """Test vectorized log-likelihood matches per-particle observation probability up to constant.
@@ -342,27 +342,23 @@ class TestEquivalenceWithPerParticleLoop:
         Test type: integration
         """
         np.random.seed(42)
-        n = 50
-        action = 1
-        observation = np.array([0.1, -0.1, 0.5, 0.2])
         particles = np.column_stack(
             [
-                np.random.uniform(-1, 1, (n, 2)),
-                np.random.uniform(-0.5, 0.5, (n, 2)),
+                np.random.uniform(-1, 1, (50, 2)),
+                np.random.uniform(-0.5, 0.5, (50, 2)),
             ]
         )
+        observation = np.array([0.1, -0.1, 0.5, 0.2])
 
-        vectorized_ll = updater.batch_observation_log_likelihood(particles, action, observation)
+        def per_particle_ll_fn(particle, action, obs):
+            obs_model = env.observation_model(next_state=particle, action=action)
+            return np.log(obs_model.probability([obs])[0])
 
-        per_particle_ll = np.empty(n)
-        for i in range(n):
-            obs_model = env.observation_model(next_state=particles[i], action=action)
-            prob = obs_model.probability([observation])[0]
-            per_particle_ll[i] = np.log(prob)
-
-        # The environment's probability() omits the Gaussian normalisation
-        # constant, so the two arrays differ by a constant offset.  Compare
-        # pairwise differences to verify the relative structure is identical.
-        vectorized_diff = vectorized_ll - vectorized_ll[0]
-        per_particle_diff = per_particle_ll - per_particle_ll[0]
-        np.testing.assert_allclose(vectorized_diff, per_particle_diff, atol=1e-10)
+        assert_batch_obs_log_likelihood_matches_loop(
+            updater=updater,
+            particles=particles,
+            action=1,
+            observation=observation,
+            per_particle_ll_fn=per_particle_ll_fn,
+            compare_mode="pairwise_diff",
+        )


### PR DESCRIPTION
## Summary
- Create shared test utility (`vectorized_updater_test_utils.py`) with reusable `assert_batch_transition_matches_loop` and `assert_batch_obs_log_likelihood_matches_loop` functions
- Add missing comparison tests for PacMan, Continuous LaserTag, and Continuous Push vectorized updaters
- Refactor existing comparison tests across 7 environments (CartPole, MountainCar, LaserTag, Push, ContinuousLightDark, SafetyAntVelocity, RockSample) to use the shared utilities

## Test plan
- [x] All 175 tests in modified files pass
- [x] Pyright: 0 errors, 0 warnings
- [x] Pylint: 9.82/10 (no new warnings)
- [x] Pre-commit hooks (black, pyright) pass