### PR TITLE
Release 0.2.0: version bump, CHANGELOG, docs refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to POMDPPlanners are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-04-17
+
+### Added
+- Vectorized belief updaters for RockSample, PacMan, LightDark (continuous and discrete), CartPole, MountainCar, Push, Continuous Push, Continuous LaserTag, and SafetyAnt POMDPs, with batched NumPy updates for significant throughput gains.
+- Observation-model-aware vectorized belief updaters for the LightDark POMDP family.
+- Shared belief-level equivalence test utilities that validate vectorized updaters against non-vectorized baselines across environments.
+- `ParallelizationLevel` option for hyperparameter tuning, enabling episode-level parallelism alongside Optuna-level parallelism.
+- Three-layer benchmark suite for planner and environment performance testing.
+- Weekly CI workflow that runs the full slow-test suite; 117 tests marked as `slow`.
+- Split Docker build pipeline: reusable base image plus a thin CI layer, with auto-build when the base image is missing from GHCR.
+- Auto-rebase workflow for open PRs whenever `develop` is updated.
+- Gaussian process noise in the CartPole and MountainCar state transition models.
+
+### Changed
+- Full test suite (including slow tests) now runs on pushes to `master`; other branches and PRs skip slow tests.
+- `develop` branch added as a CI test workflow trigger.
+- `PacManPOMDP` environment methods now accept NumPy array states.
+- Refactored hyperparameter tuning to compute `optuna_n_jobs` and `episode_n_jobs` once in `__init__`.
+- `CartPolePOMDP` and `MountainCarPOMDP` belief tests now compare against deterministic physics rather than noisy samples.
+
+### Performance
+- `PushPOMDP.sample_next_step`: ~5.2x speedup.
+- `RockSamplePOMDP.sample_next_step`: ~6.35x speedup.
+- `DiscreteLightDarkPOMDP.sample_next_step`: inlined sampling, pure-Python math for reward and beacon checks, squared-distance beacon proximity.
+- `DiscreteDistribution`: faster init and sampling.
+- `CovarianceParameterizedMultivariateNormal`: cached Cholesky transpose.
+
+### Fixed
+- CartPole and MountainCar vectorized updaters now correctly add process transition noise.
+- Removed duplicated reward logic and fixed an RNG-stream divergence in `sample_next_step` paths.
+
+## [0.1.0] - Initial release
+
+- Initial public release of POMDPPlanners.
+
+[0.2.0]: https://github.com/yaacovpariente/POMDPPlanners/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/yaacovpariente/POMDPPlanners/releases/tag/v0.1.0

--- a/POMDPPlanners/__init__.py
+++ b/POMDPPlanners/__init__.py
@@ -1,3 +1,3 @@
 """POMDPPlanners - A Python package for POMDP planning algorithms and environments."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/POMDPPlanners/tests/test_setup.py
+++ b/POMDPPlanners/tests/test_setup.py
@@ -17,14 +17,14 @@ def test_package_installed():
 
     Purpose: Validates that POMDPPlanners package is properly installed and accessible with correct version
 
-    Given: POMDPPlanners package should be installed in the Python environment with version 0.1.0
+    Given: POMDPPlanners package should be installed in the Python environment with version 0.2.0
     When: Package is imported and version is checked
-    Then: Import succeeds without error and version matches expected 0.1.0
+    Then: Import succeeds without error and version matches expected 0.2.0
 
     Test type: unit
     """
     try:
-        assert POMDPPlanners.__version__ == "0.1.0"
+        assert POMDPPlanners.__version__ == "0.2.0"
     except ImportError as e:
         raise AssertionError(f"Failed to import POMDPPlanners: {e}")
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = "2024, POMDPPlanners Team"
 author = "POMDPPlanners Team"
 
 # The full version, including alpha/beta/rc tags
-release = "1.0"
+release = "0.2.0"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/core/environments.rst
+++ b/docs/core/environments.rst
@@ -30,7 +30,18 @@ Core Environment Types
    :toctree: ../api/
 
    POMDPPlanners.environments.push_pomdp.PushPOMDP
+   POMDPPlanners.environments.push_pomdp.ContinuousPushPOMDP
    POMDPPlanners.environments.safety_ant_velocity_pomdp.SafeAntVelocityPOMDP
