### PR TITLE
Add observation-model-aware vectorized belief updaters for LightDark

### DIFF
--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_beliefs/__init__.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_beliefs/__init__.py
@@ -1,5 +1,12 @@
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs.continuous_light_dark_vectorized_updater import (
+    ContinuousLightDarkDistanceBasedVectorizedUpdater,
+    ContinuousLightDarkNoObsInDarkVectorizedUpdater,
     ContinuousLightDarkVectorizedUpdater,
+)
+from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs.discrete_light_dark_vectorized_updater import (
+    DiscreteLightDarkDistanceBasedVectorizedUpdater,
+    DiscreteLightDarkNoObsInDarkVectorizedUpdater,
+    DiscreteLightDarkVectorizedUpdater,
 )
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs.continuous_light_dark_gaussian_beliefs import (
     GaussianBeliefUpdaterType,
@@ -8,10 +15,19 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs.contin
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs.continuous_light_dark_belief_factory import (
     create_continuous_light_dark_belief,
 )
+from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs.discrete_light_dark_belief_factory import (
+    create_discrete_light_dark_belief,
+)
 
 __all__ = [
     "ContinuousLightDarkVectorizedUpdater",
+    "ContinuousLightDarkNoObsInDarkVectorizedUpdater",
+    "ContinuousLightDarkDistanceBasedVectorizedUpdater",
+    "DiscreteLightDarkVectorizedUpdater",
+    "DiscreteLightDarkNoObsInDarkVectorizedUpdater",
+    "DiscreteLightDarkDistanceBasedVectorizedUpdater",
     "GaussianBeliefUpdaterType",
     "create_continuous_light_dark_gaussian_belief",
     "create_continuous_light_dark_belief",
+    "create_discrete_light_dark_belief",
 ]

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_beliefs/continuous_light_dark_belief_factory.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_beliefs/continuous_light_dark_belief_factory.py
@@ -19,7 +19,12 @@ from POMDPPlanners.core.belief.belief_utils import get_initial_belief
 from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
     VectorizedWeightedParticleBelief,
 )
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ObservationModelType,
+)
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs.continuous_light_dark_vectorized_updater import (
+    ContinuousLightDarkDistanceBasedVectorizedUpdater,
+    ContinuousLightDarkNoObsInDarkVectorizedUpdater,
     ContinuousLightDarkVectorizedUpdater,
 )
 from POMDPPlanners.utils.belief_factory import BeliefType
@@ -97,8 +102,16 @@ def _create_gaussian_belief(env: "ContinuousLightDarkPOMDP", **kwargs: Any) -> "
     )
 
 
+_CONTINUOUS_UPDATER_MAP = {
+    ObservationModelType.NORMAL_NOISE: ContinuousLightDarkVectorizedUpdater,
+    ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK: ContinuousLightDarkNoObsInDarkVectorizedUpdater,
+    ObservationModelType.DISTANCE_BASED: ContinuousLightDarkDistanceBasedVectorizedUpdater,
+}
+
+
 def _create_vectorized_belief(env: "ContinuousLightDarkPOMDP", n_particles: int) -> "Belief":
-    updater = ContinuousLightDarkVectorizedUpdater.from_environment(env)
+    updater_cls = _CONTINUOUS_UPDATER_MAP[env.observation_model_type]
+    updater = updater_cls.from_environment(env)
     particles = np.array(env.initial_state_dist().sample(n_samples=n_particles))
     log_weights = np.log(np.ones(n_particles) / n_particles)
     return VectorizedWeightedParticleBelief(particles, log_weights, updater)

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_beliefs/continuous_light_dark_vectorized_updater.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_beliefs/continuous_light_dark_vectorized_updater.py
@@ -1,24 +1,34 @@
-"""Vectorized particle belief updater for the Continuous Light-Dark POMDP.
+"""Vectorized particle belief updaters for the Continuous Light-Dark POMDP.
 
-This module implements a concrete
+This module implements concrete
 :class:`~POMDPPlanners.core.belief.vectorized_particle_belief_updater.VectorizedParticleBeliefUpdater`
-that performs batched state transitions and observation log-likelihood
-evaluations for the Continuous Light-Dark environment, replacing
-per-particle Python loops with NumPy array operations.
+subclasses that perform batched state transitions and observation
+log-likelihood evaluations for the Continuous Light-Dark environment,
+replacing per-particle Python loops with NumPy array operations.
 
 Because the state dimension is always 2, all linear-algebra operations
 (Cholesky sampling, Mahalanobis distance, beacon distance) are expanded
 into closed-form scalar arithmetic at init time, avoiding per-call
 ``solve_triangular`` / ``np.linalg.norm`` dispatch overhead.
 
+Three updaters correspond to the three
+:class:`~POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp.ObservationModelType`
+variants:
+
 Classes:
-    ContinuousLightDarkVectorizedUpdater: Batched updater for the
-        Continuous Light-Dark POMDP.
+    ContinuousLightDarkVectorizedUpdater: ``NORMAL_NOISE`` — always
+        returns Gaussian log-likelihoods with binary near/far noise.
+    ContinuousLightDarkNoObsInDarkVectorizedUpdater:
+        ``NORMAL_NOISE_NO_OBS_IN_DARK`` — handles ``"None"``
+        observations when far from beacons.
+    ContinuousLightDarkDistanceBasedVectorizedUpdater:
+        ``DISTANCE_BASED`` — handles ``"None"`` observations when
+        beyond beacon radius.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import numpy as np
 
@@ -176,20 +186,7 @@ class ContinuousLightDarkVectorizedUpdater(VectorizedParticleBeliefUpdater):
 
     @property
     def config_id(self) -> str:
-        config_dict = {
-            "class": "ContinuousLightDarkVectorizedUpdater",
-            "state_transition_cov": self.state_transition_dist.covariance.tolist(),
-            "obs_cov_near": self.obs_dist_near_beacon.covariance.tolist(),
-            "obs_cov_far": self.obs_dist_far_from_beacon.covariance.tolist(),
-            "beacons": self.beacons.tolist(),
-            "beacon_radius": self.beacon_radius,
-            "grid_size": self.grid_size,
-        }
-        if self._action_to_vector is not None:
-            config_dict["action_to_vector"] = {
-                k: v.tolist() for k, v in self._action_to_vector.items()
-            }
-        return config_to_id(config_dict)
+        return config_to_id(self._build_config_dict("ContinuousLightDarkVectorizedUpdater"))
 
     # ------------------------------------------------------------------
     # Private helpers — pre-computation
@@ -240,3 +237,170 @@ class ContinuousLightDarkVectorizedUpdater(VectorizedParticleBeliefUpdater):
         by = py[:, np.newaxis] - self._beacon_y
         sq_distances = bx**2 + by**2
         return sq_distances.min(axis=1) <= self.beacon_radius_sq
