### PR TITLE
Accelerate continuous Light-Dark env with Numba + shared kernels module

### DIFF
--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
@@ -42,6 +42,10 @@ from POMDPPlanners.core.simulation import History, MetricValue
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.base_light_dark_pomdp import (
     BaseLightDarkPOMDP,
 )
+from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.numba_kernels import (
+    is_terminal_kernel,
+    mvn_sample_2d_kernel,
+)
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 
 # pylint: disable=no-name-in-module
@@ -132,7 +136,9 @@ class ContinuousLightDarkStateTransitionModel(StateTransitionModel):
         self.mean = state + action
 
     def sample(self, n_samples: int = 1) -> List[np.ndarray]:
-        samples = self._state_dist.sample(self.mean, n_samples)
+        z = np.random.standard_normal((n_samples, 2))
+        chol_L_T = self._state_dist._cholesky_L_T  # pylint: disable=protected-access
+        samples = mvn_sample_2d_kernel(self.mean, z, chol_L_T)
         return list(samples)
 
     def probability(self, values: List[np.ndarray]) -> np.ndarray:
@@ -408,19 +414,14 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
     def is_terminal(self, state: np.ndarray) -> bool:
         if state.shape != (2,):
             raise ValueError("state must be a 2D vector")
-
-        is_goal_state = np.linalg.norm(state - self.goal_state) <= self.goal_state_radius
-
-        if self.is_obstacle_hit_terminal:
-            # Calculate distance to each obstacle (obstacles are 2xN format)
-            distances = np.linalg.norm(state.reshape(-1, 1) - self.obstacles, axis=0)
-            is_obstacle_hit = bool(np.any(distances <= self.obstacle_radius))
-        else:
-            is_obstacle_hit = False
-
-        is_terminal = is_goal_state or is_obstacle_hit
-
-        return bool(is_terminal)
+        return is_terminal_kernel(
+            state,
+            self.goal_state,
+            self.obstacles,
+            self.goal_state_radius,
+            self.obstacle_radius,
+            self.is_obstacle_hit_terminal,
+        )
 
     def get_metric_names(self) -> List[str]:
         """Get names of Continuous Light-Dark POMDP specific metrics.

--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
@@ -44,9 +44,9 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.base_lig
 )
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.numba_kernels import (
     is_terminal_kernel,
-    mvn_sample_2d_kernel,
 )
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
+from POMDPPlanners.utils.numba_kernels import mvn_sample_2d_kernel
 
 # pylint: disable=no-name-in-module
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_observation_models import (

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_observation_models.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_observation_models.py
@@ -5,12 +5,12 @@ import numpy as np
 
 from POMDPPlanners.core.distributions import DiscreteDistribution
 from POMDPPlanners.core.environment import ObservationModel
-from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.numba_kernels import (
-    min_distance_to_beacon_kernel,
-    mvn_sample_2d_kernel,
-    near_beacon_kernel,
-)
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
+from POMDPPlanners.utils.numba_kernels import (
+    any_point_within_radius_kernel,
+    min_distance_to_points_kernel,
+    mvn_sample_2d_kernel,
+)
 
 __all__ = [
     "BaseContinuousLightDarkObservationModel",
@@ -44,7 +44,7 @@ class BaseContinuousLightDarkObservationModel(ObservationModel):
         self.near_beacon = self._near_beacon(next_state)
 
     def _near_beacon(self, next_state: np.ndarray) -> bool:
-        return near_beacon_kernel(next_state, self.beacons, self.beacon_radius)
+        return any_point_within_radius_kernel(next_state, self.beacons, self.beacon_radius)
 
     @abstractmethod
     def sample(self, n_samples: int = 1) -> List[Any]:
@@ -174,7 +174,7 @@ class ContinuousLightDarkDistanceBasedObservationModel(BaseContinuousLightDarkOb
             beacons=beacons,
             beacon_radius=beacon_radius,
         )
-        self.min_distance_to_beacon: float = min_distance_to_beacon_kernel(next_state, self.beacons)
+        self.min_distance_to_beacon: float = min_distance_to_points_kernel(next_state, self.beacons)
 
         # Select distribution based on beacon proximity
         self._active_dist = (

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_observation_models.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_observation_models.py
@@ -5,6 +5,11 @@ import numpy as np
 
 from POMDPPlanners.core.distributions import DiscreteDistribution
 from POMDPPlanners.core.environment import ObservationModel
+from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.numba_kernels import (
+    min_distance_to_beacon_kernel,
+    mvn_sample_2d_kernel,
+    near_beacon_kernel,
+)
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 
 __all__ = [
@@ -39,10 +44,7 @@ class BaseContinuousLightDarkObservationModel(ObservationModel):
         self.near_beacon = self._near_beacon(next_state)
 
     def _near_beacon(self, next_state: np.ndarray) -> bool:
-        next_state = next_state.reshape(2, 1)
-        distances = np.linalg.norm(next_state - self.beacons, axis=0)
-        # Cast to builtins.bool for mypy compatibility (np.bool_ -> bool)
-        return bool(np.any(distances <= self.beacon_radius))
+        return near_beacon_kernel(next_state, self.beacons, self.beacon_radius)
 
     @abstractmethod
     def sample(self, n_samples: int = 1) -> List[Any]:
@@ -75,11 +77,10 @@ class ContinuousLightDarkNormalNoiseObservationModel(BaseContinuousLightDarkObse
         )
 
     def sample(self, n_samples: int = 1) -> List[np.ndarray]:
-        # Sample using pre-computed Cholesky decomposition
-        observations = self._active_dist.sample(self.next_state, n_samples)
+        z = np.random.standard_normal((n_samples, 2))
+        chol_L_T = self._active_dist._cholesky_L_T  # pylint: disable=protected-access
+        observations = mvn_sample_2d_kernel(self.next_state, z, chol_L_T)
         observations = np.clip(observations, 0, self.grid_size)
-
-        # Convert to list of arrays
         return list(observations)
 
     def probability(self, values: List[np.ndarray]) -> np.ndarray:
@@ -121,8 +122,9 @@ class ContinuousLightDarkNormalNoiseNoObsInDarkObservationModel(
 
     def sample(self, n_samples: int = 1) -> List[Union[np.ndarray, str]]:
         if self._near_beacon(self.next_state):
-            # Sample using pre-computed Cholesky decomposition
-            observations = self._active_dist.sample(self.next_state, n_samples)
+            z = np.random.standard_normal((n_samples, 2))
+            chol_L_T = self._active_dist._cholesky_L_T  # pylint: disable=protected-access
+            observations = mvn_sample_2d_kernel(self.next_state, z, chol_L_T)
             observations = np.clip(observations, 0, self.grid_size)
             return list(observations)
         return ["None"] * n_samples
@@ -172,10 +174,7 @@ class ContinuousLightDarkDistanceBasedObservationModel(BaseContinuousLightDarkOb
             beacons=beacons,
             beacon_radius=beacon_radius,
         )
-        # Compute distance to nearest beacon
-        next_state_reshaped = next_state.reshape(2, 1)
-        distances = np.linalg.norm(next_state_reshaped - self.beacons, axis=0)
-        self.min_distance_to_beacon: float = float(np.min(distances))
+        self.min_distance_to_beacon: float = min_distance_to_beacon_kernel(next_state, self.beacons)
 
         # Select distribution based on beacon proximity
         self._active_dist = (
@@ -183,15 +182,13 @@ class ContinuousLightDarkDistanceBasedObservationModel(BaseContinuousLightDarkOb
         )
 
     def sample(self, n_samples: int = 1) -> List[Union[np.ndarray, str]]:
-        # If beyond beacon_radius, return "None" observations
         if self.min_distance_to_beacon > self.beacon_radius:
             return ["None"] * n_samples
 
-        # Sample using pre-computed Cholesky decomposition
-        observations = self._active_dist.sample(self.next_state, n_samples)
+        z = np.random.standard_normal((n_samples, 2))
+        chol_L_T = self._active_dist._cholesky_L_T  # pylint: disable=protected-access
+        observations = mvn_sample_2d_kernel(self.next_state, z, chol_L_T)
         observations = np.clip(observations, 0, self.grid_size)
-
-        # Convert to list of arrays
         return list(observations)
 
     def probability(self, values: List[Union[np.ndarray, str]]) -> np.ndarray:

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
@@ -2,6 +2,11 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 
+from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.numba_kernels import (
+    compute_reward_base_kernel,
+    compute_reward_decaying_hit_prob_kernel,
+)
+
 
 class BaseLightDarkRewardModel(ABC):
     @abstractmethod
@@ -61,22 +66,30 @@ class ContinuousLightDarkRewardModel(BaseLightDarkRewardModel):
         return bool(np.any(state < 0) or np.any(state > self.grid_size))
 
     def _compute_reward(self, state: np.ndarray, action: np.ndarray) -> float:
-        next_state = state + action
+        reward, in_obstacle_region = compute_reward_base_kernel(
+            state,
+            action,
+            self.goal_state,
+            self.obstacles,
+            self.goal_state_radius,
+            self.obstacle_radius,
+            float(self.grid_size),
+            self.fuel_cost,
+            self.goal_reward,
+            self.obstacle_reward,
+        )
+        if in_obstacle_region:
+            reward += self._obstacle_reward_scalar()
+        return float(reward)
 
-        is_goal_state = self._is_goal_state(next_state)
-        is_in_obstacle_range = self._is_in_obstacle_range(next_state)
-        is_out_of_grid = self._is_out_of_grid(next_state)
+    def _obstacle_reward_scalar(self) -> float:
+        """Stochastic obstacle-hit contribution.
 