+
+**Information Gathering & Pursuit**
+
+.. autosummary::
+   :toctree: ../api/
+
+   POMDPPlanners.environments.rock_sample_pomdp.RockSamplePOMDP
+   POMDPPlanners.environments.pacman_pomdp.PacManPOMDP
+   POMDPPlanners.environments.laser_tag_pomdp.LaserTagPOMDP
+   POMDPPlanners.environments.laser_tag_pomdp.ContinuousLaserTagPOMDP
 
 Environment Interface
 ---------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,9 +5,9 @@ POMDPPlanners Documentation
    :target: https://opensource.org/licenses/MIT
    :alt: License: MIT
 
-.. image:: https://img.shields.io/badge/python-3.8+-blue.svg
-   :target: https://www.python.org/downloads/release/python-380/
-   :alt: Python 3.8+
+.. image:: https://img.shields.io/badge/python-3.10+-blue.svg
+   :target: https://www.python.org/downloads/release/python-3100/
+   :alt: Python 3.10+
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
@@ -20,7 +20,7 @@ POMDPPlanners is a comprehensive Python package for **POMDP (Partially Observabl
 
 - **Comprehensive Algorithm Library**: State-of-the-art POMDP planning algorithms including POMCP, PFT-DPW, Sparse PFT, and more
 - **Rich Environment Collection**: Classic and modern POMDP environments (Tiger, Light-Dark, CartPole, Push, Safety-Ant-Velocity, etc.)
-- **Flexible Belief Representations**: Particle filters, weighted beliefs, and custom belief state implementations
+- **Flexible Belief Representations**: Particle filters (weighted and unweighted), vectorized particle beliefs with batched NumPy updates, Gaussian beliefs, and custom belief state implementations
 - **Simulation Framework**: Complete experiment management with hyperparameter tuning and distributed computing support
 - **Visualization Tools**: Built-in plotting and visualization capabilities for analysis and debugging
 - **Production Ready**: Designed for both research experiments and industrial applications
@@ -128,10 +128,13 @@ Basic Usage
 **Available Environments**
 
 - **Tiger POMDP**: Classic two-door problem
-- **Light-Dark POMDP**: Navigation with position-dependent observation noise
+- **Light-Dark POMDP**: Navigation with position-dependent observation noise (continuous and discrete variants)
 - **CartPole POMDP**: Partially observable cart-pole balancing
 - **Mountain Car POMDP**: Partially observable mountain car
-- **Push POMDP**: Object manipulation environment
+- **Push POMDP**: Object manipulation environment (discrete and continuous variants)
+- **RockSample POMDP**: Classic rock-sampling benchmark with long-horizon information gathering
+- **PacMan POMDP**: Partially observable PacMan domain
+- **Continuous LaserTag POMDP**: Laser-based pursuit-evasion with continuous state
 - **Safety Ant Velocity**: Safety-constrained locomotion task
 
 🤝 Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "POMDPPlanners"
-version = "0.1.0"
+version = "0.2.0"
 description = "A Python package for POMDP planning algorithms and environments"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to `0.2.0` in `pyproject.toml`, `POMDPPlanners/__init__.py`, and `docs/conf.py`
- Add `CHANGELOG.md` covering changes since `v0.1.0` (vectorized belief updaters across many environments, performance optimizations for PushPOMDP/RockSample/DiscreteLightDark, episode-level hyperparameter tuning parallelism, benchmark suite, slow-test marking + weekly CI, Docker base/thin split, auto-rebase workflow)
- Refresh `docs/index.rst`: Python badge `3.8+` → `3.10+`, mention vectorized particle beliefs, list RockSample / PacMan / Continuous LaserTag / Push variants under Available Environments
- Add missing environments (`RockSample`, `PacMan`, `LaserTag`, `ContinuousLaserTag`, `ContinuousPush`) to `docs/core/environments.rst` autosummary

## Release flow
This PR should merge into `develop` **before** PR #67/#71 (develop → master) merges, so the 0.2.0 version bump rides along to master. After master receives the bump, tag `v0.2.0` on master.

## Test plan
- [x] CI passes
- [x] `sphinx-build` succeeds (verified locally — build succeeds with the same tolerated warnings CI already `continue-on-error`s)
- [x] Confirm `__version__` and `pyproject.toml` stay in sync