+
+    # ------------------------------------------------------------------
+    # Config-id helpers used by subclasses
+    # ------------------------------------------------------------------
+
+    def _build_config_dict(self, class_name: str) -> dict:
+        config_dict: dict = {
+            "class": class_name,
+            "state_transition_cov": self.state_transition_dist.covariance.tolist(),
+            "obs_cov_near": self.obs_dist_near_beacon.covariance.tolist(),
+            "obs_cov_far": self.obs_dist_far_from_beacon.covariance.tolist(),
+            "beacons": self.beacons.tolist(),
+            "beacon_radius": self.beacon_radius,
+            "grid_size": self.grid_size,
+        }
+        if self._action_to_vector is not None:
+            config_dict["action_to_vector"] = {
+                k: v.tolist() for k, v in self._action_to_vector.items()
+            }
+        return config_dict
+
+
+class ContinuousLightDarkNoObsInDarkVectorizedUpdater(
+    ContinuousLightDarkVectorizedUpdater,
+):
+    """Vectorized updater for the ``NORMAL_NOISE_NO_OBS_IN_DARK`` observation model.
+
+    Particles far from all beacons receive ``"None"`` observations
+    (log-likelihood 0 for ``"None"``, ``-inf`` for any array observation).
+    Particles near a beacon use the near-beacon Gaussian distribution.
+
+    Inherits transition logic and all precomputation from
+    :class:`ContinuousLightDarkVectorizedUpdater`.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(42)
+        >>> from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+        ...     ContinuousLightDarkPOMDP, ObservationModelType,
+        ... )
+        >>> env = ContinuousLightDarkPOMDP(
+        ...     discount_factor=0.95,
+        ...     observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK,
+        ... )
+        >>> updater = ContinuousLightDarkNoObsInDarkVectorizedUpdater.from_environment(env)
+        >>> particles = np.random.rand(50, 2) * 10
+        >>> action = np.array([1.0, 0.0])
+        >>> next_p = updater.batch_transition(particles, action)
+        >>> ll = updater.batch_observation_log_likelihood(next_p, action, "None")
+        >>> ll.shape
+        (50,)
+    """
+
+    def batch_observation_log_likelihood(
+        self,
+        next_particles: np.ndarray,
+        action: np.ndarray,  # noqa: ARG002
+        observation: Union[np.ndarray, str],
+    ) -> np.ndarray:
+        px = next_particles[:, 0]
+        py = next_particles[:, 1]
+        near_mask = self._batch_near_beacon_scalar(px, py)
+
+        if isinstance(observation, str):
+            return np.where(near_mask, -np.inf, 0.0)
+
+        # For array observations, use the active distribution (near or far)
+        # matching the non-vectorized model's behavior.
+        return self._log_lik_near_far(px, py, near_mask, observation)
+
+    @property
+    def config_id(self) -> str:
+        return config_to_id(
+            self._build_config_dict("ContinuousLightDarkNoObsInDarkVectorizedUpdater")
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _log_lik_near_far(
+        self,
+        px: np.ndarray,
+        py: np.ndarray,
+        near_mask: np.ndarray,
+        observation: np.ndarray,
+    ) -> np.ndarray:
+        obs = np.asarray(observation, dtype=float).ravel()
+        dx = px - obs[0]
+        dy = py - obs[1]
+        maha_near = (
+            self._obs_near_P00 * dx**2 + self._obs_near_2P01 * dx * dy + self._obs_near_P11 * dy**2
+        )
+        maha_far = (
+            self._obs_far_P00 * dx**2 + self._obs_far_2P01 * dx * dy + self._obs_far_P11 * dy**2
+        )
+        return np.where(
+            near_mask,
+            self._obs_near_log_norm - 0.5 * maha_near,
+            self._obs_far_log_norm - 0.5 * maha_far,
+        )
+
+
+class ContinuousLightDarkDistanceBasedVectorizedUpdater(
+    ContinuousLightDarkVectorizedUpdater,
+):
+    """Vectorized updater for the ``DISTANCE_BASED`` observation model.
+
+    Unlike :class:`ContinuousLightDarkNoObsInDarkVectorizedUpdater`,
+    this model assigns probability 0 (``-inf`` in log space) to array
+    observations when the particle is beyond ``beacon_radius`` from all
+    beacons, matching the non-vectorized
+    :class:`ContinuousLightDarkDistanceBasedObservationModel` behaviour.
+
+    Inherits transition logic from
+    :class:`ContinuousLightDarkVectorizedUpdater`.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(42)
+        >>> from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+        ...     ContinuousLightDarkPOMDP, ObservationModelType,
+        ... )
+        >>> env = ContinuousLightDarkPOMDP(
+        ...     discount_factor=0.95,
+        ...     observation_model_type=ObservationModelType.DISTANCE_BASED,
+        ... )
+        >>> updater = ContinuousLightDarkDistanceBasedVectorizedUpdater.from_environment(env)
+        >>> particles = np.random.rand(50, 2) * 10
+        >>> action = np.array([1.0, 0.0])
+        >>> next_p = updater.batch_transition(particles, action)
+        >>> ll = updater.batch_observation_log_likelihood(next_p, action, "None")
+        >>> ll.shape
+        (50,)
+    """
+
+    def batch_observation_log_likelihood(
+        self,
+        next_particles: np.ndarray,
+        action: np.ndarray,  # noqa: ARG002
+        observation: Union[np.ndarray, str],
+    ) -> np.ndarray:
+        px = next_particles[:, 0]
+        py = next_particles[:, 1]
+        near_mask = self._batch_near_beacon_scalar(px, py)
+
+        if isinstance(observation, str):
+            return np.where(near_mask, -np.inf, 0.0)
+
+        # Array observations: near-beacon uses near dist, far returns -inf
+        obs = np.asarray(observation, dtype=float).ravel()
+        dx = px - obs[0]
+        dy = py - obs[1]
+        maha_near = (
+            self._obs_near_P00 * dx**2 + self._obs_near_2P01 * dx * dy + self._obs_near_P11 * dy**2
+        )
+        return np.where(
+            near_mask,
+            self._obs_near_log_norm - 0.5 * maha_near,
+            -np.inf,
+        )
+
+    @property
+    def config_id(self) -> str:
+        return config_to_id(
+            self._build_config_dict("ContinuousLightDarkDistanceBasedVectorizedUpdater")
+        )

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_beliefs/discrete_light_dark_belief_factory.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_beliefs/discrete_light_dark_belief_factory.py
@@ -1,0 +1,87 @@
+"""Belief factory for the Discrete Light-Dark POMDP.
+
+Functions:
+    create_discrete_light_dark_belief: Factory producing a configured belief
+        for DiscreteLightDarkPOMDP.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from POMDPPlanners.core.belief.belief_utils import get_initial_belief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
+    ObservationModelType,
+)
+from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs.discrete_light_dark_vectorized_updater import (
+    DiscreteLightDarkDistanceBasedVectorizedUpdater,
+    DiscreteLightDarkNoObsInDarkVectorizedUpdater,
+    DiscreteLightDarkVectorizedUpdater,
+)
+from POMDPPlanners.utils.belief_factory import BeliefType
+
+if TYPE_CHECKING:
+    from POMDPPlanners.core.belief.base_belief import Belief
+    from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
+        DiscreteLightDarkPOMDP,
+    )
+
+_SUPPORTED_TYPES = {
+    BeliefType.PARTICLE,
+    BeliefType.VECTORIZED_PARTICLE,
+}
+_DEFAULT_TYPE = BeliefType.VECTORIZED_PARTICLE
+
+_DISCRETE_UPDATER_MAP = {
+    ObservationModelType.NORMAL: DiscreteLightDarkVectorizedUpdater,
+    ObservationModelType.NO_OBS_IN_DARK: DiscreteLightDarkNoObsInDarkVectorizedUpdater,
+    ObservationModelType.DISTANCE_BASED: DiscreteLightDarkDistanceBasedVectorizedUpdater,
+}
+
+
+def create_discrete_light_dark_belief(  # pylint: disable=unused-argument
+    env: "DiscreteLightDarkPOMDP",
+    belief_type: BeliefType = _DEFAULT_TYPE,
+    n_particles: int = 200,
+    **kwargs: Any,
+) -> "Belief":
+    """Create a ready-to-use belief for the Discrete Light-Dark POMDP.
+
+    Args:
+        env: DiscreteLightDarkPOMDP environment instance.
+        belief_type: Desired belief representation.
+            Defaults to ``BeliefType.VECTORIZED_PARTICLE``.
+        n_particles: Number of particles.  Defaults to 200.
+        **kwargs: Reserved for future use; kept for interface compatibility.
+
+    Returns:
+        A configured :class:`Belief` object.
+
+    Raises:
+        ValueError: If *belief_type* is not supported.
+    """
+    if belief_type not in _SUPPORTED_TYPES:
+        raise ValueError(
+            f"DiscreteLightDarkPOMDP does not support {belief_type}. "
+            f"Supported: {_SUPPORTED_TYPES}"
+        )
+    if belief_type == BeliefType.PARTICLE:
+        return _create_particle_belief(env, n_particles)
+    return _create_vectorized_belief(env, n_particles)
+
+
+def _create_particle_belief(env: "DiscreteLightDarkPOMDP", n_particles: int) -> "Belief":
+    return get_initial_belief(env, n_particles)
+
+
+def _create_vectorized_belief(env: "DiscreteLightDarkPOMDP", n_particles: int) -> "Belief":
+    updater_cls = _DISCRETE_UPDATER_MAP[env.observation_model_type]
+    updater = updater_cls.from_environment(env)
+    particles = np.array(env.initial_state_dist().sample(n_samples=n_particles), dtype=float)
+    log_weights = np.log(np.ones(n_particles) / n_particles)
+    return VectorizedWeightedParticleBelief(particles, log_weights, updater)

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_beliefs/discrete_light_dark_vectorized_updater.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_beliefs/discrete_light_dark_vectorized_updater.py
@@ -1,0 +1,412 @@
+"""Vectorized particle belief updaters for the Discrete Light-Dark POMDP.
+
+This module implements concrete
+:class:`~POMDPPlanners.core.belief.vectorized_particle_belief_updater.VectorizedParticleBeliefUpdater`
+subclasses that perform batched state transitions and observation
+log-likelihood evaluations for the Discrete Light-Dark environment,
+replacing per-particle Python loops with NumPy array operations.
+
+Three updaters correspond to the three
+:class:`~POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp.ObservationModelType`
+variants:
+
+Classes:
+    DiscreteLightDarkVectorizedUpdater: ``NORMAL`` — discrete
+        observations with binary near/far error factor.
+    DiscreteLightDarkNoObsInDarkVectorizedUpdater:
+        ``NO_OBS_IN_DARK`` — returns ``"None"`` when far from beacons.
+    DiscreteLightDarkDistanceBasedVectorizedUpdater:
+        ``DISTANCE_BASED`` — per-particle linear error scaling by
+        distance to nearest beacon.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Union
+
+import numpy as np
+
+from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
+    VectorizedParticleBeliefUpdater,
+)
+from POMDPPlanners.utils.config_to_id import config_to_id
+
+if TYPE_CHECKING:
+    from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
+        DiscreteLightDarkPOMDP,
+    )
+
+
+class DiscreteLightDarkVectorizedUpdater(VectorizedParticleBeliefUpdater):
+    """Vectorized particle belief updater for the Discrete Light-Dark POMDP.
+
+    Performs all-particle transitions and observation log-likelihood
+    evaluations using vectorized NumPy operations.  The transition is
+    stochastic: the intended action executes with probability
+    ``1 - transition_error_prob`` and a uniformly random other action
+    executes otherwise.
+
+    Attributes:
+        transition_error_prob: Probability of executing a random action.
+        observation_error_prob: Base observation error probability.
+        beacons: Beacon positions as a (2, n_beacons) array.
+        beacon_radius: Distance threshold for beacon proximity.
+        grid_size: Grid boundary for the environment.
+        actions: List of action names.
+        action_to_vector: Mapping from action names to direction vectors.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(42)
+        >>> from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
+        ...     DiscreteLightDarkPOMDP,
+        ... )
+        >>> env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+        >>> updater = DiscreteLightDarkVectorizedUpdater.from_environment(env)
+        >>> particles = np.array([[5, 5], [3, 3], [7, 7]], dtype=float)
+        >>> next_p = updater.batch_transition(particles, "right")
+        >>> next_p.shape
+        (3, 2)
+        >>> obs = np.array([6, 5])
+        >>> ll = updater.batch_observation_log_likelihood(next_p, "right", obs)
+        >>> ll.shape
+        (3,)
+    """
+
+    def __init__(
+        self,
+        transition_error_prob: float,
+        observation_error_prob: float,
+        beacons: np.ndarray,
+        beacon_radius: float,
+        grid_size: int,
+        actions: List[str],
+        action_to_vector: Dict[str, np.ndarray],
+    ):
+        """Initialize the vectorized updater.
+
+        Args:
+            transition_error_prob: Probability of executing a random action.
+            observation_error_prob: Base observation error probability.
+            beacons: Beacon positions as a (2, n_beacons) array.
+            beacon_radius: Distance threshold for near-beacon classification.
+            grid_size: Grid boundary used by the environment.
+            actions: Ordered list of action names.
+            action_to_vector: Mapping from action name to 2-D direction vector.
+        """
+        self.transition_error_prob = transition_error_prob
+        self.observation_error_prob = observation_error_prob
+        self.beacons = np.asarray(beacons, dtype=float)
+        self.beacon_radius = beacon_radius
+        self.beacon_radius_sq = beacon_radius * beacon_radius
+        self.grid_size = grid_size
+        self.actions = actions
+        self.action_to_vector = action_to_vector
+
+        self._precompute_tables()
+
+    @classmethod
+    def from_environment(
+        cls, env: "DiscreteLightDarkPOMDP"
+    ) -> "DiscreteLightDarkVectorizedUpdater":
+        """Construct an updater from a DiscreteLightDarkPOMDP instance.
+
+        Args:
+            env: Environment to extract parameters from.
+
+        Returns:
+            A new updater instance of the called class.
+        """
+        return cls(
+            transition_error_prob=env.transition_error_prob,
+            observation_error_prob=env.observation_error_prob,
+            beacons=env.beacons,
+            beacon_radius=env.beacon_radius,
+            grid_size=env.grid_size,
+            actions=list(env.actions),
+            action_to_vector={k: v.copy() for k, v in env.action_to_vector.items()},
+        )
+
+    # ------------------------------------------------------------------
+    # VectorizedParticleBeliefUpdater interface
+    # ------------------------------------------------------------------
+
+    def batch_transition(self, particles: np.ndarray, action: np.ndarray) -> np.ndarray:
+        action_str = action if isinstance(action, str) else str(action)
+        intended_idx = self.actions.index(action_str)
+        n = particles.shape[0]
+
+        error_mask = np.random.random(n) < self.transition_error_prob
+        chosen = np.full(n, intended_idx, dtype=int)
+
+        error_count = int(error_mask.sum())
+        if error_count > 0:
+            other = [i for i in range(self._n_actions) if i != intended_idx]
+            chosen[error_mask] = np.random.choice(other, size=error_count)
+
+        return particles + self._action_vectors_matrix[chosen]
+
+    def batch_observation_log_likelihood(
+        self,
+        next_particles: np.ndarray,
+        action: np.ndarray,  # noqa: ARG002
+        observation: Union[np.ndarray, str],
+    ) -> np.ndarray:
+        px = next_particles[:, 0]
+        py = next_particles[:, 1]
+        near_mask = self._batch_near_beacon(px, py)
+
+        obs = np.asarray(observation, dtype=float).ravel()
+        matched_idx = self._match_observation_offset(next_particles, obs)
+
+        log_probs = np.full(next_particles.shape[0], -np.inf)
+        for j in range(self._n_obs):
+            mask_j = matched_idx == j
+            if not np.any(mask_j):
+                continue
+            log_probs[mask_j & near_mask] = self._obs_log_probs_near[j]
+            log_probs[mask_j & ~near_mask] = self._obs_log_probs_far[j]
+
+        return log_probs
+
+    @property
+    def config_id(self) -> str:
+        return config_to_id(self._build_config_dict("DiscreteLightDarkVectorizedUpdater"))
+
+    # ------------------------------------------------------------------
+    # Pre-computation
+    # ------------------------------------------------------------------
+
+    def _precompute_tables(self):
+        self._n_actions = len(self.actions)
+        self._n_obs = self._n_actions + 1
+
+        # Action vectors as matrix for fast indexing
+        self._action_vectors_matrix = np.array(
+            [self.action_to_vector[a] for a in self.actions], dtype=float
+        )
+
+        # Observation offsets: 4 directional + identity (exact match)
+        self._obs_offsets = np.vstack([self._action_vectors_matrix, np.zeros((1, 2))])
+
+        # Near-beacon observation log probabilities (error_factor = 0.2)
+        near_error = self.observation_error_prob * 0.2
+        near_probs = np.ones(self._n_obs) * (near_error / (self._n_obs - 1))
+        near_probs[-1] = 1.0 - near_error
+        self._obs_log_probs_near = np.log(near_probs)
+
+        # Far-from-beacon observation log probabilities (error_factor = 1.0)
+        far_error = self.observation_error_prob * 1.0
+        far_probs = np.ones(self._n_obs) * (far_error / (self._n_obs - 1))
+        far_probs[-1] = 1.0 - far_error
+        self._obs_log_probs_far = np.log(far_probs)
+
+        # Beacon arrays for vectorized distance computation
+        self._beacon_x = np.ascontiguousarray(self.beacons[0])
+        self._beacon_y = np.ascontiguousarray(self.beacons[1])
+
+    # ------------------------------------------------------------------
+    # Runtime helpers
+    # ------------------------------------------------------------------
+
+    def _batch_near_beacon(self, px: np.ndarray, py: np.ndarray) -> np.ndarray:
+        bx = px[:, np.newaxis] - self._beacon_x
+        by = py[:, np.newaxis] - self._beacon_y
+        sq_distances = bx**2 + by**2
+        return sq_distances.min(axis=1) < self.beacon_radius_sq
+
+    def _batch_min_distance_to_beacon(self, px: np.ndarray, py: np.ndarray) -> np.ndarray:
+        bx = px[:, np.newaxis] - self._beacon_x
+        by = py[:, np.newaxis] - self._beacon_y
+        sq_distances = bx**2 + by**2
+        return np.sqrt(sq_distances.min(axis=1))
+
+    def _match_observation_offset(self, next_particles: np.ndarray, obs: np.ndarray) -> np.ndarray:
+        diff = obs - next_particles  # (N, 2)
+        # Compare against each of the n_obs offsets
+        # offsets: (n_obs, 2), diff: (N, 2)
+        matches = np.all(
+            np.abs(diff[:, np.newaxis, :] - self._obs_offsets[np.newaxis, :, :]) < 1e-9,
+            axis=2,
+        )  # (N, n_obs)
+        # For each particle, find which offset matched (or -1 if none)
+        any_match = matches.any(axis=1)
+        result = np.full(next_particles.shape[0], -1, dtype=int)
+        result[any_match] = matches[any_match].argmax(axis=1)
+        return result
+
+    def _build_config_dict(self, class_name: str) -> dict:
+        return {
+            "class": class_name,
+            "transition_error_prob": self.transition_error_prob,
+            "observation_error_prob": self.observation_error_prob,
+            "beacons": self.beacons.tolist(),
+            "beacon_radius": self.beacon_radius,
+            "grid_size": self.grid_size,
+            "actions": self.actions,
+            "action_to_vector": {k: v.tolist() for k, v in self.action_to_vector.items()},
+        }
+
+
+class DiscreteLightDarkNoObsInDarkVectorizedUpdater(
+    DiscreteLightDarkVectorizedUpdater,
+):
+    """Vectorized updater for the ``NO_OBS_IN_DARK`` discrete observation model.
+
+    Particles far from all beacons receive ``"None"`` observations
+    (log-likelihood 0 for ``"None"``, ``-inf`` for any array observation).
+    Particles near a beacon use the near-beacon discrete distribution.
+
+    Inherits transition logic and precomputation from
+    :class:`DiscreteLightDarkVectorizedUpdater`.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(42)
+        >>> from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
+        ...     DiscreteLightDarkPOMDP, ObservationModelType,
+        ... )
+        >>> env = DiscreteLightDarkPOMDP(
+        ...     discount_factor=0.95,
+        ...     observation_model_type=ObservationModelType.NO_OBS_IN_DARK,
+        ... )
+        >>> updater = DiscreteLightDarkNoObsInDarkVectorizedUpdater.from_environment(env)
+        >>> particles = np.array([[5, 5], [3, 3]], dtype=float)
+        >>> next_p = updater.batch_transition(particles, "right")
+        >>> ll = updater.batch_observation_log_likelihood(next_p, "right", "None")
+        >>> ll.shape
+        (2,)
+    """
+
+    def batch_observation_log_likelihood(
+        self,
+        next_particles: np.ndarray,
+        action: np.ndarray,  # noqa: ARG002
+        observation: Union[np.ndarray, str],
+    ) -> np.ndarray:
+        px = next_particles[:, 0]
+        py = next_particles[:, 1]
+        near_mask = self._batch_near_beacon(px, py)
+
+        if isinstance(observation, str):
+            return np.where(near_mask, -np.inf, 0.0)
+
+        return self._log_lik_near_only(next_particles, near_mask, observation)
+
+    @property
+    def config_id(self) -> str:
+        return config_to_id(
+            self._build_config_dict("DiscreteLightDarkNoObsInDarkVectorizedUpdater")
+        )
+
+    def _log_lik_near_only(
+        self,
+        next_particles: np.ndarray,
+        near_mask: np.ndarray,
+        observation: np.ndarray,
+    ) -> np.ndarray:
+        obs = np.asarray(observation, dtype=float).ravel()
+        matched_idx = self._match_observation_offset(next_particles, obs)
+
+        log_probs = np.full(next_particles.shape[0], -np.inf)
+        for j in range(self._n_obs):
+            mask_j = matched_idx == j
+            if not np.any(mask_j):
+                continue
+            log_probs[mask_j & near_mask] = self._obs_log_probs_near[j]
+            # Far particles stay at -inf (actual observations impossible)
+
+        return log_probs
+
+
+class DiscreteLightDarkDistanceBasedVectorizedUpdater(
+    DiscreteLightDarkVectorizedUpdater,
+):
+    """Vectorized updater for the ``DISTANCE_BASED`` discrete observation model.
+
+    Error probability scales linearly per particle based on distance to
+    the nearest beacon.  Particles beyond ``beacon_radius`` receive
+    ``"None"`` observations.
+
+    The scaling formula is:
+        ``error_factor = 0.0001 + 0.9999 * (distance / beacon_radius)``
+
+    Inherits transition logic from
+    :class:`DiscreteLightDarkVectorizedUpdater`.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(42)
+        >>> from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
+        ...     DiscreteLightDarkPOMDP, ObservationModelType,
+        ... )
+        >>> env = DiscreteLightDarkPOMDP(
+        ...     discount_factor=0.95,
+        ...     observation_model_type=ObservationModelType.DISTANCE_BASED,
+        ... )
+        >>> updater = DiscreteLightDarkDistanceBasedVectorizedUpdater.from_environment(env)
+        >>> particles = np.array([[5, 5], [3, 3]], dtype=float)
+        >>> next_p = updater.batch_transition(particles, "right")
+        >>> ll = updater.batch_observation_log_likelihood(next_p, "right", "None")
+        >>> ll.shape
+        (2,)
+    """
+
+    _MIN_ERROR_FACTOR = 0.0001
+
+    def batch_observation_log_likelihood(
+        self,
+        next_particles: np.ndarray,
+        action: np.ndarray,  # noqa: ARG002
+        observation: Union[np.ndarray, str],
+    ) -> np.ndarray:
+        px = next_particles[:, 0]
+        py = next_particles[:, 1]
+        min_dist = self._batch_min_distance_to_beacon(px, py)
+        within_mask = min_dist <= self.beacon_radius
+
+        if isinstance(observation, str):
+            return np.where(within_mask, -np.inf, 0.0)
+
+        return self._distance_scaled_log_lik(next_particles, min_dist, within_mask, observation)
+
+    @property
+    def config_id(self) -> str:
+        return config_to_id(
+            self._build_config_dict("DiscreteLightDarkDistanceBasedVectorizedUpdater")
+        )
+
+    def _distance_scaled_log_lik(
+        self,
+        next_particles: np.ndarray,
+        min_dist: np.ndarray,
+        within_mask: np.ndarray,
+        observation: np.ndarray,
+    ) -> np.ndarray:
+        obs = np.asarray(observation, dtype=float).ravel()
+        matched_idx = self._match_observation_offset(next_particles, obs)
+        n = next_particles.shape[0]
+
+        # Compute per-particle error factor (only meaningful within beacon_radius)
+        distance_ratio = np.zeros(n)
+        distance_ratio[within_mask] = min_dist[within_mask] / self.beacon_radius
+        error_factor = self._MIN_ERROR_FACTOR + (1.0 - self._MIN_ERROR_FACTOR) * distance_ratio
+        obs_error = self.observation_error_prob * error_factor
+
+        # Per-particle log probabilities
+        is_exact = matched_idx == (self._n_obs - 1)
+        is_directional = (matched_idx >= 0) & (matched_idx < self._n_obs - 1)
+
+        log_probs = np.full(n, -np.inf)
+
+        # Exact match: log(1 - obs_error)
+        exact_within = is_exact & within_mask
+        if np.any(exact_within):
+            log_probs[exact_within] = np.log(1.0 - obs_error[exact_within])
+
+        # Directional match: log(obs_error / (n_obs - 1))
+        dir_within = is_directional & within_mask
+        if np.any(dir_within):
+            log_probs[dir_within] = np.log(obs_error[dir_within] / (self._n_obs - 1))
+
+        return log_probs

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/benchmark_light_dark_vectorized_belief.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/benchmark_light_dark_vectorized_belief.py
@@ -1,0 +1,354 @@
+"""Performance benchmark: LightDark vectorized vs non-vectorized belief.
+
+Benchmarks all 6 observation-model-aware vectorized updaters (3 continuous,
+3 discrete) against the standard per-particle loop.
+
+Run manually:
+    python -m POMDPPlanners.tests.test_environments.test_light_dark_pomdp.test_light_dark_pomdp_beliefs.benchmark_light_dark_vectorized_belief
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, List, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.belief.belief_utils import get_initial_belief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ContinuousLightDarkPOMDP,
+    ObservationModelType as ContinuousObsType,
+)
+from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
+    DiscreteLightDarkPOMDP,
+    ObservationModelType as DiscreteObsType,
+)
+from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import (
+    ContinuousLightDarkDistanceBasedVectorizedUpdater,
+    ContinuousLightDarkNoObsInDarkVectorizedUpdater,
+    ContinuousLightDarkVectorizedUpdater,
+    DiscreteLightDarkDistanceBasedVectorizedUpdater,
+    DiscreteLightDarkNoObsInDarkVectorizedUpdater,
+    DiscreteLightDarkVectorizedUpdater,
+)
+
+PARTICLE_COUNTS = [200]
+N_RUNS_FAST = 5
+N_RUNS_UPDATE = 5
+
+
+def _time_fn(fn: Callable[[], Any], n_runs: int = 100) -> Tuple[float, float]:
+    times: List[float] = []
+    for _ in range(n_runs):
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    arr = np.array(times) * 1000  # ms
+    return float(arr.mean()), float(arr.std())
+
+
+def _print_table_header(title: str) -> None:
+    print(f"\n--- {title} ---")
+    print(f"{'N':>6} | {'Loop (ms)':>14} | {'Vectorized (ms)':>16} | {'Speedup':>8}")
+    print("-" * 55)
+
+
+def _print_row(n: int, mean_loop: float, mean_vec: float) -> None:
+    speedup = mean_loop / mean_vec if mean_vec > 0 else float("inf")
+    print(f"{n:>6} | {mean_loop:>14.3f} | {mean_vec:>16.3f} | {speedup:>7.1f}x")
+
+
+# ======================================================================
+# Continuous LightDark benchmarks
+# ======================================================================
+
+
+def _benchmark_continuous_transition(env: ContinuousLightDarkPOMDP, updater) -> None:
+    _print_table_header("batch_transition vs per-particle loop")
+    action = np.array([1.0, 0.0])
+
+    for n in PARTICLE_COUNTS:
+        np.random.seed(42)
+        particles = np.random.rand(n, 2) * 10
+        states = [particles[i].copy() for i in range(n)]
+
+        mean_loop, _ = _time_fn(
+            lambda: [env.state_transition_model(s, action).sample()[0] for s in states],
+            n_runs=N_RUNS_FAST,
+        )
+        mean_vec, _ = _time_fn(
+            lambda: updater.batch_transition(particles, action),
+            n_runs=N_RUNS_FAST,
+        )
+        _print_row(n, mean_loop, mean_vec)
+
+
+def _benchmark_continuous_log_lik(env: ContinuousLightDarkPOMDP, updater, observation: Any) -> None:
+    obs_label = repr(observation) if isinstance(observation, str) else "array"
+    _print_table_header(f"batch_observation_log_likelihood vs loop (obs={obs_label})")
+    action = np.array([1.0, 0.0])
+
+    for n in PARTICLE_COUNTS:
+        np.random.seed(42)
+        particles = np.random.rand(n, 2) * 10
+
+        if isinstance(observation, str):
+            mean_loop, _ = _time_fn(
+                lambda: np.array(
+                    [
+                        (
+                            np.log(p)
+                            if (
+                                p := env.observation_model(particles[i], action).probability(
+                                    [observation]
+                                )[0]
+                            )
+                            > 0
+                            else -np.inf
+                        )
+                        for i in range(n)
+                    ]
+                ),
+                n_runs=N_RUNS_FAST,
+            )
+        else:
+
+            def _per_particle_log_lik():
+                result = np.empty(n)
+                for i in range(n):
+                    obs_model = env.observation_model(particles[i], action)
+                    dist = getattr(obs_model, "_active_dist")
+                    result[i] = dist.log_pdf(np.array([observation]), particles[i])[0]
+                return result
+
+            mean_loop, _ = _time_fn(_per_particle_log_lik, n_runs=N_RUNS_FAST)
+
+        mean_vec, _ = _time_fn(
+            lambda: updater.batch_observation_log_likelihood(particles, action, observation),
+            n_runs=N_RUNS_FAST,
+        )
+        _print_row(n, mean_loop, mean_vec)
+
+
+def _benchmark_continuous_update(env: ContinuousLightDarkPOMDP, updater, observation: Any) -> None:
+    obs_label = repr(observation) if isinstance(observation, str) else "array"
+    _print_table_header(f"belief.update() (obs={obs_label})")
+    action = np.array([1.0, 0.0])
+
+    for n in PARTICLE_COUNTS:
+        np.random.seed(42)
+        particles_array = np.random.rand(n, 2) * 10
+        log_w = np.full(n, -np.log(n))
+
+        # Per-particle baseline
+        mean_base, _ = _time_fn(
+            lambda: get_initial_belief(env, n).update(
+                action=action, observation=observation, pomdp=env
+            ),
+            n_runs=N_RUNS_UPDATE,
+        )
+
+        # Vectorized
+        def vec_update():
+            belief = VectorizedWeightedParticleBelief(
+                particles_array.copy(), log_w.copy(), updater, resampling=False
+            )
+            return belief.update(action=action, observation=observation)
+
+        # Only test array observations (VectorizedWeightedParticleBelief
+        # doesn't yet support string observations in update())
+        if isinstance(observation, str):
+            print(f"{n:>6} | {'(skipped — string obs not supported in update())':>46}")
+            continue
+
+        mean_vec, _ = _time_fn(vec_update, n_runs=N_RUNS_UPDATE)
+        _print_row(n, mean_base, mean_vec)
+
+
+def _run_continuous_benchmark(
+    name: str, obs_type: ContinuousObsType, updater_cls, observations: List[Any]
+) -> None:
+    print(f"\n{'=' * 70}")
+    print(f"Continuous LightDark — {name}")
+    print(f"{'=' * 70}")
+
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, observation_model_type=obs_type)
+    updater = updater_cls.from_environment(env)
+
+    _benchmark_continuous_transition(env, updater)
+    for obs in observations:
+        _benchmark_continuous_log_lik(env, updater, obs)
+    for obs in observations:
+        _benchmark_continuous_update(env, updater, obs)
+
+
+# ======================================================================
+# Discrete LightDark benchmarks
+# ======================================================================
+
+
+def _benchmark_discrete_transition(env: DiscreteLightDarkPOMDP, updater) -> None:
+    _print_table_header("batch_transition vs per-particle loop")
+    action = "right"
+
+    for n in PARTICLE_COUNTS:
+        np.random.seed(42)
+        particles = np.random.randint(0, 10, size=(n, 2)).astype(float)
+        states = [particles[i].copy() for i in range(n)]
+
+        mean_loop, _ = _time_fn(
+            lambda: [env.state_transition_model(s, action).sample()[0] for s in states],
+            n_runs=N_RUNS_FAST,
+        )
+        mean_vec, _ = _time_fn(
+            lambda: updater.batch_transition(particles, action),
+            n_runs=N_RUNS_FAST,
+        )
+        _print_row(n, mean_loop, mean_vec)
+
+
+def _benchmark_discrete_log_lik(env: DiscreteLightDarkPOMDP, updater, observation: Any) -> None:
+    obs_label = repr(observation) if isinstance(observation, str) else "array"
+    _print_table_header(f"batch_observation_log_likelihood vs loop (obs={obs_label})")
+    action = "right"
+
+    for n in PARTICLE_COUNTS:
+        np.random.seed(42)
+        particles = np.random.randint(0, 10, size=(n, 2)).astype(float)
+
+        mean_loop, _ = _time_fn(
+            lambda: np.array(
+                [
+                    (
+                        np.log(p)
+                        if (
+                            p := env.observation_model(particles[i], action).probability(
+                                [observation]
+                            )[0]
+                        )
+                        > 0
+                        else -np.inf
+                    )
+                    for i in range(n)
+                ]
+            ),
+            n_runs=N_RUNS_FAST,
+        )
+        mean_vec, _ = _time_fn(
+            lambda: updater.batch_observation_log_likelihood(particles, action, observation),
+            n_runs=N_RUNS_FAST,
+        )
+        _print_row(n, mean_loop, mean_vec)
+
+
+def _benchmark_discrete_update(env: DiscreteLightDarkPOMDP, updater, observation: Any) -> None:
+    obs_label = repr(observation) if isinstance(observation, str) else "array"
+    _print_table_header(f"belief.update() (obs={obs_label})")
+    action = "right"
+
+    for n in PARTICLE_COUNTS:
+        np.random.seed(42)
+
+        # Per-particle baseline
+        mean_base, _ = _time_fn(
+            lambda: get_initial_belief(env, n).update(
+                action=action, observation=observation, pomdp=env
+            ),
+            n_runs=N_RUNS_UPDATE,
+        )
+
+        # Vectorized — only for non-string observations
+        if isinstance(observation, str):
+            print(f"{n:>6} | {'(skipped — string obs not supported in update())':>46}")
+            continue
+
+        particles_array = np.random.randint(0, 10, size=(n, 2)).astype(float)
+        log_w = np.full(n, -np.log(n))
+
+        def vec_update():
+            belief = VectorizedWeightedParticleBelief(
+                particles_array.copy(), log_w.copy(), updater, resampling=False
+            )
+            return belief.update(action=action, observation=observation)
+
+        mean_vec, _ = _time_fn(vec_update, n_runs=N_RUNS_UPDATE)
+        _print_row(n, mean_base, mean_vec)
+
+
+def _run_discrete_benchmark(
+    name: str, obs_type: DiscreteObsType, updater_cls, observations: List[Any]
+) -> None:
+    print(f"\n{'=' * 70}")
+    print(f"Discrete LightDark — {name}")
+    print(f"{'=' * 70}")
+
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, observation_model_type=obs_type)
+    updater = updater_cls.from_environment(env)
+
+    _benchmark_discrete_transition(env, updater)
+    for obs in observations:
+        _benchmark_discrete_log_lik(env, updater, obs)
+    for obs in observations:
+        _benchmark_discrete_update(env, updater, obs)
+
+
+# ======================================================================
+# Main
+# ======================================================================
+
+
+def main() -> None:
+    print("=" * 70)
+    print("LightDark Vectorized Belief Benchmark")
+    print(f"Particle counts: {PARTICLE_COUNTS}")
+    print("=" * 70)
+
+    # --- Continuous ---
+    _run_continuous_benchmark(
+        "NORMAL_NOISE",
+        ContinuousObsType.NORMAL_NOISE,
+        ContinuousLightDarkVectorizedUpdater,
+        [np.array([5.0, 5.0])],
+    )
+    _run_continuous_benchmark(
+        "NORMAL_NOISE_NO_OBS_IN_DARK",
+        ContinuousObsType.NORMAL_NOISE_NO_OBS_IN_DARK,
+        ContinuousLightDarkNoObsInDarkVectorizedUpdater,
+        [np.array([5.0, 5.0]), "None"],
+    )
+    _run_continuous_benchmark(
+        "DISTANCE_BASED",
+        ContinuousObsType.DISTANCE_BASED,
+        ContinuousLightDarkDistanceBasedVectorizedUpdater,
+        [np.array([5.0, 5.0]), "None"],
+    )
+
+    # --- Discrete ---
+    _run_discrete_benchmark(
+        "NORMAL",
+        DiscreteObsType.NORMAL,
+        DiscreteLightDarkVectorizedUpdater,
+        [np.array([5, 5])],
+    )
+    _run_discrete_benchmark(
+        "NO_OBS_IN_DARK",
+        DiscreteObsType.NO_OBS_IN_DARK,
+        DiscreteLightDarkNoObsInDarkVectorizedUpdater,
+        [np.array([5, 5]), "None"],
+    )
+    _run_discrete_benchmark(
+        "DISTANCE_BASED",
+        DiscreteObsType.DISTANCE_BASED,
+        DiscreteLightDarkDistanceBasedVectorizedUpdater,
+        [np.array([5, 5]), "None"],
+    )
+
+    print(f"\n{'=' * 70}")
+    print("Benchmark complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_continuous_light_dark_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_continuous_light_dark_vectorized_updater.py
@@ -1,4 +1,4 @@
-"""Tests for ContinuousLightDarkVectorizedUpdater.
+"""Tests for ContinuousLightDarkVectorizedUpdater and observation model variants.
 
 This module tests the vectorized batch transition and observation
 log-likelihood methods, including an equivalence test that verifies
@@ -11,8 +11,11 @@ import pytest
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDP,
     ContinuousLightDarkPOMDPDiscreteActions,
+    ObservationModelType,
 )
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import (
+    ContinuousLightDarkDistanceBasedVectorizedUpdater,
+    ContinuousLightDarkNoObsInDarkVectorizedUpdater,
     ContinuousLightDarkVectorizedUpdater,
 )
 
@@ -504,3 +507,467 @@ class TestDiscreteActionConfigId:
         u_continuous = ContinuousLightDarkVectorizedUpdater.from_environment(env)
         u_discrete = ContinuousLightDarkVectorizedUpdater.from_environment(discrete_env)
         assert u_continuous.config_id != u_discrete.config_id
+
+
+# ---------------------------------------------------------------------------
+# NoObsInDark updater tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_obs_env():
+    return ContinuousLightDarkPOMDP(
+        discount_factor=0.95,
+        observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK,
+    )
+
+
+@pytest.fixture
+def no_obs_updater(no_obs_env):
+    return ContinuousLightDarkNoObsInDarkVectorizedUpdater.from_environment(no_obs_env)
+
+
+class TestNoObsInDarkFromEnvironment:
+    def test_creates_correct_subclass(self, no_obs_env):
+        """Test that from_environment returns the correct subclass.
+
+        Purpose: Validates that the factory creates the right type.
+
+        Given: A ContinuousLightDarkPOMDP with NORMAL_NOISE_NO_OBS_IN_DARK.
+        When: from_environment is called.
+        Then: The updater is a ContinuousLightDarkNoObsInDarkVectorizedUpdater.
+
+        Test type: unit
+        """
+        updater = ContinuousLightDarkNoObsInDarkVectorizedUpdater.from_environment(no_obs_env)
+        assert isinstance(updater, ContinuousLightDarkNoObsInDarkVectorizedUpdater)
+
+
+class TestNoObsInDarkObservationLogLikelihood:
+    def test_none_obs_near_beacon_returns_neg_inf(self, no_obs_updater):
+        """Test that 'None' observation near a beacon gives -inf log-likelihood.
+
+        Purpose: Validates that 'None' is impossible near beacons.
+
+        Given: A particle at (0, 0) near the origin beacon.
+        When: Log-likelihood is computed for observation 'None'.
+        Then: The result is -inf.
+
+        Test type: unit
+        """
+        particles = np.array([[0.0, 0.0]])  # at beacon (0, 0)
+        ll = no_obs_updater.batch_observation_log_likelihood(particles, np.zeros(2), "None")
+        assert ll[0] == -np.inf
+
+    def test_none_obs_far_from_beacon_returns_zero(self, no_obs_updater):
+        """Test that 'None' observation far from beacons gives 0 log-likelihood.
+
+        Purpose: Validates that 'None' is certain when far from beacons.
+
+        Given: A particle at (2.5, 2.5) far from all beacons.
+        When: Log-likelihood is computed for observation 'None'.
+        Then: The result is 0.0 (log(1)).
+
+        Test type: unit
+        """
+        particles = np.array([[2.5, 2.5]])  # far from all beacons
+        ll = no_obs_updater.batch_observation_log_likelihood(particles, np.zeros(2), "None")
+        assert ll[0] == 0.0
+
+    def test_array_obs_near_beacon_returns_finite(self, no_obs_updater):
+        """Test that array observation near a beacon gives finite log-likelihood.
+
+        Purpose: Validates that real observations work near beacons.
+
+        Given: A particle at (0, 0) near the origin beacon.
+        When: Log-likelihood is computed for a nearby array observation.
+        Then: The result is finite.
+
+        Test type: unit
+        """
+        particles = np.array([[0.0, 0.0]])
+        obs = np.array([0.1, 0.1])
+        ll = no_obs_updater.batch_observation_log_likelihood(particles, np.zeros(2), obs)
+        assert np.isfinite(ll[0])
+
+    def test_array_obs_far_from_beacon_returns_finite(self, no_obs_updater):
+        """Test that array observation far from beacons gives finite log-likelihood.
+
+        Purpose: Validates that the NoObsInDark model uses the far-beacon
+                 distribution for non-None observations when far from beacons,
+                 matching the non-vectorized model behaviour.
+
+        Given: A particle at (2.5, 2.5) far from all beacons.
+        When: Log-likelihood is computed for an array observation.
+        Then: The result is finite (using the far-beacon distribution).
+
+        Test type: unit
+        """
+        particles = np.array([[2.5, 2.5]])
+        obs = np.array([2.5, 2.5])
+        ll = no_obs_updater.batch_observation_log_likelihood(particles, np.zeros(2), obs)
+        assert np.isfinite(ll[0])
+
+    def test_batch_transition_inherited(self, no_obs_updater, updater):
+        """Test that batch_transition is inherited from parent.
+
+        Purpose: Validates that the transition logic is shared.
+
+        Given: Same particles and seed for both updaters.
+        When: batch_transition is called on both.
+        Then: Results are identical.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        particles = np.random.rand(20, 2) * 10
+        action = np.array([1.0, 0.0])
+
+        np.random.seed(99)
+        result_no_obs = no_obs_updater.batch_transition(particles, action)
+        np.random.seed(99)
+        result_normal = updater.batch_transition(particles, action)
+
+        np.testing.assert_array_equal(result_no_obs, result_normal)
+
+    def test_equivalence_with_per_particle_loop(self, no_obs_env, no_obs_updater):
+        """Test vectorized log-likelihood matches per-particle computation.
+
+        Purpose: Verifies equivalence against the non-vectorized observation model.
+
+        Given: Particles and an observation (both array and 'None').
+        When: Vectorized and per-particle log-likelihoods are computed.
+        Then: Results match within floating-point tolerance.  For array
+              observations, the per-particle path uses log_pdf directly
+              (not log(pdf())) to avoid underflow divergence.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        n = 30
+        action = np.array([1.0, 0.0])
+        particles = np.random.rand(n, 2) * 10
+
+        # Test with array observation — use log_pdf directly to match
+        observation = np.array([5.0, 5.0])
+        vectorized_ll = no_obs_updater.batch_observation_log_likelihood(
+            particles, action, observation
+        )
+        per_particle_ll = np.empty(n)
+        for i in range(n):
+            obs_model = no_obs_env.observation_model(next_state=particles[i], action=action)
+            per_particle_ll[i] = obs_model._active_dist.log_pdf(
+                np.array([observation]), particles[i]
+            )[0]
+
+        np.testing.assert_allclose(vectorized_ll, per_particle_ll, atol=1e-10)
+
+        # Test with "None" observation
+        vectorized_ll_none = no_obs_updater.batch_observation_log_likelihood(
+            particles, action, "None"
+        )
+        per_particle_ll_none = np.empty(n)
+        for i in range(n):
+            obs_model = no_obs_env.observation_model(next_state=particles[i], action=action)
+            prob = obs_model.probability(["None"])[0]
+            per_particle_ll_none[i] = np.log(prob) if prob > 0 else -np.inf
+
+        np.testing.assert_allclose(vectorized_ll_none, per_particle_ll_none, atol=1e-10)
+
+
+class TestNoObsInDarkConfigId:
+    def test_config_id_differs_from_parent(self, updater, no_obs_updater):
+        """Test that config_id differs between NORMAL_NOISE and NO_OBS_IN_DARK updaters.
+
+        Purpose: Validates distinct configuration IDs for different observation models.
+
+        Given: Updaters for NORMAL_NOISE and NO_OBS_IN_DARK.
+        When: config_id is compared.
+        Then: The IDs differ.
+
+        Test type: unit
+        """
+        assert updater.config_id != no_obs_updater.config_id
+
+
+# ---------------------------------------------------------------------------
+# DistanceBased updater tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dist_env():
+    return ContinuousLightDarkPOMDP(
+        discount_factor=0.95,
+        observation_model_type=ObservationModelType.DISTANCE_BASED,
+    )
+
+
+@pytest.fixture
+def dist_updater(dist_env):
+    return ContinuousLightDarkDistanceBasedVectorizedUpdater.from_environment(dist_env)
+
+
+class TestDistanceBasedFromEnvironment:
+    def test_creates_correct_subclass(self, dist_env):
+        """Test that from_environment returns the correct subclass.
+
+        Purpose: Validates that the factory creates the right type.
+
+        Given: A ContinuousLightDarkPOMDP with DISTANCE_BASED.
+        When: from_environment is called.
+        Then: The updater is a ContinuousLightDarkDistanceBasedVectorizedUpdater.
+
+        Test type: unit
+        """
+        updater = ContinuousLightDarkDistanceBasedVectorizedUpdater.from_environment(dist_env)
+        assert isinstance(updater, ContinuousLightDarkDistanceBasedVectorizedUpdater)
+
+
+class TestDistanceBasedObservationLogLikelihood:
+    def test_none_obs_near_beacon_returns_neg_inf(self, dist_updater):
+        """Test that 'None' observation near a beacon gives -inf.
+
+        Purpose: Validates that 'None' is impossible within beacon_radius.
+
+        Given: A particle at (0, 0) near the origin beacon.
+        When: Log-likelihood is computed for observation 'None'.
+        Then: The result is -inf.
+
+        Test type: unit
+        """
+        particles = np.array([[0.0, 0.0]])
+        ll = dist_updater.batch_observation_log_likelihood(particles, np.zeros(2), "None")
+        assert ll[0] == -np.inf
+
+    def test_none_obs_far_from_beacon_returns_zero(self, dist_updater):
+        """Test that 'None' observation beyond beacon_radius gives 0.
+
+        Purpose: Validates that 'None' is certain when beyond all beacons.
+
+        Given: A particle at (2.5, 2.5) far from all beacons.
+        When: Log-likelihood is computed for observation 'None'.
+        Then: The result is 0.0.
+
+        Test type: unit
+        """
+        particles = np.array([[2.5, 2.5]])
+        ll = dist_updater.batch_observation_log_likelihood(particles, np.zeros(2), "None")
+        assert ll[0] == 0.0
+
+    def test_array_obs_far_from_beacon_returns_neg_inf(self, dist_updater):
+        """Test that array observation beyond beacon_radius gives -inf.
+
+        Purpose: Validates that real observations are impossible beyond beacons.
+
+        Given: A particle at (2.5, 2.5) far from all beacons.
+        When: Log-likelihood is computed for an array observation.
+        Then: The result is -inf.
+
+        Test type: unit
+        """
+        particles = np.array([[2.5, 2.5]])
+        obs = np.array([2.5, 2.5])
+        ll = dist_updater.batch_observation_log_likelihood(particles, np.zeros(2), obs)
+        assert ll[0] == -np.inf
+
+    def test_equivalence_with_per_particle_loop(self, dist_env, dist_updater):
+        """Test vectorized log-likelihood matches per-particle computation.
+
+        Purpose: Verifies equivalence against the non-vectorized observation model.
+
+        Given: Particles and both array and 'None' observations.
+        When: Vectorized and per-particle log-likelihoods are computed.
+        Then: Results match within floating-point tolerance.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        n = 30
+        action = np.array([1.0, 0.0])
+        particles = np.random.rand(n, 2) * 10
+
+        # Test with "None" observation
+        vectorized_ll = dist_updater.batch_observation_log_likelihood(particles, action, "None")
+        per_particle_ll = np.empty(n)
+        for i in range(n):
+            obs_model = dist_env.observation_model(next_state=particles[i], action=action)
+            prob = obs_model.probability(["None"])[0]
+            per_particle_ll[i] = np.log(prob) if prob > 0 else -np.inf
+
+        np.testing.assert_allclose(vectorized_ll, per_particle_ll, atol=1e-10)
+
+    def test_array_obs_equivalence_with_per_particle_loop(self, dist_env, dist_updater):
+        """Test vectorized array-obs log-likelihood matches per-particle computation.
+
+        Purpose: Verifies equivalence for array observations against the
+                 non-vectorized observation model (which returns 0 for
+                 particles beyond beacon_radius).
+
+        Given: Particles near beacons and a matching array observation.
+        When: Vectorized and per-particle log-likelihoods are computed.
+        Then: Results match within floating-point tolerance.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        n = 30
+        action = np.array([1.0, 0.0])
+        # Place particles near beacon at (5,5) so some are within radius
+        particles = np.random.rand(n, 2) * 2 + 4.0
+        observation = np.array([5.0, 5.0])
+
+        vectorized_ll = dist_updater.batch_observation_log_likelihood(
+            particles, action, observation
+        )
+        per_particle_ll = np.empty(n)
+        for i in range(n):
+            obs_model = dist_env.observation_model(next_state=particles[i], action=action)
+            prob = obs_model.probability([observation])[0]
+            if prob > 0:
+                per_particle_ll[i] = obs_model._active_dist.log_pdf(
+                    np.array([observation]), particles[i]
+                )[0]
+            else:
+                per_particle_ll[i] = -np.inf
+
+        np.testing.assert_allclose(vectorized_ll, per_particle_ll, atol=1e-10)
+
+
+class TestDistanceBasedConfigId:
+    def test_config_id_differs_from_other_variants(self, updater, no_obs_updater, dist_updater):
+        """Test that all three updater variants have different config_ids.
+
+        Purpose: Validates that each observation model variant is uniquely identified.
+
+        Given: Updaters for NORMAL_NOISE, NO_OBS_IN_DARK, and DISTANCE_BASED.
+        When: config_ids are compared.
+        Then: All three IDs are different.
+
+        Test type: unit
+        """
+        ids = {updater.config_id, no_obs_updater.config_id, dist_updater.config_id}
+        assert len(ids) == 3
+
+
+# ---------------------------------------------------------------------------
+# Full update equivalence tests (vectorized vs standard particle belief)
+# ---------------------------------------------------------------------------
+
+
+class TestNoObsInDarkFullUpdateEquivalence:
+    def test_full_update_equivalence_with_array_observation(self, no_obs_env, no_obs_updater):
+        """Test full vectorized update matches WeightedParticleBelief for array observation.
+
+        Purpose: End-to-end equivalence test for the NO_OBS_IN_DARK model.
+
+        Given: Identical initial particles and weights.
+        When: One step of update with an array observation via both paths.
+        Then: Next particles match exactly, and normalized weights agree
+              for significant particles.
+
+        Note: VectorizedWeightedParticleBelief.update() does not yet support
+              string observations (e.g. 'None'). Per-observation-level
+              equivalence for 'None' is tested separately above.
+
+        Test type: integration
+        """
+        from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+        from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+            VectorizedWeightedParticleBelief,
+        )
+
+        np.random.seed(77)
+        n = 40
+        action = np.array([0.5, -0.5])
+        observation = np.array([3.0, 4.0])
+
+        particles_array = np.random.rand(n, 2) * 10
+        particles_list = [particles_array[i].copy() for i in range(n)]
+        log_w = np.full(n, -np.log(n))
+
+        np.random.seed(200)
+        v_belief = VectorizedWeightedParticleBelief(
+            particles=particles_array.copy(),
+            log_weights=log_w.copy(),
+            updater=no_obs_updater,
+            resampling=False,
+        )
+        v_updated = v_belief.update(action=action, observation=observation, pomdp=None)
+
+        np.random.seed(200)
+        w_belief = WeightedParticleBelief(
+            particles=particles_list,
+            log_weights=log_w.copy(),
+            resampling=False,
+        )
+        w_updated = w_belief.update(action=action, observation=observation, pomdp=no_obs_env)
+
+        w_particles = np.array(w_updated.particles)
+        np.testing.assert_allclose(v_updated.particles, w_particles, atol=1e-10)
+
+        v_nw = v_updated.normalized_weights
+        w_nw = w_updated.normalized_weights
+        significant = w_nw > 1e-4
+        if np.any(significant):
+            np.testing.assert_allclose(v_nw[significant], w_nw[significant], atol=1e-3)
+
+
+class TestDistanceBasedFullUpdateEquivalence:
+    def test_full_update_equivalence_with_array_observation(self, dist_env, dist_updater):
+        """Test full vectorized update matches WeightedParticleBelief for array observation.
+
+        Purpose: End-to-end equivalence test for the DISTANCE_BASED model.
+
+        Given: Particles placed near a beacon so the array observation
+               gives non-trivial weight to some particles.
+        When: One step of update with an array observation via both paths.
+        Then: Next particles match exactly, and normalized weights agree.
+
+        Note: VectorizedWeightedParticleBelief.update() does not yet support
+              string observations (e.g. 'None'). Per-observation-level
+              equivalence for 'None' is tested separately above.
+
+        Test type: integration
+        """
+        from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+        from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+            VectorizedWeightedParticleBelief,
+        )
+
+        np.random.seed(77)
+        n = 40
+        action = np.array([0.1, 0.0])
+        # Observation near beacon at (5, 5) so some particles get real weight
+        observation = np.array([5.0, 5.0])
+
+        # Place particles near beacons so they can receive array observations
+        particles_array = np.random.rand(n, 2) * 2 + 4.0  # range [4, 6]
+        particles_list = [particles_array[i].copy() for i in range(n)]
+        log_w = np.full(n, -np.log(n))
+
+        np.random.seed(200)
+        v_belief = VectorizedWeightedParticleBelief(
+            particles=particles_array.copy(),
+            log_weights=log_w.copy(),
+            updater=dist_updater,
+            resampling=False,
+        )
+        v_updated = v_belief.update(action=action, observation=observation, pomdp=None)
+
+        np.random.seed(200)
+        w_belief = WeightedParticleBelief(
+            particles=particles_list,
+            log_weights=log_w.copy(),
+            resampling=False,
+        )
+        w_updated = w_belief.update(action=action, observation=observation, pomdp=dist_env)
+
+        w_particles = np.array(w_updated.particles)
+        np.testing.assert_allclose(v_updated.particles, w_particles, atol=1e-10)
+
+        v_nw = v_updated.normalized_weights
+        w_nw = w_updated.normalized_weights
+        significant = w_nw > 1e-4
+        if np.any(significant):
+            np.testing.assert_allclose(v_nw[significant], w_nw[significant], atol=1e-3)

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_discrete_light_dark_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_discrete_light_dark_belief_factory.py
@@ -1,0 +1,154 @@
+"""Tests for the Discrete Light-Dark belief factory.
+
+This module tests that create_discrete_light_dark_belief correctly dispatches
+to the appropriate belief type and observation-model-specific updater.
+"""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
+    DiscreteLightDarkPOMDP,
+    ObservationModelType,
+)
+from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import (
+    DiscreteLightDarkDistanceBasedVectorizedUpdater,
+    DiscreteLightDarkNoObsInDarkVectorizedUpdater,
+    DiscreteLightDarkVectorizedUpdater,
+    create_discrete_light_dark_belief,
+)
+from POMDPPlanners.utils.belief_factory import BeliefType
+
+
+@pytest.fixture
+def env():
+    return DiscreteLightDarkPOMDP(discount_factor=0.95)
+
+
+class TestCreateDiscreteLightDarkBelief:
+    def test_default_type_is_vectorized_particle(self, env):
+        """Test that default belief type is VECTORIZED_PARTICLE.
+
+        Purpose: Validates the default factory behavior.
+
+        Given: A DiscreteLightDarkPOMDP instance.
+        When: create_discrete_light_dark_belief is called with defaults.
+        Then: A VectorizedWeightedParticleBelief is returned.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        belief = create_discrete_light_dark_belief(env)
+        assert isinstance(belief, VectorizedWeightedParticleBelief)
+
+    def test_particle_type_returns_weighted_particle_belief(self, env):
+        """Test that PARTICLE type returns WeightedParticleBelief.
+
+        Purpose: Validates PARTICLE type dispatch.
+
+        Given: A DiscreteLightDarkPOMDP instance.
+        When: create_discrete_light_dark_belief is called with PARTICLE.
+        Then: A WeightedParticleBelief is returned.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        belief = create_discrete_light_dark_belief(env, belief_type=BeliefType.PARTICLE)
+        assert isinstance(belief, WeightedParticleBelief)
+
+    def test_unsupported_type_raises_value_error(self, env):
+        """Test that unsupported belief type raises ValueError.
+
+        Purpose: Validates error handling for unsupported types.
+
+        Given: A DiscreteLightDarkPOMDP instance.
+        When: create_discrete_light_dark_belief is called with GAUSSIAN.
+        Then: ValueError is raised.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="does not support"):
+            create_discrete_light_dark_belief(env, belief_type=BeliefType.GAUSSIAN)
+
+    def test_n_particles_respected(self, env):
+        """Test that n_particles parameter is respected.
+
+        Purpose: Validates that the particle count is correct.
+
+        Given: A DiscreteLightDarkPOMDP instance and n_particles=50.
+        When: create_discrete_light_dark_belief is called.
+        Then: The belief has 50 particles.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        belief = create_discrete_light_dark_belief(env, n_particles=50)
+        assert isinstance(belief, VectorizedWeightedParticleBelief)
+        assert belief.particles.shape[0] == 50
+
+
+class TestObservationModelTypeDispatch:
+    def test_normal_obs_model_uses_base_updater(self):
+        """Test that NORMAL obs model produces base updater.
+
+        Purpose: Validates updater dispatch for NORMAL observation model.
+
+        Given: A DiscreteLightDarkPOMDP with NORMAL observation model.
+        When: Vectorized belief is created.
+        Then: The updater is a DiscreteLightDarkVectorizedUpdater.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        env = DiscreteLightDarkPOMDP(
+            discount_factor=0.95,
+            observation_model_type=ObservationModelType.NORMAL,
+        )
+        belief = create_discrete_light_dark_belief(env)
+        assert isinstance(belief, VectorizedWeightedParticleBelief)
+        assert isinstance(belief.updater, DiscreteLightDarkVectorizedUpdater)
+        assert not isinstance(belief.updater, DiscreteLightDarkNoObsInDarkVectorizedUpdater)
+
+    def test_no_obs_in_dark_uses_correct_updater(self):
+        """Test that NO_OBS_IN_DARK obs model produces correct updater.
+
+        Purpose: Validates updater dispatch for NO_OBS_IN_DARK observation model.
+
+        Given: A DiscreteLightDarkPOMDP with NO_OBS_IN_DARK observation model.
+        When: Vectorized belief is created.
+        Then: The updater is a DiscreteLightDarkNoObsInDarkVectorizedUpdater.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        env = DiscreteLightDarkPOMDP(
+            discount_factor=0.95,
+            observation_model_type=ObservationModelType.NO_OBS_IN_DARK,
+        )
+        belief = create_discrete_light_dark_belief(env)
+        assert isinstance(belief, VectorizedWeightedParticleBelief)
+        assert isinstance(belief.updater, DiscreteLightDarkNoObsInDarkVectorizedUpdater)
+
+    def test_distance_based_uses_correct_updater(self):
+        """Test that DISTANCE_BASED obs model produces correct updater.
+
+        Purpose: Validates updater dispatch for DISTANCE_BASED observation model.
+
+        Given: A DiscreteLightDarkPOMDP with DISTANCE_BASED observation model.
+        When: Vectorized belief is created.
+        Then: The updater is a DiscreteLightDarkDistanceBasedVectorizedUpdater.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        env = DiscreteLightDarkPOMDP(
+            discount_factor=0.95,
+            observation_model_type=ObservationModelType.DISTANCE_BASED,
+        )
+        belief = create_discrete_light_dark_belief(env)
+        assert isinstance(belief, VectorizedWeightedParticleBelief)
+        assert isinstance(belief.updater, DiscreteLightDarkDistanceBasedVectorizedUpdater)

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_discrete_light_dark_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_discrete_light_dark_vectorized_updater.py
@@ -1,0 +1,686 @@
+"""Tests for DiscreteLightDarkVectorizedUpdater and observation model variants.
+
+This module tests the vectorized batch transition and observation
+log-likelihood methods for all three discrete Light-Dark observation
+models, including equivalence tests against per-particle loops.
+"""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
+    DiscreteLightDarkPOMDP,
+    ObservationModelType,
+)
+from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import (
+    DiscreteLightDarkDistanceBasedVectorizedUpdater,
+    DiscreteLightDarkNoObsInDarkVectorizedUpdater,
+    DiscreteLightDarkVectorizedUpdater,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def env():
+    return DiscreteLightDarkPOMDP(discount_factor=0.95)
+
+
+@pytest.fixture
+def updater(env):
+    return DiscreteLightDarkVectorizedUpdater.from_environment(env)
+
+
+# ---------------------------------------------------------------------------
+# Base updater (NORMAL) tests
+# ---------------------------------------------------------------------------
+
+
+class TestFromEnvironment:
+    def test_creates_updater(self, env):
+        """Test that from_environment constructs a valid updater.
+
+        Purpose: Validates the factory classmethod.
+
+        Given: A DiscreteLightDarkPOMDP instance.
+        When: from_environment is called.
+        Then: A DiscreteLightDarkVectorizedUpdater is returned.
+
+        Test type: unit
+        """
+        updater = DiscreteLightDarkVectorizedUpdater.from_environment(env)
+        assert isinstance(updater, DiscreteLightDarkVectorizedUpdater)
+        assert updater.beacon_radius == env.beacon_radius
+        assert updater.grid_size == env.grid_size
+
+
+class TestBatchTransition:
+    def test_output_shape(self, updater):
+        """Test that batch_transition returns correct shape.
+
+        Purpose: Validates output shape of batch_transition.
+
+        Given: 30 particles of dimension 2.
+        When: batch_transition is called with action 'right'.
+        Then: Result has shape (30, 2).
+
+        Test type: unit
+        """
+        np.random.seed(0)
+        particles = np.array([[5, 5]] * 30, dtype=float)
+        result = updater.batch_transition(particles, "right")
+        assert result.shape == (30, 2)
+
+    def test_stochastic_transition(self, updater):
+        """Test that stochastic transitions produce some unexpected actions.
+
+        Purpose: Validates that transition_error_prob causes some particles
+                 to execute different actions.
+
+        Given: Many identical particles and a nonzero transition_error_prob.
+        When: batch_transition is called many times.
+        Then: Not all particles move in the intended direction.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        n = 1000
+        particles = np.tile([5.0, 5.0], (n, 1))
+        result = updater.batch_transition(particles, "right")
+        # 'right' moves [1, 0], so intended result is [6, 5]
+        # With error_prob=0.05, some should move differently
+        intended = np.array([6.0, 5.0])
+        not_intended = ~np.all(result == intended, axis=1)
+        assert np.any(not_intended), "Expected some stochastic transitions"
+
+    def test_transition_distribution_matches_environment(self, env, updater):
+        """Test that vectorized transition has same distribution as environment.
+
+        Purpose: Verifies statistical equivalence with the environment's
+                 state_transition_model.
+
+        Given: Many identical particles and the 'right' action.
+        When: Transitions are computed via vectorized path.
+        Then: The fraction of intended vs error transitions matches
+              the configured transition_error_prob.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        n = 5000
+        particles = np.tile([5.0, 5.0], (n, 1))
+        action = "right"
+
+        result = updater.batch_transition(particles, action)
+        # 'right' moves [1, 0], intended result is [6, 5]
+        intended = np.all(result == [6.0, 5.0], axis=1)
+        intended_frac = intended.sum() / n
+        expected_frac = 1.0 - env.transition_error_prob
+        np.testing.assert_allclose(intended_frac, expected_frac, atol=0.03)
+
+
+class TestBatchObservationLogLikelihood:
+    def test_output_shape(self, updater):
+        """Test that batch_observation_log_likelihood returns correct shape.
+
+        Purpose: Validates output shape.
+
+        Given: 20 particles.
+        When: batch_observation_log_likelihood is called.
+        Then: Result has shape (20,).
+
+        Test type: unit
+        """
+        particles = np.array([[5, 5]] * 20, dtype=float)
+        obs = np.array([5, 5], dtype=float)
+        result = updater.batch_observation_log_likelihood(particles, "right", obs)
+        assert result.shape == (20,)
+
+    def test_exact_match_highest_likelihood(self, updater):
+        """Test that exact observation match has highest log-likelihood.
+
+        Purpose: Validates that P(obs=state | state) is highest for exact match.
+
+        Given: Particles at (5, 5).
+        When: Log-likelihood computed for obs=(5,5) vs obs=(6,5).
+        Then: Exact match has higher log-likelihood.
+
+        Test type: unit
+        """
+        particles = np.array([[5.0, 5.0]])
+        ll_exact = updater.batch_observation_log_likelihood(
+            particles, "right", np.array([5.0, 5.0])
+        )
+        ll_offset = updater.batch_observation_log_likelihood(
+            particles, "right", np.array([6.0, 5.0])
+        )
+        assert ll_exact[0] > ll_offset[0]
+
+    def test_unmatched_observation_neg_inf(self, updater):
+        """Test that observation not matching any offset gives -inf.
+
+        Purpose: Validates that impossible observations get -inf.
+
+        Given: A particle at (5, 5).
+        When: Log-likelihood computed for obs=(10, 10) (no offset match).
+        Then: Result is -inf.
+
+        Test type: unit
+        """
+        particles = np.array([[5.0, 5.0]])
+        obs = np.array([10.0, 10.0])
+        ll = updater.batch_observation_log_likelihood(particles, "right", obs)
+        assert ll[0] == -np.inf
+
+    def test_near_beacon_higher_confidence(self, updater):
+        """Test that near-beacon particles have higher exact-match confidence.
+
+        Purpose: Validates beacon-dependent observation quality.
+
+        Given: One particle near beacon at (0,0), one far at (2.5, 2.5).
+        When: Log-likelihood for exact observation match is computed.
+        Then: Near-beacon particle has higher log-likelihood.
+
+        Test type: unit
+        """
+        near = np.array([[0.0, 0.0]])
+        far = np.array([[2.5, 2.5]])
+        ll_near = updater.batch_observation_log_likelihood(near, "right", np.array([0.0, 0.0]))
+        ll_far = updater.batch_observation_log_likelihood(far, "right", np.array([2.5, 2.5]))
+        assert ll_near[0] > ll_far[0]
+
+    def test_equivalence_with_per_particle_loop(self, env, updater):
+        """Test vectorized log-likelihood matches per-particle observation model.
+
+        Purpose: Verifies equivalence with the environment's observation_model.
+
+        Given: Particles and observations (including exact match and offset).
+        When: Vectorized and per-particle probabilities are computed.
+        Then: Results match within floating-point tolerance.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        n = 30
+        action = "right"
+        particles = np.random.randint(1, 9, size=(n, 2)).astype(float)
+
+        # Test with exact observation
+        for i in range(min(n, 5)):
+            obs = particles[i].copy()
+            vectorized_ll = updater.batch_observation_log_likelihood(particles, action, obs)
+            per_particle_ll = np.empty(n)
+            for j in range(n):
+                obs_model = env.observation_model(next_state=particles[j], action=action)
+                prob = obs_model.probability([obs])[0]
+                per_particle_ll[j] = np.log(prob) if prob > 0 else -np.inf
+
+            np.testing.assert_allclose(vectorized_ll, per_particle_ll, atol=1e-10)
+
+
+class TestConfigId:
+    def test_deterministic(self, updater):
+        """Test that config_id is deterministic.
+
+        Purpose: Validates reproducibility.
+
+        Given: An updater.
+        When: config_id is called twice.
+        Then: The same ID is returned.
+
+        Test type: unit
+        """
+        assert updater.config_id == updater.config_id
+
+
+# ---------------------------------------------------------------------------
+# NoObsInDark updater tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_obs_env():
+    return DiscreteLightDarkPOMDP(
+        discount_factor=0.95,
+        observation_model_type=ObservationModelType.NO_OBS_IN_DARK,
+    )
+
+
+@pytest.fixture
+def no_obs_updater(no_obs_env):
+    return DiscreteLightDarkNoObsInDarkVectorizedUpdater.from_environment(no_obs_env)
+
+
+class TestNoObsInDarkFromEnvironment:
+    def test_creates_correct_subclass(self, no_obs_env):
+        """Test that from_environment returns the correct subclass.
+
+        Purpose: Validates that the factory creates the right type.
+
+        Given: A DiscreteLightDarkPOMDP with NO_OBS_IN_DARK.
+        When: from_environment is called.
+        Then: The updater is a DiscreteLightDarkNoObsInDarkVectorizedUpdater.
+
+        Test type: unit
+        """
+        updater = DiscreteLightDarkNoObsInDarkVectorizedUpdater.from_environment(no_obs_env)
+        assert isinstance(updater, DiscreteLightDarkNoObsInDarkVectorizedUpdater)
+
+
+class TestNoObsInDarkLogLikelihood:
+    def test_none_obs_near_beacon_returns_neg_inf(self, no_obs_updater):
+        """Test that 'None' observation near beacon gives -inf.
+
+        Purpose: Validates that 'None' is impossible near beacons.
+
+        Given: A particle at (0, 0) near the origin beacon.
+        When: Log-likelihood is computed for observation 'None'.
+        Then: The result is -inf.
+
+        Test type: unit
+        """
+        particles = np.array([[0.0, 0.0]])
+        ll = no_obs_updater.batch_observation_log_likelihood(particles, "right", "None")
+        assert ll[0] == -np.inf
+
+    def test_none_obs_far_from_beacon_returns_zero(self, no_obs_updater):
+        """Test that 'None' observation far from beacons gives 0.
+
+        Purpose: Validates that 'None' is certain when far from beacons.
+
+        Given: A particle at (2.5, 2.5) far from all beacons.
+        When: Log-likelihood is computed for observation 'None'.
+        Then: The result is 0.0.
+
+        Test type: unit
+        """
+        particles = np.array([[2.5, 2.5]])
+        ll = no_obs_updater.batch_observation_log_likelihood(particles, "right", "None")
+        assert ll[0] == 0.0
+
+    def test_array_obs_near_beacon(self, no_obs_updater):
+        """Test that array observation near beacon gives finite log-likelihood.
+
+        Purpose: Validates that real observations work near beacons.
+
+        Given: A particle at (0, 0) near the origin beacon.
+        When: Log-likelihood is computed for exact match observation.
+        Then: The result is finite.
+
+        Test type: unit
+        """
+        particles = np.array([[0.0, 0.0]])
+        obs = np.array([0.0, 0.0])
+        ll = no_obs_updater.batch_observation_log_likelihood(particles, "right", obs)
+        assert np.isfinite(ll[0])
+
+    def test_array_obs_far_from_beacon_returns_neg_inf(self, no_obs_updater):
+        """Test that array observation far from beacons gives -inf.
+
+        Purpose: Validates that real observations are impossible far from beacons.
+
+        Given: A particle at (2.5, 2.5) far from all beacons.
+        When: Log-likelihood is computed for an array observation.
+        Then: The result is -inf.
+
+        Test type: unit
+        """
+        particles = np.array([[2.5, 2.5]])
+        obs = np.array([2.5, 2.5])
+        ll = no_obs_updater.batch_observation_log_likelihood(particles, "right", obs)
+        assert ll[0] == -np.inf
+
+    def test_equivalence_with_per_particle_loop(self, no_obs_env, no_obs_updater):
+        """Test vectorized log-likelihood matches per-particle computation.
+
+        Purpose: Verifies equivalence against the non-vectorized observation model.
+
+        Given: Particles and both array and 'None' observations.
+        When: Vectorized and per-particle log-likelihoods are computed.
+        Then: Results match.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        n = 30
+        action = "right"
+        particles = np.random.randint(0, 10, size=(n, 2)).astype(float)
+
+        # Test "None" observation
+        vectorized_ll = no_obs_updater.batch_observation_log_likelihood(particles, action, "None")
+        per_particle_ll = np.empty(n)
+        for i in range(n):
+            obs_model = no_obs_env.observation_model(next_state=particles[i], action=action)
+            prob = obs_model.probability(["None"])[0]
+            per_particle_ll[i] = np.log(prob) if prob > 0 else -np.inf
+
+        np.testing.assert_allclose(vectorized_ll, per_particle_ll, atol=1e-10)
+
+        # Test exact-match observation for a near-beacon particle
+        near_particles = np.array([[0.0, 0.0], [5.0, 5.0], [2.5, 2.5]])
+        for particle in near_particles:
+            obs = particle.copy()
+            v_ll = no_obs_updater.batch_observation_log_likelihood(near_particles, action, obs)
+            pp_ll = np.empty(len(near_particles))
+            for j, np_j in enumerate(near_particles):
+                obs_model = no_obs_env.observation_model(next_state=np_j, action=action)
+                prob = obs_model.probability([obs])[0]
+                pp_ll[j] = np.log(prob) if prob > 0 else -np.inf
+
+            np.testing.assert_allclose(v_ll, pp_ll, atol=1e-10)
+
+
+class TestNoObsInDarkConfigId:
+    def test_config_id_differs_from_base(self, updater, no_obs_updater):
+        """Test that config_id differs between NORMAL and NO_OBS_IN_DARK.
+
+        Purpose: Validates distinct configuration IDs.
+
+        Given: Updaters for NORMAL and NO_OBS_IN_DARK.
+        When: config_id is compared.
+        Then: The IDs differ.
+
+        Test type: unit
+        """
+        assert updater.config_id != no_obs_updater.config_id
+
+
+# ---------------------------------------------------------------------------
+# DistanceBased updater tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dist_env():
+    return DiscreteLightDarkPOMDP(
+        discount_factor=0.95,
+        observation_model_type=ObservationModelType.DISTANCE_BASED,
+    )
+
+
+@pytest.fixture
+def dist_updater(dist_env):
+    return DiscreteLightDarkDistanceBasedVectorizedUpdater.from_environment(dist_env)
+
+
+class TestDistanceBasedFromEnvironment:
+    def test_creates_correct_subclass(self, dist_env):
+        """Test that from_environment returns the correct subclass.
+
+        Purpose: Validates that the factory creates the right type.
+
+        Given: A DiscreteLightDarkPOMDP with DISTANCE_BASED.
+        When: from_environment is called.
+        Then: The updater is a DiscreteLightDarkDistanceBasedVectorizedUpdater.
+
+        Test type: unit
+        """
+        updater = DiscreteLightDarkDistanceBasedVectorizedUpdater.from_environment(dist_env)
+        assert isinstance(updater, DiscreteLightDarkDistanceBasedVectorizedUpdater)
+
+
+class TestDistanceBasedLogLikelihood:
+    def test_none_obs_within_radius_returns_neg_inf(self, dist_updater):
+        """Test that 'None' observation within beacon_radius gives -inf.
+
+        Purpose: Validates that 'None' is impossible within beacon_radius.
+
+        Given: A particle at (0, 0) at the origin beacon.
+        When: Log-likelihood is computed for observation 'None'.
+        Then: The result is -inf.
+
+        Test type: unit
+        """
+        particles = np.array([[0.0, 0.0]])
+        ll = dist_updater.batch_observation_log_likelihood(particles, "right", "None")
+        assert ll[0] == -np.inf
+
+    def test_none_obs_beyond_radius_returns_zero(self, dist_updater):
+        """Test that 'None' observation beyond beacon_radius gives 0.
+
+        Purpose: Validates that 'None' is certain beyond all beacons.
+
+        Given: A particle at (2.5, 2.5) beyond beacon_radius from all beacons.
+        When: Log-likelihood is computed for observation 'None'.
+        Then: The result is 0.0.
+
+        Test type: unit
+        """
+        particles = np.array([[2.5, 2.5]])
+        ll = dist_updater.batch_observation_log_likelihood(particles, "right", "None")
+        assert ll[0] == 0.0
+
+    def test_closer_to_beacon_higher_exact_match_prob(self, dist_updater):
+        """Test that particles closer to beacon have higher exact-match probability.
+
+        Purpose: Validates distance-based error scaling.
+
+        Given: One particle near beacon, one farther (but still within radius).
+        When: Log-likelihood for exact observation match is computed.
+        Then: Closer particle has higher log-likelihood.
+
+        Test type: unit
+        """
+        # Beacons at (0,0), (0,5), etc. beacon_radius=1.0
+        # Particle at (0.1, 0) is very close to beacon (0,0)
+        # Particle at (0.9, 0) is near edge of beacon_radius
+        near = np.array([[0.1, 0.0]])
+        far = np.array([[0.9, 0.0]])
+        ll_near = dist_updater.batch_observation_log_likelihood(near, "right", np.array([0.1, 0.0]))
+        ll_far = dist_updater.batch_observation_log_likelihood(far, "right", np.array([0.9, 0.0]))
+        assert ll_near[0] > ll_far[0]
+
+    def test_equivalence_with_per_particle_loop(self, dist_env, dist_updater):
+        """Test vectorized log-likelihood matches per-particle computation.
+
+        Purpose: Verifies equivalence against the non-vectorized observation model.
+
+        Given: Particles and both array and 'None' observations.
+        When: Vectorized and per-particle log-likelihoods are computed.
+        Then: Results match.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        n = 30
+        action = "right"
+        particles = np.random.randint(0, 10, size=(n, 2)).astype(float)
+
+        # Test "None" observation
+        vectorized_ll = dist_updater.batch_observation_log_likelihood(particles, action, "None")
+        per_particle_ll = np.empty(n)
+        for i in range(n):
+            obs_model = dist_env.observation_model(next_state=particles[i], action=action)
+            prob = obs_model.probability(["None"])[0]
+            per_particle_ll[i] = np.log(prob) if prob > 0 else -np.inf
+
+        np.testing.assert_allclose(vectorized_ll, per_particle_ll, atol=1e-10)
+
+        # Test exact-match observation
+        test_particles = np.array([[0.0, 0.0], [0.5, 0.0], [2.5, 2.5]])
+        for particle in test_particles:
+            obs = particle.copy()
+            v_ll = dist_updater.batch_observation_log_likelihood(test_particles, action, obs)
+            pp_ll = np.empty(len(test_particles))
+            for j, tp in enumerate(test_particles):
+                obs_model = dist_env.observation_model(next_state=tp, action=action)
+                prob = obs_model.probability([obs])[0]
+                pp_ll[j] = np.log(prob) if prob > 0 else -np.inf
+
+            np.testing.assert_allclose(v_ll, pp_ll, atol=1e-10)
+
+
+class TestDistanceBasedConfigId:
+    def test_all_variants_differ(self, updater, no_obs_updater, dist_updater):
+        """Test that all three discrete updater variants have different config_ids.
+
+        Purpose: Validates that each observation model variant is uniquely identified.
+
+        Given: Updaters for NORMAL, NO_OBS_IN_DARK, and DISTANCE_BASED.
+        When: config_ids are compared.
+        Then: All three IDs are different.
+
+        Test type: unit
+        """
+        ids = {updater.config_id, no_obs_updater.config_id, dist_updater.config_id}
+        assert len(ids) == 3
+
+
+# ---------------------------------------------------------------------------
+# Full update equivalence tests (vectorized vs standard particle belief)
+# ---------------------------------------------------------------------------
+
+
+class TestFullUpdateEquivalence:
+    def test_normal_updater_full_update(self, env, updater):
+        """Test full vectorized update matches WeightedParticleBelief for NORMAL model.
+
+        Purpose: End-to-end equivalence test comparing VectorizedWeightedParticleBelief
+                 update against WeightedParticleBelief update.
+
+        Given: Identical initial particles and weights.
+        When: One step of update is performed via both paths with the same random seed.
+        Then: Both paths agree on which particles carry significant weight
+              and the top-ranked particles match.
+
+        Test type: integration
+        """
+        np.random.seed(77)
+        n = 40
+        action = "right"
+        # Observation at (6, 5) — exact match for a particle at (5, 5) moved right
+        observation = np.array([6.0, 5.0])
+
+        particles_array = np.random.randint(1, 9, size=(n, 2)).astype(float)
+        particles_list = [particles_array[i].copy() for i in range(n)]
+        log_w = np.full(n, -np.log(n))
+
+        # Vectorized path
+        np.random.seed(200)
+        v_belief = VectorizedWeightedParticleBelief(
+            particles=particles_array.copy(),
+            log_weights=log_w.copy(),
+            updater=updater,
+            resampling=False,
+        )
+        v_updated = v_belief.update(action=action, observation=observation, pomdp=None)
+
+        # Per-particle path
+        np.random.seed(200)
+        w_belief = WeightedParticleBelief(
+            particles=particles_list,
+            log_weights=log_w.copy(),
+            resampling=False,
+        )
+        w_updated = w_belief.update(action=action, observation=observation, pomdp=env)
+
+        # Compare normalized weights for significant particles.
+        # Tolerance is relaxed because WeightedParticleBelief uses
+        # log(eps + prob) while vectorized uses log_prob directly.
+        v_nw = v_updated.normalized_weights
+        w_nw = w_updated.normalized_weights
+        significant = w_nw > 1e-4
+        if np.any(significant):
+            np.testing.assert_allclose(v_nw[significant], w_nw[significant], atol=1e-2)
+
+    def test_no_obs_in_dark_full_update_with_array(self, no_obs_env, no_obs_updater):
+        """Test full update equivalence for NO_OBS_IN_DARK with array observation.
+
+        Purpose: End-to-end equivalence test for the NO_OBS_IN_DARK model.
+
+        Given: Identical initial particles and weights.
+        When: One step of update with array observation via both paths.
+        Then: Weight distributions agree on significant particles.
+
+        Note: VectorizedWeightedParticleBelief.update() does not yet support
+              string observations. Per-observation-level equivalence for
+              'None' is tested separately above.
+
+        Test type: integration
+        """
+        np.random.seed(77)
+        n = 40
+        action = "right"
+        observation = np.array([6.0, 5.0])
+
+        particles_array = np.random.randint(1, 9, size=(n, 2)).astype(float)
+        particles_list = [particles_array[i].copy() for i in range(n)]
+        log_w = np.full(n, -np.log(n))
+
+        np.random.seed(200)
+        v_belief = VectorizedWeightedParticleBelief(
+            particles=particles_array.copy(),
+            log_weights=log_w.copy(),
+            updater=no_obs_updater,
+            resampling=False,
+        )
+        v_updated = v_belief.update(action=action, observation=observation, pomdp=None)
+
+        np.random.seed(200)
+        w_belief = WeightedParticleBelief(
+            particles=particles_list,
+            log_weights=log_w.copy(),
+            resampling=False,
+        )
+        w_updated = w_belief.update(action=action, observation=observation, pomdp=no_obs_env)
+
+        v_nw = v_updated.normalized_weights
+        w_nw = w_updated.normalized_weights
+        significant = w_nw > 1e-4
+        if np.any(significant):
+            np.testing.assert_allclose(v_nw[significant], w_nw[significant], atol=1e-2)
+
+    def test_distance_based_full_update_with_array(self, dist_env, dist_updater):
+        """Test full update equivalence for DISTANCE_BASED with array observation.
+
+        Purpose: End-to-end equivalence test for the DISTANCE_BASED model.
+
+        Given: Particles near beacons so array observations have non-trivial weight.
+        When: One step of update with array observation via both paths.
+        Then: Weight distributions agree on significant particles.
+
+        Note: VectorizedWeightedParticleBelief.update() does not yet support
+              string observations. Per-observation-level equivalence for
+              'None' is tested separately above.
+
+        Test type: integration
+        """
+        np.random.seed(77)
+        n = 40
+        action = "right"
+        observation = np.array([1.0, 0.0])
+
+        # Place particles near beacon at (0, 0)
+        particles_array = np.random.rand(n, 2).astype(float)
+        particles_list = [particles_array[i].copy() for i in range(n)]
+        log_w = np.full(n, -np.log(n))
+
+        np.random.seed(200)
+        v_belief = VectorizedWeightedParticleBelief(
+            particles=particles_array.copy(),
+            log_weights=log_w.copy(),
+            updater=dist_updater,
+            resampling=False,
+        )
+        v_updated = v_belief.update(action=action, observation=observation, pomdp=None)
+
+        np.random.seed(200)
+        w_belief = WeightedParticleBelief(
+            particles=particles_list,
+            log_weights=log_w.copy(),
+            resampling=False,
+        )
+        w_updated = w_belief.update(action=action, observation=observation, pomdp=dist_env)
+
+        v_nw = v_updated.normalized_weights
+        w_nw = w_updated.normalized_weights
+        significant = w_nw > 1e-4
+        if np.any(significant):
+            np.testing.assert_allclose(v_nw[significant], w_nw[significant], atol=1e-2)

--- a/POMDPPlanners/utils/belief_factory.py
+++ b/POMDPPlanners/utils/belief_factory.py
@@ -78,6 +78,11 @@ _ENV_FACTORY_REGISTRY: dict[str, tuple[str, str, BeliefType]] = {
         "create_safety_ant_velocity_belief",
         BeliefType.VECTORIZED_PARTICLE,
     ),
+    "DiscreteLightDarkPOMDP": (
+        "POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs",
+        "create_discrete_light_dark_belief",
+        BeliefType.VECTORIZED_PARTICLE,
+    ),
     "ContinuousLightDarkPOMDP": (
         "POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs",
         "create_continuous_light_dark_belief",


### PR DESCRIPTION
## Summary

- Add 5 new vectorized particle belief updaters for all LightDark observation model variants (2 continuous + 3 discrete), achieving **36x–274x speedup** over per-particle loops at 200 particles
- Add discrete belief factory with automatic observation model type routing
- Update continuous belief factory to route to the correct updater by `ObservationModelType`
- Register `DiscreteLightDarkPOMDP` in global belief factory registry

### New classes
| Class | Observation Model |
|-------|-------------------|
| `ContinuousLightDarkNoObsInDarkVectorizedUpdater` | `NORMAL_NOISE_NO_OBS_IN_DARK` |
| `ContinuousLightDarkDistanceBasedVectorizedUpdater` | `DISTANCE_BASED` |
| `DiscreteLightDarkVectorizedUpdater` | `NORMAL` |
| `DiscreteLightDarkNoObsInDarkVectorizedUpdater` | `NO_OBS_IN_DARK` |
| `DiscreteLightDarkDistanceBasedVectorizedUpdater` | `DISTANCE_BASED` |

## Test plan
- [x] 95 unit/integration tests covering all 6 updaters
- [x] Per-particle equivalence tests (vectorized vs `observation_model().probability()`)
- [x] Full update equivalence tests (`VectorizedWeightedParticleBelief.update()` vs `WeightedParticleBelief.update()`)
- [x] Belief factory dispatch tests for all observation model types
- [x] Doctests pass for all new classes
- [x] Pyright: 0 errors, Pylint: 10.00/10 on source files
- [x] Performance benchmark script included

## Known limitation
`VectorizedWeightedParticleBelief.update()` does not yet support `"None"` string observations (it calls `np.asarray(observation, dtype=float)`). The vectorized `batch_observation_log_likelihood` methods handle `"None"` correctly, but end-to-end belief update with `"None"` observations requires a small change to the core belief class.