-        reward = float(-self.fuel_cost - np.linalg.norm(next_state - self.goal_state))
-
-        if is_goal_state:
-            reward += self.goal_reward
-        elif is_in_obstacle_range:
-            reward += self._obstacle_reward(next_state)
-        elif is_out_of_grid:
-            reward += self.obstacle_reward
-
-        return reward
+        Called by ``_compute_reward`` only when the Numba kernel reports the
+        next state landed in an obstacle region but was not at goal / out-of-grid,
+        preserving the pre-refactor RNG call pattern.
+        """
+        return self.obstacle_reward if np.random.rand() < self.obstacle_hit_probability else 0.0
 
     def _obstacle_reward(self, state: np.ndarray) -> float:  # pylint: disable=unused-argument
         return self.obstacle_reward if np.random.rand() < self.obstacle_hit_probability else 0.0
@@ -107,6 +120,10 @@ class ContinuousLightDarkRewardModel(BaseLightDarkRewardModel):
 
 
 class ContinuousLDDangerousStatesRewardModel(ContinuousLightDarkRewardModel):
+    def _obstacle_reward_scalar(self) -> float:
+        """The expected reward is 0.0, but the variance is high."""
+        return self.obstacle_reward if np.random.rand() < 0.5 else -self.obstacle_reward
+
     def _obstacle_reward(self, state: np.ndarray) -> float:
         """The expected reward is 0.0, but the variance is high."""
         return self.obstacle_reward if np.random.rand() < 0.5 else -self.obstacle_reward
@@ -142,22 +159,22 @@ class ContinuousLightDarkDecayingHitProbabilityRewardModel(BaseLightDarkRewardMo
         self.penalty_decay = penalty_decay
 
     def _compute_reward(self, state: np.ndarray, action: np.ndarray) -> float:
-        next_state = state + action
-
-        is_goal_state = bool(np.linalg.norm(next_state - self.goal_state) <= self.goal_state_radius)
-
-        is_out_of_grid = bool(np.any(next_state < 0) or np.any(next_state > self.grid_size))
-
-        reward = float(-self.fuel_cost - np.linalg.norm(next_state - self.goal_state))
-
-        if is_goal_state:
-            reward += self.goal_reward
-        elif is_out_of_grid:
-            reward += self.obstacle_reward
-
-        reward += self._obstacle_reward(next_state)
-
-        return reward
+        uniform = float(np.random.rand())
+        return float(
+            compute_reward_decaying_hit_prob_kernel(
+                state,
+                action,
+                self.goal_state,
+                self.obstacles,
+                self.goal_state_radius,
+                float(self.grid_size),
+                self.fuel_cost,
+                self.goal_reward,
+                self.obstacle_reward,
+                self.penalty_decay,
+                uniform,
+            )
+        )
 
     def _obstacle_reward(self, state: np.ndarray) -> float:
         # Calculate distance to nearest obstacle

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py
@@ -1,30 +1,18 @@
-"""Numba-JIT kernels for the Continuous Light-Dark POMDP hot paths.
+"""Light-Dark-specific Numba-JIT kernels.
 
-This module holds pure numeric kernels that replace the NumPy-overhead-bound
-inner loops of the continuous Light-Dark environment. Each kernel is decorated
-with ``@njit(cache=True)`` so the LLVM-compiled version is cached to disk
-between runs.
+Holds kernels whose signatures or logic hardcode light-dark concepts
+(goal+obstacles+out-of-grid shape, standard / dangerous-states / decaying-
+hit-probability reward formulas). Generic geometric / numerical primitives
+used here also by other envs live in
+``POMDPPlanners.utils.numba_kernels`` instead.
 
-Conventions
------------
-- **All inputs are plain numeric arrays / scalars.** No Python objects, no
-  class instances. Callers hand in ``float64`` arrays (contiguous) and
-  ``float``/``int``/``bool`` scalars.
-- **RNG stays in Python.** Any stochastic draw (``np.random.standard_normal``,
-  ``np.random.rand``) happens in the Python caller and is passed in as ``z``
-  or ``u``. This preserves the seed semantics of the pre-refactor code and
-  guarantees bit-identical results under seeded tests.
-- **Obstacle / beacon arrays are shape (2, N).** This matches the
-  internal representation produced by ``_convert_*_to_array`` in
-  ``base_light_dark_pomdp.py``.
+Conventions match the shared module: contiguous ``float64`` arrays, scalar
+floats/ints/bools, no Python objects, all RNG draws happen in the caller and
+are passed in as parameters.
 
 Public kernels
 --------------
 - :func:`is_terminal_kernel` — replaces ``ContinuousLightDarkPOMDP.is_terminal``.
-- :func:`near_beacon_kernel` — replaces ``_near_beacon`` proximity check.
-- :func:`min_distance_to_beacon_kernel` — distance to the nearest beacon.
-- :func:`mvn_sample_2d_kernel` — 2-D multivariate-normal sample given
-  pre-drawn standard normals and a Cholesky upper factor.
 - :func:`compute_reward_base_kernel` — deterministic part of the Standard /
   DangerousStates reward model plus an ``is_obstacle_hit_region`` flag so the
   Python caller can decide whether to draw a uniform.
@@ -65,67 +53,6 @@ def is_terminal_kernel(
         if ox * ox + oy * oy <= radius_sq:
             return True
     return False
-
-
-@njit(cache=True)  # type: ignore[misc]
-def near_beacon_kernel(
-    next_state: np.ndarray,
-    beacons: np.ndarray,
-    beacon_radius: float,
-) -> bool:
-    n_beacons = beacons.shape[1]
-    radius_sq = beacon_radius * beacon_radius
-    for i in range(n_beacons):
-        dx = next_state[0] - beacons[0, i]
-        dy = next_state[1] - beacons[1, i]
-        if dx * dx + dy * dy <= radius_sq:
-            return True
-    return False
-
-
-@njit(cache=True)  # type: ignore[misc]
-def min_distance_to_beacon_kernel(
-    next_state: np.ndarray,
-    beacons: np.ndarray,
-) -> float:
-    n_beacons = beacons.shape[1]
-    min_sq = np.inf
-    for i in range(n_beacons):
-        dx = next_state[0] - beacons[0, i]
-        dy = next_state[1] - beacons[1, i]
-        d_sq = dx * dx + dy * dy
-        min_sq = min(min_sq, d_sq)
-    return min_sq**0.5
-
-
-@njit(cache=True)  # type: ignore[misc]
-def mvn_sample_2d_kernel(
-    mean: np.ndarray,
-    z: np.ndarray,
-    cholesky_L_T: np.ndarray,
-) -> np.ndarray:
-    """Sample n points from a 2-D Gaussian with fixed Cholesky factor.
-
-    Given pre-drawn standard-normal ``z`` of shape ``(n, 2)`` and the
-    transposed Cholesky factor ``L.T`` of shape ``(2, 2)``, compute
-    ``mean + z @ L.T`` and return samples of shape ``(n, 2)``. The
-    hand-rolled matmul avoids NumPy's per-call dispatch cost for the tiny
-    ``(n, 2) @ (2, 2)`` product.
-    """
-    n_samples = z.shape[0]
-    out = np.empty((n_samples, 2), dtype=np.float64)
-    m0 = mean[0]
-    m1 = mean[1]
-    lt00 = cholesky_L_T[0, 0]
-    lt01 = cholesky_L_T[0, 1]
-    lt10 = cholesky_L_T[1, 0]
-    lt11 = cholesky_L_T[1, 1]
-    for i in range(n_samples):
-        z0 = z[i, 0]
-        z1 = z[i, 1]
-        out[i, 0] = m0 + z0 * lt00 + z1 * lt10
-        out[i, 1] = m1 + z0 * lt01 + z1 * lt11
-    return out
 
 
 @njit(cache=True)  # type: ignore[misc]

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py
@@ -1,0 +1,224 @@
+"""Numba-JIT kernels for the Continuous Light-Dark POMDP hot paths.
+
+This module holds pure numeric kernels that replace the NumPy-overhead-bound
+inner loops of the continuous Light-Dark environment. Each kernel is decorated
+with ``@njit(cache=True)`` so the LLVM-compiled version is cached to disk
+between runs.
+
+Conventions
+-----------
+- **All inputs are plain numeric arrays / scalars.** No Python objects, no
+  class instances. Callers hand in ``float64`` arrays (contiguous) and
+  ``float``/``int``/``bool`` scalars.
+- **RNG stays in Python.** Any stochastic draw (``np.random.standard_normal``,
+  ``np.random.rand``) happens in the Python caller and is passed in as ``z``
+  or ``u``. This preserves the seed semantics of the pre-refactor code and
+  guarantees bit-identical results under seeded tests.
+- **Obstacle / beacon arrays are shape (2, N).** This matches the
+  internal representation produced by ``_convert_*_to_array`` in
+  ``base_light_dark_pomdp.py``.
+
+Public kernels
+--------------
+- :func:`is_terminal_kernel` — replaces ``ContinuousLightDarkPOMDP.is_terminal``.
+- :func:`near_beacon_kernel` — replaces ``_near_beacon`` proximity check.
+- :func:`min_distance_to_beacon_kernel` — distance to the nearest beacon.
+- :func:`mvn_sample_2d_kernel` — 2-D multivariate-normal sample given
+  pre-drawn standard normals and a Cholesky upper factor.
+- :func:`compute_reward_base_kernel` — deterministic part of the Standard /
+  DangerousStates reward model plus an ``is_obstacle_hit_region`` flag so the
+  Python caller can decide whether to draw a uniform.
+- :func:`compute_reward_decaying_hit_prob_kernel` — full reward for the
+  Decaying-Hit-Probability model (uniform drawn in Python and passed in).
+"""
+
+from typing import Tuple
+
+import numpy as np
+from numba import njit
+
+# pylint: disable=no-value-for-parameter,not-an-iterable
+
+
+@njit(cache=True)  # type: ignore[misc]
+def is_terminal_kernel(
+    state: np.ndarray,
+    goal_state: np.ndarray,
+    obstacles: np.ndarray,
+    goal_state_radius: float,
+    obstacle_radius: float,
+    is_obstacle_hit_terminal: bool,
+) -> bool:
+    dx = state[0] - goal_state[0]
+    dy = state[1] - goal_state[1]
+    if (dx * dx + dy * dy) ** 0.5 <= goal_state_radius:
+        return True
+
+    if not is_obstacle_hit_terminal:
+        return False
+
+    n_obs = obstacles.shape[1]
+    radius_sq = obstacle_radius * obstacle_radius
+    for i in range(n_obs):
+        ox = state[0] - obstacles[0, i]
+        oy = state[1] - obstacles[1, i]
+        if ox * ox + oy * oy <= radius_sq:
+            return True
+    return False
+
+
+@njit(cache=True)  # type: ignore[misc]
+def near_beacon_kernel(
+    next_state: np.ndarray,
+    beacons: np.ndarray,
+    beacon_radius: float,
+) -> bool:
+    n_beacons = beacons.shape[1]
+    radius_sq = beacon_radius * beacon_radius
+    for i in range(n_beacons):
+        dx = next_state[0] - beacons[0, i]
+        dy = next_state[1] - beacons[1, i]
+        if dx * dx + dy * dy <= radius_sq:
+            return True
+    return False
+
+
+@njit(cache=True)  # type: ignore[misc]
+def min_distance_to_beacon_kernel(
+    next_state: np.ndarray,
+    beacons: np.ndarray,
+) -> float:
+    n_beacons = beacons.shape[1]
+    min_sq = np.inf
+    for i in range(n_beacons):
+        dx = next_state[0] - beacons[0, i]
+        dy = next_state[1] - beacons[1, i]
+        d_sq = dx * dx + dy * dy
+        min_sq = min(min_sq, d_sq)
+    return min_sq**0.5
+
+
+@njit(cache=True)  # type: ignore[misc]
+def mvn_sample_2d_kernel(
+    mean: np.ndarray,
+    z: np.ndarray,
+    cholesky_L_T: np.ndarray,
+) -> np.ndarray:
+    """Sample n points from a 2-D Gaussian with fixed Cholesky factor.
+
+    Given pre-drawn standard-normal ``z`` of shape ``(n, 2)`` and the
+    transposed Cholesky factor ``L.T`` of shape ``(2, 2)``, compute
+    ``mean + z @ L.T`` and return samples of shape ``(n, 2)``. The
+    hand-rolled matmul avoids NumPy's per-call dispatch cost for the tiny
+    ``(n, 2) @ (2, 2)`` product.
+    """
+    n_samples = z.shape[0]
+    out = np.empty((n_samples, 2), dtype=np.float64)
+    m0 = mean[0]
+    m1 = mean[1]
+    lt00 = cholesky_L_T[0, 0]
+    lt01 = cholesky_L_T[0, 1]
+    lt10 = cholesky_L_T[1, 0]
+    lt11 = cholesky_L_T[1, 1]
+    for i in range(n_samples):
+        z0 = z[i, 0]
+        z1 = z[i, 1]
+        out[i, 0] = m0 + z0 * lt00 + z1 * lt10
+        out[i, 1] = m1 + z0 * lt01 + z1 * lt11
+    return out
+
+
+@njit(cache=True)  # type: ignore[misc]
+def compute_reward_base_kernel(
+    state: np.ndarray,
+    action: np.ndarray,
+    goal_state: np.ndarray,
+    obstacles: np.ndarray,
+    goal_state_radius: float,
+    obstacle_radius: float,
+    grid_size: float,
+    fuel_cost: float,
+    goal_reward: float,
+    obstacle_reward: float,
+) -> Tuple[float, bool]:
+    """Return ``(base_reward, is_obstacle_hit_region)``.
+
+    ``base_reward`` already includes fuel, goal-distance, and the
+    out-of-grid penalty. The caller (Python) must add the stochastic
+    obstacle-hit contribution when ``is_obstacle_hit_region`` is ``True``,
+    using its own ``np.random.rand()`` draw so seeded tests stay bit-identical.
+    Used by Standard and DangerousStates reward models.
+    """
+    next_x = state[0] + action[0]
+    next_y = state[1] + action[1]
+    gx = next_x - goal_state[0]
+    gy = next_y - goal_state[1]
+    dist_to_goal = (gx * gx + gy * gy) ** 0.5
+    reward = -fuel_cost - dist_to_goal
+    is_goal = dist_to_goal <= goal_state_radius
+    if is_goal:
+        return reward + goal_reward, False
+
+    n_obs = obstacles.shape[1]
+    obs_radius_sq = obstacle_radius * obstacle_radius
+    in_obstacle_range = False
+    for i in range(n_obs):
+        ox = next_x - obstacles[0, i]
+        oy = next_y - obstacles[1, i]
+        if ox * ox + oy * oy <= obs_radius_sq:
+            in_obstacle_range = True
+            break
+    if in_obstacle_range:
+        return reward, True
+
+    if next_x < 0.0 or next_y < 0.0 or next_x > grid_size or next_y > grid_size:
+        return reward + obstacle_reward, False
+    return reward, False
+
+
+@njit(cache=True)  # type: ignore[misc]
+def compute_reward_decaying_hit_prob_kernel(
+    state: np.ndarray,
+    action: np.ndarray,
+    goal_state: np.ndarray,
+    obstacles: np.ndarray,
+    goal_state_radius: float,
+    grid_size: float,
+    fuel_cost: float,
+    goal_reward: float,
+    obstacle_reward: float,
+    penalty_decay: float,
+    uniform: float,
+) -> float:
+    """Full reward for the Decaying-Hit-Probability model.
+
+    The caller draws a single ``uniform ~ U[0,1)`` (via ``np.random.rand()``)
+    and passes it in. Matches the pre-refactor RNG call pattern, which
+    unconditionally drew one uniform in ``_obstacle_reward``.
+    """
+    next_x = state[0] + action[0]
+    next_y = state[1] + action[1]
+    gx = next_x - goal_state[0]
+    gy = next_y - goal_state[1]
+    dist_to_goal = (gx * gx + gy * gy) ** 0.5
+    reward = -fuel_cost - dist_to_goal
+
+    is_goal = dist_to_goal <= goal_state_radius
+    is_out_of_grid = next_x < 0.0 or next_y < 0.0 or next_x > grid_size or next_y > grid_size
+    if is_goal:
+        reward += goal_reward
+    elif is_out_of_grid:
+        reward += obstacle_reward
+
+    n_obs = obstacles.shape[1]
+    min_obs_sq = np.inf
+    for i in range(n_obs):
+        ox = next_x - obstacles[0, i]
+        oy = next_y - obstacles[1, i]
+        d_sq = ox * ox + oy * oy
+        min_obs_sq = min(min_obs_sq, d_sq)
+    min_obs_dist = min_obs_sq**0.5
+    hit_prob = np.exp(-min_obs_dist / penalty_decay)
+    if uniform < hit_prob:
+        reward += obstacle_reward
+    return reward

--- a/POMDPPlanners/tests/benchmarks/conftest.py
+++ b/POMDPPlanners/tests/benchmarks/conftest.py
@@ -9,6 +9,9 @@ import pytest
 
 from POMDPPlanners.core.belief import get_initial_belief
 from POMDPPlanners.environments.laser_tag_pomdp import LaserTagPOMDP
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ContinuousLightDarkPOMDPDiscreteActions,
+)
 from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
     DiscreteLightDarkPOMDP,
 )
@@ -43,6 +46,12 @@ def tiger_env():
 def discrete_ld_env():
     """DiscreteLightDarkPOMDP environment for benchmarking."""
     return DiscreteLightDarkPOMDP(discount_factor=DISCOUNT_FACTOR)
+
+
+@pytest.fixture
+def continuous_ld_env():
+    """ContinuousLightDarkPOMDPDiscreteActions environment for benchmarking."""
+    return ContinuousLightDarkPOMDPDiscreteActions(discount_factor=DISCOUNT_FACTOR)
 
 
 @pytest.fixture
@@ -81,6 +90,15 @@ def discrete_ld_state_action(discrete_ld_env):
 
 
 @pytest.fixture
+def continuous_ld_state_action(continuous_ld_env):
+    """Initial state and action for ContinuousLightDarkPOMDPDiscreteActions."""
+    np.random.seed(SEED)
+    state = continuous_ld_env.initial_state_dist().sample()[0]
+    action = continuous_ld_env.get_actions()[0]
+    return continuous_ld_env, state, action
+
+
+@pytest.fixture
 def rock_sample_state_action(rock_sample_env):
     """Initial state and action for RockSamplePOMDP."""
     np.random.seed(SEED)
@@ -115,6 +133,13 @@ def discrete_ld_belief(discrete_ld_env):
     """Initial belief for DiscreteLightDarkPOMDP."""
     np.random.seed(SEED)
     return get_initial_belief(pomdp=discrete_ld_env, n_particles=N_PARTICLES)
+
+
+@pytest.fixture
+def continuous_ld_belief(continuous_ld_env):
+    """Initial belief for ContinuousLightDarkPOMDPDiscreteActions."""
+    np.random.seed(SEED)
+    return get_initial_belief(pomdp=continuous_ld_env, n_particles=N_PARTICLES)
 
 
 @pytest.fixture

--- a/POMDPPlanners/tests/benchmarks/test_benchmark_environments.py
+++ b/POMDPPlanners/tests/benchmarks/test_benchmark_environments.py
@@ -205,6 +205,103 @@ def test_bench_discrete_ld_is_terminal(benchmark, discrete_ld_state_action):
 
 
 # ---------------------------------------------------------------------------
+# ContinuousLightDarkPOMDPDiscreteActions benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="env-sample_next_step")
+def test_bench_continuous_ld_sample_next_step(benchmark, continuous_ld_state_action):
+    """Benchmark ContinuousLightDarkPOMDPDiscreteActions.sample_next_step.
+
+    Purpose: Measure full environment step performance for continuous Light-Dark.
+
+    Given: A ContinuousLightDarkPOMDPDiscreteActions with a valid state and action.
+    When: sample_next_step is called repeatedly.
+    Then: Execution time is recorded for regression tracking.
+
+    Test type: performance
+    """
+    env, state, action = continuous_ld_state_action
+    np.random.seed(42)
+    benchmark(env.sample_next_step, state, action)
+
+
+@pytest.mark.benchmark(group="env-state_transition")
+def test_bench_continuous_ld_state_transition(benchmark, continuous_ld_state_action):
+    """Benchmark ContinuousLightDarkPOMDPDiscreteActions state transition model.
+
+    Purpose: Measure state transition sampling in isolation.
+
+    Given: A ContinuousLightDarkPOMDPDiscreteActions with a valid state and action.
+    When: state_transition_model is called and sampled repeatedly.
+    Then: Execution time is recorded for regression tracking.
+
+    Test type: performance
+    """
+    env, state, action = continuous_ld_state_action
+    np.random.seed(42)
+
+    def run():
+        return env.state_transition_model(state=state, action=action).sample()[0]
+
+    benchmark(run)
+
+
+@pytest.mark.benchmark(group="env-observation_model")
+def test_bench_continuous_ld_observation_model(benchmark, continuous_ld_state_action):
+    """Benchmark ContinuousLightDarkPOMDPDiscreteActions observation model.
+
+    Purpose: Measure observation sampling in isolation.
+
+    Given: A ContinuousLightDarkPOMDPDiscreteActions with a sampled next state and action.
+    When: observation_model is called and sampled repeatedly.
+    Then: Execution time is recorded for regression tracking.
+
+    Test type: performance
+    """
+    env, state, action = continuous_ld_state_action
+    np.random.seed(42)
+    next_state = env.state_transition_model(state=state, action=action).sample()[0]
+
+    def run():
+        return env.observation_model(next_state=next_state, action=action).sample()[0]
+
+    benchmark(run)
+
+
+@pytest.mark.benchmark(group="env-reward")
+def test_bench_continuous_ld_reward(benchmark, continuous_ld_state_action):
+    """Benchmark ContinuousLightDarkPOMDPDiscreteActions reward computation.
+
+    Purpose: Measure reward function performance.
+
+    Given: A ContinuousLightDarkPOMDPDiscreteActions with a valid state and action.
+    When: reward is called repeatedly.
+    Then: Execution time is recorded for regression tracking.
+
+    Test type: performance
+    """
+    env, state, action = continuous_ld_state_action
+    benchmark(env.reward, state=state, action=action)
+
+
+@pytest.mark.benchmark(group="env-is_terminal")
+def test_bench_continuous_ld_is_terminal(benchmark, continuous_ld_state_action):
+    """Benchmark ContinuousLightDarkPOMDPDiscreteActions terminal check.
+
+    Purpose: Measure terminal state check performance.
+
+    Given: A ContinuousLightDarkPOMDPDiscreteActions with a valid state.
+    When: is_terminal is called repeatedly.
+    Then: Execution time is recorded for regression tracking.
+
+    Test type: performance
+    """
+    env, state, _ = continuous_ld_state_action
+    benchmark(env.is_terminal, state)
+
+
+# ---------------------------------------------------------------------------
 # RockSamplePOMDP benchmarks
 # ---------------------------------------------------------------------------
 

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_numba_kernels.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_numba_kernels.py
@@ -1,0 +1,407 @@
+"""Numerical-equivalence tests for the light-dark Numba kernels.
+
+Each test pairs a kernel against a pure-NumPy reference implementation
+assembled from the pre-refactor class methods, and asserts bit-identical
+(or ``np.isclose``) results over a mix of representative and edge-case
+inputs. Running these before wiring the kernels into the env classes
+catches any kernel-logic drift in isolation.
+"""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.numba_kernels import (
+    compute_reward_base_kernel,
+    compute_reward_decaying_hit_prob_kernel,
+    is_terminal_kernel,
+    min_distance_to_beacon_kernel,
+    mvn_sample_2d_kernel,
+    near_beacon_kernel,
+)
+
+
+def _ref_is_terminal(
+    state: np.ndarray,
+    goal_state: np.ndarray,
+    obstacles: np.ndarray,
+    goal_state_radius: float,
+    obstacle_radius: float,
+    is_obstacle_hit_terminal: bool,
+) -> bool:
+    is_goal = bool(np.linalg.norm(state - goal_state) <= goal_state_radius)
+    if is_goal:
+        return True
+    if not is_obstacle_hit_terminal:
+        return False
+    distances = np.linalg.norm(state.reshape(-1, 1) - obstacles, axis=0)
+    return bool(np.any(distances <= obstacle_radius))
+
+
+def _ref_near_beacon(next_state: np.ndarray, beacons: np.ndarray, beacon_radius: float) -> bool:
+    distances = np.linalg.norm(next_state.reshape(2, 1) - beacons, axis=0)
+    return bool(np.any(distances <= beacon_radius))
+
+
+def _ref_min_distance_to_beacon(next_state: np.ndarray, beacons: np.ndarray) -> float:
+    distances = np.linalg.norm(next_state.reshape(2, 1) - beacons, axis=0)
+    return float(np.min(distances))
+
+
+def _ref_compute_reward_standard(
+    state: np.ndarray,
+    action: np.ndarray,
+    goal_state: np.ndarray,
+    obstacles: np.ndarray,
+    goal_state_radius: float,
+    obstacle_radius: float,
+    grid_size: float,
+    fuel_cost: float,
+    goal_reward: float,
+    obstacle_reward: float,
+    obstacle_hit_probability: float,
+    uniform: float,
+) -> float:
+    next_state = state + action
+    is_goal = bool(np.linalg.norm(next_state - goal_state) <= goal_state_radius)
+    is_in_obs = bool(
+        (np.linalg.norm(next_state.reshape(-1, 1) - obstacles, axis=0) <= obstacle_radius).any()
+    )
+    is_oog = bool(np.any(next_state < 0) or np.any(next_state > grid_size))
+    reward = float(-fuel_cost - np.linalg.norm(next_state - goal_state))
+    if is_goal:
+        reward += goal_reward
+    elif is_in_obs:
+        if uniform < obstacle_hit_probability:
+            reward += obstacle_reward
+    elif is_oog:
+        reward += obstacle_reward
+    return reward
+
+
+def _ref_compute_reward_decaying(
+    state: np.ndarray,
+    action: np.ndarray,
+    goal_state: np.ndarray,
+    obstacles: np.ndarray,
+    goal_state_radius: float,
+    grid_size: float,
+    fuel_cost: float,
+    goal_reward: float,
+    obstacle_reward: float,
+    penalty_decay: float,
+    uniform: float,
+) -> float:
+    next_state = state + action
+    is_goal = bool(np.linalg.norm(next_state - goal_state) <= goal_state_radius)
+    is_oog = bool(np.any(next_state < 0) or np.any(next_state > grid_size))
+    reward = float(-fuel_cost - np.linalg.norm(next_state - goal_state))
+    if is_goal:
+        reward += goal_reward
+    elif is_oog:
+        reward += obstacle_reward
+    distances = np.linalg.norm(next_state.reshape(-1, 1) - obstacles, axis=0)
+    d = float(np.min(distances))
+    p = float(np.exp(-d / penalty_decay))
+    if uniform < p:
+        reward += obstacle_reward
+    return reward
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def default_obstacles() -> np.ndarray:
+    """Two obstacles at (3, 7) and (5, 5) in 2xN layout (matches env default)."""
+    return np.array([[3.0, 5.0], [7.0, 5.0]])
+
+
+@pytest.fixture
+def default_beacons() -> np.ndarray:
+    """3x3 grid of beacons in 2xN layout."""
+    xs = [0.0, 0.0, 0.0, 5.0, 5.0, 5.0, 10.0, 10.0, 10.0]
+    ys = [0.0, 5.0, 10.0, 0.0, 5.0, 10.0, 0.0, 5.0, 10.0]
+    return np.array([xs, ys])
+
+
+@pytest.fixture
+def default_goal() -> np.ndarray:
+    return np.array([10.0, 5.0])
+
+
+# ---------------------------------------------------------------------------
+# is_terminal_kernel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        np.array([0.0, 5.0]),
+        np.array([5.0, 5.0]),
+        np.array([9.9, 5.1]),
+        np.array([3.5, 7.2]),
+        np.array([-0.5, 5.0]),
+    ],
+)
+def test_is_terminal_kernel_matches_reference(state, default_goal, default_obstacles):
+    """Validates is_terminal_kernel numerical equivalence to the NumPy reference.
+
+    Purpose: Ensure the Numba is_terminal kernel agrees with the pre-refactor
+        ContinuousLightDarkPOMDP.is_terminal logic on representative states.
+
+    Given: Various states inside/outside goal, obstacle, and grid regions.
+    When: is_terminal_kernel and _ref_is_terminal are both evaluated.
+    Then: They return the same boolean.
+
+    Test type: unit
+    """
+    for is_term in (True, False):
+        got = is_terminal_kernel(state, default_goal, default_obstacles, 1.5, 1.5, is_term)
+        expected = _ref_is_terminal(state, default_goal, default_obstacles, 1.5, 1.5, is_term)
+        assert got == expected
+
+
+def test_is_terminal_kernel_obstacle_hit_flag_off(default_goal, default_obstacles):
+    """Validates that obstacle checks are skipped when is_obstacle_hit_terminal=False.
+
+    Purpose: Ensure that with the obstacle-terminal flag disabled the kernel
+        returns False on an obstacle overlap, matching env behavior.
+
+    Given: A state directly on an obstacle coordinate.
+    When: is_terminal_kernel is called with is_obstacle_hit_terminal=False.
+    Then: The result is False.
+
+    Test type: unit
+    """
+    # default_obstacles layout: row0=[x0,x1]=[3,5], row1=[y0,y1]=[7,5] → obstacles at (3,7),(5,5)
+    on_obstacle = np.array([3.0, 7.0])
+    assert not is_terminal_kernel(on_obstacle, default_goal, default_obstacles, 1.5, 1.5, False)
+    assert is_terminal_kernel(on_obstacle, default_goal, default_obstacles, 1.5, 1.5, True)
+
+
+def test_is_terminal_kernel_empty_obstacles():
+    """Validates is_terminal_kernel accepts an empty (2, 0) obstacles array.
+
+    Purpose: Edge case — no obstacles configured.
+
+    Given: An empty 2x0 obstacles array.
+    When: is_terminal_kernel is called on a non-goal state.
+    Then: Returns False (no goal, no obstacles).
+
+    Test type: unit
+    """
+    empty_obs = np.empty((2, 0))
+    state = np.array([5.0, 5.0])
+    assert not is_terminal_kernel(state, np.array([10.0, 5.0]), empty_obs, 1.5, 1.5, True)
+
+
+# ---------------------------------------------------------------------------
+# near_beacon_kernel / min_distance_to_beacon_kernel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        np.array([0.0, 5.0]),
+        np.array([2.5, 2.5]),
+        np.array([5.0, 5.0]),
+        np.array([5.4, 5.0]),
+        np.array([10.0, 10.0]),
+    ],
+)
+def test_near_beacon_kernel_matches_reference(state, default_beacons):
+    """Validates near_beacon_kernel against NumPy reference.
+
+    Purpose: Ensure boolean proximity checks match for representative states.
+
+    Given: States covering directly-on-beacon, inside-radius, outside-radius.
+    When: Both the kernel and the reference are evaluated.
+    Then: They return the same boolean across a range of beacon radii.
+
+    Test type: unit
+    """
+    for radius in (0.5, 1.0, 2.0):
+        got = near_beacon_kernel(state, default_beacons, radius)
+        expected = _ref_near_beacon(state, default_beacons, radius)
+        assert got == expected, f"state={state} radius={radius}"
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        np.array([0.0, 5.0]),
+        np.array([2.5, 2.5]),
+        np.array([5.0, 5.0]),
+        np.array([7.5, 2.5]),
+    ],
+)
+def test_min_distance_to_beacon_kernel_matches_reference(state, default_beacons):
+    """Validates min_distance_to_beacon_kernel numerical equivalence.
+
+    Purpose: Ensure scalar min-distance output agrees with NumPy reference
+        to within floating-point tolerance.
+
+    Given: A state and a 3x3 beacon grid.
+    When: Both min_distance_to_beacon_kernel and its reference are evaluated.
+    Then: Results agree within 1e-12.
+
+    Test type: unit
+    """
+    got = min_distance_to_beacon_kernel(state, default_beacons)
+    expected = _ref_min_distance_to_beacon(state, default_beacons)
+    assert np.isclose(got, expected, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# mvn_sample_2d_kernel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_samples", [1, 5, 64])
+def test_mvn_sample_2d_kernel_matches_reference(n_samples):
+    """Validates mvn_sample_2d_kernel matches mean + z @ L.T.
+
+    Purpose: Confirm the hand-rolled 2D matmul agrees with NumPy's @ operator
+        to machine precision on representative covariance matrices.
+
+    Given: Pre-drawn standard-normal z and a 2x2 Cholesky upper factor.
+    When: The kernel and a NumPy reference both compute mean + z @ L.T.
+    Then: Outputs are bit-identical within 1e-12 atol.
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(0)
+    cov = np.array([[1.0, 0.3], [0.3, 2.0]])
+    chol_L = np.linalg.cholesky(cov)
+    chol_L_T = chol_L.T.copy()
+    mean = np.array([1.5, -0.25])
+    z = rng.standard_normal((n_samples, 2))
+
+    got = mvn_sample_2d_kernel(mean, z, chol_L_T)
+    expected = mean + z @ chol_L_T
+    assert got.shape == (n_samples, 2)
+    assert np.allclose(got, expected, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# compute_reward_base_kernel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state,action,hit_prob,uniform,expected_branch",
+    [
+        # at goal — no obstacle-hit-region flag
+        (np.array([9.9, 5.0]), np.array([0.05, 0.0]), 0.2, 0.1, "goal"),
+        # in obstacle region — flag True, uniform < hit_prob → obstacle reward
+        (np.array([2.0, 5.0]), np.array([1.0, 0.0]), 0.2, 0.1, "obstacle_hit"),
+        # in obstacle region — flag True, uniform >= hit_prob → no obstacle reward
+        (np.array([2.0, 5.0]), np.array([1.0, 0.0]), 0.2, 0.5, "obstacle_miss"),
+        # out of grid — flag False, reward includes OOG penalty
+        (np.array([0.5, 0.5]), np.array([-1.0, 0.0]), 0.2, 0.0, "out_of_grid"),
+        # plain interior — flag False, reward is just fuel + dist_to_goal
+        (np.array([1.0, 5.0]), np.array([1.0, 0.0]), 0.2, 0.0, "interior"),
+    ],
+)
+def test_compute_reward_base_kernel_matches_reference(
+    state, action, hit_prob, uniform, expected_branch, default_goal, default_obstacles
+):
+    """Validates compute_reward_base_kernel across all reward branches.
+
+    Purpose: Verify the deterministic base reward plus the
+        is_obstacle_hit_region flag against the NumPy reference, for every
+        branch the Standard reward model can take.
+
+    Given: State/action pairs that land in each branch (goal, obstacle-hit,
+        obstacle-miss, out-of-grid, interior) and matching uniforms.
+    When: The kernel's (reward, flag) is composed in Python with the same
+        branching used by ContinuousLightDarkRewardModel._compute_reward,
+        then compared to _ref_compute_reward_standard.
+    Then: Numerical equivalence to 1e-12.
+
+    Test type: unit
+    """
+    del expected_branch  # descriptive parameter only
+    reward, should_draw = compute_reward_base_kernel(
+        state, action, default_goal, default_obstacles, 1.5, 1.5, 11.0, 2.0, 10.0, -10.0
+    )
+    if should_draw and uniform < hit_prob:
+        reward += -10.0
+    expected = _ref_compute_reward_standard(
+        state,
+        action,
+        default_goal,
+        default_obstacles,
+        1.5,
+        1.5,
+        11.0,
+        2.0,
+        10.0,
+        -10.0,
+        hit_prob,
+        uniform,
+    )
+    assert np.isclose(reward, expected, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# compute_reward_decaying_hit_prob_kernel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state,action,uniform",
+    [
+        (np.array([9.9, 5.0]), np.array([0.05, 0.0]), 0.1),  # at goal
+        (np.array([2.0, 5.0]), np.array([1.0, 0.0]), 0.01),  # near obstacle, likely hit
+        (np.array([1.0, 5.0]), np.array([1.0, 0.0]), 0.99),  # interior, unlikely hit
+        (np.array([0.5, 0.5]), np.array([-1.0, 0.0]), 0.5),  # out of grid
+    ],
+)
+def test_compute_reward_decaying_hit_prob_kernel_matches_reference(
+    state, action, uniform, default_goal, default_obstacles
+):
+    """Validates compute_reward_decaying_hit_prob_kernel numerical equivalence.
+
+    Purpose: Verify the decaying-hit-probability reward model kernel agrees
+        with the NumPy reference across goal / obstacle-proximity / OOG /
+        interior cases.
+
+    Given: Representative state/action pairs and uniforms spanning the
+        decision thresholds.
+    When: The kernel and reference both compute the full reward.
+    Then: Numerical equivalence to 1e-12.
+
+    Test type: unit
+    """
+    got = compute_reward_decaying_hit_prob_kernel(
+        state,
+        action,
+        default_goal,
+        default_obstacles,
+        1.5,
+        11.0,
+        2.0,
+        10.0,
+        -10.0,
+        1.0,
+        uniform,
+    )
+    expected = _ref_compute_reward_decaying(
+        state,
+        action,
+        default_goal,
+        default_obstacles,
+        1.5,
+        11.0,
+        2.0,
+        10.0,
+        -10.0,
+        1.0,
+        uniform,
+    )
+    assert np.isclose(got, expected, atol=1e-12)

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_numba_kernels.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_numba_kernels.py
@@ -1,10 +1,10 @@
-"""Numerical-equivalence tests for the light-dark Numba kernels.
+"""Numerical-equivalence tests for the light-dark-specific Numba kernels.
 
 Each test pairs a kernel against a pure-NumPy reference implementation
