### PR TITLE
Batch native path for particle belief updates (MountainCar)

### DIFF
--- a/POMDPPlanners/core/_cpp/include/pomdp_native/models.hpp
+++ b/POMDPPlanners/core/_cpp/include/pomdp_native/models.hpp
@@ -75,6 +75,45 @@ class TransitionModelCpp {
         return out;
     }
 
+    // Batch sample: given N particles (N, Dim), return N next particles
+    // (N, Dim) using the model's stored action, noise, and compute_mean_from_state
+    // + post_sample_transform hooks. Uses the module default RNG.
+    // The model's own state_ is NOT read on this path -- state is varied per row
+    // from the input array.
+    pybind11::array_t<double> batch_sample(
+        pybind11::array_t<double, pybind11::array::c_style | pybind11::array::forcecast> particles)
+        const {
+        if (particles.ndim() != 2 ||
+            static_cast<std::size_t>(particles.shape(1)) != Dim) {
+            throw std::invalid_argument("particles must have shape (N, Dim)");
+        }
+        const auto n_rows = static_cast<std::size_t>(particles.shape(0));
+        auto particles_view = particles.template unchecked<2>();
+
+        auto out = pybind11::array_t<double>(
+            {static_cast<pybind11::ssize_t>(n_rows), static_cast<pybind11::ssize_t>(Dim)});
+        auto out_view = out.template mutable_unchecked<2>();
+
+        double state_row[Dim];  // NOLINT(modernize-avoid-c-arrays)
+        double mean[Dim];       // NOLINT(modernize-avoid-c-arrays)
+        double buf[Dim];        // NOLINT(modernize-avoid-c-arrays)
+        RNGState &rng = default_rng();
+        for (std::size_t i = 0; i < n_rows; ++i) {
+            for (std::size_t d = 0; d < Dim; ++d) {
+                state_row[d] = particles_view(static_cast<pybind11::ssize_t>(i),
+                                              static_cast<pybind11::ssize_t>(d));
+            }
+            compute_mean_from_state(state_row, mean);
+            noise_.sample_into(buf, mean, rng);
+            post_sample_transform(buf);
+            for (std::size_t d = 0; d < Dim; ++d) {
+                out_view(static_cast<pybind11::ssize_t>(i),
+                         static_cast<pybind11::ssize_t>(d)) = buf[d];
+            }
+        }
+        return out;
+    }
+
     const std::array<double, Dim> &state_arr() const noexcept { return state_; }
     const pybind11::object &action_obj() const noexcept { return action_; }
 
@@ -132,6 +171,49 @@ class ObservationModelCpp {
         for (std::size_t i = 0; i < batch.n; ++i) {
             const double *x = batch.flat.data() + i * Dim;
             buf(static_cast<pybind11::ssize_t>(i)) = std::exp(noise_.log_pdf(x, mean));
+        }
+        return out;
+    }
+
+    // Batch log-likelihood: given N next-state particles (N, Dim) and a single
+    // observation (Dim,), return the per-particle log P(observation | next_state,
+    // action). Uses the model's stored action, noise, and
+    // compute_mean_from_next_state hook. The model's own next_state_ is NOT read
+    // on this path.
+    pybind11::array_t<double> batch_log_likelihood(
+        pybind11::array_t<double, pybind11::array::c_style | pybind11::array::forcecast>
+            next_particles,
+        pybind11::array_t<double, pybind11::array::c_style | pybind11::array::forcecast>
+            observation) const {
+        if (next_particles.ndim() != 2 ||
+            static_cast<std::size_t>(next_particles.shape(1)) != Dim) {
+            throw std::invalid_argument("next_particles must have shape (N, Dim)");
+        }
+        if (observation.ndim() != 1 ||
+            static_cast<std::size_t>(observation.shape(0)) != Dim) {
+            throw std::invalid_argument("observation must have shape (Dim,)");
+        }
+        const auto n_rows = static_cast<std::size_t>(next_particles.shape(0));
+        auto particles_view = next_particles.template unchecked<2>();
+        auto obs_view = observation.template unchecked<1>();
+
+        double obs_buf[Dim];  // NOLINT(modernize-avoid-c-arrays)
+        for (std::size_t d = 0; d < Dim; ++d) {
+            obs_buf[d] = obs_view(static_cast<pybind11::ssize_t>(d));
+        }
+
+        auto out = pybind11::array_t<double>(static_cast<pybind11::ssize_t>(n_rows));
+        auto out_view = out.mutable_unchecked<1>();
+
+        double next_state_row[Dim];  // NOLINT(modernize-avoid-c-arrays)
+        double mean[Dim];            // NOLINT(modernize-avoid-c-arrays)
+        for (std::size_t i = 0; i < n_rows; ++i) {
+            for (std::size_t d = 0; d < Dim; ++d) {
+                next_state_row[d] = particles_view(static_cast<pybind11::ssize_t>(i),
+                                                   static_cast<pybind11::ssize_t>(d));
+            }
+            compute_mean_from_next_state(next_state_row, mean);
+            out_view(static_cast<pybind11::ssize_t>(i)) = noise_.log_pdf(obs_buf, mean);
         }
         return out;
     }

--- a/POMDPPlanners/core/_cpp/include/pomdp_native/models.hpp
+++ b/POMDPPlanners/core/_cpp/include/pomdp_native/models.hpp
@@ -3,10 +3,18 @@
 //
 // These classes are NOT exposed to Python. Per-env pybind11 extensions
 // instantiate the base at their dimension (e.g. MountainCar uses
-// ``TransitionModelCpp<2>``), override the env-specific ``compute_mean``
-// (and optional ``post_sample_transform``) hook, and bind the concrete
-// subclass. The sample() / probability() loops, RNG selection, and
-// stack-allocated scratch all live here.
+// ``TransitionModelCpp<2>``), override the env-specific
+// ``compute_mean_from_state`` (transition) /
+// ``compute_mean_from_next_state`` (observation) hook (plus optional
+// ``post_sample_transform``), and bind the concrete subclass. The
+// sample() / probability() loops, RNG selection, and stack-allocated
+// scratch all live here.
+//
+// The ``compute_mean_from_*`` hooks take the state / next_state as an
+// explicit argument so batched entry points (see Layer 2) can vary it
+// across rows without mutating the model's ``state_`` / ``next_state_``
+// members. Single-instance ``sample()`` / ``probability()`` simply pass
+// ``state_.data()`` / ``next_state_.data()`` through.
 
 #ifndef POMDP_NATIVE_MODELS_HPP_
 #define POMDP_NATIVE_MODELS_HPP_
