### PR TITLE
Add belief-level equivalence tests for vectorized beliefs; fix MountainCar/CartPole transition noise

### DIFF
--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp_beliefs.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp_beliefs.py
@@ -48,12 +48,15 @@ class CartPoleVectorizedUpdater(VectorizedParticleBeliefUpdater):
     evaluations using vectorized NumPy operations, replacing per-particle
     Python loops with batched array operations.
 
-    The CartPole transition is deterministic (no process noise), so
-    ``batch_transition`` applies the exact same physics to all particles
-    simultaneously.  Observations follow a single Gaussian centred on the
-    true state.
+    ``batch_transition`` applies the deterministic cart-pole physics to
+    all particles and then adds a per-particle Gaussian process-noise
+    sample drawn from ``state_transition_dist`` (mirroring
+    :meth:`CartPoleTransition.sample`).  Observations follow a single
+    Gaussian centred on the true state.
 
     Attributes:
+        state_transition_dist: Process-noise distribution added after the
+            deterministic physics step.
         obs_dist: Observation noise distribution.
         force_mag: Magnitude of force applied to the cart.
         gravity: Gravitational acceleration constant.
@@ -85,6 +88,7 @@ class CartPoleVectorizedUpdater(VectorizedParticleBeliefUpdater):
 
     def __init__(
         self,
+        state_transition_dist: CovarianceParameterizedMultivariateNormal,
         obs_dist: CovarianceParameterizedMultivariateNormal,
         force_mag: float,
         gravity: float,
@@ -99,6 +103,8 @@ class CartPoleVectorizedUpdater(VectorizedParticleBeliefUpdater):
         """Initialize the vectorized updater.
 
         Args:
+            state_transition_dist: Pre-built MVN for process noise added on
+                top of the deterministic next-state physics.
             obs_dist: Pre-built MVN for observation noise.
             force_mag: Magnitude of applied force.
             gravity: Gravitational acceleration constant.
@@ -110,6 +116,7 @@ class CartPoleVectorizedUpdater(VectorizedParticleBeliefUpdater):
             tau: Integration time step.
             kinematics_integrator: Integration method.
         """
+        self.state_transition_dist = state_transition_dist
         self.obs_dist = obs_dist
         self.force_mag = force_mag
         self.gravity = gravity
@@ -133,6 +140,7 @@ class CartPoleVectorizedUpdater(VectorizedParticleBeliefUpdater):
         """
         # pylint: disable=protected-access
         return cls(
+            state_transition_dist=env._state_transition_dist,
             obs_dist=env._obs_dist,
             force_mag=env.force_mag,
             gravity=env.gravity,
@@ -152,6 +160,11 @@ class CartPoleVectorizedUpdater(VectorizedParticleBeliefUpdater):
 
     def batch_transition(self, particles: np.ndarray, action: np.ndarray) -> np.ndarray:
         # particles: (N, 4) = [x, x_dot, theta, theta_dot]
+        next_particles = self._deterministic_next_state(particles, action)
+        noise = self.state_transition_dist.sample(np.zeros(4), n_samples=particles.shape[0])
+        return next_particles + noise
+
+    def _deterministic_next_state(self, particles: np.ndarray, action: np.ndarray) -> np.ndarray:
         force = self.force_mag if action == 1 else -self.force_mag
 
         theta = particles[:, 2]
@@ -193,6 +206,7 @@ class CartPoleVectorizedUpdater(VectorizedParticleBeliefUpdater):
     def config_id(self) -> str:
         config_dict = {
             "class": "CartPoleVectorizedUpdater",
+            "state_transition_cov": self.state_transition_dist.covariance.tolist(),
             "obs_cov": self.obs_dist.covariance.tolist(),
             "force_mag": self.force_mag,
             "gravity": self.gravity,

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp_beliefs.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp_beliefs.py
@@ -48,12 +48,16 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
     evaluations using vectorized NumPy operations, replacing per-particle
     Python loops with batched array operations.
 
-    The Mountain Car transition is deterministic (no process noise), so
-    ``batch_transition`` applies the exact same physics to all particles
-    simultaneously.  Observations follow a single Gaussian centred on the
-    true state.
+    ``batch_transition`` applies the deterministic cart physics to all
+    particles, then adds a per-particle Gaussian process-noise sample drawn
+    from ``state_transition_dist`` (mirroring
+    :meth:`MountainCarTransition.sample`), and finally re-applies the
+    position/velocity clipping and wall-stop boundary rule. Observations
+    follow a single Gaussian centred on the true state.
 
     Attributes:
+        state_transition_dist: Process-noise distribution added after the
+            deterministic physics step.
         obs_dist: Observation noise distribution.
         power: Engine power scaling factor.
         gravity: Gravitational force constant.
@@ -83,6 +87,7 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
 
     def __init__(
         self,
+        state_transition_dist: CovarianceParameterizedMultivariateNormal,
         obs_dist: CovarianceParameterizedMultivariateNormal,
         power: float,
         gravity: float,
@@ -93,6 +98,8 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
         """Initialize the vectorized updater.
 
         Args:
+            state_transition_dist: Pre-built MVN for process noise added on
+                top of the deterministic next-state physics.
             obs_dist: Pre-built MVN for observation noise.
             power: Engine power scaling factor.
             gravity: Gravitational force constant.
@@ -100,6 +107,7 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
             min_position: Minimum position boundary.
             max_position: Maximum position boundary.
         """
+        self.state_transition_dist = state_transition_dist
         self.obs_dist = obs_dist
         self.power = power
         self.gravity = gravity
@@ -119,6 +127,7 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
         """
         # pylint: disable=protected-access
         return cls(
+            state_transition_dist=env._state_transition_dist,
             obs_dist=env._obs_dist,
             power=env.power,
             gravity=env.gravity,
@@ -134,19 +143,35 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
 
     def batch_transition(self, particles: np.ndarray, action: np.ndarray) -> np.ndarray:
         # particles: (N, 2) = [position, velocity]
+        position, velocity = self._deterministic_next_state(particles, action)
+        position, velocity = self._add_transition_noise(position, velocity, particles.shape[0])
+        position, velocity = self._apply_clipping_and_wall_stop(position, velocity)
+        return np.column_stack([position, velocity])
+
+    def _deterministic_next_state(
+        self, particles: np.ndarray, action: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
         position = particles[:, 0]
         velocity = particles[:, 1]
-
         velocity = velocity + action * self.power + np.cos(3.0 * position) * (-self.gravity)
         velocity = np.clip(velocity, -self.max_speed, self.max_speed)
         position = position + velocity
-        position = np.clip(position, self.min_position, self.max_position)
+        return self._apply_clipping_and_wall_stop(position, velocity)
 
-        # Boundary condition: if hit left wall, zero out velocity
+    def _add_transition_noise(
+        self, position: np.ndarray, velocity: np.ndarray, n: int
+    ) -> tuple[np.ndarray, np.ndarray]:
+        noise = self.state_transition_dist.sample(np.zeros(2), n_samples=n)
+        return position + noise[:, 0], velocity + noise[:, 1]
+
+    def _apply_clipping_and_wall_stop(
+        self, position: np.ndarray, velocity: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        velocity = np.clip(velocity, -self.max_speed, self.max_speed)
+        position = np.clip(position, self.min_position, self.max_position)
         at_min = position == self.min_position
         velocity = np.where(at_min & (velocity < 0), 0.0, velocity)
-
-        return np.column_stack([position, velocity])
+        return position, velocity
 
     def batch_observation_log_likelihood(
         self,
@@ -161,6 +186,7 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
     def config_id(self) -> str:
         config_dict = {
             "class": "MountainCarVectorizedUpdater",
+            "state_transition_cov": self.state_transition_dist.covariance.tolist(),
             "obs_cov": self.obs_dist.covariance.tolist(),
             "power": self.power,
             "gravity": self.gravity,

--- a/POMDPPlanners/tests/test_core/test_belief/belief_equivalence_utils.py
+++ b/POMDPPlanners/tests/test_core/test_belief/belief_equivalence_utils.py
@@ -1,0 +1,436 @@
+"""Shared belief-level equivalence checks for particle beliefs.
+
+This module provides environment-agnostic assertion helpers that compare a
+standard :class:`~POMDPPlanners.core.belief.particle_beliefs.WeightedParticleBelief`
+against a
+:class:`~POMDPPlanners.core.belief.vectorized_weighted_particle_belief.VectorizedWeightedParticleBelief`
+through their public interface (``update``, ``normalized_weights``, ``sample``).
+
+Callers build the two beliefs with aligned particles and weights; the helpers
+run the supplied action/observation through both paths and assert the expected
+invariants. Each ``update``-invoking helper seeds ``numpy``'s global RNG
+identically on both paths so stochastic transitions and observation draws
+consume the same random numbers, mirroring the pattern used in
+:mod:`POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils`.
+
+Functions:
+    assert_update_particles_match: Next particles agree after one ``update``.
+    assert_update_weights_match: Normalized weights agree after one ``update``.
+    assert_update_top_k_ranking_agrees: Top-K particle ranking agrees.
+    assert_update_equivalence: Combined particle + weight + ranking check.
+    assert_chained_update_equivalence: Invariants hold across a sequence of updates.
+    assert_normalized_weights_match: Pre-update weight-vector sanity check.
+    assert_sample_distributions_match: Empirical ``sample`` histograms agree.
+"""
+
+from typing import Any, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.core.environment import Environment
+
+
+BeliefPair = Tuple[WeightedParticleBelief, VectorizedWeightedParticleBelief]
+ActionObservationStep = Tuple[Any, Any]
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def assert_update_particles_match(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    action: Any,
+    observation: Any,
+    pomdp: Environment,
+    atol: float = 1e-10,
+    seed: Optional[int] = None,
+) -> BeliefPair:
+    """Run one update on both beliefs and assert next particles agree.
+
+    Args:
+        base: Baseline ``WeightedParticleBelief`` with aligned particles.
+        vec: Vectorized belief holding the same particles as ``base``.
+        action: Action passed to both ``update`` calls.
+        observation: Observation passed to both ``update`` calls.
+        pomdp: Environment used by the baseline's per-particle transition loop.
+        atol: Absolute tolerance for the particle array comparison.
+        seed: If provided, ``numpy``'s global RNG is seeded to this value
+            before each path so stochastic transitions consume identical
+            random sequences.
+
+    Returns:
+        The updated ``(base, vec)`` belief pair so callers can chain asserts.
+    """
+    base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed)
+    _check_particles(base_next, vec_next, atol=atol)
+    return base_next, vec_next
+
+
+def assert_update_weights_match(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    action: Any,
+    observation: Any,
+    pomdp: Environment,
+    atol: float = 1e-6,
+    significance_threshold: Optional[float] = None,
+    seed: Optional[int] = None,
+) -> BeliefPair:
+    """Run one update on both beliefs and assert normalized weights agree.
+
+    Args:
+        base: Baseline ``WeightedParticleBelief`` with aligned particles.
+        vec: Vectorized belief holding the same particles as ``base``.
+        action: Action passed to both ``update`` calls.
+        observation: Observation passed to both ``update`` calls.
+        pomdp: Environment used by the baseline's per-particle transition loop.
+        atol: Absolute tolerance for the weight comparison.
+        significance_threshold: If given, only compare normalized weights for
+            baseline particles with ``normalized_weight > significance_threshold``.
+            This absorbs the ``log(eps + p)`` floor in
+            ``WeightedParticleBelief._update_weights`` vs. the vectorized
+            path's direct log-space accumulation, which drives tiny
+            low-weight particles apart without affecting the belief's
+            effective distribution.
+        seed: If provided, ``numpy``'s global RNG is seeded to this value
+            before each path so stochastic transitions consume identical
+            random sequences.
+
+    Returns:
+        The updated ``(base, vec)`` belief pair.
+    """
+    base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed)
+    _check_weights(base_next, vec_next, atol=atol, significance_threshold=significance_threshold)
+    return base_next, vec_next
+
+
+def assert_update_top_k_ranking_agrees(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    action: Any,
+    observation: Any,
+    pomdp: Environment,
+    k: int = 5,
+    seed: Optional[int] = None,
+) -> BeliefPair:
+    """Run one update and assert the top-``k`` particle indices agree.
+
+    Args:
+        base: Baseline ``WeightedParticleBelief`` with aligned particles.
+        vec: Vectorized belief holding the same particles as ``base``.
+        action: Action passed to both ``update`` calls.
+        observation: Observation passed to both ``update`` calls.
+        pomdp: Environment used by the baseline's per-particle transition loop.
+        k: Number of top particles by weight to compare.
+        seed: If provided, ``numpy``'s global RNG is seeded to this value
+            before each path.
+
+    Returns:
+        The updated ``(base, vec)`` belief pair.
+    """
+    base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed)
+    _check_top_k_ranking(base_next, vec_next, k=k)
+    return base_next, vec_next
+
+
+def assert_update_equivalence(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    action: Any,
+    observation: Any,
+    pomdp: Environment,
+    atol_particles: float = 1e-10,
+    atol_weights: float = 1e-6,
+    significance_threshold: Optional[float] = 1e-4,
+    top_k: int = 5,
+    seed: Optional[int] = None,
+) -> BeliefPair:
+    """Run one update and assert particles, weights, and top-``k`` all agree.
+
+    Combines :func:`assert_update_particles_match`,
+    :func:`assert_update_weights_match`, and
+    :func:`assert_update_top_k_ranking_agrees` into a single end-to-end check
+    for callers that want the full equivalence invariant in one line.
+
+    Args:
+        base: Baseline ``WeightedParticleBelief`` with aligned particles.
+        vec: Vectorized belief holding the same particles as ``base``.
+        action: Action passed to both ``update`` calls.
+        observation: Observation passed to both ``update`` calls.
+        pomdp: Environment used by the baseline's per-particle transition loop.
+        atol_particles: Absolute tolerance for the next-particle comparison.
+        atol_weights: Absolute tolerance for the normalized-weight comparison.
+        significance_threshold: Weight-masking threshold passed to the weight
+            check; set to ``None`` to disable masking.
+        top_k: Number of top particles by weight compared for ranking agreement.
+        seed: If provided, ``numpy``'s global RNG is seeded to this value
+            before each path.
+
+    Returns:
+        The updated ``(base, vec)`` belief pair.
+    """
+    base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed)
+    _check_particles(base_next, vec_next, atol=atol_particles)
+    _check_weights(
+        base_next,
+        vec_next,
+        atol=atol_weights,
+        significance_threshold=significance_threshold,
+    )
+    _check_top_k_ranking(base_next, vec_next, k=top_k)
+    return base_next, vec_next
+
+
+def assert_chained_update_equivalence(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    steps: Sequence[ActionObservationStep],
+    pomdp: Environment,
+    atol_particles: float = 1e-10,
+    atol_weights: float = 1e-5,
+    seed: Optional[int] = None,
+) -> BeliefPair:
+    """Run a sequence of updates and assert final particles and weights agree.
+
+    Args:
+        base: Baseline ``WeightedParticleBelief`` with aligned particles.
+        vec: Vectorized belief holding the same particles as ``base``.
+        steps: Iterable of ``(action, observation)`` pairs applied in order.
+        pomdp: Environment used by the baseline's per-particle transition loop.
+        atol_particles: Absolute tolerance for the final particle comparison.
+        atol_weights: Absolute tolerance for the final normalized-weight comparison.
+        seed: If provided, ``numpy``'s global RNG is seeded to this value
+            before each path of every step.
+
+    Returns:
+        The final ``(base, vec)`` belief pair.
+    """
+    for action, observation in steps:
+        base, vec = _run_updates(base, vec, action, observation, pomdp, seed)
+    _check_particles(base, vec, atol=atol_particles)
+    _check_weights(base, vec, atol=atol_weights, significance_threshold=None)
+    return base, vec
+
+
+def assert_normalized_weights_match(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    atol: float = 1e-10,
+) -> None:
+    """Assert the two beliefs expose the same probability vector over particles.
+
+    Intended as a pre-update sanity check on aligned beliefs.
+
+    Args:
+        base: Baseline ``WeightedParticleBelief``.
+        vec: Vectorized belief.
+        atol: Absolute tolerance for the weight comparison.
+    """
+    np.testing.assert_allclose(
+        vec.normalized_weights,
+        base.normalized_weights,
+        atol=atol,
+        err_msg="Normalized weights diverge between baseline and vectorized beliefs",
+    )
+
+
+def assert_sample_distributions_match(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    n_samples: int = 20_000,
+    tol: float = 0.03,
+    atol_weights: float = 0.03,
+    seed: Optional[int] = None,
+) -> None:
+    """Assert ``sample`` output distributions agree across beliefs and match weights.
+
+    Draws ``n_samples`` from each belief, aggregates by particle identity
+    (duplicate particle rows are merged into their first occurrence so
+    discrete-state environments are handled correctly), and runs three checks:
+
+    1. The two empirical histograms agree in L-infinity within ``tol``.
+    2. ``base``'s histogram agrees with its own ``normalized_weights``
+       within ``atol_weights`` (verifies ``base.sample()`` is unbiased).
+    3. Same for ``vec`` (verifies ``vec.sample()`` is unbiased).
+
+    Check 1 alone would pass even if both ``sample()`` impls were biased
+    the same way. Checks 2 and 3 close that hole.
+
+    The helper assumes particles are convertible to fixed-length numeric
+    arrays -- the same constraint ``VectorizedWeightedParticleBelief``
+    imposes on the particle store itself.
+
+    Args:
+        base: Baseline ``WeightedParticleBelief``.
+        vec: Vectorized belief sharing the same particles as ``base``.
+        n_samples: Number of samples drawn from each belief.
+        tol: L-infinity tolerance for the two histograms agreeing.
+        atol_weights: L-infinity tolerance for each histogram agreeing with
+            its belief's ``normalized_weights``.
+        seed: If provided, ``numpy``'s global RNG is seeded to this value
+            before each sampling path so the test is deterministic.
+    """
+    reference = _stack_particles(base.particles)
+    first_of = _canonical_group_indices(reference)
+    base_hist = _sample_histogram(base, reference, n_samples, seed)
+    vec_hist = _sample_histogram(vec, reference, n_samples, seed)
+    base_weights_agg = _aggregate_by_groups(base.normalized_weights, first_of)
+    vec_weights_agg = _aggregate_by_groups(vec.normalized_weights, first_of)
+
+    _assert_distributions_match(base_hist, vec_hist, tol, "base hist", "vec hist")
+    _assert_distributions_match(
+        base_hist, base_weights_agg, atol_weights, "base hist", "base normalized_weights"
+    )
+    _assert_distributions_match(
+        vec_hist, vec_weights_agg, atol_weights, "vec hist", "vec normalized_weights"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_updates(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    action: Any,
+    observation: Any,
+    pomdp: Environment,
+    seed: Optional[int],
+) -> BeliefPair:
+    if seed is not None:
+        np.random.seed(seed)
+    vec_next = vec.update(action=action, observation=observation, pomdp=pomdp)
+    if seed is not None:
+        np.random.seed(seed)
+    base_next = base.update(action=action, observation=observation, pomdp=pomdp)
+    return base_next, vec_next
+
+
+def _check_particles(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    atol: float,
+) -> None:
+    base_particles = _stack_particles(base.particles)
+    np.testing.assert_allclose(
+        vec.particles,
+        base_particles,
+        atol=atol,
+        err_msg="Vectorized belief particles diverged from per-particle baseline",
+    )
+
+
+def _check_weights(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    atol: float,
+    significance_threshold: Optional[float],
+) -> None:
+    base_weights = base.normalized_weights
+    vec_weights = vec.normalized_weights
+    mask = _build_significance_mask(base_weights, significance_threshold)
+    np.testing.assert_allclose(
+        vec_weights[mask],
+        base_weights[mask],
+        atol=atol,
+        err_msg="Normalized weights diverge between baseline and vectorized beliefs after update",
+    )
+
+
+def _check_top_k_ranking(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    k: int,
+) -> None:
+    effective_k = min(k, len(base.normalized_weights))
+    base_top = np.argsort(base.normalized_weights)[::-1][:effective_k]
+    vec_top = np.argsort(vec.normalized_weights)[::-1][:effective_k]
+    np.testing.assert_array_equal(
+        vec_top,
+        base_top,
+        err_msg=f"Top-{effective_k} particle ranking disagrees between baseline and vectorized beliefs",
+    )
+
+
+def _build_significance_mask(
+    base_weights: np.ndarray,
+    significance_threshold: Optional[float],
+) -> np.ndarray:
+    if significance_threshold is None:
+        return np.ones_like(base_weights, dtype=bool)
+    mask = base_weights > significance_threshold
+    assert np.any(mask), (
+        f"No baseline particle exceeds significance_threshold={significance_threshold}; "
+        "relax the threshold or pick a different action/observation"
+    )
+    return mask
+
+
+def _stack_particles(particles: List[Any]) -> np.ndarray:
+    return np.stack([np.asarray(p) for p in particles])
+
+
+def _sample_histogram(
+    belief: Any,
+    reference_particles: np.ndarray,
+    n_samples: int,
+    seed: Optional[int],
+) -> np.ndarray:
+    if seed is not None:
+        np.random.seed(seed)
+    n_particles = reference_particles.shape[0]
+    hist = np.zeros(n_particles, dtype=float)
+    for _ in range(n_samples):
+        idx = _locate_first_match_index(belief.sample(), reference_particles)
+        hist[idx] += 1.0
+    hist /= n_samples
+    return hist
+
+
+def _locate_first_match_index(sample: Any, reference_particles: np.ndarray) -> int:
+    sample_array = np.asarray(sample)
+    matches = np.where(np.all(reference_particles == sample_array, axis=1))[0]
+    if len(matches) == 0:
+        raise AssertionError(
+            "Sampled state does not match any reference particle; "
+            "beliefs are not aligned on the same particle set"
+        )
+    return int(matches[0])
+
+
+def _canonical_group_indices(particles_2d: np.ndarray) -> np.ndarray:
+    n = particles_2d.shape[0]
+    first_of = np.arange(n)
+    for i in range(1, n):
+        matches = np.where(np.all(particles_2d[:i] == particles_2d[i], axis=1))[0]
+        if len(matches) > 0:
+            first_of[i] = matches[0]
+    return first_of
+
+
+def _aggregate_by_groups(values_per_index: np.ndarray, first_of: np.ndarray) -> np.ndarray:
+    n = len(first_of)
+    agg = np.zeros(n, dtype=float)
+    for i in range(n):
+        agg[first_of[i]] += float(values_per_index[i])
+    return agg
+
+
+def _assert_distributions_match(
+    distribution_a: np.ndarray,
+    distribution_b: np.ndarray,
+    tol: float,
+    label_a: str,
+    label_b: str,
+) -> None:
+    max_diff = float(np.max(np.abs(distribution_a - distribution_b)))
+    assert max_diff <= tol, f"{label_a} vs {label_b}: max L-inf diff {max_diff:.4f} > tol={tol}"

--- a/POMDPPlanners/tests/test_core/test_belief/belief_equivalence_utils.py
+++ b/POMDPPlanners/tests/test_core/test_belief/belief_equivalence_utils.py
@@ -227,6 +227,102 @@ def assert_chained_update_equivalence(
     return base, vec
 
 
+def assert_update_particles_match_per_particle_seeded(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    action: Any,
+    observation: Any,
+    pomdp: Environment,
+    atol: float = 1e-10,
+    base_seed: int = 0,
+    particle_to_array: Optional[ParticleToArray] = None,
+) -> BeliefPair:
+    """Per-particle-seeded variant of :func:`assert_update_particles_match`.
+
+    See :func:`assert_update_equivalence_per_particle_seeded` for why
+    bulk-vs-interleaved RNG ordering forces per-particle seeding. This
+    helper only checks the next-particle array -- use it when weight
+    agreement is blocked by the ``log(eps + prob)`` floor in
+    ``WeightedParticleBelief._update_weights`` for observations that
+    underflow the Gaussian PDF across every particle.
+
+    Args:
+        base: Baseline ``WeightedParticleBelief`` with aligned particles.
+        vec: Vectorized belief holding the same particles as ``base``.
+        action: Action passed to both ``update`` calls.
+        observation: Observation passed to both ``update`` calls.
+        pomdp: Environment used by the baseline's per-particle transition loop.
+        atol: Absolute tolerance for the particle array comparison.
+        base_seed: Seed for particle ``i`` is ``base_seed + i``.
+        particle_to_array: Optional converter passed through to the
+            particle comparison. See :func:`assert_update_particles_match`.
+
+    Returns:
+        The updated ``(base, vec)`` belief pair.
+    """
+    new_base, new_vec = _run_per_particle_updates(base, vec, action, observation, pomdp, base_seed)
+    _check_particles(new_base, new_vec, atol=atol, particle_to_array=particle_to_array)
+    return new_base, new_vec
+
+
+def assert_update_equivalence_per_particle_seeded(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    action: Any,
+    observation: Any,
+    pomdp: Environment,
+    atol_particles: float = 1e-10,
+    atol_weights: float = 1e-6,
+    significance_threshold: Optional[float] = None,
+    top_k: int = 5,
+    base_seed: int = 0,
+    particle_to_array: Optional[ParticleToArray] = None,
+) -> BeliefPair:
+    """Per-particle-seeded variant of :func:`assert_update_equivalence`.
+
+    For each particle index ``i``, build a single-particle belief on both
+    sides, seed ``numpy``'s global RNG to ``base_seed + i``, run one
+    ``update``, and stitch the per-particle results back into aggregate
+    beliefs before running the usual particle / weight / top-K checks.
+
+    Use this helper for environments whose vectorized ``batch_transition``
+    consumes the RNG in a different *order* than the baseline per-particle
+    loop (e.g. LaserTag, which bulk-samples robot noise then opponent
+    noise while the standard path interleaves them per particle). Under
+    bulk-vs-interleaved ordering, a single shared seed cannot make the
+    two paths agree for ``N > 1``; per-particle seeding restores
+    bit-for-bit equivalence at the cost of ``O(N)`` update calls.
+
+    Args:
+        base: Baseline ``WeightedParticleBelief`` with aligned particles.
+        vec: Vectorized belief holding the same particles as ``base``.
+        action: Action passed to both ``update`` calls.
+        observation: Observation passed to both ``update`` calls.
+        pomdp: Environment used by the baseline's per-particle transition loop.
+        atol_particles: Absolute tolerance for the next-particle comparison.
+        atol_weights: Absolute tolerance for the normalized-weight comparison.
+        significance_threshold: Weight-masking threshold; ``None`` disables.
+        top_k: Number of top particles by weight compared for ranking agreement.
+        base_seed: Seed for particle ``i`` is ``base_seed + i``.
+        particle_to_array: Optional converter passed through to the particle
+            comparison. See :func:`assert_update_particles_match`.
+
+    Returns:
+        The updated ``(base, vec)`` belief pair built by aggregating the
+        per-particle results.
+    """
+    new_base, new_vec = _run_per_particle_updates(base, vec, action, observation, pomdp, base_seed)
+    _check_particles(new_base, new_vec, atol=atol_particles, particle_to_array=particle_to_array)
+    _check_weights(
+        new_base,
+        new_vec,
+        atol=atol_weights,
+        significance_threshold=significance_threshold,
+    )
+    _check_top_k_ranking(new_base, new_vec, k=top_k)
+    return new_base, new_vec
+
+
 def assert_normalized_weights_match(
     base: WeightedParticleBelief,
     vec: VectorizedWeightedParticleBelief,
@@ -322,6 +418,70 @@ def _run_updates(
         np.random.seed(seed)
     base_next = base.update(action=action, observation=observation, pomdp=pomdp)
     return base_next, vec_next
+
+
+def _run_per_particle_updates(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    action: Any,
+    observation: Any,
+    pomdp: Environment,
+    base_seed: int,
+) -> BeliefPair:
+    n = vec.particles.shape[0]
+    next_vec_particles = np.empty_like(vec.particles)
+    next_vec_log_weights = np.empty(n)
+    next_base_particles: List[Any] = []
+    next_base_log_weights = np.empty(n)
+
+    for i in range(n):
+        next_base_step, next_vec_step = _single_particle_update_step(
+            base, vec, i, action, observation, pomdp, base_seed + i
+        )
+        next_vec_particles[i] = next_vec_step.particles[0]
+        next_vec_log_weights[i] = next_vec_step.log_weights[0]
+        next_base_particles.append(next_base_step.particles[0])
+        next_base_log_weights[i] = next_base_step.log_weights[0]
+
+    new_vec = VectorizedWeightedParticleBelief(
+        particles=next_vec_particles,
+        log_weights=next_vec_log_weights,
+        updater=vec.updater,
+        resampling=False,
+    )
+    new_base = WeightedParticleBelief(
+        particles=next_base_particles,
+        log_weights=next_base_log_weights,
+        resampling=False,
+    )
+    return new_base, new_vec
+
+
+def _single_particle_update_step(
+    base: WeightedParticleBelief,
+    vec: VectorizedWeightedParticleBelief,
+    i: int,
+    action: Any,
+    observation: Any,
+    pomdp: Environment,
+    seed: int,
+) -> BeliefPair:
+    single_vec = VectorizedWeightedParticleBelief(
+        particles=vec.particles[i : i + 1].copy(),
+        log_weights=vec.log_weights[i : i + 1].copy(),
+        updater=vec.updater,
+        resampling=False,
+    )
+    single_base = WeightedParticleBelief(
+        particles=[base.particles[i]],
+        log_weights=np.array([base.log_weights[i]]),
+        resampling=False,
+    )
+    np.random.seed(seed)
+    next_vec_step = single_vec.update(action=action, observation=observation, pomdp=pomdp)
+    np.random.seed(seed)
+    next_base_step = single_base.update(action=action, observation=observation, pomdp=pomdp)
+    return next_base_step, next_vec_step
 
 
 def _check_particles(

--- a/POMDPPlanners/tests/test_core/test_belief/belief_equivalence_utils.py
+++ b/POMDPPlanners/tests/test_core/test_belief/belief_equivalence_utils.py
@@ -23,7 +23,7 @@ Functions:
     assert_sample_distributions_match: Empirical ``sample`` histograms agree.
 """
 
-from typing import Any, List, Optional, Sequence, Tuple
+from typing import Any, Callable, List, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -36,6 +36,7 @@ from POMDPPlanners.core.environment import Environment
 
 BeliefPair = Tuple[WeightedParticleBelief, VectorizedWeightedParticleBelief]
 ActionObservationStep = Tuple[Any, Any]
+ParticleToArray = Callable[[Any], np.ndarray]
 
 
 # ---------------------------------------------------------------------------
@@ -51,6 +52,7 @@ def assert_update_particles_match(
     pomdp: Environment,
     atol: float = 1e-10,
     seed: Optional[int] = None,
+    particle_to_array: Optional[ParticleToArray] = None,
 ) -> BeliefPair:
     """Run one update on both beliefs and assert next particles agree.
 
@@ -64,12 +66,16 @@ def assert_update_particles_match(
         seed: If provided, ``numpy``'s global RNG is seeded to this value
             before each path so stochastic transitions consume identical
             random sequences.
+        particle_to_array: Optional callable converting a baseline particle
+            to a 1-D ``np.ndarray``. Needed when ``base.particles`` holds
+            non-ndarray objects (e.g. dataclasses) whose layout matches
+            ``vec.particles`` rows. Defaults to :func:`np.asarray`.
 
     Returns:
         The updated ``(base, vec)`` belief pair so callers can chain asserts.
     """
     base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed)
-    _check_particles(base_next, vec_next, atol=atol)
+    _check_particles(base_next, vec_next, atol=atol, particle_to_array=particle_to_array)
     return base_next, vec_next
 
 
@@ -151,6 +157,7 @@ def assert_update_equivalence(
     significance_threshold: Optional[float] = 1e-4,
     top_k: int = 5,
     seed: Optional[int] = None,
+    particle_to_array: Optional[ParticleToArray] = None,
 ) -> BeliefPair:
     """Run one update and assert particles, weights, and top-``k`` all agree.
 
@@ -177,7 +184,7 @@ def assert_update_equivalence(
         The updated ``(base, vec)`` belief pair.
     """
     base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed)
-    _check_particles(base_next, vec_next, atol=atol_particles)
+    _check_particles(base_next, vec_next, atol=atol_particles, particle_to_array=particle_to_array)
     _check_weights(
         base_next,
         vec_next,
@@ -196,6 +203,7 @@ def assert_chained_update_equivalence(
     atol_particles: float = 1e-10,
     atol_weights: float = 1e-5,
     seed: Optional[int] = None,
+    particle_to_array: Optional[ParticleToArray] = None,
 ) -> BeliefPair:
     """Run a sequence of updates and assert final particles and weights agree.
 
@@ -214,7 +222,7 @@ def assert_chained_update_equivalence(
     """
     for action, observation in steps:
         base, vec = _run_updates(base, vec, action, observation, pomdp, seed)
-    _check_particles(base, vec, atol=atol_particles)
+    _check_particles(base, vec, atol=atol_particles, particle_to_array=particle_to_array)
     _check_weights(base, vec, atol=atol_weights, significance_threshold=None)
     return base, vec
 
@@ -248,6 +256,7 @@ def assert_sample_distributions_match(
     tol: float = 0.03,
     atol_weights: float = 0.03,
     seed: Optional[int] = None,
+    particle_to_array: Optional[ParticleToArray] = None,
 ) -> None:
     """Assert ``sample`` output distributions agree across beliefs and match weights.
 
@@ -277,10 +286,10 @@ def assert_sample_distributions_match(
         seed: If provided, ``numpy``'s global RNG is seeded to this value
             before each sampling path so the test is deterministic.
     """
-    reference = _stack_particles(base.particles)
+    reference = _stack_particles(base.particles, particle_to_array=particle_to_array)
     first_of = _canonical_group_indices(reference)
-    base_hist = _sample_histogram(base, reference, n_samples, seed)
-    vec_hist = _sample_histogram(vec, reference, n_samples, seed)
+    base_hist = _sample_histogram(base, reference, n_samples, seed, particle_to_array)
+    vec_hist = _sample_histogram(vec, reference, n_samples, seed, particle_to_array=None)
     base_weights_agg = _aggregate_by_groups(base.normalized_weights, first_of)
     vec_weights_agg = _aggregate_by_groups(vec.normalized_weights, first_of)
 
@@ -319,8 +328,9 @@ def _check_particles(
     base: WeightedParticleBelief,
     vec: VectorizedWeightedParticleBelief,
     atol: float,
+    particle_to_array: Optional[ParticleToArray] = None,
 ) -> None:
-    base_particles = _stack_particles(base.particles)
+    base_particles = _stack_particles(base.particles, particle_to_array=particle_to_array)
     np.testing.assert_allclose(
         vec.particles,
         base_particles,
@@ -375,8 +385,12 @@ def _build_significance_mask(
     return mask
 
 
-def _stack_particles(particles: List[Any]) -> np.ndarray:
-    return np.stack([np.asarray(p) for p in particles])
+def _stack_particles(
+    particles: List[Any],
+    particle_to_array: Optional[ParticleToArray] = None,
+) -> np.ndarray:
+    converter = particle_to_array or np.asarray
+    return np.stack([converter(p) for p in particles])
 
 
 def _sample_histogram(
@@ -384,20 +398,26 @@ def _sample_histogram(
     reference_particles: np.ndarray,
     n_samples: int,
     seed: Optional[int],
+    particle_to_array: Optional[ParticleToArray] = None,
 ) -> np.ndarray:
     if seed is not None:
         np.random.seed(seed)
     n_particles = reference_particles.shape[0]
     hist = np.zeros(n_particles, dtype=float)
     for _ in range(n_samples):
-        idx = _locate_first_match_index(belief.sample(), reference_particles)
+        idx = _locate_first_match_index(belief.sample(), reference_particles, particle_to_array)
         hist[idx] += 1.0
     hist /= n_samples
     return hist
 
 
-def _locate_first_match_index(sample: Any, reference_particles: np.ndarray) -> int:
-    sample_array = np.asarray(sample)
+def _locate_first_match_index(
+    sample: Any,
+    reference_particles: np.ndarray,
+    particle_to_array: Optional[ParticleToArray] = None,
+) -> int:
+    converter = particle_to_array or np.asarray
+    sample_array = converter(sample)
     matches = np.where(np.all(reference_particles == sample_array, axis=1))[0]
     if len(matches) == 0:
         raise AssertionError(

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py
@@ -8,14 +8,44 @@ the vectorized results match the per-particle loop.
 import numpy as np
 import pytest
 
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
 from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
 from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp_beliefs import (
     CartPoleVectorizedUpdater,
+)
+from POMDPPlanners.tests.test_core.test_belief.belief_equivalence_utils import (
+    assert_sample_distributions_match,
+    assert_update_particles_match,
+    assert_update_weights_match,
 )
 from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+
+
+def _make_aligned_beliefs(updater, n_particles=60):
+    """Create baseline + vectorized beliefs with identical initial particles."""
+    np.random.seed(42)
+    particles_array = np.random.uniform(-0.05, 0.05, (n_particles, 4))
+    particles_list = [particles_array[i].copy() for i in range(n_particles)]
+    log_weights = np.log(np.ones(n_particles) / n_particles)
+
+    base = WeightedParticleBelief(
+        particles=particles_list,
+        log_weights=log_weights.copy(),
+        resampling=False,
+    )
+    vec = VectorizedWeightedParticleBelief(
+        particles=particles_array.copy(),
+        log_weights=log_weights.copy(),
+        updater=updater,
+        resampling=False,
+    )
+    return base, vec
 
 
 # ---------------------------------------------------------------------------
@@ -86,30 +116,36 @@ class TestBatchTransition:
         result = updater.batch_transition(particles, action=1)
         assert result.shape == (30, 4)
 
-    def test_deterministic_transition(self, updater):
-        """Test that batch_transition is deterministic.
+    def test_deterministic_under_fixed_seed(self, updater):
+        """Test that batch_transition is deterministic under a fixed seed.
 
-        Purpose: Validates that repeated calls with the same input give
-                 identical output (CartPole has no process noise).
+        Purpose: Validates that the stochastic batch_transition produces
+                 identical output when the global numpy RNG is seeded
+                 identically before each call.
 
-        Given: A set of particles and an action.
-        When: batch_transition is called twice with the same inputs.
+        Given: A set of particles and an action, with np.random.seed fixed
+               before each call.
+        When: batch_transition is called twice.
         Then: Both results are identical.
 
         Test type: unit
         """
         particles = np.array([[0.0, 0.0, 0.1, 0.0], [0.01, -0.02, 0.05, 0.1]])
+        np.random.seed(7)
         result_a = updater.batch_transition(particles, action=1)
+        np.random.seed(7)
         result_b = updater.batch_transition(particles, action=1)
         np.testing.assert_array_equal(result_a, result_b)
 
-    def test_physics_correctness_single_particle(self, updater):
-        """Test that vectorized physics matches hand-computed values.
+    def test_physics_deterministic_component(self, updater):
+        """Test that the deterministic physics component matches hand-computed values.
 
-        Purpose: Validates the physics equations for a single particle.
+        Purpose: Validates the deterministic physics equations for a single
+                 particle. We inspect the internal deterministic helper so
+                 stochastic noise does not enter the comparison.
 
         Given: A single particle at [0, 0, 0.1, 0] and action=1 (right force).
-        When: batch_transition is called.
+        When: The deterministic component of the transition is computed.
         Then: The result matches the expected Euler integration result.
 
         Test type: unit
@@ -117,7 +153,9 @@ class TestBatchTransition:
         import math
 
         state = np.array([[0.0, 0.0, 0.1, 0.0]])
-        result = updater.batch_transition(state, action=1)
+        # pylint: disable=protected-access
+        result = updater._deterministic_next_state(state, action=1)
+        # pylint: enable=protected-access
 
         # Hand-compute expected values
         force = updater.force_mag  # 10.0
@@ -237,6 +275,7 @@ class TestConfigId:
         """
         u1 = CartPoleVectorizedUpdater.from_environment(env)
         u2 = CartPoleVectorizedUpdater(
+            state_transition_dist=env._state_transition_dist,
             obs_dist=env._obs_dist,
             force_mag=env.force_mag * 2,
             gravity=env.gravity,
@@ -258,14 +297,15 @@ class TestConfigId:
 
 class TestEquivalenceWithPerParticleLoop:
     def test_batch_transition_matches_per_particle_loop(self, env, updater):
-        """Test vectorized batch_transition matches per-particle deterministic physics.
+        """Test vectorized batch_transition matches per-particle state_transition_model.sample.
 
-        Purpose: Verifies that batch_transition produces the same deterministic
-                 next states as the environment's state_transition_model physics.
+        Purpose: Verifies that batch_transition produces the same stochastic
+                 next states as the environment's state_transition_model.sample
+                 when the global RNG is seeded identically on both paths.
 
         Given: A set of particles, an action, and a fixed random seed.
-        When: batch_transition is called, and the same deterministic transitions
-              are computed per-particle using the environment's state_transition_model.
+        When: batch_transition is called, and the same transitions are computed
+              per-particle using the environment's state_transition_model.sample.
         Then: Results match within floating-point tolerance.
 
         Test type: integration
@@ -274,14 +314,14 @@ class TestEquivalenceWithPerParticleLoop:
         particles = np.random.uniform(-0.05, 0.05, (50, 4))
 
         def per_particle_fn(particle, action):
-            transition = env.state_transition_model(state=particle, action=action)
-            return transition._compute_deterministic_next_state()
+            return env.state_transition_model(state=particle, action=action).sample()[0]
 
         assert_batch_transition_matches_loop(
             updater=updater,
             particles=particles,
             action=1,
             per_particle_transition_fn=per_particle_fn,
+            seed=999,
         )
 
     def test_batch_observation_log_likelihood_matches_per_particle_loop(self, env, updater):
@@ -311,4 +351,80 @@ class TestEquivalenceWithPerParticleLoop:
             action=1,
             observation=observation,
             per_particle_ll_fn=per_particle_ll_fn,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Belief-level equivalence against WeightedParticleBelief
+# ---------------------------------------------------------------------------
+
+
+class TestBeliefEquivalenceWithBaseline:
+    def test_update_particles_match(self, env, updater):
+        """Test vectorized belief update produces identical next particles.
+
+        Purpose: Validates that VectorizedWeightedParticleBelief.update and
+            WeightedParticleBelief.update agree on next-state particles once
+            the vectorized updater mirrors the standard transition noise.
+
+        Given: 60 aligned particles.
+        When: Both beliefs are updated with action=1 under a shared seed.
+        Then: Next particles agree within floating-point tolerance.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater)
+        obs = np.array([0.01, 0.0, 0.02, 0.0])
+        assert_update_particles_match(
+            base=base, vec=vec, action=1, observation=obs, pomdp=env, seed=999
+        )
+
+    def test_update_weights_match(self, env, updater):
+        """Test vectorized and baseline beliefs produce identical normalized weights.
+
+        Purpose: Validates observation-reweighting consistency post-update.
+
+        Given: 60 aligned particles.
+        When: Both beliefs are updated with action=1 under a shared seed.
+        Then: Normalized weights agree within 1e-6 L-infinity.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater)
+        obs = np.array([0.01, 0.0, 0.02, 0.0])
+        assert_update_weights_match(
+            base=base,
+            vec=vec,
+            action=1,
+            observation=obs,
+            pomdp=env,
+            atol=1e-6,
+            seed=999,
+        )
+
+    def test_sample_distributions_match_post_update(self, env, updater):
+        """Test sample() on both beliefs draws unbiased from normalized_weights.
+
+        Purpose: Validates sample() unbiasedness and cross-belief agreement.
+
+        Given: 60 aligned particles; one update step seeded identically.
+        When: 20,000 samples are drawn from each belief.
+        Then: Empirical histograms agree and each matches its normalized_weights.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater)
+        obs = np.array([0.01, 0.0, 0.02, 0.0])
+        np.random.seed(999)
+        vec = vec.update(action=1, observation=obs, pomdp=env)
+        np.random.seed(999)
+        base = base.update(action=1, observation=obs, pomdp=env)
+
+        assert_sample_distributions_match(
+            base=base,
+            vec=vec,
+            n_samples=20_000,
+            tol=0.02,
+            atol_weights=0.02,
+            seed=400,
         )

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_continuous_laser_tag_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_continuous_laser_tag_vectorized_updater.py
@@ -7,6 +7,10 @@ from_environment construction, and config_id generation.
 import numpy as np
 import pytest
 
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
 from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_pomdp import (
     ContinuousLaserTagPOMDP,
     ContinuousLaserTagPOMDPDiscreteActions,
@@ -14,9 +18,41 @@ from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_pomdp impor
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_beliefs.continuous_laser_tag_vectorized_updater import (
     ContinuousLaserTagVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.belief_equivalence_utils import (
+    assert_update_particles_match_per_particle_seeded,
+)
 from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
     assert_batch_obs_log_likelihood_matches_loop,
 )
+
+
+def _make_aligned_beliefs(updater, n_particles=20):
+    """Create baseline + vectorized beliefs with identical initial particles."""
+    np.random.seed(42)
+    particles_array = np.column_stack(
+        [
+            np.random.rand(n_particles) * 10,
+            np.random.rand(n_particles) * 6,
+            np.random.rand(n_particles) * 10,
+            np.random.rand(n_particles) * 6,
+            np.zeros(n_particles),
+        ]
+    )
+    particles_list = [particles_array[i].copy() for i in range(n_particles)]
+    log_weights = np.log(np.ones(n_particles) / n_particles)
+
+    base = WeightedParticleBelief(
+        particles=particles_list,
+        log_weights=log_weights.copy(),
+        resampling=False,
+    )
+    vec = VectorizedWeightedParticleBelief(
+        particles=particles_array.copy(),
+        log_weights=log_weights.copy(),
+        updater=updater,
+        resampling=False,
+    )
+    return base, vec
 
 
 @pytest.fixture
@@ -396,3 +432,44 @@ class TestConfigId:
         u1 = ContinuousLaserTagVectorizedUpdater.from_environment(env)
         u2 = ContinuousLaserTagVectorizedUpdater.from_environment(env)
         assert u1.config_id == u2.config_id
+
+
+class TestBeliefEquivalenceWithBaseline:
+    def test_update_particles_match_per_particle_seeded(self, env, updater):
+        """Test vectorized and baseline beliefs agree on particles under per-particle seeding.
+
+        Purpose: Validates that VectorizedWeightedParticleBelief.update and
+            WeightedParticleBelief.update produce identical next particles
+            when each particle's update is seeded independently. The
+            vectorized path samples robot and opponent continuous Gaussian
+            noise in bulk, which differs in RNG order from the baseline
+            per-particle loop. Per-particle seeding restores bit-for-bit
+            equivalence on the particle array (mirroring the updater-level
+            workaround in this file's TestEquivalenceWithPerParticleLoop).
+
+            Weights are not compared here: for out-of-distribution
+            observations (like the random one used here) every particle's
+            Gaussian PDF underflows to zero, which the baseline floors via
+            ``log(eps + prob)`` and the vectorized preserves exactly via
+            ``log_pdf``. The resulting softmax distributions differ even
+            when particles match.
+
+        Given: 20 aligned continuous-space particles.
+        When: Each particle is updated individually with a shared
+            per-particle seed (base_seed + i) on both paths.
+        Then: Aggregate next-particle arrays agree within floating-point
+            tolerance.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater)
+        obs = np.random.rand(8) * 5
+        assert_update_particles_match_per_particle_seeded(
+            base=base,
+            vec=vec,
+            action=np.array([1.0, 0.5, 0.0]),
+            observation=obs,
+            pomdp=env,
+            atol=1e-10,
+            base_seed=1000,
+        )

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_continuous_light_dark_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_continuous_light_dark_vectorized_updater.py
@@ -8,12 +8,20 @@ the vectorized results match the per-particle loop in WeightedParticleBelief.
 import numpy as np
 import pytest
 
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDP,
     ContinuousLightDarkPOMDPDiscreteActions,
 )
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import (
     ContinuousLightDarkVectorizedUpdater,
+)
+from POMDPPlanners.tests.test_core.test_belief.belief_equivalence_utils import (
+    assert_sample_distributions_match,
+    assert_update_equivalence,
 )
 from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
     assert_batch_obs_log_likelihood_matches_loop,
@@ -292,11 +300,6 @@ class TestEquivalenceWithPerParticleLoop:
 
         Test type: integration
         """
-        from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
-        from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
-            VectorizedWeightedParticleBelief,
-        )
-
         np.random.seed(77)
         n = 40
         action = np.array([0.5, -0.5])
@@ -306,44 +309,81 @@ class TestEquivalenceWithPerParticleLoop:
         particles_list = [particles_array[i].copy() for i in range(n)]
         log_w = np.full(n, -np.log(n))
 
-        # Vectorized path
-        np.random.seed(200)
         v_belief = VectorizedWeightedParticleBelief(
             particles=particles_array.copy(),
             log_weights=log_w.copy(),
             updater=updater,
             resampling=False,
         )
-        v_updated = v_belief.update(action=action, observation=observation, pomdp=None)
-
-        # Per-particle path (WeightedParticleBelief)
-        np.random.seed(200)
         w_belief = WeightedParticleBelief(
             particles=particles_list,
             log_weights=log_w.copy(),
             resampling=False,
         )
+
+        assert_update_equivalence(
+            base=w_belief,
+            vec=v_belief,
+            action=action,
+            observation=observation,
+            pomdp=env,
+            atol_particles=1e-10,
+            atol_weights=1e-3,
+            significance_threshold=1e-4,
+            top_k=5,
+            seed=200,
+        )
+
+    def test_sample_distributions_match_post_update(self, env, updater):
+        """Test sample() on both beliefs draws from normalized_weights post-update.
+
+        Purpose: Validates that WeightedParticleBelief.sample() and
+                 VectorizedWeightedParticleBelief.sample() are unbiased draws
+                 from their respective updated belief distributions, and that
+                 the two distributions agree.
+
+        Given: Identical initial particles/weights; one update step applied
+               via both paths with the same seed.
+        When: 20,000 samples are drawn from each belief.
+        Then: The two empirical histograms agree in L-infinity, and each
+              histogram agrees with its belief's normalized_weights.
+
+        Test type: integration
+        """
+        np.random.seed(77)
+        n = 40
+        action = np.array([0.5, -0.5])
+        observation = np.array([3.0, 4.0])
+
+        particles_array = np.random.rand(n, 2) * 10
+        particles_list = [particles_array[i].copy() for i in range(n)]
+        log_w = np.full(n, -np.log(n))
+
+        v_belief = VectorizedWeightedParticleBelief(
+            particles=particles_array.copy(),
+            log_weights=log_w.copy(),
+            updater=updater,
+            resampling=False,
+        )
+        w_belief = WeightedParticleBelief(
+            particles=particles_list,
+            log_weights=log_w.copy(),
+            resampling=False,
+        )
+
+        np.random.seed(200)
+        v_updated = v_belief.update(action=action, observation=observation, pomdp=None)
+        np.random.seed(200)
         w_updated = w_belief.update(action=action, observation=observation, pomdp=env)
 
-        # Compare next particles
-        w_particles = np.array(w_updated.particles)
-        np.testing.assert_allclose(v_updated.particles, w_particles, atol=1e-10)
-
-        # Compare normalized weights for particles with non-negligible weight.
-        # WeightedParticleBelief uses log(eps + prob), vectorized uses log_pdf directly.
-        # When prob underflows to 0.0, the eps floor creates divergent normalized
-        # weights for low-probability particles. We restrict comparison to particles
-        # where the per-particle path assigns meaningful weight (above eps-floor level).
-        v_nw = v_updated.normalized_weights
-        w_nw = w_updated.normalized_weights
-        significant = w_nw > 1e-4
-        assert np.any(significant), "No particles have significant weight"
-        np.testing.assert_allclose(v_nw[significant], w_nw[significant], atol=1e-3)
-
-        # Verify both paths agree on the ranking of top particles
-        v_top = np.argsort(v_nw)[::-1][:5]
-        w_top = np.argsort(w_nw)[::-1][:5]
-        np.testing.assert_array_equal(v_top, w_top)
+        assert_sample_distributions_match(
+            base=w_updated,
+            vec=v_updated,
+            n_samples=20_000,
+            tol=0.02,
+            atol_weights=0.02,
+            seed=400,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -466,10 +506,6 @@ class TestDiscreteActionFullUpdate:
 
         Test type: integration
         """
-        from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
-            VectorizedWeightedParticleBelief,
-        )
-
         np.random.seed(42)
         n = 30
         particles = np.random.rand(n, 2) * 10

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
@@ -8,14 +8,49 @@ the vectorized results match the per-particle loop.
 import numpy as np
 import pytest
 
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
 from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP
 from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp_beliefs import (
     MountainCarVectorizedUpdater,
+)
+from POMDPPlanners.tests.test_core.test_belief.belief_equivalence_utils import (
+    assert_sample_distributions_match,
+    assert_update_particles_match,
+    assert_update_weights_match,
 )
 from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+
+
+def _make_aligned_beliefs(updater, n_particles=60):
+    """Create baseline + vectorized beliefs with identical initial particles."""
+    np.random.seed(42)
+    particles_array = np.column_stack(
+        [
+            np.random.uniform(-0.6, -0.4, n_particles),
+            np.random.uniform(-0.02, 0.02, n_particles),
+        ]
+    )
+    particles_list = [particles_array[i].copy() for i in range(n_particles)]
+    log_weights = np.log(np.ones(n_particles) / n_particles)
+
+    base = WeightedParticleBelief(
+        particles=particles_list,
+        log_weights=log_weights.copy(),
+        resampling=False,
+    )
+    vec = VectorizedWeightedParticleBelief(
+        particles=particles_array.copy(),
+        log_weights=log_weights.copy(),
+        updater=updater,
+        resampling=False,
+    )
+    return base, vec
 
 
 # ---------------------------------------------------------------------------
@@ -86,44 +121,51 @@ class TestBatchTransition:
         result = updater.batch_transition(particles, action=1)
         assert result.shape == (30, 2)
 
-    def test_deterministic_transition(self, updater):
-        """Test that batch_transition is deterministic.
+    def test_deterministic_under_fixed_seed(self, updater):
+        """Test that batch_transition is deterministic under a fixed seed.
 
-        Purpose: Validates that repeated calls with the same input give
-                 identical output (Mountain Car has no process noise).
+        Purpose: Validates that the stochastic batch_transition produces
+                 identical output when the global numpy RNG is seeded
+                 identically before each call.
 
-        Given: A set of particles and an action.
-        When: batch_transition is called twice with the same inputs.
+        Given: A set of particles and an action, with np.random.seed fixed
+               before each call.
+        When: batch_transition is called twice.
         Then: Both results are identical.
 
         Test type: unit
         """
         particles = np.array([[-0.5, 0.0], [-0.6, 0.01]])
+        np.random.seed(7)
         result_a = updater.batch_transition(particles, action=1)
+        np.random.seed(7)
         result_b = updater.batch_transition(particles, action=1)
         np.testing.assert_array_equal(result_a, result_b)
 
-    def test_physics_correctness_single_particle(self, updater):
-        """Test that vectorized physics matches hand-computed values.
+    def test_physics_deterministic_component(self, updater):
+        """Test that the deterministic physics component matches hand-computed values.
 
-        Purpose: Validates the physics equations for a single particle.
+        Purpose: Validates the deterministic physics equations for a single
+                 particle. We inspect the internal deterministic helper so
+                 stochastic noise does not enter the comparison.
 
         Given: A single particle at [-0.5, 0.0] and action=1 (forward).
-        When: batch_transition is called.
+        When: The deterministic component of the transition is computed.
         Then: The result matches the expected physics computation.
 
         Test type: unit
         """
         state = np.array([[-0.5, 0.0]])
-        result = updater.batch_transition(state, action=1)
+        # pylint: disable=protected-access
+        position, velocity = updater._deterministic_next_state(state, action=1)
+        # pylint: enable=protected-access
 
-        # Hand-compute expected
         v = 0.0 + 1 * updater.power + np.cos(3.0 * (-0.5)) * (-updater.gravity)
         v = np.clip(v, -updater.max_speed, updater.max_speed)
         p = -0.5 + v
         p = np.clip(p, updater.min_position, updater.max_position)
 
-        np.testing.assert_allclose(result[0], [p, v], atol=1e-12)
+        np.testing.assert_allclose([position[0], velocity[0]], [p, v], atol=1e-12)
 
     def test_position_clipping(self, updater):
         """Test that positions are clipped at boundaries.
@@ -264,6 +306,7 @@ class TestConfigId:
         """
         u1 = MountainCarVectorizedUpdater.from_environment(env)
         u2 = MountainCarVectorizedUpdater(
+            state_transition_dist=env._state_transition_dist,
             obs_dist=env._obs_dist,
             power=env.power * 2,
             gravity=env.gravity,
@@ -275,20 +318,97 @@ class TestConfigId:
 
 
 # ---------------------------------------------------------------------------
+# Belief-level equivalence against WeightedParticleBelief
+# ---------------------------------------------------------------------------
+
+
+class TestBeliefEquivalenceWithBaseline:
+    def test_update_particles_match(self, env, updater):
+        """Test vectorized belief update produces identical next particles.
+
+        Purpose: Validates that VectorizedWeightedParticleBelief.update and
+            WeightedParticleBelief.update agree on next-state particles once
+            the vectorized updater mirrors the standard transition noise.
+
+        Given: 60 aligned particles.
+        When: Both beliefs are updated with action=1 under a shared seed.
+        Then: Next particles agree within floating-point tolerance.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater)
+        obs = np.array([-0.5, 0.0])
+        assert_update_particles_match(
+            base=base, vec=vec, action=1, observation=obs, pomdp=env, seed=999
+        )
+
+    def test_update_weights_match(self, env, updater):
+        """Test vectorized and baseline beliefs produce identical normalized weights.
+
+        Purpose: Validates observation-reweighting consistency post-update.
+
+        Given: 60 aligned particles.
+        When: Both beliefs are updated with action=1 under a shared seed.
+        Then: Normalized weights agree within 1e-6 L-infinity.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater)
+        obs = np.array([-0.5, 0.0])
+        assert_update_weights_match(
+            base=base,
+            vec=vec,
+            action=1,
+            observation=obs,
+            pomdp=env,
+            atol=1e-6,
+            seed=999,
+        )
+
+    def test_sample_distributions_match_post_update(self, env, updater):
+        """Test sample() on both beliefs draws unbiased from normalized_weights.
+
+        Purpose: Validates sample() unbiasedness and cross-belief agreement.
+
+        Given: 60 aligned particles; one update step seeded identically.
+        When: 20,000 samples are drawn from each belief.
+        Then: Empirical histograms agree and each matches its normalized_weights.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater)
+        obs = np.array([-0.5, 0.0])
+        np.random.seed(999)
+        vec = vec.update(action=1, observation=obs, pomdp=env)
+        np.random.seed(999)
+        base = base.update(action=1, observation=obs, pomdp=env)
+
+        assert_sample_distributions_match(
+            base=base,
+            vec=vec,
+            n_samples=20_000,
+            tol=0.02,
+            atol_weights=0.02,
+            seed=400,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Equivalence test: vectorized vs per-particle loop
 # ---------------------------------------------------------------------------
 
 
 class TestEquivalenceWithPerParticleLoop:
     def test_batch_transition_matches_per_particle_loop(self, env, updater):
-        """Test vectorized batch_transition matches per-particle deterministic physics.
+        """Test vectorized batch_transition matches per-particle state_transition_model.sample.
 
-        Purpose: Verifies that batch_transition produces the same deterministic
-                 next states as the environment's state_transition_model physics.
+        Purpose: Verifies that batch_transition produces the same stochastic
+                 next states as the environment's state_transition_model.sample
+                 when the global RNG is seeded identically on both paths.
 
         Given: A set of particles, an action, and a fixed random seed.
-        When: batch_transition is called, and the same deterministic transitions
-              are computed per-particle using the environment's state_transition_model.
+        When: batch_transition is called, and the same transitions are computed
+              per-particle using the environment's state_transition_model.sample.
         Then: Results match within floating-point tolerance.
 
         Test type: integration
@@ -302,14 +422,14 @@ class TestEquivalenceWithPerParticleLoop:
         )
 
         def per_particle_fn(particle, action):
-            transition = env.state_transition_model(state=tuple(particle), action=action)
-            return transition._compute_deterministic_next_state()
+            return env.state_transition_model(state=tuple(particle), action=action).sample()[0]
 
         assert_batch_transition_matches_loop(
             updater=updater,
             particles=particles,
             action=1,
             per_particle_transition_fn=per_particle_fn,
+            seed=999,
         )
 
     def test_batch_observation_log_likelihood_matches_per_particle_loop(self, env, updater):

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_vectorized_updater.py
@@ -5,14 +5,56 @@
 import numpy as np
 import pytest
 
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
 from POMDPPlanners.environments.pacman_pomdp import PacManPOMDP, PacManState
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_vectorized_updater import (
     PacManVectorizedUpdater,
+)
+from POMDPPlanners.tests.test_core.test_belief.belief_equivalence_utils import (
+    assert_sample_distributions_match,
+    assert_update_particles_match,
+    assert_update_weights_match,
 )
 from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+
+
+def _make_aligned_beliefs(env, updater, n_particles=50):
+    """Create baseline + vectorized beliefs with identical initial particles."""
+    np.random.seed(42)
+    states = env.initial_state_dist().sample(n_samples=n_particles)
+    particles_array = env.states_to_array(states)
+    particles_list = [particles_array[i].copy() for i in range(n_particles)]
+    log_weights = np.log(np.ones(n_particles) / n_particles)
+
+    base = WeightedParticleBelief(
+        particles=particles_list,
+        log_weights=log_weights.copy(),
+        resampling=False,
+    )
+    vec = VectorizedWeightedParticleBelief(
+        particles=particles_array.copy(),
+        log_weights=log_weights.copy(),
+        updater=updater,
+        resampling=False,
+    )
+    return base, vec
+
+
+def _make_particle_to_array(env):
+    """Build a PacManState-or-ndarray → state-array converter bound to env."""
+
+    def convert(particle):
+        if isinstance(particle, np.ndarray):
+            return particle
+        return env.state_to_array(particle)
+
+    return convert
 
 
 @pytest.fixture()
@@ -325,6 +367,90 @@ class TestEquivalenceWithPerParticleLoop:
             action=0,
             observation=obs_array,
             per_particle_ll_fn=per_particle_ll_fn,
+        )
+
+
+class TestBeliefEquivalenceWithBaseline:
+    def test_update_particles_match(self, simple_env, updater):
+        """Test vectorized belief update produces identical next particles.
+
+        Purpose: Validates that VectorizedWeightedParticleBelief.update and
+            WeightedParticleBelief.update agree on next-state particles. The
+            baseline belief stores particles as ndarray rows on initialization
+            but WeightedParticleBelief.update stores returned PacManState
+            instances after the step, so particle comparison is routed
+            through env.state_to_array via particle_to_array.
+
+        Given: 50 aligned particles in both beliefs.
+        When: Both beliefs are updated with action=0 and a fixed observation.
+        Then: Next-particle arrays agree within floating-point tolerance.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(simple_env, updater)
+        obs = ((3, 3),)
+        assert_update_particles_match(
+            base=base,
+            vec=vec,
+            action=0,
+            observation=obs,
+            pomdp=simple_env,
+            seed=999,
+            particle_to_array=_make_particle_to_array(simple_env),
+        )
+
+    def test_update_weights_match(self, simple_env, updater):
+        """Test vectorized and baseline beliefs produce identical normalized weights.
+
+        Purpose: Validates observation-reweighting consistency on PacMan's
+            ghost-position observations.
+
+        Given: 50 aligned particles.
+        When: Both beliefs are updated with action=0 under a shared seed.
+        Then: Normalized weights agree within 1e-6 L-infinity.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(simple_env, updater)
+        obs = ((3, 3),)
+        assert_update_weights_match(
+            base=base,
+            vec=vec,
+            action=0,
+            observation=obs,
+            pomdp=simple_env,
+            atol=1e-6,
+            seed=999,
+        )
+
+    def test_sample_distributions_match_post_update(self, simple_env, updater):
+        """Test sample() on both beliefs draws unbiased from normalized_weights.
+
+        Purpose: Validates sample() unbiasedness and cross-belief agreement.
+            PacMan particles duplicate heavily (small grid), so aggregation by
+            particle identity inside the helper handles discrete duplicates.
+
+        Given: 50 aligned particles; one update step seeded identically.
+        When: 20,000 samples are drawn from each belief.
+        Then: Empirical histograms agree and each matches its normalized_weights.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(simple_env, updater)
+        obs = ((3, 3),)
+        np.random.seed(999)
+        vec = vec.update(action=0, observation=obs, pomdp=simple_env)
+        np.random.seed(999)
+        base = base.update(action=0, observation=obs, pomdp=simple_env)
+
+        assert_sample_distributions_match(
+            base=base,
+            vec=vec,
+            n_samples=20_000,
+            tol=0.03,
+            atol_weights=0.03,
+            seed=400,
+            particle_to_array=_make_particle_to_array(simple_env),
         )
 
 

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_continuous_push_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_continuous_push_vectorized_updater.py
@@ -8,6 +8,10 @@ log-likelihood methods for the Continuous Push POMDP.
 
 import numpy as np
 
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
 from POMDPPlanners.environments.push_pomdp.continuous_push_pomdp import (
     ContinuousPushPOMDP,
     ContinuousPushPOMDPDiscreteActions,
@@ -15,10 +19,37 @@ from POMDPPlanners.environments.push_pomdp.continuous_push_pomdp import (
 from POMDPPlanners.environments.push_pomdp.push_pomdp_beliefs.continuous_push_vectorized_updater import (
     ContinuousPushVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.belief_equivalence_utils import (
+    assert_sample_distributions_match,
+    assert_update_particles_match,
+    assert_update_weights_match,
+)
 from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+
+
+def _make_aligned_beliefs(updater, n_particles=60):
+    """Create baseline + vectorized beliefs with identical initial particles."""
+    np.random.seed(42)
+    particles_array = np.random.uniform(0.5, 3.5, (n_particles, 6))
+    particles_array[:, 4:6] = [3.5, 3.5]
+    particles_list = [particles_array[i].copy() for i in range(n_particles)]
+    log_weights = np.log(np.ones(n_particles) / n_particles)
+
+    base = WeightedParticleBelief(
+        particles=particles_list,
+        log_weights=log_weights.copy(),
+        resampling=False,
+    )
+    vec = VectorizedWeightedParticleBelief(
+        particles=particles_array.copy(),
+        log_weights=log_weights.copy(),
+        updater=updater,
+        resampling=False,
+    )
+    return base, vec
 
 
 class TestContinuousPushVectorizedUpdater:
@@ -230,3 +261,89 @@ class TestContinuousPushVectorizedUpdater:
         updater = ContinuousPushVectorizedUpdater.from_environment(env_d)
         assert updater._action_to_vector is not None
         assert "right" in updater._action_to_vector
+
+
+class TestBeliefEquivalenceWithBaseline:
+    """Belief-level equivalence checks against WeightedParticleBelief."""
+
+    def setup_method(self):
+        """Set up shared test fixtures."""
+        self.env = ContinuousPushPOMDP(
+            discount_factor=0.99,
+            state_transition_cov_matrix=np.eye(2) * 0.01,
+            robot_radius=0.3,
+        )
+        self.updater = ContinuousPushVectorizedUpdater.from_environment(self.env)
+
+    def test_update_particles_match(self):
+        """Test vectorized belief update produces identical next particles.
+
+        Purpose: Validates that VectorizedWeightedParticleBelief.update and
+            WeightedParticleBelief.update agree on next-state particles for
+            continuous Push when the RNG is seeded identically on both paths.
+
+        Given: 60 aligned particles; both beliefs share the same updater.
+        When: Both are updated with a 2D continuous action and fixed observation.
+        Then: Next-particle arrays agree within floating-point tolerance.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(self.updater)
+        action = np.array([0.5, 0.3])
+        obs = np.array([2.0, 2.0, 2.0, 2.0, 3.5, 3.5])
+        assert_update_particles_match(
+            base=base, vec=vec, action=action, observation=obs, pomdp=self.env, seed=999
+        )
+
+    def test_update_weights_match(self):
+        """Test vectorized and baseline beliefs produce identical normalized weights.
+
+        Purpose: Validates that observation-reweighting is consistent between
+            vectorized and per-particle update implementations.
+
+        Given: 60 aligned particles.
+        When: Both are updated with the same action, observation, and seed.
+        Then: Normalized weights agree within 1e-6 L-infinity.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(self.updater)
+        action = np.array([0.5, 0.3])
+        obs = np.array([2.0, 2.0, 2.0, 2.0, 3.5, 3.5])
+        assert_update_weights_match(
+            base=base,
+            vec=vec,
+            action=action,
+            observation=obs,
+            pomdp=self.env,
+            atol=1e-6,
+            seed=999,
+        )
+
+    def test_sample_distributions_match_post_update(self):
+        """Test sample() on both beliefs draws unbiased from normalized_weights.
+
+        Purpose: Validates sample() unbiasedness and cross-belief agreement.
+
+        Given: 60 aligned particles; one update step seeded identically.
+        When: 20,000 samples are drawn from each belief.
+        Then: Empirical histograms agree and each matches its normalized_weights.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(self.updater)
+        action = np.array([0.5, 0.3])
+        obs = np.array([2.0, 2.0, 2.0, 2.0, 3.5, 3.5])
+        np.random.seed(999)
+        vec = vec.update(action=action, observation=obs, pomdp=self.env)
+        np.random.seed(999)
+        base = base.update(action=action, observation=obs, pomdp=self.env)
+
+        assert_sample_distributions_match(
+            base=base,
+            vec=vec,
+            n_samples=20_000,
+            tol=0.02,
+            atol_weights=0.02,
+            seed=400,
+        )

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_push_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_push_vectorized_updater.py
@@ -8,14 +8,45 @@ that verifies the vectorized results match the per-particle loop.
 import numpy as np
 import pytest
 
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
 from POMDPPlanners.environments.push_pomdp import PushPOMDP
 from POMDPPlanners.environments.push_pomdp.push_pomdp_beliefs import (
     PushVectorizedUpdater,
+)
+from POMDPPlanners.tests.test_core.test_belief.belief_equivalence_utils import (
+    assert_sample_distributions_match,
+    assert_update_particles_match,
+    assert_update_weights_match,
 )
 from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+
+
+def _make_aligned_beliefs(updater, n_particles=100):
+    """Create baseline + vectorized beliefs with identical initial particles."""
+    np.random.seed(42)
+    particles_array = np.random.uniform(1, 8, (n_particles, 6))
+    particles_array[:, 4:6] = [9.0, 9.0]
+    particles_list = [particles_array[i].copy() for i in range(n_particles)]
+    log_weights = np.log(np.ones(n_particles) / n_particles)
+
+    base = WeightedParticleBelief(
+        particles=particles_list,
+        log_weights=log_weights.copy(),
+        resampling=False,
+    )
+    vec = VectorizedWeightedParticleBelief(
+        particles=particles_array.copy(),
+        log_weights=log_weights.copy(),
+        updater=updater,
+        resampling=False,
+    )
+    return base, vec
 
 
 # ---------------------------------------------------------------------------
@@ -536,3 +567,85 @@ class TestEquivalenceWithPerParticleLoop:
                 per_particle_transition_fn=per_particle_fn,
                 err_msg=f"Obstacle mismatch for action {action_idx} ({action_str})",
             )
+
+
+# ---------------------------------------------------------------------------
+# Belief-level equivalence against WeightedParticleBelief
+# ---------------------------------------------------------------------------
+
+
+class TestBeliefEquivalenceWithBaseline:
+    def test_update_particles_match(self, env_no_obstacles, updater_no_obstacles):
+        """Test vectorized belief update produces identical next particles.
+
+        Purpose: Validates that VectorizedWeightedParticleBelief.update and
+            WeightedParticleBelief.update agree on next-state particles for
+            Push's deterministic transitions (transition_error_prob=0).
+
+        Given: 100 aligned particles; both beliefs share the same updater.
+        When: Both are updated with the string action "up" and a fixed observation.
+        Then: Next-particle arrays agree within floating-point tolerance.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater_no_obstacles)
+        obs = np.array([4.0, 4.0, 4.0, 4.0, 9.0, 9.0])
+        assert_update_particles_match(
+            base=base,
+            vec=vec,
+            action="up",
+            observation=obs,
+            pomdp=env_no_obstacles,
+            atol=1e-10,
+        )
+
+    def test_update_weights_match(self, env_no_obstacles, updater_no_obstacles):
+        """Test vectorized and baseline beliefs produce identical normalized weights.
+
+        Purpose: Validates that the observation-reweighting path is consistent
+            between the vectorized and per-particle update implementations.
+
+        Given: 100 aligned particles.
+        When: Both beliefs are updated with "up" and a fixed observation.
+        Then: Normalized weights agree within 1e-6 L-infinity.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater_no_obstacles)
+        obs = np.array([4.0, 4.0, 4.0, 4.0, 9.0, 9.0])
+        assert_update_weights_match(
+            base=base,
+            vec=vec,
+            action="up",
+            observation=obs,
+            pomdp=env_no_obstacles,
+            atol=1e-6,
+        )
+
+    def test_sample_distributions_match_post_update(self, env_no_obstacles, updater_no_obstacles):
+        """Test sample() on both beliefs draws unbiased from normalized_weights.
+
+        Purpose: Validates that WeightedParticleBelief.sample() and
+            VectorizedWeightedParticleBelief.sample() are unbiased draws
+            from their belief distributions after an update.
+
+        Given: 100 aligned particles, one update with a non-trivial observation.
+        When: 20,000 samples are drawn from each belief.
+        Then: Empirical histograms agree with each other and each agrees with
+            its belief's normalized_weights.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater_no_obstacles)
+        obs = np.array([4.0, 4.0, 4.0, 4.0, 9.0, 9.0])
+        base = base.update(action="up", observation=obs, pomdp=env_no_obstacles)
+        vec = vec.update(action="up", observation=obs, pomdp=env_no_obstacles)
+
+        assert_sample_distributions_match(
+            base=base,
+            vec=vec,
+            n_samples=20_000,
+            tol=0.02,
+            atol_weights=0.02,
+            seed=400,
+        )

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_belief_integration.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_belief_integration.py
@@ -9,6 +9,15 @@ from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rock
     RockSampleVectorizedWeightedParticleBelief,
     create_rocksample_belief,
 )
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rocksample_vectorized_updater import (
+    RockSampleVectorizedUpdater,
+)
+from POMDPPlanners.tests.test_core.test_belief.belief_equivalence_utils import (
+    assert_chained_update_equivalence,
+    assert_sample_distributions_match,
+    assert_update_particles_match,
+    assert_update_weights_match,
+)
 from POMDPPlanners.utils.belief_factory import BeliefType
 
 
@@ -159,10 +168,6 @@ def _make_aligned_beliefs(env, n_particles=200):
     particles_array = np.stack(states)
     log_weights = np.log(np.ones(n_particles) / n_particles)
 
-    from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rocksample_vectorized_updater import (
-        RockSampleVectorizedUpdater,
-    )
-
     base = WeightedParticleBelief(
         particles=particles_list,
         log_weights=log_weights.copy(),
@@ -193,14 +198,9 @@ class TestVectorizedMatchesBaseline:
         Test type: integration
         """
         base, vec = _make_aligned_beliefs(simple_env)
-        action = 2  # East
-        obs = "none"
-
-        base_updated = base.update(action=action, observation=obs, pomdp=simple_env)
-        vec_updated = vec.update(action=action, observation=obs)
-
-        base_particles = np.stack(base_updated.particles)
-        np.testing.assert_array_equal(vec_updated.particles, base_particles)
+        assert_update_particles_match(
+            base=base, vec=vec, action=2, observation="none", pomdp=simple_env, atol=0.0
+        )
 
     def test_transition_particles_match_for_sample_action(self, simple_env):
         """Test that transitioned particles match for sample action.
@@ -215,14 +215,9 @@ class TestVectorizedMatchesBaseline:
         Test type: integration
         """
         base, vec = _make_aligned_beliefs(simple_env)
-        action = 0  # Sample
-        obs = "none"
-
-        base_updated = base.update(action=action, observation=obs, pomdp=simple_env)
-        vec_updated = vec.update(action=action, observation=obs)
-
-        base_particles = np.stack(base_updated.particles)
-        np.testing.assert_array_equal(vec_updated.particles, base_particles)
+        assert_update_particles_match(
+            base=base, vec=vec, action=0, observation="none", pomdp=simple_env, atol=0.0
+        )
 
     def test_transition_particles_match_for_check_action(self, simple_env):
         """Test that transitioned particles match for check actions.
@@ -237,14 +232,9 @@ class TestVectorizedMatchesBaseline:
         Test type: integration
         """
         base, vec = _make_aligned_beliefs(simple_env)
-        action = 5  # Check rock 0
-        obs = "good"
-
-        base_updated = base.update(action=action, observation=obs, pomdp=simple_env)
-        vec_updated = vec.update(action=action, observation=obs)
-
-        base_particles = np.stack(base_updated.particles)
-        np.testing.assert_array_equal(vec_updated.particles, base_particles)
+        assert_update_particles_match(
+            base=base, vec=vec, action=5, observation="good", pomdp=simple_env, atol=0.0
+        )
 
     def test_normalized_weights_match_for_movement(self, simple_env):
         """Test that normalized weights match for movement actions.
@@ -259,16 +249,8 @@ class TestVectorizedMatchesBaseline:
         Test type: integration
         """
         base, vec = _make_aligned_beliefs(simple_env)
-        action = 1  # North
-        obs = "none"
-
-        base_updated = base.update(action=action, observation=obs, pomdp=simple_env)
-        vec_updated = vec.update(action=action, observation=obs)
-
-        np.testing.assert_allclose(
-            vec_updated.normalized_weights,
-            base_updated.normalized_weights,
-            atol=1e-6,
+        assert_update_weights_match(
+            base=base, vec=vec, action=1, observation="none", pomdp=simple_env, atol=1e-6
         )
 
     def test_normalized_weights_close_for_check_action(self, simple_env):
@@ -285,16 +267,8 @@ class TestVectorizedMatchesBaseline:
         Test type: integration
         """
         base, vec = _make_aligned_beliefs(simple_env)
-        action = 5  # Check rock 0
-        obs = "good"
-
-        base_updated = base.update(action=action, observation=obs, pomdp=simple_env)
-        vec_updated = vec.update(action=action, observation=obs)
-
-        np.testing.assert_allclose(
-            vec_updated.normalized_weights,
-            base_updated.normalized_weights,
-            atol=1e-6,
+        assert_update_weights_match(
+            base=base, vec=vec, action=5, observation="good", pomdp=simple_env, atol=1e-6
         )
 
     def test_weights_match_after_multiple_updates(self, simple_env):
@@ -310,7 +284,6 @@ class TestVectorizedMatchesBaseline:
         Test type: integration
         """
         base, vec = _make_aligned_beliefs(simple_env, n_particles=500)
-
         steps = [
             (5, "good"),  # check rock 0
             (2, "none"),  # move east
@@ -318,15 +291,43 @@ class TestVectorizedMatchesBaseline:
             (1, "none"),  # move north
             (5, "good"),  # check rock 0 again
         ]
+        assert_chained_update_equivalence(
+            base=base,
+            vec=vec,
+            steps=steps,
+            pomdp=simple_env,
+            atol_particles=0.0,
+            atol_weights=1e-5,
+        )
 
-        for action, obs in steps:
-            base = base.update(action=action, observation=obs, pomdp=simple_env)
-            vec = vec.update(action=action, observation=obs)
+    def test_sample_distributions_match_post_update(self, simple_env):
+        """Test sample() on both beliefs draws from normalized_weights post-update.
 
-        base_particles = np.stack(base.particles)
-        np.testing.assert_array_equal(vec.particles, base_particles)
-        np.testing.assert_allclose(
-            vec.normalized_weights,
-            base.normalized_weights,
-            atol=1e-5,
+        Purpose: Validates that WeightedParticleBelief.sample() and
+            RockSampleVectorizedWeightedParticleBelief.sample() are unbiased
+            draws from their updated belief distributions after a non-trivial
+            check action that re-weights particles, and that the two
+            distributions agree.
+
+        Given: 200 aligned particles in both beliefs, updated with Check
+            rock 0 and 'good' observation.
+        When: 20,000 samples are drawn from each belief.
+        Then: The two empirical histograms agree in L-infinity, and each
+            histogram agrees with its belief's normalized_weights. Duplicate
+            particles (common in RockSample) are aggregated by particle
+            identity before comparison.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(simple_env)
+        base = base.update(action=5, observation="good", pomdp=simple_env)
+        vec = vec.update(action=5, observation="good")
+
+        assert_sample_distributions_match(
+            base=base,
+            vec=vec,
+            n_samples=20_000,
+            tol=0.02,
+            atol_weights=0.02,
+            seed=400,
         )

--- a/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp_beliefs/test_safety_ant_velocity_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp_beliefs/test_safety_ant_velocity_vectorized_updater.py
@@ -8,16 +8,51 @@ the vectorized results match the per-particle loop.
 import numpy as np
 import pytest
 
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
 from POMDPPlanners.environments.safety_ant_velocity_pomdp import (
     SafeAntVelocityPOMDP,
 )
 from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_pomdp_beliefs import (
     SafetyAntVelocityVectorizedUpdater,
 )
+from POMDPPlanners.tests.test_core.test_belief.belief_equivalence_utils import (
+    assert_sample_distributions_match,
+    assert_update_particles_match,
+    assert_update_weights_match,
+)
 from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+
+
+def _make_aligned_beliefs(updater, n_particles=60):
+    """Create baseline + vectorized beliefs with identical initial particles."""
+    np.random.seed(42)
+    particles_array = np.column_stack(
+        [
+            np.random.uniform(-1, 1, (n_particles, 2)),
+            np.random.uniform(-0.5, 0.5, (n_particles, 2)),
+        ]
+    )
+    particles_list = [particles_array[i].copy() for i in range(n_particles)]
+    log_weights = np.log(np.ones(n_particles) / n_particles)
+
+    base = WeightedParticleBelief(
+        particles=particles_list,
+        log_weights=log_weights.copy(),
+        resampling=False,
+    )
+    vec = VectorizedWeightedParticleBelief(
+        particles=particles_array.copy(),
+        log_weights=log_weights.copy(),
+        updater=updater,
+        resampling=False,
+    )
+    return base, vec
 
 
 # ---------------------------------------------------------------------------
@@ -361,4 +396,80 @@ class TestEquivalenceWithPerParticleLoop:
             observation=observation,
             per_particle_ll_fn=per_particle_ll_fn,
             compare_mode="pairwise_diff",
+        )
+
+
+class TestBeliefEquivalenceWithBaseline:
+    def test_update_particles_match(self, env, updater):
+        """Test vectorized belief update produces identical next particles.
+
+        Purpose: Validates that VectorizedWeightedParticleBelief.update and
+            WeightedParticleBelief.update agree on next-state particles when
+            both paths are seeded identically. SafetyAnt's stochastic force
+            direction is consumed in the same order by both paths.
+
+        Given: 60 aligned particles.
+        When: Both beliefs are updated with action=2 and a fixed observation,
+            seed=999 on both paths.
+        Then: Next particles agree within floating-point tolerance.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater)
+        obs = np.array([0.1, -0.1, 0.5, 0.2])
+        assert_update_particles_match(
+            base=base, vec=vec, action=2, observation=obs, pomdp=env, seed=999
+        )
+
+    def test_update_weights_match(self, env, updater):
+        """Test vectorized and baseline beliefs produce identical normalized weights.
+
+        Purpose: Validates observation-reweighting consistency. The two paths
+            compute log-likelihoods that differ by a constant normalization
+            offset, which cancels out in the softmax-normalized weight vector.
+
+        Given: 60 aligned particles.
+        When: Both beliefs are updated with action=1 and a fixed observation.
+        Then: Normalized weights agree within 1e-6 L-infinity.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater)
+        obs = np.array([0.1, -0.1, 0.5, 0.2])
+        assert_update_weights_match(
+            base=base,
+            vec=vec,
+            action=1,
+            observation=obs,
+            pomdp=env,
+            atol=1e-3,
+            significance_threshold=1e-4,
+            seed=999,
+        )
+
+    def test_sample_distributions_match_post_update(self, env, updater):
+        """Test sample() on both beliefs draws unbiased from normalized_weights.
+
+        Purpose: Validates sample() unbiasedness and cross-belief agreement.
+
+        Given: 60 aligned particles; one update step seeded identically.
+        When: 20,000 samples are drawn from each belief.
+        Then: Empirical histograms agree and each matches its normalized_weights.
+
+        Test type: integration
+        """
+        base, vec = _make_aligned_beliefs(updater)
+        obs = np.array([0.1, -0.1, 0.5, 0.2])
+        np.random.seed(999)
+        vec = vec.update(action=1, observation=obs, pomdp=env)
+        np.random.seed(999)
+        base = base.update(action=1, observation=obs, pomdp=env)
+
+        assert_sample_distributions_match(
+            base=base,
+            vec=vec,
+            n_samples=20_000,
+            tol=0.02,
+            atol_weights=0.02,
+            seed=400,
         )


### PR DESCRIPTION
## Summary

- Add a shared, environment-agnostic test module `belief_equivalence_utils.py` that compares `WeightedParticleBelief` against `VectorizedWeightedParticleBelief` via their public API (`update`, `normalized_weights`, `sample`), plus a per-particle-seeded variant for envs whose vectorized batch_transition consumes RNG in a different order than the baseline.
- Port belief-level equivalence tests into LightDark (continuous), RockSample, Push (discrete + continuous), SafetyAnt, MountainCar, CartPole, PacMan, and continuous LaserTag.
- **Bug fix**: `MountainCarVectorizedUpdater` and `CartPoleVectorizedUpdater` were silently dropping the Gaussian process noise that `<Env>Transition.sample()` adds. Both updaters now accept `state_transition_dist` and sample N bulk noise vectors inside `batch_transition`, matching the standard belief's dynamics. The new belief-level tests surfaced the divergence.

## Coverage by environment

| Env | Ported | Notes |
|-----|--------|-------|
| LightDark continuous | Yes | `assert_update_equivalence` |
| RockSample | Yes | Full `TestVectorizedMatchesBaseline` |
| Push (discrete + continuous) | Yes | Particles + weights + sample distribution |
| SafetyAnt | Yes | Uses `significance_threshold=1e-4` like LightDark |
| MountainCar, CartPole | Yes | After the transition-noise bug fix |
| PacMan | Yes | Uses new `particle_to_array=env.state_to_array` hook |
| Continuous LaserTag | Yes | Per-particle-seeded variant; particles only (weights underflow under random obs) |
| Discrete LaserTag | No | Opponent movement distribution doesn't align even under per-particle seeding; existing updater tests also compare robot positions only |

## Test plan

- [x] pyright 0/0 on new module and all touched files
- [x] pylint 10.00/10 on `belief_equivalence_utils.py`
- [x] `pytest` on the 12 touched files: 444 passed
- [x] Downstream gaussian-belief / belief-factory tests for MountainCar and CartPole: 59 passed
- [x] Pre-commit hooks (black, pylint, pyright) passed on every commit