-assembled from the pre-refactor class methods, and asserts bit-identical
-(or ``np.isclose``) results over a mix of representative and edge-case
-inputs. Running these before wiring the kernels into the env classes
-catches any kernel-logic drift in isolation.
+assembled from the pre-refactor class methods, and asserts results agree
+within floating-point tolerance. Covers only kernels whose signature /
+logic hardcodes light-dark concepts (goal+obstacles+reward shape); tests
+for shared generic kernels live under ``POMDPPlanners/tests/test_utils/``.
 """
 
 import numpy as np
@@ -14,9 +14,6 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.numba_ke
     compute_reward_base_kernel,
     compute_reward_decaying_hit_prob_kernel,
     is_terminal_kernel,
-    min_distance_to_beacon_kernel,
-    mvn_sample_2d_kernel,
-    near_beacon_kernel,
 )
 
 
@@ -35,16 +32,6 @@ def _ref_is_terminal(
         return False
     distances = np.linalg.norm(state.reshape(-1, 1) - obstacles, axis=0)
     return bool(np.any(distances <= obstacle_radius))
-
-
-def _ref_near_beacon(next_state: np.ndarray, beacons: np.ndarray, beacon_radius: float) -> bool:
-    distances = np.linalg.norm(next_state.reshape(2, 1) - beacons, axis=0)
-    return bool(np.any(distances <= beacon_radius))
-
-
-def _ref_min_distance_to_beacon(next_state: np.ndarray, beacons: np.ndarray) -> float:
-    distances = np.linalg.norm(next_state.reshape(2, 1) - beacons, axis=0)
-    return float(np.min(distances))
 
 
 def _ref_compute_reward_standard(
@@ -119,14 +106,6 @@ def default_obstacles() -> np.ndarray:
 
 
 @pytest.fixture
-def default_beacons() -> np.ndarray:
-    """3x3 grid of beacons in 2xN layout."""
-    xs = [0.0, 0.0, 0.0, 5.0, 5.0, 5.0, 10.0, 10.0, 10.0]
-    ys = [0.0, 5.0, 10.0, 0.0, 5.0, 10.0, 0.0, 5.0, 10.0]
-    return np.array([xs, ys])
-
-
-@pytest.fixture
 def default_goal() -> np.ndarray:
     return np.array([10.0, 5.0])
 
@@ -196,95 +175,6 @@ def test_is_terminal_kernel_empty_obstacles():
     empty_obs = np.empty((2, 0))
     state = np.array([5.0, 5.0])
     assert not is_terminal_kernel(state, np.array([10.0, 5.0]), empty_obs, 1.5, 1.5, True)
-
-
-# ---------------------------------------------------------------------------
-# near_beacon_kernel / min_distance_to_beacon_kernel
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "state",
-    [
-        np.array([0.0, 5.0]),
-        np.array([2.5, 2.5]),
-        np.array([5.0, 5.0]),
-        np.array([5.4, 5.0]),
-        np.array([10.0, 10.0]),
-    ],
-)
-def test_near_beacon_kernel_matches_reference(state, default_beacons):
-    """Validates near_beacon_kernel against NumPy reference.
-
-    Purpose: Ensure boolean proximity checks match for representative states.
-
-    Given: States covering directly-on-beacon, inside-radius, outside-radius.
-    When: Both the kernel and the reference are evaluated.
-    Then: They return the same boolean across a range of beacon radii.
-
-    Test type: unit
-    """
-    for radius in (0.5, 1.0, 2.0):
-        got = near_beacon_kernel(state, default_beacons, radius)
-        expected = _ref_near_beacon(state, default_beacons, radius)
-        assert got == expected, f"state={state} radius={radius}"
-
-
-@pytest.mark.parametrize(
-    "state",
-    [
-        np.array([0.0, 5.0]),
-        np.array([2.5, 2.5]),
-        np.array([5.0, 5.0]),
-        np.array([7.5, 2.5]),
-    ],
-)
-def test_min_distance_to_beacon_kernel_matches_reference(state, default_beacons):
-    """Validates min_distance_to_beacon_kernel numerical equivalence.
-
-    Purpose: Ensure scalar min-distance output agrees with NumPy reference
-        to within floating-point tolerance.
-
-    Given: A state and a 3x3 beacon grid.
-    When: Both min_distance_to_beacon_kernel and its reference are evaluated.
-    Then: Results agree within 1e-12.
-
-    Test type: unit
-    """
-    got = min_distance_to_beacon_kernel(state, default_beacons)
-    expected = _ref_min_distance_to_beacon(state, default_beacons)
-    assert np.isclose(got, expected, atol=1e-12)
-
-
-# ---------------------------------------------------------------------------
-# mvn_sample_2d_kernel
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("n_samples", [1, 5, 64])
-def test_mvn_sample_2d_kernel_matches_reference(n_samples):
-    """Validates mvn_sample_2d_kernel matches mean + z @ L.T.
-
-    Purpose: Confirm the hand-rolled 2D matmul agrees with NumPy's @ operator
-        to machine precision on representative covariance matrices.
-
-    Given: Pre-drawn standard-normal z and a 2x2 Cholesky upper factor.
-    When: The kernel and a NumPy reference both compute mean + z @ L.T.
-    Then: Outputs are bit-identical within 1e-12 atol.
-
-    Test type: unit
-    """
-    rng = np.random.default_rng(0)
-    cov = np.array([[1.0, 0.3], [0.3, 2.0]])
-    chol_L = np.linalg.cholesky(cov)
-    chol_L_T = chol_L.T.copy()
-    mean = np.array([1.5, -0.25])
-    z = rng.standard_normal((n_samples, 2))
-
-    got = mvn_sample_2d_kernel(mean, z, chol_L_T)
-    expected = mean + z @ chol_L_T
-    assert got.shape == (n_samples, 2)
-    assert np.allclose(got, expected, atol=1e-12)
 
 
 # ---------------------------------------------------------------------------

--- a/POMDPPlanners/tests/test_setup.py
+++ b/POMDPPlanners/tests/test_setup.py
@@ -5,8 +5,9 @@ import importlib.metadata
 import random
 
 import numpy as np
+from packaging.requirements import Requirement
+
 import POMDPPlanners
-from packaging import version
 
 np.random.seed(42)
 random.seed(42)
@@ -44,30 +45,20 @@ def test_required_packages():
     # Filter to direct dependencies only (exclude extras like dev/docs)
     requirements = [r for r in requirements if "; extra ==" not in r]
 
-    # Check each requirement
-    for req in requirements:
+    # Check each requirement using packaging.requirements.Requirement, which
+    # correctly parses any PEP 508 version spec (including compound specs
+    # like ">=0.59,<0.62").
+    for req_str in requirements:
+        req = Requirement(req_str)
         try:
-            # Parse package name and version constraint
-            if "==" in req:
-                package_name, expected_version = req.split("==")
-                installed_version = importlib.metadata.version(package_name.strip())
-                if installed_version != expected_version.strip():
-                    raise AssertionError(
-                        f"Package {package_name} version mismatch: expected {expected_version}, got {installed_version}"
-                    )
-            elif ">=" in req:
-                package_name, min_version = req.split(">=")
-                installed_version = importlib.metadata.version(package_name.strip())
-                # Proper semantic version comparison
-                if version.parse(installed_version) < version.parse(min_version.strip()):
-                    raise AssertionError(
-                        f"Package {package_name} version too old: expected >= {min_version}, got {installed_version}"
-                    )
-            else:
-                # Just check if package is installed
-                importlib.metadata.version(req.strip())
+            installed_version = importlib.metadata.version(req.name)
         except importlib.metadata.PackageNotFoundError as e:
-            raise AssertionError(f"Package requirement not met: {req} - {e}")
+            raise AssertionError(f"Package requirement not met: {req_str} - {e}") from e
+        if req.specifier and not req.specifier.contains(installed_version, prereleases=True):
+            raise AssertionError(
+                f"Package {req.name} version mismatch: expected {req.specifier}, "
+                f"got {installed_version}"
+            )
 
 
 def test_imports():

--- a/POMDPPlanners/tests/test_utils/test_numba_kernels.py
+++ b/POMDPPlanners/tests/test_utils/test_numba_kernels.py
@@ -1,0 +1,149 @@
+"""Numerical-equivalence tests for the shared Numba kernels in ``POMDPPlanners.utils``.
+
+Each test pairs a kernel against a pure-NumPy reference implementation and
+asserts results agree within floating-point tolerance over a mix of
+representative and edge-case inputs. These kernels are generic primitives
+reused across POMDP environments — the tests here exercise them without any
+env-specific semantics.
+"""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.utils.numba_kernels import (
+    any_point_within_radius_kernel,
+    min_distance_to_points_kernel,
+    mvn_sample_2d_kernel,
+)
+
+
+def _ref_any_point_within_radius(query: np.ndarray, points: np.ndarray, radius: float) -> bool:
+    distances = np.linalg.norm(query.reshape(2, 1) - points, axis=0)
+    return bool(np.any(distances <= radius))
+
+
+def _ref_min_distance_to_points(query: np.ndarray, points: np.ndarray) -> float:
+    distances = np.linalg.norm(query.reshape(2, 1) - points, axis=0)
+    return float(np.min(distances))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def default_points() -> np.ndarray:
+    """3x3 grid of points in 2xN layout (stand-in for beacons/targets/rocks)."""
+    xs = [0.0, 0.0, 0.0, 5.0, 5.0, 5.0, 10.0, 10.0, 10.0]
+    ys = [0.0, 5.0, 10.0, 0.0, 5.0, 10.0, 0.0, 5.0, 10.0]
+    return np.array([xs, ys])
+
+
+# ---------------------------------------------------------------------------
+# any_point_within_radius_kernel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        np.array([0.0, 5.0]),
+        np.array([2.5, 2.5]),
+        np.array([5.0, 5.0]),
+        np.array([5.4, 5.0]),
+        np.array([10.0, 10.0]),
+    ],
+)
+def test_any_point_within_radius_kernel_matches_reference(query, default_points):
+    """Validates any_point_within_radius_kernel against NumPy reference.
+
+    Purpose: Ensure boolean proximity checks match for representative queries.
+
+    Given: Queries covering directly-on-point, inside-radius, outside-radius.
+    When: Both the kernel and the reference are evaluated.
+    Then: They return the same boolean across a range of radii.
+
+    Test type: unit
+    """
+    for radius in (0.5, 1.0, 2.0):
+        got = any_point_within_radius_kernel(query, default_points, radius)
+        expected = _ref_any_point_within_radius(query, default_points, radius)
+        assert got == expected, f"query={query} radius={radius}"
+
+
+def test_any_point_within_radius_kernel_empty_points():
+    """Validates any_point_within_radius_kernel with an empty (2, 0) array.
+
+    Purpose: Edge case — no candidate points.
+
+    Given: Empty 2x0 points array.
+    When: The kernel is called.
+    Then: Returns False.
+
+    Test type: unit
+    """
+    empty = np.empty((2, 0))
+    assert not any_point_within_radius_kernel(np.array([1.0, 1.0]), empty, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# min_distance_to_points_kernel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        np.array([0.0, 5.0]),
+        np.array([2.5, 2.5]),
+        np.array([5.0, 5.0]),
+        np.array([7.5, 2.5]),
+    ],
+)
+def test_min_distance_to_points_kernel_matches_reference(query, default_points):
+    """Validates min_distance_to_points_kernel numerical equivalence.
+
+    Purpose: Ensure scalar min-distance output agrees with NumPy reference
+        to within floating-point tolerance.
+
+    Given: A query and a 3x3 point grid.
+    When: Both min_distance_to_points_kernel and its reference are evaluated.
+    Then: Results agree within 1e-12.
+
+    Test type: unit
+    """
+    got = min_distance_to_points_kernel(query, default_points)
+    expected = _ref_min_distance_to_points(query, default_points)
+    assert np.isclose(got, expected, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# mvn_sample_2d_kernel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_samples", [1, 5, 64])
+def test_mvn_sample_2d_kernel_matches_reference(n_samples):
+    """Validates mvn_sample_2d_kernel matches mean + z @ L.T.
+
+    Purpose: Confirm the hand-rolled 2D matmul agrees with NumPy's @ operator
+        to machine precision on representative covariance matrices.
+
+    Given: Pre-drawn standard-normal z and a 2x2 Cholesky upper factor.
+    When: The kernel and a NumPy reference both compute mean + z @ L.T.
+    Then: Outputs are bit-identical within 1e-12 atol.
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(0)
+    cov = np.array([[1.0, 0.3], [0.3, 2.0]])
+    chol_L = np.linalg.cholesky(cov)
+    chol_L_T = chol_L.T.copy()
+    mean = np.array([1.5, -0.25])
+    z = rng.standard_normal((n_samples, 2))
+
+    got = mvn_sample_2d_kernel(mean, z, chol_L_T)
+    expected = mean + z @ chol_L_T
+    assert got.shape == (n_samples, 2)
+    assert np.allclose(got, expected, atol=1e-12)