@@ -40,7 +48,7 @@ class TransitionModelCpp {
             throw std::invalid_argument("n_samples must be non-negative");
         }
         double mean[Dim];  // NOLINT(modernize-avoid-c-arrays)
-        compute_mean(mean);
+        compute_mean_from_state(state_.data(), mean);
 
         double buf[Dim];  // NOLINT(modernize-avoid-c-arrays)
         pybind11::list out;
@@ -55,7 +63,7 @@ class TransitionModelCpp {
 
     pybind11::array_t<double> probability(const pybind11::object &values) const {
         double mean[Dim];  // NOLINT(modernize-avoid-c-arrays)
-        compute_mean(mean);
+        compute_mean_from_state(state_.data(), mean);
 
         auto batch = extract_rows_nd(values, Dim);
         auto out = pybind11::array_t<double>(static_cast<pybind11::ssize_t>(batch.n));
@@ -71,9 +79,13 @@ class TransitionModelCpp {
     const pybind11::object &action_obj() const noexcept { return action_; }
 
   protected:
-    // Env-specific deterministic next-state computation. Writes Dim doubles
-    // to out. Called once per sample() / probability() call.
-    virtual void compute_mean(double *out) const = 0;
+    // Env-specific deterministic next-state computation. Given a state vector
+    // (length Dim) and the model's stored action, writes the deterministic
+    // next-state mean into out (also length Dim). Called once per sample() /
+    // probability() invocation; called N times per batch_sample() call with
+    // varying state. env-specific params (power, gravity, ...) stay as
+    // members on the subclass.
+    virtual void compute_mean_from_state(const double *state, double *out) const = 0;
 
     // Optional hook, called after each additive Gaussian draw so envs can
     // clip, wrap, or otherwise project the sample onto their feasible set.
@@ -98,7 +110,7 @@ class ObservationModelCpp {
             throw std::invalid_argument("n_samples must be non-negative");
         }
         double mean[Dim];  // NOLINT(modernize-avoid-c-arrays)
-        compute_mean(mean);
+        compute_mean_from_next_state(next_state_.data(), mean);
 
         double buf[Dim];  // NOLINT(modernize-avoid-c-arrays)
         pybind11::list out;
@@ -112,7 +124,7 @@ class ObservationModelCpp {
 
     pybind11::array_t<double> probability(const pybind11::object &values) const {
         double mean[Dim];  // NOLINT(modernize-avoid-c-arrays)
-        compute_mean(mean);
+        compute_mean_from_next_state(next_state_.data(), mean);
 
         auto batch = extract_rows_nd(values, Dim);
         auto out = pybind11::array_t<double>(static_cast<pybind11::ssize_t>(batch.n));
@@ -130,9 +142,11 @@ class ObservationModelCpp {
   protected:
     // Default behavior: observation mean equals the input next_state. Envs
     // with state-dependent observation means (e.g. light-dark) can override.
-    virtual void compute_mean(double *out) const {
+    // Called once per sample() / probability() invocation; called N times
+    // per batch_log_likelihood() call with varying next_state.
+    virtual void compute_mean_from_next_state(const double *next_state, double *out) const {
         for (std::size_t i = 0; i < Dim; ++i) {
-            out[i] = next_state_[i];
+            out[i] = next_state[i];
         }
     }
 

--- a/POMDPPlanners/core/belief/particle_beliefs.py
+++ b/POMDPPlanners/core/belief/particle_beliefs.py
@@ -260,6 +260,22 @@ class WeightedParticleBelief(Belief):
     def _update_weights(
         self, action: Any, observation: Any, pomdp: Environment
     ) -> Tuple[List[Any], np.ndarray]:
+        # Fast path: if the env's transition model exposes a native batch
+        # entry point, process all particles in a single C++ call. When the
+        # observation model also exposes batch_log_likelihood, the
+        # per-particle Python loop is eliminated entirely and the belief
+        # update becomes O(1) Python round trips instead of O(N).
+        transition_model = pomdp.state_transition_model(state=self.particles[0], action=action)
+        if hasattr(transition_model, "batch_sample"):
+            return self._update_weights_batch(
+                action=action,
+                observation=observation,
+                pomdp=pomdp,
+                transition_model=transition_model,
+            )
+
+        # Fallback: per-particle Python loop. Byte-identical to pre-Layer-2
+        # behaviour for envs without native batch support.
         next_particles = [
             pomdp.state_transition_model(state=particle, action=action).sample()[0]
             for particle in self.particles
@@ -275,6 +291,43 @@ class WeightedParticleBelief(Belief):
 
         next_log_weights = self.log_weights + np.log(self.eps + probs)
 
+        return next_particles, next_log_weights
+
+    def _update_weights_batch(
+        self,
+        action: Any,
+        observation: Any,
+        pomdp: Environment,
+        transition_model: Any,
+    ) -> Tuple[List[Any], np.ndarray]:
+        particles_arr = np.asarray(self.particles, dtype=float)
+        next_arr = transition_model.batch_sample(particles_arr)
+        next_particles: List[Any] = [next_arr[i] for i in range(len(next_arr))]
+
+        obs_model = pomdp.observation_model(next_state=next_arr[0], action=action)
+        if hasattr(obs_model, "batch_log_likelihood"):
+            observation_arr = np.asarray(observation, dtype=float).ravel()
+            # pyright cannot see through the hasattr narrowing onto a
+            # concrete native subclass (e.g. MountainCarObservationCpp);
+            # the runtime hasattr guarantees the call is safe.
+            log_ll = obs_model.batch_log_likelihood(  # type: ignore[attr-defined]
+                next_arr, observation_arr
+            )
+            # No eps clamp on the native batch path -- log_pdf is always
+            # finite for Gaussian observation models, matching the existing
+            # VectorizedWeightedParticleBelief contract.
+            next_log_weights = self.log_weights + log_ll
+            return next_particles, next_log_weights
+
+        probs = np.array(
+            [
+                pomdp.observation_model(next_state=next_particle, action=action).probability(
+                    [observation]
+                )[0]
+                for next_particle in next_particles
+            ]
+        )
+        next_log_weights = self.log_weights + np.log(self.eps + probs)
         return next_particles, next_log_weights
 
     def update(

--- a/POMDPPlanners/environments/mountain_car_pomdp/_cpp/mountain_car.cpp
+++ b/POMDPPlanners/environments/mountain_car_pomdp/_cpp/mountain_car.cpp
@@ -124,6 +124,7 @@ PYBIND11_MODULE(_native, m) {
              py::arg("covariance"))
         .def("sample", &MountainCarTransitionCpp::sample, py::arg("n_samples") = 1)
         .def("probability", &MountainCarTransitionCpp::probability, py::arg("values"))
+        .def("batch_sample", &MountainCarTransitionCpp::batch_sample, py::arg("particles"))
         .def("_compute_deterministic_next_state",
              &MountainCarTransitionCpp::compute_deterministic_next_state_py)
         .def_property_readonly("state", &MountainCarTransitionCpp::state_property)
@@ -139,6 +140,8 @@ PYBIND11_MODULE(_native, m) {
              py::arg("next_state"), py::arg("action"), py::arg("covariance"))
         .def("sample", &MountainCarObservationCpp::sample, py::arg("n_samples") = 1)
         .def("probability", &MountainCarObservationCpp::probability, py::arg("values"))
+        .def("batch_log_likelihood", &MountainCarObservationCpp::batch_log_likelihood,
+             py::arg("next_particles"), py::arg("observation"))
         .def_property_readonly("next_state", &MountainCarObservationCpp::next_state_property)
         .def_property_readonly("action", &MountainCarObservationCpp::action_property)
         .def_property_readonly("mean", &MountainCarObservationCpp::mean_property);

--- a/POMDPPlanners/environments/mountain_car_pomdp/_cpp/mountain_car.cpp
+++ b/POMDPPlanners/environments/mountain_car_pomdp/_cpp/mountain_car.cpp
@@ -49,16 +49,16 @@ class MountainCarTransitionCpp : public pomdp_native::TransitionModelCpp<kMounta
 
     py::array_t<double> compute_deterministic_next_state_py() const {
         double out[kMountainCarStateDim];
-        compute_mean(out);
+        compute_mean_from_state(state_.data(), out);
         return pomdp_native::array_from_vector(out, kMountainCarStateDim);
     }
 
   protected:
-    void compute_mean(double *out) const override {
-        double v = state_[1] + static_cast<double>(action_int_) * power_ +
-                   std::cos(3.0 * state_[0]) * (-gravity_);
+    void compute_mean_from_state(const double *state, double *out) const override {
+        double v = state[1] + static_cast<double>(action_int_) * power_ +
+                   std::cos(3.0 * state[0]) * (-gravity_);
         v = std::clamp(v, -max_speed_, max_speed_);
-        double p = state_[0] + v;
+        double p = state[0] + v;
         p = std::clamp(p, min_position_, max_position_);
         if (p == min_position_ && v < 0.0) {
             v = 0.0;

--- a/POMDPPlanners/environments/mountain_car_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/mountain_car_pomdp/_native.pyi
@@ -5,6 +5,8 @@ type-check modules that import from it. The runtime implementation lives
 in ``_cpp/mountain_car.cpp``.
 """
 
+# pylint: disable=unused-argument,unnecessary-ellipsis
+
 from typing import List, Sequence, Tuple, Union
 
 import numpy as np
@@ -41,6 +43,7 @@ class MountainCarTransitionCpp:
         self,
         values: Union[Sequence[NDArray[np.floating]], NDArray[np.floating]],
     ) -> NDArray[np.float64]: ...
+    def batch_sample(self, particles: NDArray[np.floating]) -> NDArray[np.float64]: ...
     def _compute_deterministic_next_state(self) -> NDArray[np.float64]: ...
 
 class MountainCarObservationCpp:
@@ -60,4 +63,9 @@ class MountainCarObservationCpp:
     def probability(
         self,
         values: Union[Sequence[NDArray[np.floating]], NDArray[np.floating]],
+    ) -> NDArray[np.float64]: ...
+    def batch_log_likelihood(
+        self,
+        next_particles: NDArray[np.floating],
+        observation: NDArray[np.floating],
     ) -> NDArray[np.float64]: ...

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp_beliefs.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp_beliefs.py
@@ -26,6 +26,7 @@ from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
 from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
     VectorizedWeightedParticleBelief,
 )
+from POMDPPlanners.environments.mountain_car_pomdp import _native
 from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp_gaussian_beliefs import (
     GaussianBeliefUpdaterType,
     create_mountain_car_gaussian_belief,
@@ -114,6 +115,11 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
         self.max_speed = max_speed
         self.min_position = min_position
         self.max_position = max_position
+        # Cached covariance arrays for the native batch entry points. The
+        # MVN objects' ``covariance`` property returns a copy, so we pay the
+        # allocation once instead of on every batch_transition call.
+        self._state_transition_cov: np.ndarray = state_transition_dist.covariance
+        self._obs_cov: np.ndarray = obs_dist.covariance
 
     @classmethod
     def from_environment(cls, env: "MountainCarPOMDP") -> "MountainCarVectorizedUpdater":
@@ -142,27 +148,36 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
     # ------------------------------------------------------------------
 
     def batch_transition(self, particles: np.ndarray, action: np.ndarray) -> np.ndarray:
-        # particles: (N, 2) = [position, velocity]
-        position, velocity = self._deterministic_next_state(particles, action)
-        position, velocity = self._add_transition_noise(position, velocity, particles.shape[0])
-        position, velocity = self._apply_clipping_and_wall_stop(position, velocity)
-        return np.column_stack([position, velocity])
+        # particles: (N, 2) = [position, velocity]. Delegates to the native
+        # C++ batch sampler so both this path and the per-particle
+        # MountainCarTransition.sample() share the same C++ RNG (closes the
+        # cross-path divergence that used to skip the equivalence tests).
+        # The `state=particles[0]` passed to the ctor is unused on the
+        # batch path; only the ctor signature requires it.
+        transition = _native.MountainCarTransitionCpp(
+            state=tuple(particles[0]),
+            action=int(action),
+            power=self.power,
+            gravity=self.gravity,
+            max_speed=self.max_speed,
+            min_position=self.min_position,
+            max_position=self.max_position,
+            covariance=self._state_transition_cov,
+        )
+        return transition.batch_sample(particles)
 
     def _deterministic_next_state(
         self, particles: np.ndarray, action: np.ndarray
     ) -> tuple[np.ndarray, np.ndarray]:
+        # Retained as a public-via-tests helper; mirrors the C++
+        # deterministic path so unit tests of physics don't depend on
+        # constructing a native object.
         position = particles[:, 0]
         velocity = particles[:, 1]
         velocity = velocity + action * self.power + np.cos(3.0 * position) * (-self.gravity)
         velocity = np.clip(velocity, -self.max_speed, self.max_speed)
         position = position + velocity
         return self._apply_clipping_and_wall_stop(position, velocity)
-
-    def _add_transition_noise(
-        self, position: np.ndarray, velocity: np.ndarray, n: int
-    ) -> tuple[np.ndarray, np.ndarray]:
-        noise = self.state_transition_dist.sample(np.zeros(2), n_samples=n)
-        return position + noise[:, 0], velocity + noise[:, 1]
 
     def _apply_clipping_and_wall_stop(
         self, position: np.ndarray, velocity: np.ndarray
@@ -179,8 +194,15 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
         action: np.ndarray,
         observation: np.ndarray,
     ) -> np.ndarray:
-        observation = np.asarray(observation, dtype=float).ravel()
-        return self.obs_dist.log_pdf(next_particles, observation)
+        observation_arr = np.asarray(observation, dtype=float).ravel()
+        # Delegate to the native C++ observation likelihood. `next_state`
+        # passed to the ctor is unused on the batch path.
+        obs_model = _native.MountainCarObservationCpp(
+            next_state=tuple(next_particles[0]),
+            action=int(action),
+            covariance=self._obs_cov,
+        )
+        return obs_model.batch_log_likelihood(next_particles, observation_arr)
 
     @property
     def config_id(self) -> str:

--- a/POMDPPlanners/tests/benchmarks/test_benchmark_particle_belief_update.py
+++ b/POMDPPlanners/tests/benchmarks/test_benchmark_particle_belief_update.py
@@ -1,0 +1,185 @@
+"""Benchmarks for WeightedParticleBelief / VectorizedWeightedParticleBelief
+update paths across native (MountainCar) and non-native (CartPole) envs.
+
+Measures the four cases laid out in Layer 2's plan:
+
+    | Case                  | Env        | Belief class                        | Path            |
+    |-----------------------|------------|-------------------------------------|-----------------|
+    | MC-generic-cpp        | MountainCar| WeightedParticleBelief.update       | C++ batch       |
+    | MC-vectorized-cpp     | MountainCar| VectorizedWeightedParticleBelief    | C++ batch       |
+    | CP-generic-python     | CartPole   | WeightedParticleBelief.update       | Python fallback |
+    | CP-vectorized-numpy   | CartPole   | VectorizedWeightedParticleBelief    | numpy batch     |
+
+Same N=100 particles, same action, same observation across all four.
+
+Use ``pytest-benchmark compare`` across the four cases to report:
+    1. MC-generic-cpp vs MC-vectorized-cpp   -- auto-dispatch parity with
+        the explicit vectorized path on a native env.
+    2. CP-generic-python vs CP-vectorized-numpy -- the non-native baseline
+        gap (the prize a future CartPole port to pomdp_native would close).
+    3. MC-generic-cpp vs CP-generic-python   -- headline speedup a native
+        port buys for callers who use plain WeightedParticleBelief.
+
+Run::
+
+    pytest POMDPPlanners/tests/benchmarks/test_benchmark_particle_belief_update.py \\
+        -m benchmark --benchmark-save=layer2_batch_dispatch -v
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
+from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp_beliefs import (
+    CartPoleVectorizedUpdater,
+)
+from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP
+from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp_beliefs import (
+    MountainCarVectorizedUpdater,
+)
+
+pytestmark = [pytest.mark.slow]
+
+_N_PARTICLES = 100
+
+
+# ---------------------------------------------------------------------------
+# MountainCar (native) cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="belief-update-mc-generic-cpp")
+def test_bench_mc_generic_belief_update(benchmark):
+    """Benchmark WeightedParticleBelief.update on MountainCar (auto-dispatch).
+
+    Purpose: Measures the generic per-particle-looking belief update path
+    on an env whose transition/observation models expose native batch
+    entry points. WeightedParticleBelief._update_weights sniffs the batch
+    interface and dispatches to C++ batch_sample / batch_log_likelihood in
+    a single round-trip per update.
+
+    Given: MountainCarPOMDP + WeightedParticleBelief with N=100 particles.
+    When: belief.update(action, observation, pomdp) is called repeatedly.
+    Then: Execution time is recorded.
+
+    Test type: performance
+    """
+    env = MountainCarPOMDP(discount_factor=0.99)
+    particles = list(env.initial_state_dist().sample(n_samples=_N_PARTICLES))
+    log_weights = np.log(np.ones(_N_PARTICLES) / _N_PARTICLES)
+    belief = WeightedParticleBelief(particles=particles, log_weights=log_weights)
+    observation = np.array([-0.5, 0.0])
+
+    def run():
+        return belief.update(action=1, observation=observation, pomdp=env)
+
+    benchmark(run)
+
+
+@pytest.mark.benchmark(group="belief-update-mc-vectorized-cpp")
+def test_bench_mc_vectorized_belief_update(benchmark):
+    """Benchmark VectorizedWeightedParticleBelief.update on MountainCar.
+
+    Purpose: Measures the explicit vectorized belief path on MountainCar.
+    Its updater (MountainCarVectorizedUpdater) delegates batch_transition
+    and batch_observation_log_likelihood directly to the native C++ batch
+    methods.
+
+    Given: MountainCarPOMDP + VectorizedWeightedParticleBelief with N=100.
+    When: belief.update(action, observation, pomdp) is called repeatedly.
+    Then: Execution time is recorded.
+
+    Test type: performance
+    """
+    env = MountainCarPOMDP(discount_factor=0.99)
+    updater = MountainCarVectorizedUpdater.from_environment(env)
+    particles = np.array(env.initial_state_dist().sample(n_samples=_N_PARTICLES))
+    log_weights = np.log(np.ones(_N_PARTICLES) / _N_PARTICLES)
+    belief = VectorizedWeightedParticleBelief(
+        particles=particles,
+        log_weights=log_weights,
+        updater=updater,
+    )
+    observation = np.array([-0.5, 0.0])
+
+    def run():
+        return belief.update(action=1, observation=observation, pomdp=env)
+
+    benchmark(run)
+
+
+# ---------------------------------------------------------------------------
+# CartPole (non-native) cases
+# ---------------------------------------------------------------------------
+
+
+def _cartpole_initial_particles(env: CartPolePOMDP, n: int) -> Any:
+    """Draw n initial CartPole state particles (ndarray or list format)."""
+    return env.initial_state_dist().sample(n_samples=n)
+
+
+@pytest.mark.benchmark(group="belief-update-cp-generic-python")
+def test_bench_cp_generic_belief_update(benchmark):
+    """Benchmark WeightedParticleBelief.update on CartPole (Python fallback).
+
+    Purpose: Measures the generic per-particle Python loop on a non-native
+    env. CartPole has no ``_cpp`` extension; the auto-dispatch hasattr check
+    fails, and _update_weights falls back to its pre-Layer-2 per-particle
+    ``state_transition_model().sample()`` loop. This is the baseline a
+    future CartPole port to ``pomdp_native`` would target.
+
+    Given: CartPolePOMDP + WeightedParticleBelief with N=100 particles.
+    When: belief.update(action, observation, pomdp) is called repeatedly.
+    Then: Execution time is recorded.
+
+    Test type: performance
+    """
+    env = CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    particles = list(_cartpole_initial_particles(env, _N_PARTICLES))
+    log_weights = np.log(np.ones(_N_PARTICLES) / _N_PARTICLES)
+    belief = WeightedParticleBelief(particles=particles, log_weights=log_weights)
+    action = env.get_actions()[0]
+    observation = env.initial_observation_dist().sample(n_samples=1)[0]
+
+    def run():
+        return belief.update(action=action, observation=observation, pomdp=env)
+
+    benchmark(run)
+
+
+@pytest.mark.benchmark(group="belief-update-cp-vectorized-numpy")
+def test_bench_cp_vectorized_belief_update(benchmark):
+    """Benchmark VectorizedWeightedParticleBelief.update on CartPole (numpy).
+
+    Purpose: Measures the explicit vectorized belief path on CartPole. The
+    updater (CartPoleVectorizedUpdater) implements batch_transition and
+    batch_observation_log_likelihood in numpy -- no C++ involved.
+
+    Given: CartPolePOMDP + VectorizedWeightedParticleBelief with N=100.
+    When: belief.update(action, observation, pomdp) is called repeatedly.
+    Then: Execution time is recorded.
+
+    Test type: performance
+    """
+    env = CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    updater = CartPoleVectorizedUpdater.from_environment(env)
+    particles = np.array(_cartpole_initial_particles(env, _N_PARTICLES))
+    log_weights = np.log(np.ones(_N_PARTICLES) / _N_PARTICLES)
+    belief = VectorizedWeightedParticleBelief(
+        particles=particles,
+        log_weights=log_weights,
+        updater=updater,
+    )
+    action = env.get_actions()[0]
+    observation = env.initial_observation_dist().sample(n_samples=1)[0]
+
+    def run():
+        return belief.update(action=action, observation=observation, pomdp=env)
+
+    benchmark(run)

--- a/POMDPPlanners/tests/test_core/test_belief/belief_equivalence_utils.py
+++ b/POMDPPlanners/tests/test_core/test_belief/belief_equivalence_utils.py
@@ -52,6 +52,7 @@ def assert_update_particles_match(
     pomdp: Environment,
     atol: float = 1e-10,
     seed: Optional[int] = None,
+    seed_fn: Optional[Callable[[int], None]] = None,
     particle_to_array: Optional[ParticleToArray] = None,
 ) -> BeliefPair:
     """Run one update on both beliefs and assert next particles agree.
@@ -74,7 +75,7 @@ def assert_update_particles_match(
     Returns:
         The updated ``(base, vec)`` belief pair so callers can chain asserts.
     """
-    base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed)
+    base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed, seed_fn)
     _check_particles(base_next, vec_next, atol=atol, particle_to_array=particle_to_array)
     return base_next, vec_next
 
@@ -88,6 +89,7 @@ def assert_update_weights_match(
     atol: float = 1e-6,
     significance_threshold: Optional[float] = None,
     seed: Optional[int] = None,
+    seed_fn: Optional[Callable[[int], None]] = None,
 ) -> BeliefPair:
     """Run one update on both beliefs and assert normalized weights agree.
 
@@ -112,7 +114,7 @@ def assert_update_weights_match(
     Returns:
         The updated ``(base, vec)`` belief pair.
     """
-    base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed)
+    base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed, seed_fn)
     _check_weights(base_next, vec_next, atol=atol, significance_threshold=significance_threshold)
     return base_next, vec_next
 
@@ -410,12 +412,14 @@ def _run_updates(
     observation: Any,
     pomdp: Environment,
     seed: Optional[int],
+    seed_fn: Optional[Callable[[int], None]] = None,
 ) -> BeliefPair:
+    effective_seed_fn = seed_fn if seed_fn is not None else np.random.seed
     if seed is not None:
-        np.random.seed(seed)
+        effective_seed_fn(seed)
     vec_next = vec.update(action=action, observation=observation, pomdp=pomdp)
     if seed is not None:
-        np.random.seed(seed)
+        effective_seed_fn(seed)
     base_next = base.update(action=action, observation=observation, pomdp=pomdp)
     return base_next, vec_next
 

--- a/POMDPPlanners/tests/test_core/test_belief/vectorized_updater_test_utils.py
+++ b/POMDPPlanners/tests/test_core/test_belief/vectorized_updater_test_utils.py
@@ -26,6 +26,7 @@ def assert_batch_transition_matches_loop(
     per_particle_transition_fn: Callable[[np.ndarray, Any], np.ndarray],
     atol: float = 1e-10,
     seed: Optional[int] = None,
+    seed_fn: Optional[Callable[[int], None]] = None,
     err_msg: str = "",
 ) -> None:
     """Assert that batch_transition matches a per-particle transition loop.
@@ -37,13 +38,20 @@ def assert_batch_transition_matches_loop(
         per_particle_transition_fn: Callable(particle_1d, action) -> next_state_1d
             that wraps the environment's per-particle transition logic.
         atol: Absolute tolerance for comparison.
-        seed: If provided, seeds np.random before each path so stochastic
+        seed: If provided, the RNG is seeded before each path so stochastic
             transitions consume the same random sequence.
+        seed_fn: Callable used to seed the RNG. Defaults to ``np.random.seed``.
+            Envs whose updater draws noise from a non-numpy RNG (e.g.
+            MountainCar's native C++ extension) should pass their own seeder,
+            e.g. ``_native.set_seed``.
         err_msg: Optional message appended on failure.
     """
-    vectorized_result = _run_vectorized_transition(updater, particles, action, seed)
+    effective_seed_fn = seed_fn if seed_fn is not None else np.random.seed
+    vectorized_result = _run_vectorized_transition(
+        updater, particles, action, seed, effective_seed_fn
+    )
     per_particle_result = _run_per_particle_transition(
-        particles, action, per_particle_transition_fn, seed
+        particles, action, per_particle_transition_fn, seed, effective_seed_fn
     )
     np.testing.assert_allclose(vectorized_result, per_particle_result, atol=atol, err_msg=err_msg)
 
@@ -100,9 +108,10 @@ def _run_vectorized_transition(
     particles: np.ndarray,
     action: Any,
     seed: Optional[int],
+    seed_fn: Callable[[int], None],
 ) -> np.ndarray:
     if seed is not None:
-        np.random.seed(seed)
+        seed_fn(seed)
     return updater.batch_transition(particles, action)
 
 
@@ -111,9 +120,10 @@ def _run_per_particle_transition(
     action: Any,
     per_particle_fn: Callable[[np.ndarray, Any], np.ndarray],
     seed: Optional[int],
+    seed_fn: Callable[[int], None],
 ) -> np.ndarray:
     if seed is not None:
-        np.random.seed(seed)
+        seed_fn(seed)
     n = len(particles)
     result = np.empty_like(particles)
     for i in range(n):

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
@@ -12,7 +12,7 @@ from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
 from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
     VectorizedWeightedParticleBelief,
 )
-from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP
+from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP, _native
 from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp_beliefs import (
     MountainCarVectorizedUpdater,
 )
@@ -125,20 +125,21 @@ class TestBatchTransition:
         """Test that batch_transition is deterministic under a fixed seed.
 
         Purpose: Validates that the stochastic batch_transition produces
-                 identical output when the global numpy RNG is seeded
+                 identical output when the module-level C++ RNG (now the
+                 source of randomness for the updater) is seeded
                  identically before each call.
 
-        Given: A set of particles and an action, with np.random.seed fixed
-               before each call.
+        Given: A set of particles and an action, with ``_native.set_seed``
+               fixed before each call.
         When: batch_transition is called twice.
         Then: Both results are identical.
 
         Test type: unit
         """
         particles = np.array([[-0.5, 0.0], [-0.6, 0.01]])
-        np.random.seed(7)
+        _native.set_seed(7)
         result_a = updater.batch_transition(particles, action=1)
-        np.random.seed(7)
+        _native.set_seed(7)
         result_b = updater.batch_transition(particles, action=1)
         np.testing.assert_array_equal(result_a, result_b)
 
@@ -305,6 +306,7 @@ class TestConfigId:
         Test type: unit
         """
         u1 = MountainCarVectorizedUpdater.from_environment(env)
+        # pylint: disable=protected-access
         u2 = MountainCarVectorizedUpdater(
             state_transition_dist=env._state_transition_dist,
             obs_dist=env._obs_dist,
@@ -314,6 +316,7 @@ class TestConfigId:
             min_position=env.min_position,
             max_position=env.max_position,
         )
+        # pylint: enable=protected-access
         assert u1.config_id != u2.config_id
 
 

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
@@ -325,27 +325,18 @@ class TestConfigId:
 # ---------------------------------------------------------------------------
 
 
-_CPP_RNG_SKIP_REASON = (
-    "Bit-exact equivalence between the vectorized numpy path and the per-particle "
-    "path is no longer achievable: MountainCarTransition.sample() now uses the "
-    "_native C++ std::mt19937_64 RNG while MountainCarVectorizedUpdater.batch_transition "
-    "still consumes numpy's RNG. A follow-up can route batch_transition through "
-    "_native to restore cross-path bit-exactness; distributional correctness of "
-    "each path is still covered by the other tests in this module."
-)
-
-
 class TestBeliefEquivalenceWithBaseline:
-    @pytest.mark.skip(reason=_CPP_RNG_SKIP_REASON)
     def test_update_particles_match(self, env, updater):
         """Test vectorized belief update produces identical next particles.
 
         Purpose: Validates that VectorizedWeightedParticleBelief.update and
             WeightedParticleBelief.update agree on next-state particles once
-            the vectorized updater mirrors the standard transition noise.
+            both paths route through the shared pomdp_native batch methods
+            (and therefore share the module-level C++ RNG).
 
         Given: 60 aligned particles.
-        When: Both beliefs are updated with action=1 under a shared seed.
+        When: Both beliefs are updated with action=1 under a shared seed
+            applied via ``_native.set_seed``.
         Then: Next particles agree within floating-point tolerance.
 
         Test type: integration
@@ -353,10 +344,15 @@ class TestBeliefEquivalenceWithBaseline:
         base, vec = _make_aligned_beliefs(updater)
         obs = np.array([-0.5, 0.0])
         assert_update_particles_match(
-            base=base, vec=vec, action=1, observation=obs, pomdp=env, seed=999
+            base=base,
+            vec=vec,
+            action=1,
+            observation=obs,
+            pomdp=env,
+            seed=999,
+            seed_fn=_native.set_seed,
         )
 
-    @pytest.mark.skip(reason=_CPP_RNG_SKIP_REASON)
     def test_update_weights_match(self, env, updater):
         """Test vectorized and baseline beliefs produce identical normalized weights.
 
@@ -378,15 +374,17 @@ class TestBeliefEquivalenceWithBaseline:
             pomdp=env,
             atol=1e-6,
             seed=999,
+            seed_fn=_native.set_seed,
         )
 
-    @pytest.mark.skip(reason=_CPP_RNG_SKIP_REASON)
     def test_sample_distributions_match_post_update(self, env, updater):
         """Test sample() on both beliefs draws unbiased from normalized_weights.
 
         Purpose: Validates sample() unbiasedness and cross-belief agreement.
 
-        Given: 60 aligned particles; one update step seeded identically.
+        Given: 60 aligned particles; one update step seeded identically
+            via ``_native.set_seed`` (for the C++ transition batch) and
+            ``np.random.seed`` (for particle resampling -- still numpy).
         When: 20,000 samples are drawn from each belief.
         Then: Empirical histograms agree and each matches its normalized_weights.
 
@@ -394,9 +392,9 @@ class TestBeliefEquivalenceWithBaseline:
         """
         base, vec = _make_aligned_beliefs(updater)
         obs = np.array([-0.5, 0.0])
-        np.random.seed(999)
+        _native.set_seed(999)
         vec = vec.update(action=1, observation=obs, pomdp=env)
-        np.random.seed(999)
+        _native.set_seed(999)
         base = base.update(action=1, observation=obs, pomdp=env)
 
         assert_sample_distributions_match(
@@ -415,13 +413,12 @@ class TestBeliefEquivalenceWithBaseline:
 
 
 class TestEquivalenceWithPerParticleLoop:
-    @pytest.mark.skip(reason=_CPP_RNG_SKIP_REASON)
     def test_batch_transition_matches_per_particle_loop(self, env, updater):
         """Test vectorized batch_transition matches per-particle state_transition_model.sample.
 
         Purpose: Verifies that batch_transition produces the same stochastic
                  next states as the environment's state_transition_model.sample
-                 when the global RNG is seeded identically on both paths.
+                 when the shared C++ RNG is seeded identically on both paths.
 
         Given: A set of particles, an action, and a fixed random seed.
         When: batch_transition is called, and the same transitions are computed
@@ -447,6 +444,7 @@ class TestEquivalenceWithPerParticleLoop:
             action=1,
             per_particle_transition_fn=per_particle_fn,
             seed=999,
+            seed_fn=_native.set_seed,
         )
 
     def test_batch_observation_log_likelihood_matches_per_particle_loop(self, env, updater):

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_native_equivalence.py
@@ -312,3 +312,123 @@ def test_sample_returns_list_of_1d_ndarrays(transition):
         n_samples=3,
         expected_dim=2,
     )
+
+
+# ---------------------------------------------------------------------------
+# Batch entry points
+# ---------------------------------------------------------------------------
+
+
+def test_transition_batch_sample_matches_per_particle_sample(env):
+    """batch_sample(P) is bit-identical to sample(1) per row under fixed seed.
+
+    Purpose: Validates that the new TransitionModelCpp<Dim>.batch_sample
+    produces the same noise sequence as N per-particle sample(1) calls when
+    both consume the same module-level C++ RNG seeded once.
+
+    Given: 64 particles spanning the valid MountainCar state range.
+    When: batch_sample runs under seed=777; then for each particle a fresh
+        MountainCarTransition is built and sample(1) is called in the same
+        order under the same seed.
+    Then: The two (64, 2) arrays are array_equal.
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(123)
+    particles = np.column_stack(
+        [
+            rng.uniform(-1.0, 0.5, 64),
+            rng.uniform(-0.05, 0.05, 64),
+        ]
+    )
+    action = 1
+
+    _native.set_seed(777)
+    transition = env.state_transition_model(state=(-0.5, 0.0), action=action)
+    batch_result = transition.batch_sample(particles)
+
+    _native.set_seed(777)
+    per_particle_rows = []
+    for row in particles:
+        model = env.state_transition_model(state=tuple(row.tolist()), action=action)
+        per_particle_rows.append(model.sample(1)[0])
+    per_particle_result = np.stack(per_particle_rows, axis=0)
+
+    np.testing.assert_array_equal(batch_result, per_particle_result)
+
+
+def test_observation_batch_log_likelihood_matches_per_particle(env):
+    """batch_log_likelihood matches np.log(probability([observation])) per row.
+
+    Purpose: Validates the observation batch path against the per-particle
+    reference (C++ probability() uses the same log_pdf internally, then
+    exp's it; we take log to invert).
+
+    Given: 64 random next-state particles and a single observation.
+    When: batch_log_likelihood(next_particles, observation) is called, and
+        for each particle a fresh MountainCarObservation is built and
+        probability([observation]) is computed.
+    Then: The batch log-likelihoods equal np.log of the per-particle
+        probabilities within atol=1e-12.
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(456)
+    next_particles = np.column_stack(
+        [
+            rng.uniform(-1.0, 0.5, 64),
+            rng.uniform(-0.05, 0.05, 64),
+        ]
+    )
+    observation = np.array([-0.3, 0.015])
+    action = 0
+
+    obs_model = env.observation_model(next_state=(-0.5, 0.0), action=action)
+    batch_log_ll = obs_model.batch_log_likelihood(next_particles, observation)
+
+    per_particle_log_ll = np.empty(len(next_particles))
+    for i, next_state in enumerate(next_particles):
+        model = env.observation_model(next_state=tuple(next_state.tolist()), action=action)
+        per_particle_log_ll[i] = np.log(model.probability([observation])[0])
+
+    np.testing.assert_allclose(batch_log_ll, per_particle_log_ll, atol=1e-12, rtol=0.0)
+
+
+def test_transition_batch_sample_shape_contract(env):
+    """batch_sample returns a 2-D ndarray matching the input shape.
+
+    Purpose: Guards the shape contract used by belief-level callers.
+
+    Given: A MountainCarTransition and a (37, 2) particles ndarray.
+    When: batch_sample is called.
+    Then: The result is an ndarray of shape (37, 2) and dtype float64.
+
+    Test type: unit
+    """
+    transition = env.state_transition_model(state=(-0.5, 0.0), action=1)
+    particles = np.zeros((37, 2), dtype=np.float64)
+    _native.set_seed(0)
+    result = transition.batch_sample(particles)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (37, 2)
+    assert result.dtype == np.float64
+
+
+def test_observation_batch_log_likelihood_shape_contract(env):
+    """batch_log_likelihood returns a 1-D ndarray of length N.
+
+    Purpose: Guards the shape contract used by belief-level callers.
+
+    Given: A MountainCarObservation, 37 next-particles, and one observation.
+    When: batch_log_likelihood is called.
+    Then: The result is an ndarray of shape (37,) and dtype float64.
+
+    Test type: unit
+    """
+    obs_model = env.observation_model(next_state=(-0.5, 0.0), action=1)
+    next_particles = np.zeros((37, 2), dtype=np.float64)
+    observation = np.array([-0.5, 0.0])
+    result = obs_model.batch_log_likelihood(next_particles, observation)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (37,)
+    assert result.dtype == np.float64


### PR DESCRIPTION
## Summary

Stacks on top of #81 (shared pomdp_native core). Adds a batch C++ entry point on the shared `TransitionModelCpp<Dim>` / `ObservationModelCpp<Dim>` bases and has `WeightedParticleBelief._update_weights` auto-dispatch to it when the env's models expose batch support. MountainCar's extension picks up the batch methods for free; `MountainCarVectorizedUpdater`'s internals swap from numpy to the shared C++ batch — closing the cross-path RNG divergence that used to skip 4 belief-equivalence tests.

- `pomdp_native::TransitionModelCpp<Dim>::batch_sample(particles)` and `::ObservationModelCpp<Dim>::batch_log_likelihood(next_particles, observation)` — loop internally using the compile-time-unrolled `GaussianND<Dim>` ops. Zero Python round-trips per particle.
- `WeightedParticleBelief._update_weights` sniffs `hasattr(transition_model, "batch_sample")`. Native env → batch path (O(1) Python round trips regardless of N). Non-native env → unchanged per-particle fallback.
- `MountainCarVectorizedUpdater.batch_transition` / `batch_observation_log_likelihood` now delegate to the shared C++ batch methods. Both `WeightedParticleBelief` and `VectorizedWeightedParticleBelief` now share one C++ implementation and one RNG on MountainCar.
- The 4 skipped `TestBeliefEquivalenceWithBaseline` / `TestEquivalenceWithPerParticleLoop` tests are re-enabled; their helpers grew an optional `seed_fn` parameter (default `np.random.seed`) so env-specific seeders can plug in.

## Commits

- `7136a1f` Rename `compute_mean` hook to take state as argument
- `36d3185` Add `batch_sample` / `batch_log_likelihood` to pomdp_native model bases
- `606089f` Auto-dispatch `WeightedParticleBelief` to native batch path
- `2abe5f5` Un-skip cross-path equivalence tests; add belief-update benchmarks

## Design decisions

- **Batch methods on per-instance models** (not a separate batch class). The per-instance model already owns `(action, noise, env params)` — only `state` varies across rows. A batch-only class would duplicate every env's constructor boilerplate.
- **`compute_mean` signature refactor** (Commit A): `compute_mean(double* out)` → `compute_mean_from_state(const double* state, double* out)` for `TransitionModelCpp<Dim>`; symmetric for `ObservationModelCpp<Dim>`. The state argument lets batch routines vary state across rows without touching the member.
- **`hasattr` sniff for auto-dispatch**. Invisible opt-in for native envs; 7+ non-native envs fall through unchanged. No Protocol, no subclass factory rewiring.
- **Replace `MountainCarVectorizedUpdater` internals in-place** (not a parallel native updater). Both belief paths end up sharing the same RNG, which is exactly what closes the skip.
- **No eps clamp on the native batch path** — log_pdf is finite for Gaussian models, matching `VectorizedWeightedParticleBelief`'s pre-existing contract. Fallback path keeps the eps clamp.

## Benchmark — 4 cases, same N=100

| Case | Env | Belief class | Median |
|------|-----|--------------|---:|
| `belief-update-mc-generic-cpp` | MountainCar | `WeightedParticleBelief` (auto-dispatch) | **41 µs** |
| `belief-update-mc-vectorized-cpp` | MountainCar | `VectorizedWeightedParticleBelief` (C++ updater) | **25 µs** |
| `belief-update-cp-generic-python` | CartPole | `WeightedParticleBelief` (Python fallback) | **2076 µs** |
| `belief-update-cp-vectorized-numpy` | CartPole | `VectorizedWeightedParticleBelief` (numpy updater) | **108 µs** |

Three comparisons:

1. **MC-generic-cpp vs MC-vectorized-cpp** — 1.6× overhead from the auto-dispatch path's extra list↔ndarray conversion and hasattr check. Both share the same C++ batch internals.
2. **CP-generic-python vs CP-vectorized-numpy** — 19× gap on a non-native env. This is the baseline a future CartPole port onto `pomdp_native` would close (and would automatically light up `WeightedParticleBelief` via auto-dispatch).
3. **MC-generic-cpp vs CP-generic-python** — **50× speedup** for callers using plain `WeightedParticleBelief.update` once an env is ported to native. No need to write a per-env numpy-vectorized updater.

## Verification

- `pyright`: 0 errors / 0 warnings on all touched files.
- `pylint`: 10.00 / 10 on all touched files.
- `pytest POMDPPlanners/tests/`: **2894 passed, 10 skipped** (4 fewer than pre-Layer-2 — the RNG-divergence tests now pass).
- `pytest POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_native_equivalence.py`: 15 / 15 pass (11 pre-existing + 4 new for `batch_sample` / `batch_log_likelihood` parity).
- `pytest POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py`: 16 / 16 pass (0 skips, was 12 / 4).

## Cross-env regression audit

The 7+ non-native envs (CartPole, LightDark, LaserTag, PacMan, Push, RockSample, SafetyAnt) construct transition models via their Python-only classes; `hasattr(transition_model, "batch_sample")` returns False → fallback. No behaviour change on those envs. Full suite is green (2894 passed).

## Staging note

PR targets `refactor/pomdp-native-shared-core` (Layer 1 PR #81). When Layer 1 merges, GitHub auto-retargets this PR to `develop`, leaving only Layer 2's diff visible to reviewers.

## Out of scope (follow-ups)

- Port the 7+ other envs' transition / observation models onto `pomdp_native` so they light up the auto-dispatch path too.
- Native `Environment.sample_next_step` that fuses transition + observation + reward in C++.
- Native particle resampling (still in Python).
- Numpy `Generator` interop for `RNGState`.

## Test plan

- [ ] CI green on `refactor/pomdp-native-batch-beliefs`
- [ ] Reviewer spot-checks that `WeightedParticleBelief._update_weights` fallback path is byte-identical for non-native envs
- [ ] Reviewer agrees the 50× generic-path speedup and 1.6× auto-dispatch overhead are acceptable tradeoffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)