### PR TITLE
Bundle PacMan sprites and golden visualizations in PyPI distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,16 @@ Documentation = "https://yaacovpariente.github.io/POMDPPlanners/"
 where = ["."]
 include = ["POMDPPlanners*"]
 
+[tool.setuptools.package-data]
+# PacMan visualizer loads these sprites at runtime via
+# pacman_visualizer.py: `sprite_dir / "<file>"`. Bundle them so PyPI
+# installs include the assets, not just the .py files.
+"POMDPPlanners.environments.pacman_pomdp" = ["img/*"]
+# Golden visualization GIFs used by the bundled test suite to validate
+# environment renderings. ~1.2MB total; ships so installed-package smoke
+# tests can run without re-downloading fixtures.
+"POMDPPlanners.tests.test_environments" = ["golden_visualizations/*"]
+
 # ---------------------------------------------------------------------------
 # Tool configuration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Setuptools' default sdist/wheel rules only bundle \`.py\` files from package directories. Two sets of tracked, runtime-relevant data files were silently dropped from the v0.2.0 build:

- **PacMan sprites** — \`POMDPPlanners/environments/pacman_pomdp/img/{ghosts.png, pacman_head.jpg, pocman.png}\`. \`pacman_visualizer.py:58,59,84\` loads these at runtime via \`sprite_dir / \"<file>\"\`. A pip-installed user calling the PacMan visualizer would crash with \`FileNotFoundError\`. **Real bug for the v0.2.0 release.**
- **Golden visualizations** — \`POMDPPlanners/tests/test_environments/golden_visualizations/*.gif\` (8 files, ~1.2MB) used by the bundled test suite to validate environment renderings.

Both directories are tracked on master but were missing from \`pomdpplanners-0.2.0.tar.gz\` and \`pomdpplanners-0.2.0-py3-none-any.whl\` until this fix.

## Why a targeted stanza

Two ways to include non-py files in setuptools:
- **\`include-package-data = true\`** would also pick up unrelated test fixtures, \`__pycache__\`, etc. depending on what git tracks.
- **\`[tool.setuptools.package-data]\` per-package** is explicit and safe — only the listed glob patterns ship.

Picked the targeted approach.

## Test plan

- [x] Rebuilt \`dist/*\` and verified all 3 sprites + 9 golden viz files appear in both the wheel and sdist (\`python -m zipfile -l\` / \`tar tzf\`).
- [x] \`twine check dist/*\` passes both artifacts.
- [x] Wheel grew from 1.18MB → 2.30MB; sdist grew from 0.98MB → 2.10MB. Acceptable for a research package; alternative would be hosting golden viz off-package.

## After this lands

The current \`v0.2.0\` git tag (commit \`290d651\`) does **not** contain this fix. Once merged into master, you'll want to either:
1. Move the \`v0.2.0\` tag to the new master HEAD (the package version on PyPI hasn't been published yet, so this is still safe), or
2. Bump to \`0.2.1\` and tag that.

I'd recommend option 1 since 0.2.0 has not yet been uploaded to PyPI.