--- a/POMDPPlanners/utils/numba_kernels.py
+++ b/POMDPPlanners/utils/numba_kernels.py
@@ -1,0 +1,95 @@
+"""Shared Numba-JIT kernels for POMDP environment hot paths.
+
+Holds pure geometric / numerical kernels reused across POMDP environments
+(light-dark, push, safety-ant-velocity, continuous laser-tag, ...). Each
+kernel is decorated with ``@njit(cache=True)`` so the LLVM-compiled version
+is cached to disk between runs.
+
+Conventions
+-----------
+- **All inputs are plain numeric arrays / scalars.** No Python objects, no
+  class instances. Callers hand in ``float64`` arrays (contiguous) and
+  ``float``/``int``/``bool`` scalars.
+- **RNG stays in Python.** Any stochastic draw (``np.random.standard_normal``,
+  ``np.random.rand``) happens in the Python caller and is passed into the
+  kernel (e.g. as ``z``). This preserves seed semantics and keeps outputs
+  bit-identical under fixed seeds.
+- **Point arrays are shape (2, N).** ``x`` coordinates on row 0, ``y`` on
+  row 1. Matches the ``_convert_*_to_array`` helpers already used by the
+  POMDP environment base classes.
+
+Public kernels
+--------------
+- :func:`any_point_within_radius_kernel` — ``True`` iff any of ``N`` points
+  lies within ``radius`` of the query.
+- :func:`min_distance_to_points_kernel` — minimum Euclidean distance from
+  the query to any of ``N`` points.
+- :func:`mvn_sample_2d_kernel` — 2-D multivariate-normal sample given
+  pre-drawn standard normals and a transposed Cholesky factor.
+"""
+
+import numpy as np
+from numba import njit
+
+# pylint: disable=no-value-for-parameter,not-an-iterable
+
+
+@njit(cache=True)  # type: ignore[misc]
+def any_point_within_radius_kernel(
+    query: np.ndarray,
+    points: np.ndarray,
+    radius: float,
+) -> bool:
+    n_points = points.shape[1]
+    radius_sq = radius * radius
+    for i in range(n_points):
+        dx = query[0] - points[0, i]
+        dy = query[1] - points[1, i]
+        if dx * dx + dy * dy <= radius_sq:
+            return True
+    return False
+
+
+@njit(cache=True)  # type: ignore[misc]
+def min_distance_to_points_kernel(
+    query: np.ndarray,
+    points: np.ndarray,
+) -> float:
+    n_points = points.shape[1]
+    min_sq = np.inf
+    for i in range(n_points):
+        dx = query[0] - points[0, i]
+        dy = query[1] - points[1, i]
+        d_sq = dx * dx + dy * dy
+        min_sq = min(min_sq, d_sq)
+    return min_sq**0.5
+
+
+@njit(cache=True)  # type: ignore[misc]
+def mvn_sample_2d_kernel(
+    mean: np.ndarray,
+    z: np.ndarray,
+    cholesky_L_T: np.ndarray,
+) -> np.ndarray:
+    """Sample n points from a 2-D Gaussian with fixed Cholesky factor.
+
+    Given pre-drawn standard-normal ``z`` of shape ``(n, 2)`` and the
+    transposed Cholesky factor ``L.T`` of shape ``(2, 2)``, compute
+    ``mean + z @ L.T`` and return samples of shape ``(n, 2)``. The
+    hand-rolled matmul avoids NumPy's per-call dispatch cost for the tiny
+    ``(n, 2) @ (2, 2)`` product.
+    """
+    n_samples = z.shape[0]
+    out = np.empty((n_samples, 2), dtype=np.float64)
+    m0 = mean[0]
+    m1 = mean[1]
+    lt00 = cholesky_L_T[0, 0]
+    lt01 = cholesky_L_T[0, 1]
+    lt10 = cholesky_L_T[1, 0]
+    lt11 = cholesky_L_T[1, 1]
+    for i in range(n_samples):
+        z0 = z[i, 0]
+        z1 = z[i, 1]
+        out[i, 0] = m0 + z0 * lt00 + z1 * lt10
+        out[i, 1] = m1 + z0 * lt01 + z1 * lt11
+    return out

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -9,5 +9,6 @@ WORKDIR /app
 COPY . .
 
 # Re-install the package in editable mode so entry-points pick up new code.
-# Dependencies are already installed in the base image, so this is fast.
-RUN pip install --no-deps -e ".[dev,docs]"
+# Base image has most deps pre-installed; pip install reuses the cache for those
+# and picks up any newly-added deps on top.
+RUN pip install -e ".[dev,docs]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "memory_profiler>=0.60.0",
     "psutil>=5.8.0",
     "bokeh>=3.0.0",
+    "numba>=0.59,<0.62",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Replaces the closed PR #78 with a broader set of changes. Two cohesive pieces:

### 1. Numba acceleration of the continuous Light-Dark POMDP
Six `@njit(cache=True)` kernels cover the hot paths of `ContinuousLightDarkPOMDP` / `ContinuousLightDarkPOMDPDiscreteActions` (`is_terminal`, beacon proximity / min-distance, 2-D MVN sampling, and the three reward-model variants). All random draws remain in Python and are passed into kernels as parameters, so every seeded test is still bit-identical.

Measured speedups on `ContinuousLightDarkPOMDPDiscreteActions` primitives (pytest-benchmark, mean of ~100k rounds):

| Primitive | Baseline (µs) | After (µs) | Speedup | Improvement |
| --- | ---: | ---: | ---: | ---: |
| `is_terminal` | 7.456 | 0.451 | **16.5×** | 93.95% |
| `reward` | 13.496 | 0.817 | **16.5×** | 93.95% |
| `sample_next_step` | 38.361 | 9.786 | **3.9×** | 74.49% |
| `observation_model` | 12.901 | 5.689 | **2.3×** | 55.90% |
| `state_transition` | 4.171 | 3.121 | **1.3×** | 25.17% |

### 2. Promote generic kernels to a shared `utils/numba_kernels.py`
Three of the kernels are pure geometric / numerical primitives with no LD semantics and will be reused by the upcoming push / safety-ant-velocity / continuous-laser-tag refactors. They now live in `POMDPPlanners/utils/numba_kernels.py` with domain-neutral names:

| Before (LD-flavored) | After (shared) |
| --- | --- |
| `near_beacon_kernel` | `any_point_within_radius_kernel` |
| `min_distance_to_beacon_kernel` | `min_distance_to_points_kernel` |
| `mvn_sample_2d_kernel` | `mvn_sample_2d_kernel` (unchanged) |

LD-specific kernels (`is_terminal_kernel`, two reward kernels) stay in `light_dark_pomdp_utils/numba_kernels.py` — their signatures hardcode the LD goal/obstacles/reward shape.

### 3. Also bundled
- **CI fix** (`docker/Dockerfile.ci`): drops `--no-deps` so PRs that add new dependencies are picked up on top of the cached base image. Without this, PR #78 CI was failing with `ModuleNotFoundError: No module named 'numba'` even though `pyproject.toml` listed it.
- **test_setup.py fix**: replaces the ad-hoc `>=` string-split parser with `packaging.requirements.Requirement`, which correctly handles compound PEP 508 specs like `numba>=0.59,<0.62`. PR #78 was the first project instance to trip the pre-existing parser bug.

## Commits (in order)
1. `Add continuous Light-Dark POMDP fixtures and Layer-1 benchmarks`
2. `Add numba dependency for JIT-compiled POMDP kernels`
3. `Accelerate continuous Light-Dark environment hot paths with Numba kernels`
4. `Fix CI: drop --no-deps in Dockerfile.ci so new dependencies are picked up`
5. `Add generic Numba kernels module in POMDPPlanners/utils`
6. `Trim light-dark kernel tests to LD-specific kernels only`
7. `Drop generic kernels from light-dark numba_kernels (use shared utils module)`
8. `Fix test_setup.py PEP 508 parser to handle compound version specs`

## Test plan
- [x] `pytest POMDPPlanners/tests/test_environments/` — 1114 passed
- [x] `pytest POMDPPlanners/tests/test_utils/test_numba_kernels.py` — generic-kernel equivalence tests pass
- [x] `pytest POMDPPlanners/tests/test_setup.py` — all 3 setup checks pass (including `test_required_packages` that tripped on PR #78 CI)
- [x] `pyright` 0 errors / 0 warnings on all modified files
- [x] `pylint` 10.00 on new files (kernels + their tests)
- [x] `black --check` clean
- [x] Baseline and post-refactor pytest-benchmark JSONs saved for regression tracking

## Files
- **NEW** `POMDPPlanners/utils/numba_kernels.py` — 3 generic kernels
- **NEW** `POMDPPlanners/tests/test_utils/test_numba_kernels.py` — equivalence tests for generic kernels
- **NEW** `POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py` — LD-specific kernels
- **NEW** `POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_numba_kernels.py` — LD-specific kernel tests
- `continuous_light_dark_pomdp.py`, `light_dark_observation_models.py`, `light_dark_reward_models.py` — kernel call sites
- `tests/benchmarks/conftest.py`, `tests/benchmarks/test_benchmark_environments.py` — fixtures + 5 Layer-1 benchmarks
- `pyproject.toml` — `numba>=0.59,<0.62`
- `docker/Dockerfile.ci` — drop `--no-deps`
- `tests/test_setup.py` — proper PEP 508 parser