### PR TITLE
Port CartPole to pomdp_native (batch belief path)

### DIFF
--- a/POMDPPlanners/core/_cpp/include/pomdp_native/models.hpp
+++ b/POMDPPlanners/core/_cpp/include/pomdp_native/models.hpp
@@ -75,6 +75,45 @@ class TransitionModelCpp {
         return out;
     }
 
+    // Batch sample: given N particles (N, Dim), return N next particles
+    // (N, Dim) using the model's stored action, noise, and compute_mean_from_state
+    // + post_sample_transform hooks. Uses the module default RNG.
+    // The model's own state_ is NOT read on this path -- state is varied per row
+    // from the input array.
+    pybind11::array_t<double> batch_sample(
+        pybind11::array_t<double, pybind11::array::c_style | pybind11::array::forcecast> particles)
+        const {
+        if (particles.ndim() != 2 ||
+            static_cast<std::size_t>(particles.shape(1)) != Dim) {
+            throw std::invalid_argument("particles must have shape (N, Dim)");
+        }
+        const auto n_rows = static_cast<std::size_t>(particles.shape(0));
+        auto particles_view = particles.template unchecked<2>();
+
+        auto out = pybind11::array_t<double>(
+            {static_cast<pybind11::ssize_t>(n_rows), static_cast<pybind11::ssize_t>(Dim)});
+        auto out_view = out.template mutable_unchecked<2>();
+
+        double state_row[Dim];  // NOLINT(modernize-avoid-c-arrays)
+        double mean[Dim];       // NOLINT(modernize-avoid-c-arrays)
+        double buf[Dim];        // NOLINT(modernize-avoid-c-arrays)
+        RNGState &rng = default_rng();
+        for (std::size_t i = 0; i < n_rows; ++i) {
+            for (std::size_t d = 0; d < Dim; ++d) {
+                state_row[d] = particles_view(static_cast<pybind11::ssize_t>(i),
+                                              static_cast<pybind11::ssize_t>(d));
+            }
+            compute_mean_from_state(state_row, mean);
+            noise_.sample_into(buf, mean, rng);
+            post_sample_transform(buf);
+            for (std::size_t d = 0; d < Dim; ++d) {
+                out_view(static_cast<pybind11::ssize_t>(i),
+                         static_cast<pybind11::ssize_t>(d)) = buf[d];
+            }
+        }
+        return out;
+    }
+
     const std::array<double, Dim> &state_arr() const noexcept { return state_; }
     const pybind11::object &action_obj() const noexcept { return action_; }
 
@@ -132,6 +171,49 @@ class ObservationModelCpp {
         for (std::size_t i = 0; i < batch.n; ++i) {
             const double *x = batch.flat.data() + i * Dim;
             buf(static_cast<pybind11::ssize_t>(i)) = std::exp(noise_.log_pdf(x, mean));
+        }
+        return out;
+    }
+
+    // Batch log-likelihood: given N next-state particles (N, Dim) and a single
+    // observation (Dim,), return the per-particle log P(observation | next_state,
+    // action). Uses the model's stored action, noise, and
+    // compute_mean_from_next_state hook. The model's own next_state_ is NOT read
+    // on this path.
+    pybind11::array_t<double> batch_log_likelihood(
+        pybind11::array_t<double, pybind11::array::c_style | pybind11::array::forcecast>
+            next_particles,
+        pybind11::array_t<double, pybind11::array::c_style | pybind11::array::forcecast>
+            observation) const {
+        if (next_particles.ndim() != 2 ||
+            static_cast<std::size_t>(next_particles.shape(1)) != Dim) {
+            throw std::invalid_argument("next_particles must have shape (N, Dim)");
+        }
+        if (observation.ndim() != 1 ||
+            static_cast<std::size_t>(observation.shape(0)) != Dim) {
+            throw std::invalid_argument("observation must have shape (Dim,)");
+        }
+        const auto n_rows = static_cast<std::size_t>(next_particles.shape(0));
+        auto particles_view = next_particles.template unchecked<2>();
+        auto obs_view = observation.template unchecked<1>();
+
+        double obs_buf[Dim];  // NOLINT(modernize-avoid-c-arrays)
+        for (std::size_t d = 0; d < Dim; ++d) {
+            obs_buf[d] = obs_view(static_cast<pybind11::ssize_t>(d));
+        }
+
+        auto out = pybind11::array_t<double>(static_cast<pybind11::ssize_t>(n_rows));
+        auto out_view = out.mutable_unchecked<1>();
+
+        double next_state_row[Dim];  // NOLINT(modernize-avoid-c-arrays)
+        double mean[Dim];            // NOLINT(modernize-avoid-c-arrays)
+        for (std::size_t i = 0; i < n_rows; ++i) {
+            for (std::size_t d = 0; d < Dim; ++d) {
+                next_state_row[d] = particles_view(static_cast<pybind11::ssize_t>(i),
+                                                   static_cast<pybind11::ssize_t>(d));
+            }
+            compute_mean_from_next_state(next_state_row, mean);
+            out_view(static_cast<pybind11::ssize_t>(i)) = noise_.log_pdf(obs_buf, mean);
         }
         return out;
     }

--- a/POMDPPlanners/core/_cpp/include/pomdp_native/models.hpp
+++ b/POMDPPlanners/core/_cpp/include/pomdp_native/models.hpp
@@ -3,10 +3,18 @@
 //
 // These classes are NOT exposed to Python. Per-env pybind11 extensions
 // instantiate the base at their dimension (e.g. MountainCar uses
-// ``TransitionModelCpp<2>``), override the env-specific ``compute_mean``
-// (and optional ``post_sample_transform``) hook, and bind the concrete
-// subclass. The sample() / probability() loops, RNG selection, and
-// stack-allocated scratch all live here.
+// ``TransitionModelCpp<2>``), override the env-specific
+// ``compute_mean_from_state`` (transition) /
+// ``compute_mean_from_next_state`` (observation) hook (plus optional
+// ``post_sample_transform``), and bind the concrete subclass. The
+// sample() / probability() loops, RNG selection, and stack-allocated
+// scratch all live here.
+//
+// The ``compute_mean_from_*`` hooks take the state / next_state as an
+// explicit argument so batched entry points (see Layer 2) can vary it
+// across rows without mutating the model's ``state_`` / ``next_state_``
+// members. Single-instance ``sample()`` / ``probability()`` simply pass
+// ``state_.data()`` / ``next_state_.data()`` through.
 
 #ifndef POMDP_NATIVE_MODELS_HPP_
 #define POMDP_NATIVE_MODELS_HPP_
@@ -40,7 +48,7 @@ class TransitionModelCpp {
             throw std::invalid_argument("n_samples must be non-negative");
         }
         double mean[Dim];  // NOLINT(modernize-avoid-c-arrays)
-        compute_mean(mean);
+        compute_mean_from_state(state_.data(), mean);
 
         double buf[Dim];  // NOLINT(modernize-avoid-c-arrays)
         pybind11::list out;
@@ -55,7 +63,7 @@ class TransitionModelCpp {
 
     pybind11::array_t<double> probability(const pybind11::object &values) const {
         double mean[Dim];  // NOLINT(modernize-avoid-c-arrays)
-        compute_mean(mean);
+        compute_mean_from_state(state_.data(), mean);
 
         auto batch = extract_rows_nd(values, Dim);
         auto out = pybind11::array_t<double>(static_cast<pybind11::ssize_t>(batch.n));
@@ -71,9 +79,13 @@ class TransitionModelCpp {
     const pybind11::object &action_obj() const noexcept { return action_; }
 
   protected:
-    // Env-specific deterministic next-state computation. Writes Dim doubles
-    // to out. Called once per sample() / probability() call.
-    virtual void compute_mean(double *out) const = 0;
+    // Env-specific deterministic next-state computation. Given a state vector
+    // (length Dim) and the model's stored action, writes the deterministic
+    // next-state mean into out (also length Dim). Called once per sample() /
+    // probability() invocation; called N times per batch_sample() call with
+    // varying state. env-specific params (power, gravity, ...) stay as
+    // members on the subclass.
+    virtual void compute_mean_from_state(const double *state, double *out) const = 0;
 
     // Optional hook, called after each additive Gaussian draw so envs can
     // clip, wrap, or otherwise project the sample onto their feasible set.
@@ -98,7 +110,7 @@ class ObservationModelCpp {
             throw std::invalid_argument("n_samples must be non-negative");
         }
         double mean[Dim];  // NOLINT(modernize-avoid-c-arrays)
-        compute_mean(mean);
+        compute_mean_from_next_state(next_state_.data(), mean);
 
         double buf[Dim];  // NOLINT(modernize-avoid-c-arrays)
         pybind11::list out;
@@ -112,7 +124,7 @@ class ObservationModelCpp {
 
     pybind11::array_t<double> probability(const pybind11::object &values) const {
         double mean[Dim];  // NOLINT(modernize-avoid-c-arrays)
-        compute_mean(mean);
+        compute_mean_from_next_state(next_state_.data(), mean);
 
         auto batch = extract_rows_nd(values, Dim);
         auto out = pybind11::array_t<double>(static_cast<pybind11::ssize_t>(batch.n));
@@ -130,9 +142,11 @@ class ObservationModelCpp {
   protected:
     // Default behavior: observation mean equals the input next_state. Envs
     // with state-dependent observation means (e.g. light-dark) can override.
-    virtual void compute_mean(double *out) const {
+    // Called once per sample() / probability() invocation; called N times
+    // per batch_log_likelihood() call with varying next_state.
+    virtual void compute_mean_from_next_state(const double *next_state, double *out) const {
         for (std::size_t i = 0; i < Dim; ++i) {
-            out[i] = next_state_[i];
+            out[i] = next_state[i];
         }
     }
 

--- a/POMDPPlanners/core/belief/particle_beliefs.py
+++ b/POMDPPlanners/core/belief/particle_beliefs.py
@@ -260,6 +260,22 @@ class WeightedParticleBelief(Belief):
     def _update_weights(
         self, action: Any, observation: Any, pomdp: Environment
     ) -> Tuple[List[Any], np.ndarray]:
+        # Fast path: if the env's transition model exposes a native batch
+        # entry point, process all particles in a single C++ call. When the
+        # observation model also exposes batch_log_likelihood, the
+        # per-particle Python loop is eliminated entirely and the belief
+        # update becomes O(1) Python round trips instead of O(N).
+        transition_model = pomdp.state_transition_model(state=self.particles[0], action=action)
+        if hasattr(transition_model, "batch_sample"):
+            return self._update_weights_batch(
+                action=action,
+                observation=observation,
+                pomdp=pomdp,
+                transition_model=transition_model,
+            )
+
+        # Fallback: per-particle Python loop. Byte-identical to pre-Layer-2
+        # behaviour for envs without native batch support.
         next_particles = [
             pomdp.state_transition_model(state=particle, action=action).sample()[0]
             for particle in self.particles
@@ -275,6 +291,43 @@ class WeightedParticleBelief(Belief):
 
         next_log_weights = self.log_weights + np.log(self.eps + probs)
 
+        return next_particles, next_log_weights
+
+    def _update_weights_batch(
+        self,
+        action: Any,
+        observation: Any,
+        pomdp: Environment,
+        transition_model: Any,
+    ) -> Tuple[List[Any], np.ndarray]:
+        particles_arr = np.asarray(self.particles, dtype=float)
+        next_arr = transition_model.batch_sample(particles_arr)
+        next_particles: List[Any] = [next_arr[i] for i in range(len(next_arr))]
+
+        obs_model = pomdp.observation_model(next_state=next_arr[0], action=action)
+        if hasattr(obs_model, "batch_log_likelihood"):
+            observation_arr = np.asarray(observation, dtype=float).ravel()
+            # pyright cannot see through the hasattr narrowing onto a
+            # concrete native subclass (e.g. MountainCarObservationCpp);
+            # the runtime hasattr guarantees the call is safe.
+            log_ll = obs_model.batch_log_likelihood(  # type: ignore[attr-defined]
+                next_arr, observation_arr
+            )
+            # No eps clamp on the native batch path -- log_pdf is always
+            # finite for Gaussian observation models, matching the existing
+            # VectorizedWeightedParticleBelief contract.
+            next_log_weights = self.log_weights + log_ll
+            return next_particles, next_log_weights
+
+        probs = np.array(
+            [
+                pomdp.observation_model(next_state=next_particle, action=action).probability(
+                    [observation]
+                )[0]
+                for next_particle in next_particles
+            ]
+        )
+        next_log_weights = self.log_weights + np.log(self.eps + probs)
         return next_particles, next_log_weights
 
     def update(

--- a/POMDPPlanners/environments/cartpole_pomdp/_cpp/cartpole.cpp
+++ b/POMDPPlanners/environments/cartpole_pomdp/_cpp/cartpole.cpp
@@ -1,0 +1,208 @@
+// CartPole POMDP native sampling hot path, built on the shared
+// pomdp_native core (templated on the compile-time state dimension).
+// CartPole instantiates TransitionModelCpp<4> / ObservationModelCpp<4>
+// so the Gaussian loops are fully unrolled by the compiler.
+//
+// The transition model implements the classical cart-pole physics
+// (see e.g. https://coneural.org/florian/papers/05_cart_pole.pdf):
+//
+//   temp      = (force + polemass_length * theta_dot^2 * sin(theta)) / total_mass
+//   theta_acc = (gravity * sin(theta) - cos(theta) * temp)
+//             / (length * (4/3 - masspole * cos(theta)^2 / total_mass))
+//   x_acc     = temp - polemass_length * theta_acc * cos(theta) / total_mass
+//
+// and integrates one step with either plain Euler or semi-implicit Euler.
+// No state clamping is applied -- terminal states are out-of-bounds
+// positions/angles that the Python reward / is_terminal methods detect
+// after the fact, matching the pre-port behavior. ``post_sample_transform``
+// is therefore a no-op (inherited default).
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "pomdp_native/gaussian.hpp"
+#include "pomdp_native/marshalling.hpp"
+#include "pomdp_native/models.hpp"
+#include "pomdp_native/rng.hpp"
+
+namespace py = pybind11;
+
+namespace {
+
+constexpr std::size_t kCartPoleStateDim = 4;
+constexpr int kEulerIntegrator = 0;
+constexpr int kSemiImplicitEulerIntegrator = 1;
+
+int encode_integrator(const std::string &name) {
+    if (name == "euler") {
+        return kEulerIntegrator;
+    }
+    if (name == "semi-implicit euler") {
+        return kSemiImplicitEulerIntegrator;
+    }
+    throw std::invalid_argument("kinematics_integrator must be 'euler' or 'semi-implicit euler'");
+}
+
+class CartPoleTransitionCpp : public pomdp_native::TransitionModelCpp<kCartPoleStateDim> {
+  public:
+    CartPoleTransitionCpp(const py::object &state_obj, int action, double force_mag,
+                          double total_mass, double polemass_length, double gravity, double length,
+                          const std::string &kinematics_integrator, double tau, double masspole,
+                          const py::array_t<double> &covariance)
+        : pomdp_native::TransitionModelCpp<kCartPoleStateDim>(
+              pomdp_native::to_array<kCartPoleStateDim>(state_obj, "state"), py::cast(action),
+              pomdp_native::GaussianND<kCartPoleStateDim>::from_covariance(covariance)),
+          action_int_(action),
+          force_mag_(force_mag),
+          total_mass_(total_mass),
+          polemass_length_(polemass_length),
+          gravity_(gravity),
+          length_(length),
+          kinematics_integrator_name_(kinematics_integrator),
+          kinematics_integrator_(encode_integrator(kinematics_integrator)),
+          tau_(tau),
+          masspole_(masspole) {}
+
+    py::array_t<double> state_property() const {
+        return pomdp_native::array_from_vector(state_.data(), state_.size());
+    }
+    int action_property() const { return action_int_; }
+    double force_mag_property() const { return force_mag_; }
+    double total_mass_property() const { return total_mass_; }
+    double polemass_length_property() const { return polemass_length_; }
+    double gravity_property() const { return gravity_; }
+    double length_property() const { return length_; }
+    std::string kinematics_integrator_property() const { return kinematics_integrator_name_; }
+    double tau_property() const { return tau_; }
+    double masspole_property() const { return masspole_; }
+
+    py::array_t<double> compute_deterministic_next_state_py() const {
+        double out[kCartPoleStateDim];
+        compute_mean_from_state(state_.data(), out);
+        return pomdp_native::array_from_vector(out, kCartPoleStateDim);
+    }
+
+  protected:
+    void compute_mean_from_state(const double *state, double *out) const override {
+        const double x = state[0];
+        const double x_dot = state[1];
+        const double theta = state[2];
+        const double theta_dot = state[3];
+
+        const double force = (action_int_ == 1) ? force_mag_ : -force_mag_;
+        const double costheta = std::cos(theta);
+        const double sintheta = std::sin(theta);
+
+        const double temp =
+            (force + polemass_length_ * theta_dot * theta_dot * sintheta) / total_mass_;
+        const double thetaacc =
+            (gravity_ * sintheta - costheta * temp) /
+            (length_ * (4.0 / 3.0 - masspole_ * costheta * costheta / total_mass_));
+        const double xacc = temp - polemass_length_ * thetaacc * costheta / total_mass_;
+
+        double next_x;
+        double next_x_dot;
+        double next_theta;
+        double next_theta_dot;
+        if (kinematics_integrator_ == kEulerIntegrator) {
+            next_x = x + tau_ * x_dot;
+            next_x_dot = x_dot + tau_ * xacc;
+            next_theta = theta + tau_ * theta_dot;
+            next_theta_dot = theta_dot + tau_ * thetaacc;
+        } else {  // semi-implicit euler
+            next_x_dot = x_dot + tau_ * xacc;
+            next_x = x + tau_ * next_x_dot;
+            next_theta_dot = theta_dot + tau_ * thetaacc;
+            next_theta = theta + tau_ * next_theta_dot;
+        }
+        out[0] = next_x;
+        out[1] = next_x_dot;
+        out[2] = next_theta;
+        out[3] = next_theta_dot;
+    }
+
+  private:
+    int action_int_;
+    double force_mag_;
+    double total_mass_;
+    double polemass_length_;
+    double gravity_;
+    double length_;
+    std::string kinematics_integrator_name_;
+    int kinematics_integrator_;
+    double tau_;
+    double masspole_;
+};
+
+class CartPoleObservationCpp : public pomdp_native::ObservationModelCpp<kCartPoleStateDim> {
+  public:
+    CartPoleObservationCpp(const py::object &next_state_obj, int action,
+                           const py::array_t<double> &covariance)
+        : pomdp_native::ObservationModelCpp<kCartPoleStateDim>(
+              pomdp_native::to_array<kCartPoleStateDim>(next_state_obj, "next_state"),
+              py::cast(action),
+              pomdp_native::GaussianND<kCartPoleStateDim>::from_covariance(covariance)),
+          action_int_(action) {}
+
+    py::array_t<double> next_state_property() const {
+        return pomdp_native::array_from_vector(next_state_.data(), next_state_.size());
+    }
+    int action_property() const { return action_int_; }
+    py::array_t<double> mean_property() const {
+        return pomdp_native::array_from_vector(next_state_.data(), next_state_.size());
+    }
+
+  private:
+    int action_int_;
+};
+
+}  // anonymous namespace
+
+PYBIND11_MODULE(_native, m) {
+    m.doc() = "Native (C++) sampling hot path for CartPole POMDP.";
+
+    m.def("set_seed", &pomdp_native::set_default_seed, py::arg("seed"),
+          "Seed the module-level RNG used by sample().");
+
+    py::class_<CartPoleTransitionCpp>(m, "CartPoleTransitionCpp")
+        .def(py::init<const py::object &, int, double, double, double, double, double,
+                      const std::string &, double, double, const py::array_t<double> &>(),
+             py::arg("state"), py::arg("action"), py::arg("force_mag"), py::arg("total_mass"),
+             py::arg("polemass_length"), py::arg("gravity"), py::arg("length"),
+             py::arg("kinematics_integrator"), py::arg("tau"), py::arg("masspole"),
+             py::arg("covariance"))
+        .def("sample", &CartPoleTransitionCpp::sample, py::arg("n_samples") = 1)
+        .def("probability", &CartPoleTransitionCpp::probability, py::arg("values"))
+        .def("batch_sample", &CartPoleTransitionCpp::batch_sample, py::arg("particles"))
+        .def("_compute_deterministic_next_state",
+             &CartPoleTransitionCpp::compute_deterministic_next_state_py)
+        .def_property_readonly("state", &CartPoleTransitionCpp::state_property)
+        .def_property_readonly("action", &CartPoleTransitionCpp::action_property)
+        .def_property_readonly("force_mag", &CartPoleTransitionCpp::force_mag_property)
+        .def_property_readonly("total_mass", &CartPoleTransitionCpp::total_mass_property)
+        .def_property_readonly("polemass_length", &CartPoleTransitionCpp::polemass_length_property)
+        .def_property_readonly("gravity", &CartPoleTransitionCpp::gravity_property)
+        .def_property_readonly("length", &CartPoleTransitionCpp::length_property)
+        .def_property_readonly("kinematics_integrator",
+                               &CartPoleTransitionCpp::kinematics_integrator_property)
+        .def_property_readonly("tau", &CartPoleTransitionCpp::tau_property)
+        .def_property_readonly("masspole", &CartPoleTransitionCpp::masspole_property);
+
+    py::class_<CartPoleObservationCpp>(m, "CartPoleObservationCpp")
+        .def(py::init<const py::object &, int, const py::array_t<double> &>(),
+             py::arg("next_state"), py::arg("action"), py::arg("covariance"))
+        .def("sample", &CartPoleObservationCpp::sample, py::arg("n_samples") = 1)
+        .def("probability", &CartPoleObservationCpp::probability, py::arg("values"))
+        .def("batch_log_likelihood", &CartPoleObservationCpp::batch_log_likelihood,
+             py::arg("next_particles"), py::arg("observation"))
+        .def_property_readonly("next_state", &CartPoleObservationCpp::next_state_property)
+        .def_property_readonly("action", &CartPoleObservationCpp::action_property)
+        .def_property_readonly("mean", &CartPoleObservationCpp::mean_property);
+}

--- a/POMDPPlanners/environments/cartpole_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/cartpole_pomdp/_native.pyi
@@ -1,0 +1,77 @@
+"""Type stubs for the native C++ CartPole sampling extension.
+
+Declares the Python-visible API of the ``_native`` module so pyright can
+type-check modules that import from it. The runtime implementation lives
+in ``_cpp/cartpole.cpp``.
+"""
+
+# pylint: disable=unused-argument,unnecessary-ellipsis
+
+from typing import List, Sequence, Union
+
+import numpy as np
+from numpy.typing import NDArray
+
+def set_seed(seed: int) -> None:
+    """Seed the module-level RNG used by ``sample()`` calls."""
+    ...
+
+class CartPoleTransitionCpp:
+    """Native physics + Gaussian-noise transition sampler."""
+
+    state: NDArray[np.float64]
+    action: int
+    force_mag: float
+    total_mass: float
+    polemass_length: float
+    gravity: float
+    length: float
+    kinematics_integrator: str
+    tau: float
+    masspole: float
+
+    def __init__(
+        self,
+        state: Union[Sequence[float], NDArray[np.floating]],
+        action: int,
+        force_mag: float,
+        total_mass: float,
+        polemass_length: float,
+        gravity: float,
+        length: float,
+        kinematics_integrator: str,
+        tau: float,
+        masspole: float,
+        covariance: NDArray[np.floating],
+    ) -> None: ...
+    def sample(self, n_samples: int = 1) -> List[NDArray[np.float64]]: ...
+    def probability(
+        self,
+        values: Union[Sequence[NDArray[np.floating]], NDArray[np.floating]],
+    ) -> NDArray[np.float64]: ...
+    def batch_sample(self, particles: NDArray[np.floating]) -> NDArray[np.float64]: ...
+    def _compute_deterministic_next_state(self) -> NDArray[np.float64]: ...
+
+class CartPoleObservationCpp:
+    """Native Gaussian-noise observation sampler."""
+
+    next_state: NDArray[np.float64]
+    action: int
+    mean: NDArray[np.float64]
+
+    def __init__(
+        self,
+        next_state: Union[Sequence[float], NDArray[np.floating]],
+        action: int,
+        covariance: NDArray[np.floating],
+    ) -> None: ...
+    def sample(self, n_samples: int = 1) -> List[NDArray[np.float64]]: ...
+    def probability(
+        self,
+        values: Union[Sequence[NDArray[np.floating]], NDArray[np.floating]],
+    ) -> NDArray[np.float64]: ...
+    def batch_log_likelihood(
+        self,
+        next_particles: NDArray[np.floating],
+        observation: NDArray[np.floating],
+    ) -> NDArray[np.float64]: ...

--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
@@ -34,6 +34,7 @@ from POMDPPlanners.core.environment import (
     StateTransitionModel,
 )
 from POMDPPlanners.core.simulation import History, MetricValue
+from POMDPPlanners.environments.cartpole_pomdp import _native
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 from POMDPPlanners.utils.statistics_utils import confidence_interval
 
@@ -44,13 +45,18 @@ class CartPolePOMDPMetrics(Enum):
     GOAL_REACHING_RATE = "goal_reaching_rate"
 
 
-class CartPoleStateTransition(StateTransitionModel):
+class CartPoleStateTransition(_native.CartPoleTransitionCpp):
     """Physics-based state transition model for CartPole POMDP.
 
     This model implements the classical cart-pole dynamics with Gaussian
     process noise. The cart experiences forces that affect both cart
     acceleration and pole angular acceleration through coupled equations
     of motion, with additive Normal noise on the resulting next state.
+
+    The ``sample()`` and ``probability()`` methods execute entirely in C++
+    via the ``_native`` extension; this Python subclass only wraps the
+    constructor so existing call sites that pass a
+    :class:`CovarianceParameterizedMultivariateNormal` keep working.
 
     Attributes:
         state: Current state [cart_position, cart_velocity, pole_angle, pole_velocity]
@@ -65,36 +71,41 @@ class CartPoleStateTransition(StateTransitionModel):
         masspole: Mass of the pole
 
     Example:
-        >>> import numpy as np
-        >>> np.random.seed(42)  # For reproducible results
-        >>> from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
-        >>> # Define initial state [position, velocity, angle, angular_velocity]
-        >>> state = np.array([0.0, 0.0, 0.1, 0.0])
-        >>> action = 1  # Apply right force
+        Using the CartPole transition model::
 
-        >>> # Create transition model with physics parameters and noise
-        >>> state_transition_cov = np.diag([1e-4, 1e-4, 2.5e-5, 1e-4])
-        >>> state_transition_dist = CovarianceParameterizedMultivariateNormal(state_transition_cov)
-        >>> transition = CartPoleStateTransition(
-        ...     state=state,
-        ...     action=action,
-        ...     force_mag=10.0,
-        ...     total_mass=1.1,
-        ...     polemass_length=0.05,
-        ...     gravity=9.8,
-        ...     length=0.5,
-        ...     kinematics_integrator="euler",
-        ...     tau=0.02,
-        ...     masspole=0.1,
-        ...     state_transition_dist=state_transition_dist
-        ... )
-
-        >>> # Simulate physics step
-        >>> next_state = transition.sample()[0]
-        >>> len(next_state) == 4  # [pos, vel, angle, ang_vel]
-        True
-        >>> isinstance(next_state, np.ndarray)
-        True
+            >>> import numpy as np
+            >>> np.random.seed(42)  # For reproducible results
+            >>> from POMDPPlanners.environments.cartpole_pomdp import _native
+            >>> _native.set_seed(42)
+            >>> from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
+            >>>
+            >>> # Define initial state [position, velocity, angle, angular_velocity]
+            >>> state = np.array([0.0, 0.0, 0.1, 0.0])
+            >>> action = 1  # Apply right force
+            >>>
+            >>> # Create transition model with physics parameters and noise
+            >>> state_transition_cov = np.diag([1e-4, 1e-4, 2.5e-5, 1e-4])
+            >>> state_transition_dist = CovarianceParameterizedMultivariateNormal(state_transition_cov)
+            >>> transition = CartPoleStateTransition(
+            ...     state=state,
+            ...     action=action,
+            ...     force_mag=10.0,
+            ...     total_mass=1.1,
+            ...     polemass_length=0.05,
+            ...     gravity=9.8,
+            ...     length=0.5,
+            ...     kinematics_integrator="euler",
+            ...     tau=0.02,
+            ...     masspole=0.1,
+            ...     state_transition_dist=state_transition_dist
+            ... )
+            >>>
+            >>> # Simulate physics step
+            >>> next_state = transition.sample()[0]
+            >>> len(next_state) == 4  # [pos, vel, angle, ang_vel]
+            True
+            >>> isinstance(next_state, np.ndarray)
+            True
     """
 
     def __init__(
@@ -111,98 +122,75 @@ class CartPoleStateTransition(StateTransitionModel):
         masspole: float,
         state_transition_dist: CovarianceParameterizedMultivariateNormal,
     ):
-        super().__init__(state, action)
-
-        self.force_mag = force_mag
-        self.total_mass = total_mass
-        self.polemass_length = polemass_length
-        self.gravity = gravity
-        self.length = length
-        self.kinematics_integrator = kinematics_integrator
-        self.tau = tau
-        self.masspole = masspole
+        super().__init__(
+            state=state,
+            action=action,
+            force_mag=force_mag,
+            total_mass=total_mass,
+            polemass_length=polemass_length,
+            gravity=gravity,
+            length=length,
+            kinematics_integrator=kinematics_integrator,
+            tau=tau,
+            masspole=masspole,
+            covariance=state_transition_dist.covariance,
+        )
         self._state_transition_dist = state_transition_dist
 
-    def sample(self, n_samples: int = 1) -> List[np.ndarray]:
-        deterministic_next_state = self._compute_deterministic_next_state()
-        noise_samples = self._state_transition_dist.sample(np.zeros(4), n_samples=n_samples)
-        return [deterministic_next_state + noise_samples[i] for i in range(n_samples)]
 
-    def _compute_deterministic_next_state(self) -> np.ndarray:
-        x, x_dot, theta, theta_dot = self.state
-        force = self.force_mag if self.action == 1 else -self.force_mag
-        costheta = math.cos(theta)
-        sintheta = math.sin(theta)
-
-        # For the interested reader:
-        # https://coneural.org/florian/papers/05_cart_pole.pdf
-        temp = (force + self.polemass_length * theta_dot**2 * sintheta) / self.total_mass
-        thetaacc = (self.gravity * sintheta - costheta * temp) / (
-            self.length * (4.0 / 3.0 - self.masspole * costheta**2 / self.total_mass)
-        )
-        xacc = temp - self.polemass_length * thetaacc * costheta / self.total_mass
-
-        if self.kinematics_integrator == "euler":
-            x = x + self.tau * x_dot
-            x_dot = x_dot + self.tau * xacc
-            theta = theta + self.tau * theta_dot
-            theta_dot = theta_dot + self.tau * thetaacc
-        else:  # semi-implicit euler
-            x_dot = x_dot + self.tau * xacc
-            x = x + self.tau * x_dot
-            theta_dot = theta_dot + self.tau * thetaacc
-            theta = theta + self.tau * theta_dot
-
-        return np.array([x, x_dot, theta, theta_dot])
-
-    def probability(self, values: List[np.ndarray]) -> np.ndarray:
-        deterministic_next_state = self._compute_deterministic_next_state()
-        values_array = np.array(values)
-        return self._state_transition_dist.pdf(values_array, deterministic_next_state)
+StateTransitionModel.register(CartPoleStateTransition)
 
 
-class CartPoleObservation(ObservationModel):
+class CartPoleObservation(_native.CartPoleObservationCpp):
     """Noisy observation model for CartPole POMDP.
 
     This model adds Gaussian noise to the true state to create partial observability.
     The agent receives a noisy version of the full state vector, making it challenging
     to determine the exact cart-pole configuration.
 
+    The ``sample()`` and ``probability()`` methods execute entirely in C++
+    via the ``_native`` extension.
+
     Attributes:
         next_state: True state after action execution
         action: Action that was taken (not used in observation generation)
-        obs_dist: Pre-computed multivariate normal distribution for efficient sampling/PDF
+        mean: Expected observation (equals ``next_state``)
 
     Example:
-        >>> import numpy as np
-        >>> np.random.seed(42)  # For reproducible results
-        >>> from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
-        >>> # Define true state after action
-        >>> true_state = np.array([0.1, 0.05, 0.02, -0.1])
-        >>> action = 1
+        Using the CartPole observation model::
 
-        >>> # Define observation noise covariance and create distribution
-        >>> noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-        >>> obs_dist = CovarianceParameterizedMultivariateNormal(noise_cov)
-
-        >>> # Create observation model
-        >>> obs_model = CartPoleObservation(
-        ...     next_state=true_state,
-        ...     action=action,
-        ...     obs_dist=obs_dist
-        ... )
-
-        >>> # Sample noisy observation
-        >>> observation = obs_model.sample()[0]
-        >>> len(observation) == 4  # Same dimensionality as state
-        True
-        >>> isinstance(observation, np.ndarray)
-        True
-
-        >>> # Calculate probability of specific observation
-        >>> prob = obs_model.probability([observation])
-        >>> len(prob) == 1
-        True
+            >>> import numpy as np
+            >>> np.random.seed(42)  # For reproducible results
+            >>> from POMDPPlanners.environments.cartpole_pomdp import _native
+            >>> _native.set_seed(42)
+            >>> from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
+            >>>
+            >>> # Define true state after action
+            >>> true_state = np.array([0.1, 0.05, 0.02, -0.1])
+            >>> action = 1
+            >>>
+            >>> # Define observation noise covariance and create distribution
+            >>> noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
+            >>> obs_dist = CovarianceParameterizedMultivariateNormal(noise_cov)
+            >>>
+            >>> # Create observation model
+            >>> obs_model = CartPoleObservation(
+            ...     next_state=true_state,
+            ...     action=action,
+            ...     obs_dist=obs_dist
+            ... )
+            >>>
+            >>> # Sample noisy observation
+            >>> observation = obs_model.sample()[0]
+            >>> len(observation) == 4  # Same dimensionality as state
+            True
+            >>> isinstance(observation, np.ndarray)
+            True
+            >>>
+            >>> # Calculate probability of specific observation
+            >>> prob = obs_model.probability([observation])
+            >>> len(prob) == 1
+            True
     """
 
     def __init__(
@@ -211,19 +199,11 @@ class CartPoleObservation(ObservationModel):
         action: int,
         obs_dist: CovarianceParameterizedMultivariateNormal,
     ):
-        super().__init__(next_state=next_state, action=action)
-        self.obs_dist = obs_dist
+        super().__init__(next_state=next_state, action=action, covariance=obs_dist.covariance)
+        self._obs_dist = obs_dist
 
-    def sample(self, n_samples: int = 1) -> List[np.ndarray]:
-        samples = self.obs_dist.sample(self.next_state, n_samples)
-        return [samples[i] for i in range(n_samples)]
 
-    def probability(self, values: List[np.ndarray]) -> np.ndarray:
-        if len(values) == 0:
-            return np.array([])
-
-        values_array = np.array(values)
-        return self.obs_dist.pdf(values_array, self.next_state)
+ObservationModel.register(CartPoleObservation)
 
 
 class CartPoleInitialStateDistribution(Distribution):
@@ -362,7 +342,7 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
         )
 
     def state_transition_model(self, state: np.ndarray, action: int) -> StateTransitionModel:
-        return CartPoleStateTransition(
+        return CartPoleStateTransition(  # pyright: ignore[reportReturnType]
             state=state,
             action=action,
             force_mag=self.force_mag,
@@ -377,7 +357,9 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
         )
 
     def observation_model(self, next_state: np.ndarray, action: int) -> ObservationModel:
-        return CartPoleObservation(next_state=next_state, action=action, obs_dist=self._obs_dist)
+        return CartPoleObservation(  # pyright: ignore[reportReturnType]
+            next_state=next_state, action=action, obs_dist=self._obs_dist
+        )
 
     def reward(self, state: np.ndarray, action: int) -> float:
         terminated = self.is_terminal(state)

--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp_beliefs.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp_beliefs.py
@@ -26,6 +26,7 @@ from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
 from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
     VectorizedWeightedParticleBelief,
 )
+from POMDPPlanners.environments.cartpole_pomdp import _native
 from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp_gaussian_beliefs import (
     GaussianBeliefUpdaterType,
     create_cartpole_gaussian_belief,
@@ -127,6 +128,11 @@ class CartPoleVectorizedUpdater(VectorizedParticleBeliefUpdater):
         self.polemass_length = polemass_length
         self.tau = tau
         self.kinematics_integrator = kinematics_integrator
+        # Cached covariance arrays for the native batch entry points. The
+        # MVN objects' ``covariance`` property returns a copy, so we pay the
+        # allocation once instead of on every batch_transition call.
+        self._state_transition_cov: np.ndarray = state_transition_dist.covariance
+        self._obs_cov: np.ndarray = obs_dist.covariance
 
     @classmethod
     def from_environment(cls, env: "CartPolePOMDP") -> "CartPoleVectorizedUpdater":
@@ -159,12 +165,31 @@ class CartPoleVectorizedUpdater(VectorizedParticleBeliefUpdater):
     # ------------------------------------------------------------------
 
     def batch_transition(self, particles: np.ndarray, action: np.ndarray) -> np.ndarray:
-        # particles: (N, 4) = [x, x_dot, theta, theta_dot]
-        next_particles = self._deterministic_next_state(particles, action)
-        noise = self.state_transition_dist.sample(np.zeros(4), n_samples=particles.shape[0])
-        return next_particles + noise
+        # particles: (N, 4) = [x, x_dot, theta, theta_dot]. Delegates to the
+        # native C++ batch sampler so both this path and the per-particle
+        # CartPoleStateTransition.sample() share the same C++ RNG (closes
+        # the cross-path divergence that used to skip the equivalence
+        # tests). The `state=particles[0]` passed to the ctor is unused on
+        # the batch path; only the ctor signature requires it.
+        transition = _native.CartPoleTransitionCpp(
+            state=particles[0],
+            action=int(action),
+            force_mag=self.force_mag,
+            total_mass=self.total_mass,
+            polemass_length=self.polemass_length,
+            gravity=self.gravity,
+            length=self.length,
+            kinematics_integrator=self.kinematics_integrator,
+            tau=self.tau,
+            masspole=self.masspole,
+            covariance=self._state_transition_cov,
+        )
+        return transition.batch_sample(particles)
 
     def _deterministic_next_state(self, particles: np.ndarray, action: np.ndarray) -> np.ndarray:
+        # Retained as a public-via-tests helper; mirrors the C++
+        # deterministic path so unit tests of physics don't depend on
+        # constructing a native object.
         force = self.force_mag if action == 1 else -self.force_mag
 
         theta = particles[:, 2]
@@ -199,8 +224,15 @@ class CartPoleVectorizedUpdater(VectorizedParticleBeliefUpdater):
         action: np.ndarray,
         observation: np.ndarray,
     ) -> np.ndarray:
-        observation = np.asarray(observation, dtype=float).ravel()
-        return self.obs_dist.log_pdf(next_particles, observation)
+        observation_arr = np.asarray(observation, dtype=float).ravel()
+        # Delegate to the native C++ observation likelihood. `next_state`
+        # passed to the ctor is unused on the batch path.
+        obs_model = _native.CartPoleObservationCpp(
+            next_state=next_particles[0],
+            action=int(action),
+            covariance=self._obs_cov,
+        )
+        return obs_model.batch_log_likelihood(next_particles, observation_arr)
 
     @property
     def config_id(self) -> str:

--- a/POMDPPlanners/environments/mountain_car_pomdp/_cpp/mountain_car.cpp
+++ b/POMDPPlanners/environments/mountain_car_pomdp/_cpp/mountain_car.cpp
@@ -124,6 +124,7 @@ PYBIND11_MODULE(_native, m) {
              py::arg("covariance"))
         .def("sample", &MountainCarTransitionCpp::sample, py::arg("n_samples") = 1)
         .def("probability", &MountainCarTransitionCpp::probability, py::arg("values"))
+        .def("batch_sample", &MountainCarTransitionCpp::batch_sample, py::arg("particles"))
         .def("_compute_deterministic_next_state",
              &MountainCarTransitionCpp::compute_deterministic_next_state_py)
         .def_property_readonly("state", &MountainCarTransitionCpp::state_property)
@@ -139,6 +140,8 @@ PYBIND11_MODULE(_native, m) {
              py::arg("next_state"), py::arg("action"), py::arg("covariance"))
         .def("sample", &MountainCarObservationCpp::sample, py::arg("n_samples") = 1)
         .def("probability", &MountainCarObservationCpp::probability, py::arg("values"))
+        .def("batch_log_likelihood", &MountainCarObservationCpp::batch_log_likelihood,
+             py::arg("next_particles"), py::arg("observation"))
         .def_property_readonly("next_state", &MountainCarObservationCpp::next_state_property)
         .def_property_readonly("action", &MountainCarObservationCpp::action_property)
         .def_property_readonly("mean", &MountainCarObservationCpp::mean_property);

--- a/POMDPPlanners/environments/mountain_car_pomdp/_cpp/mountain_car.cpp
+++ b/POMDPPlanners/environments/mountain_car_pomdp/_cpp/mountain_car.cpp
@@ -49,16 +49,16 @@ class MountainCarTransitionCpp : public pomdp_native::TransitionModelCpp<kMounta
 
     py::array_t<double> compute_deterministic_next_state_py() const {
         double out[kMountainCarStateDim];
-        compute_mean(out);
+        compute_mean_from_state(state_.data(), out);
         return pomdp_native::array_from_vector(out, kMountainCarStateDim);
     }
 
   protected:
-    void compute_mean(double *out) const override {
-        double v = state_[1] + static_cast<double>(action_int_) * power_ +
-                   std::cos(3.0 * state_[0]) * (-gravity_);
+    void compute_mean_from_state(const double *state, double *out) const override {
+        double v = state[1] + static_cast<double>(action_int_) * power_ +
+                   std::cos(3.0 * state[0]) * (-gravity_);
         v = std::clamp(v, -max_speed_, max_speed_);
-        double p = state_[0] + v;
+        double p = state[0] + v;
         p = std::clamp(p, min_position_, max_position_);
         if (p == min_position_ && v < 0.0) {
             v = 0.0;

--- a/POMDPPlanners/environments/mountain_car_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/mountain_car_pomdp/_native.pyi
@@ -5,6 +5,8 @@ type-check modules that import from it. The runtime implementation lives
 in ``_cpp/mountain_car.cpp``.
 """
 
+# pylint: disable=unused-argument,unnecessary-ellipsis
+
 from typing import List, Sequence, Tuple, Union
 
 import numpy as np
@@ -41,6 +43,7 @@ class MountainCarTransitionCpp:
         self,
         values: Union[Sequence[NDArray[np.floating]], NDArray[np.floating]],
     ) -> NDArray[np.float64]: ...
+    def batch_sample(self, particles: NDArray[np.floating]) -> NDArray[np.float64]: ...
     def _compute_deterministic_next_state(self) -> NDArray[np.float64]: ...
 
 class MountainCarObservationCpp:
@@ -60,4 +63,9 @@ class MountainCarObservationCpp:
     def probability(
         self,
         values: Union[Sequence[NDArray[np.floating]], NDArray[np.floating]],
+    ) -> NDArray[np.float64]: ...
+    def batch_log_likelihood(
+        self,
+        next_particles: NDArray[np.floating],
+        observation: NDArray[np.floating],
     ) -> NDArray[np.float64]: ...

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp_beliefs.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp_beliefs.py
@@ -26,6 +26,7 @@ from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
 from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
     VectorizedWeightedParticleBelief,
 )
+from POMDPPlanners.environments.mountain_car_pomdp import _native
 from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp_gaussian_beliefs import (
     GaussianBeliefUpdaterType,
     create_mountain_car_gaussian_belief,
@@ -114,6 +115,11 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
         self.max_speed = max_speed
         self.min_position = min_position
         self.max_position = max_position
+        # Cached covariance arrays for the native batch entry points. The
+        # MVN objects' ``covariance`` property returns a copy, so we pay the
+        # allocation once instead of on every batch_transition call.
+        self._state_transition_cov: np.ndarray = state_transition_dist.covariance
+        self._obs_cov: np.ndarray = obs_dist.covariance
 
     @classmethod
     def from_environment(cls, env: "MountainCarPOMDP") -> "MountainCarVectorizedUpdater":
@@ -142,27 +148,36 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
     # ------------------------------------------------------------------
 
     def batch_transition(self, particles: np.ndarray, action: np.ndarray) -> np.ndarray:
-        # particles: (N, 2) = [position, velocity]
-        position, velocity = self._deterministic_next_state(particles, action)
-        position, velocity = self._add_transition_noise(position, velocity, particles.shape[0])
-        position, velocity = self._apply_clipping_and_wall_stop(position, velocity)
-        return np.column_stack([position, velocity])
+        # particles: (N, 2) = [position, velocity]. Delegates to the native
+        # C++ batch sampler so both this path and the per-particle
+        # MountainCarTransition.sample() share the same C++ RNG (closes the
+        # cross-path divergence that used to skip the equivalence tests).
+        # The `state=particles[0]` passed to the ctor is unused on the
+        # batch path; only the ctor signature requires it.
+        transition = _native.MountainCarTransitionCpp(
+            state=tuple(particles[0]),
+            action=int(action),
+            power=self.power,
+            gravity=self.gravity,
+            max_speed=self.max_speed,
+            min_position=self.min_position,
+            max_position=self.max_position,
+            covariance=self._state_transition_cov,
+        )
+        return transition.batch_sample(particles)
 
     def _deterministic_next_state(
         self, particles: np.ndarray, action: np.ndarray
     ) -> tuple[np.ndarray, np.ndarray]:
+        # Retained as a public-via-tests helper; mirrors the C++
+        # deterministic path so unit tests of physics don't depend on
+        # constructing a native object.
         position = particles[:, 0]
         velocity = particles[:, 1]
         velocity = velocity + action * self.power + np.cos(3.0 * position) * (-self.gravity)
         velocity = np.clip(velocity, -self.max_speed, self.max_speed)
         position = position + velocity
         return self._apply_clipping_and_wall_stop(position, velocity)
-
-    def _add_transition_noise(
-        self, position: np.ndarray, velocity: np.ndarray, n: int
-    ) -> tuple[np.ndarray, np.ndarray]:
-        noise = self.state_transition_dist.sample(np.zeros(2), n_samples=n)
-        return position + noise[:, 0], velocity + noise[:, 1]
 
     def _apply_clipping_and_wall_stop(
         self, position: np.ndarray, velocity: np.ndarray
@@ -179,8 +194,15 @@ class MountainCarVectorizedUpdater(VectorizedParticleBeliefUpdater):
         action: np.ndarray,
         observation: np.ndarray,
     ) -> np.ndarray:
-        observation = np.asarray(observation, dtype=float).ravel()
-        return self.obs_dist.log_pdf(next_particles, observation)
+        observation_arr = np.asarray(observation, dtype=float).ravel()
+        # Delegate to the native C++ observation likelihood. `next_state`
+        # passed to the ctor is unused on the batch path.
+        obs_model = _native.MountainCarObservationCpp(
+            next_state=tuple(next_particles[0]),
+            action=int(action),
+            covariance=self._obs_cov,
+        )
+        return obs_model.batch_log_likelihood(next_particles, observation_arr)
 
     @property
     def config_id(self) -> str:

--- a/POMDPPlanners/tests/benchmarks/test_benchmark_particle_belief_update.py
+++ b/POMDPPlanners/tests/benchmarks/test_benchmark_particle_belief_update.py
@@ -1,24 +1,34 @@
 """Benchmarks for WeightedParticleBelief / VectorizedWeightedParticleBelief
-update paths across native (MountainCar) and non-native (CartPole) envs.
+update paths across natively-ported (MountainCar, CartPole) envs.
 
-Measures the four cases laid out in Layer 2's plan:
+Measures the cases laid out in the pomdp_native port plan:
 
     | Case                  | Env        | Belief class                        | Path            |
     |-----------------------|------------|-------------------------------------|-----------------|
     | MC-generic-cpp        | MountainCar| WeightedParticleBelief.update       | C++ batch       |
     | MC-vectorized-cpp     | MountainCar| VectorizedWeightedParticleBelief    | C++ batch       |
-    | CP-generic-python     | CartPole   | WeightedParticleBelief.update       | Python fallback |
-    | CP-vectorized-numpy   | CartPole   | VectorizedWeightedParticleBelief    | numpy batch     |
+    | CP-generic-python     | CartPole   | WeightedParticleBelief.update       | pre-port Python |
+    | CP-vectorized-numpy   | CartPole   | VectorizedWeightedParticleBelief    | pre-port numpy  |
+    | CP-generic-cpp        | CartPole   | WeightedParticleBelief.update       | C++ batch       |
+    | CP-vectorized-cpp     | CartPole   | VectorizedWeightedParticleBelief    | C++ batch       |
 
-Same N=100 particles, same action, same observation across all four.
+Same N=100 particles, same action, same observation across all cases of
+the same env. The two CartPole "python" / "numpy" cases snapshot the
+pre-port implementations (reproduced inline below) so they keep running
+the pure-Python reference code even after the native port replaces the
+shipped CartPole model classes. They give the baseline numbers the port
+replaces; the two "cpp" cases sit on the shipped (post-port) module path.
 
-Use ``pytest-benchmark compare`` across the four cases to report:
+Use ``pytest-benchmark compare`` across the cases to report:
     1. MC-generic-cpp vs MC-vectorized-cpp   -- auto-dispatch parity with
         the explicit vectorized path on a native env.
-    2. CP-generic-python vs CP-vectorized-numpy -- the non-native baseline
-        gap (the prize a future CartPole port to pomdp_native would close).
-    3. MC-generic-cpp vs CP-generic-python   -- headline speedup a native
-        port buys for callers who use plain WeightedParticleBelief.
+    2. CP-generic-python vs CP-vectorized-numpy -- the pre-port baseline
+        gap (vectorization win before any native port).
+    3. CP-generic-cpp vs CP-generic-python   -- headline speedup the
+        native port buys for callers who use plain WeightedParticleBelief.
+    4. CP-vectorized-cpp vs CP-vectorized-numpy -- speedup the native
+        port buys for callers already on the vectorized path.
+    5. CP-generic-cpp vs CP-vectorized-cpp   -- auto-dispatch overhead.
 
 Run::
 
@@ -26,15 +36,20 @@ Run::
         -m benchmark --benchmark-save=layer2_batch_dispatch -v
 """
 
-from typing import Any
+import math
+from typing import Any, List
 
 import numpy as np
 import pytest
 
 from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
+    VectorizedParticleBeliefUpdater,
+)
 from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
     VectorizedWeightedParticleBelief,
 )
+from POMDPPlanners.core.environment import ObservationModel, StateTransitionModel
 from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
 from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp_beliefs import (
     CartPoleVectorizedUpdater,
@@ -43,6 +58,7 @@ from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP
 from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp_beliefs import (
     MountainCarVectorizedUpdater,
 )
+from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 
 pytestmark = [pytest.mark.slow]
 
@@ -115,8 +131,16 @@ def test_bench_mc_vectorized_belief_update(benchmark):
 
 
 # ---------------------------------------------------------------------------
-# CartPole (non-native) cases
+# CartPole cases
 # ---------------------------------------------------------------------------
+#
+# The pre-port CartPole "python" / "numpy" benchmarks snapshot the Python /
+# numpy implementations that used to ship before the native port, so the
+# port's speedup stays measurable after the shipped classes switched to
+# C++. These reference classes are lifted verbatim from the pre-port
+# cartpole_pomdp.py / cartpole_pomdp_beliefs.py; they are test-only and
+# intentionally do not reach into the shipped CartPoleStateTransition /
+# CartPoleObservation (which are now C++-backed).
 
 
 def _cartpole_initial_particles(env: CartPolePOMDP, n: int) -> Any:
@@ -124,15 +148,276 @@ def _cartpole_initial_particles(env: CartPolePOMDP, n: int) -> Any:
     return env.initial_state_dist().sample(n_samples=n)
 
 
-@pytest.mark.benchmark(group="belief-update-cp-generic-python")
-def test_bench_cp_generic_belief_update(benchmark):
-    """Benchmark WeightedParticleBelief.update on CartPole (Python fallback).
+class _PrePortCartPoleTransition(StateTransitionModel):
+    # Pre-port Python reference kept for baseline benchmarking only.
+    # pylint: disable=too-many-instance-attributes
+    def __init__(
+        self,
+        state: np.ndarray,
+        action: int,
+        force_mag: float,
+        total_mass: float,
+        polemass_length: float,
+        gravity: float,
+        length: float,
+        kinematics_integrator: str,
+        tau: float,
+        masspole: float,
+        state_transition_dist: CovarianceParameterizedMultivariateNormal,
+    ):
+        super().__init__(state, action)
+        self.force_mag = force_mag
+        self.total_mass = total_mass
+        self.polemass_length = polemass_length
+        self.gravity = gravity
+        self.length = length
+        self.kinematics_integrator = kinematics_integrator
+        self.tau = tau
+        self.masspole = masspole
+        self._state_transition_dist = state_transition_dist
 
-    Purpose: Measures the generic per-particle Python loop on a non-native
-    env. CartPole has no ``_cpp`` extension; the auto-dispatch hasattr check
-    fails, and _update_weights falls back to its pre-Layer-2 per-particle
-    ``state_transition_model().sample()`` loop. This is the baseline a
-    future CartPole port to ``pomdp_native`` would target.
+    def sample(self, n_samples: int = 1) -> List[np.ndarray]:
+        deterministic = self._compute_deterministic_next_state()
+        noise = self._state_transition_dist.sample(np.zeros(4), n_samples=n_samples)
+        return [deterministic + noise[i] for i in range(n_samples)]
+
+    def _compute_deterministic_next_state(self) -> np.ndarray:
+        x, x_dot, theta, theta_dot = self.state
+        force = self.force_mag if self.action == 1 else -self.force_mag
+        costheta = math.cos(theta)
+        sintheta = math.sin(theta)
+        temp = (force + self.polemass_length * theta_dot**2 * sintheta) / self.total_mass
+        thetaacc = (self.gravity * sintheta - costheta * temp) / (
+            self.length * (4.0 / 3.0 - self.masspole * costheta**2 / self.total_mass)
+        )
+        xacc = temp - self.polemass_length * thetaacc * costheta / self.total_mass
+        if self.kinematics_integrator == "euler":
+            x = x + self.tau * x_dot
+            x_dot = x_dot + self.tau * xacc
+            theta = theta + self.tau * theta_dot
+            theta_dot = theta_dot + self.tau * thetaacc
+        else:
+            x_dot = x_dot + self.tau * xacc
+            x = x + self.tau * x_dot
+            theta_dot = theta_dot + self.tau * thetaacc
+            theta = theta + self.tau * theta_dot
+        return np.array([x, x_dot, theta, theta_dot])
+
+    def probability(self, values: List[np.ndarray]) -> np.ndarray:
+        deterministic = self._compute_deterministic_next_state()
+        values_array = np.array(values)
+        return self._state_transition_dist.pdf(values_array, deterministic)
+
+
+class _PrePortCartPoleObservation(ObservationModel):
+    # Pre-port Python reference kept for baseline benchmarking only.
+    def __init__(
+        self,
+        next_state: np.ndarray,
+        action: int,
+        obs_dist: CovarianceParameterizedMultivariateNormal,
+    ):
+        super().__init__(next_state=next_state, action=action)
+        self.obs_dist = obs_dist
+
+    def sample(self, n_samples: int = 1) -> List[np.ndarray]:
+        samples = self.obs_dist.sample(self.next_state, n_samples)
+        return [samples[i] for i in range(n_samples)]
+
+    def probability(self, values: List[np.ndarray]) -> np.ndarray:
+        if len(values) == 0:
+            return np.array([])
+        values_array = np.array(values)
+        return self.obs_dist.pdf(values_array, self.next_state)
+
+
+class _PrePortCartPolePOMDP(CartPolePOMDP):
+    """Pre-port CartPolePOMDP whose factories return the Python reference models."""
+
+    def state_transition_model(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self, state: np.ndarray, action: int
+    ) -> StateTransitionModel:
+        return _PrePortCartPoleTransition(
+            state=state,
+            action=action,
+            force_mag=self.force_mag,
+            total_mass=self.total_mass,
+            polemass_length=self.polemass_length,
+            gravity=self.gravity,
+            length=self.length,
+            kinematics_integrator=self.kinematics_integrator,
+            tau=self.tau,
+            masspole=self.masspole,
+            state_transition_dist=self._state_transition_dist,
+        )
+
+    def observation_model(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self, next_state: np.ndarray, action: int
+    ) -> ObservationModel:
+        return _PrePortCartPoleObservation(
+            next_state=next_state, action=action, obs_dist=self._obs_dist
+        )
+
+
+class _PrePortCartPoleVectorizedUpdater(VectorizedParticleBeliefUpdater):
+    """Pre-port numpy-only vectorized updater preserved for baseline benchmarks."""
+
+    # pylint: disable=too-many-instance-attributes
+    def __init__(
+        self,
+        state_transition_dist: CovarianceParameterizedMultivariateNormal,
+        obs_dist: CovarianceParameterizedMultivariateNormal,
+        force_mag: float,
+        gravity: float,
+        masspole: float,
+        total_mass: float,
+        length: float,
+        polemass_length: float,
+        tau: float,
+        kinematics_integrator: str,
+    ):
+        self.state_transition_dist = state_transition_dist
+        self.obs_dist = obs_dist
+        self.force_mag = force_mag
+        self.gravity = gravity
+        self.masspole = masspole
+        self.total_mass = total_mass
+        self.length = length
+        self.polemass_length = polemass_length
+        self.tau = tau
+        self.kinematics_integrator = kinematics_integrator
+
+    @classmethod
+    def from_environment(cls, env: CartPolePOMDP) -> "_PrePortCartPoleVectorizedUpdater":
+        # pylint: disable=protected-access
+        return cls(
+            state_transition_dist=env._state_transition_dist,
+            obs_dist=env._obs_dist,
+            force_mag=env.force_mag,
+            gravity=env.gravity,
+            masspole=env.masspole,
+            total_mass=env.total_mass,
+            length=env.length,
+            polemass_length=env.polemass_length,
+            tau=env.tau,
+            kinematics_integrator=env.kinematics_integrator,
+        )
+
+    def batch_transition(self, particles: np.ndarray, action: np.ndarray) -> np.ndarray:
+        next_particles = self._deterministic_next_state(particles, action)
+        noise = self.state_transition_dist.sample(np.zeros(4), n_samples=particles.shape[0])
+        return next_particles + noise
+
+    def _deterministic_next_state(self, particles: np.ndarray, action: np.ndarray) -> np.ndarray:
+        force = self.force_mag if action == 1 else -self.force_mag
+        theta = particles[:, 2]
+        theta_dot = particles[:, 3]
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        temp = (force + self.polemass_length * theta_dot**2 * sin_theta) / self.total_mass
+        theta_acc = (self.gravity * sin_theta - cos_theta * temp) / (
+            self.length * (4.0 / 3.0 - self.masspole * cos_theta**2 / self.total_mass)
+        )
+        x_acc = temp - self.polemass_length * theta_acc * cos_theta / self.total_mass
+        next_particles = np.empty_like(particles)
+        if self.kinematics_integrator == "euler":
+            next_particles[:, 0] = particles[:, 0] + self.tau * particles[:, 1]
+            next_particles[:, 1] = particles[:, 1] + self.tau * x_acc
+            next_particles[:, 2] = particles[:, 2] + self.tau * particles[:, 3]
+            next_particles[:, 3] = particles[:, 3] + self.tau * theta_acc
+        else:
+            next_particles[:, 1] = particles[:, 1] + self.tau * x_acc
+            next_particles[:, 0] = particles[:, 0] + self.tau * next_particles[:, 1]
+            next_particles[:, 3] = particles[:, 3] + self.tau * theta_acc
+            next_particles[:, 2] = particles[:, 2] + self.tau * next_particles[:, 3]
+        return next_particles
+
+    def batch_observation_log_likelihood(
+        self,
+        next_particles: np.ndarray,
+        action: np.ndarray,
+        observation: np.ndarray,
+    ) -> np.ndarray:
+        observation_arr = np.asarray(observation, dtype=float).ravel()
+        return self.obs_dist.log_pdf(next_particles, observation_arr)
+
+    @property
+    def config_id(self) -> str:
+        return "_PrePortCartPoleVectorizedUpdater"
+
+
+@pytest.mark.benchmark(group="belief-update-cp-generic-python")
+def test_bench_cp_generic_belief_update_python(benchmark):
+    """Benchmark WeightedParticleBelief.update on CartPole (pre-port Python).
+
+    Purpose: Pre-port baseline. Measures the generic per-particle Python
+    loop using the pre-port reference CartPole transition / observation
+    classes (kept inline in this module). These models do NOT expose
+    batch_sample, so WeightedParticleBelief._update_weights falls back to
+    its per-particle ``state_transition_model().sample()`` loop.
+
+    Given: Pre-port CartPolePOMDP + WeightedParticleBelief with N=100.
+    When: belief.update(action, observation, pomdp) is called repeatedly.
+    Then: Execution time is recorded.
+
+    Test type: performance
+    """
+    env = _PrePortCartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    particles = list(_cartpole_initial_particles(env, _N_PARTICLES))
+    log_weights = np.log(np.ones(_N_PARTICLES) / _N_PARTICLES)
+    belief = WeightedParticleBelief(particles=particles, log_weights=log_weights)
+    action = env.get_actions()[0]
+    observation = env.initial_observation_dist().sample(n_samples=1)[0]
+
+    def run():
+        return belief.update(action=action, observation=observation, pomdp=env)
+
+    benchmark(run)
+
+
+@pytest.mark.benchmark(group="belief-update-cp-vectorized-numpy")
+def test_bench_cp_vectorized_belief_update_numpy(benchmark):
+    """Benchmark VectorizedWeightedParticleBelief.update on CartPole (pre-port numpy).
+
+    Purpose: Pre-port baseline. Measures the explicit vectorized belief
+    path using the numpy-only reference updater (kept inline in this
+    module). ``batch_transition`` and ``batch_observation_log_likelihood``
+    run entirely in numpy -- no C++ involved.
+
+    Given: CartPolePOMDP + VectorizedWeightedParticleBelief with N=100.
+    When: belief.update(action, observation, pomdp) is called repeatedly.
+    Then: Execution time is recorded.
+
+    Test type: performance
+    """
+    env = CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    updater = _PrePortCartPoleVectorizedUpdater.from_environment(env)
+    particles = np.array(_cartpole_initial_particles(env, _N_PARTICLES))
+    log_weights = np.log(np.ones(_N_PARTICLES) / _N_PARTICLES)
+    belief = VectorizedWeightedParticleBelief(
+        particles=particles,
+        log_weights=log_weights,
+        updater=updater,
+    )
+    action = env.get_actions()[0]
+    observation = env.initial_observation_dist().sample(n_samples=1)[0]
+
+    def run():
+        return belief.update(action=action, observation=observation, pomdp=env)
+
+    benchmark(run)
+
+
+@pytest.mark.benchmark(group="belief-update-cp-generic-cpp")
+def test_bench_cp_generic_belief_update_cpp(benchmark):
+    """Benchmark WeightedParticleBelief.update on CartPole (C++ auto-dispatch).
+
+    Purpose: Measures the generic per-particle-looking belief update path
+    on the post-port CartPole, where the shipped transition / observation
+    models expose native batch entry points.
+    WeightedParticleBelief._update_weights sniffs the batch interface and
+    dispatches to C++ batch_sample / batch_log_likelihood in a single
+    round-trip per update.
 
     Given: CartPolePOMDP + WeightedParticleBelief with N=100 particles.
     When: belief.update(action, observation, pomdp) is called repeatedly.
@@ -153,13 +438,14 @@ def test_bench_cp_generic_belief_update(benchmark):
     benchmark(run)
 
 
-@pytest.mark.benchmark(group="belief-update-cp-vectorized-numpy")
-def test_bench_cp_vectorized_belief_update(benchmark):
-    """Benchmark VectorizedWeightedParticleBelief.update on CartPole (numpy).
+@pytest.mark.benchmark(group="belief-update-cp-vectorized-cpp")
+def test_bench_cp_vectorized_belief_update_cpp(benchmark):
+    """Benchmark VectorizedWeightedParticleBelief.update on CartPole (C++).
 
-    Purpose: Measures the explicit vectorized belief path on CartPole. The
-    updater (CartPoleVectorizedUpdater) implements batch_transition and
-    batch_observation_log_likelihood in numpy -- no C++ involved.
+    Purpose: Measures the explicit vectorized belief path on the post-port
+    CartPole. Its updater (CartPoleVectorizedUpdater) now delegates
+    batch_transition and batch_observation_log_likelihood directly to the
+    native C++ batch methods.
 
     Given: CartPolePOMDP + VectorizedWeightedParticleBelief with N=100.
     When: belief.update(action, observation, pomdp) is called repeatedly.

--- a/POMDPPlanners/tests/benchmarks/test_benchmark_particle_belief_update.py
+++ b/POMDPPlanners/tests/benchmarks/test_benchmark_particle_belief_update.py
@@ -1,0 +1,185 @@
+"""Benchmarks for WeightedParticleBelief / VectorizedWeightedParticleBelief
+update paths across native (MountainCar) and non-native (CartPole) envs.
+
+Measures the four cases laid out in Layer 2's plan:
+
+    | Case                  | Env        | Belief class                        | Path            |
+    |-----------------------|------------|-------------------------------------|-----------------|
+    | MC-generic-cpp        | MountainCar| WeightedParticleBelief.update       | C++ batch       |
+    | MC-vectorized-cpp     | MountainCar| VectorizedWeightedParticleBelief    | C++ batch       |
+    | CP-generic-python     | CartPole   | WeightedParticleBelief.update       | Python fallback |
+    | CP-vectorized-numpy   | CartPole   | VectorizedWeightedParticleBelief    | numpy batch     |
+
+Same N=100 particles, same action, same observation across all four.
+
+Use ``pytest-benchmark compare`` across the four cases to report:
+    1. MC-generic-cpp vs MC-vectorized-cpp   -- auto-dispatch parity with
+        the explicit vectorized path on a native env.
+    2. CP-generic-python vs CP-vectorized-numpy -- the non-native baseline
+        gap (the prize a future CartPole port to pomdp_native would close).
+    3. MC-generic-cpp vs CP-generic-python   -- headline speedup a native
+        port buys for callers who use plain WeightedParticleBelief.
+
+Run::
+
+    pytest POMDPPlanners/tests/benchmarks/test_benchmark_particle_belief_update.py \\
+        -m benchmark --benchmark-save=layer2_batch_dispatch -v
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
+from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp_beliefs import (
+    CartPoleVectorizedUpdater,
+)
+from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP
+from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp_beliefs import (
+    MountainCarVectorizedUpdater,
+)
+
+pytestmark = [pytest.mark.slow]
+
+_N_PARTICLES = 100
+
+
+# ---------------------------------------------------------------------------
+# MountainCar (native) cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="belief-update-mc-generic-cpp")
+def test_bench_mc_generic_belief_update(benchmark):
+    """Benchmark WeightedParticleBelief.update on MountainCar (auto-dispatch).
+
+    Purpose: Measures the generic per-particle-looking belief update path
+    on an env whose transition/observation models expose native batch
+    entry points. WeightedParticleBelief._update_weights sniffs the batch
+    interface and dispatches to C++ batch_sample / batch_log_likelihood in
+    a single round-trip per update.
+
+    Given: MountainCarPOMDP + WeightedParticleBelief with N=100 particles.
+    When: belief.update(action, observation, pomdp) is called repeatedly.
+    Then: Execution time is recorded.
+
+    Test type: performance
+    """
+    env = MountainCarPOMDP(discount_factor=0.99)
+    particles = list(env.initial_state_dist().sample(n_samples=_N_PARTICLES))
+    log_weights = np.log(np.ones(_N_PARTICLES) / _N_PARTICLES)
+    belief = WeightedParticleBelief(particles=particles, log_weights=log_weights)
+    observation = np.array([-0.5, 0.0])
+
+    def run():
+        return belief.update(action=1, observation=observation, pomdp=env)
+
+    benchmark(run)
+
+
+@pytest.mark.benchmark(group="belief-update-mc-vectorized-cpp")
+def test_bench_mc_vectorized_belief_update(benchmark):
+    """Benchmark VectorizedWeightedParticleBelief.update on MountainCar.
+
+    Purpose: Measures the explicit vectorized belief path on MountainCar.
+    Its updater (MountainCarVectorizedUpdater) delegates batch_transition
+    and batch_observation_log_likelihood directly to the native C++ batch
+    methods.
+
+    Given: MountainCarPOMDP + VectorizedWeightedParticleBelief with N=100.
+    When: belief.update(action, observation, pomdp) is called repeatedly.
+    Then: Execution time is recorded.
+
+    Test type: performance
+    """
+    env = MountainCarPOMDP(discount_factor=0.99)
+    updater = MountainCarVectorizedUpdater.from_environment(env)
+    particles = np.array(env.initial_state_dist().sample(n_samples=_N_PARTICLES))
+    log_weights = np.log(np.ones(_N_PARTICLES) / _N_PARTICLES)
+    belief = VectorizedWeightedParticleBelief(
+        particles=particles,
+        log_weights=log_weights,
+        updater=updater,
+    )
+    observation = np.array([-0.5, 0.0])
+
+    def run():
+        return belief.update(action=1, observation=observation, pomdp=env)
+
+    benchmark(run)
+
+
+# ---------------------------------------------------------------------------
+# CartPole (non-native) cases
+# ---------------------------------------------------------------------------
+
+
+def _cartpole_initial_particles(env: CartPolePOMDP, n: int) -> Any:
+    """Draw n initial CartPole state particles (ndarray or list format)."""
+    return env.initial_state_dist().sample(n_samples=n)
+
+
+@pytest.mark.benchmark(group="belief-update-cp-generic-python")
+def test_bench_cp_generic_belief_update(benchmark):
+    """Benchmark WeightedParticleBelief.update on CartPole (Python fallback).
+
+    Purpose: Measures the generic per-particle Python loop on a non-native
+    env. CartPole has no ``_cpp`` extension; the auto-dispatch hasattr check
+    fails, and _update_weights falls back to its pre-Layer-2 per-particle
+    ``state_transition_model().sample()`` loop. This is the baseline a
+    future CartPole port to ``pomdp_native`` would target.
+
+    Given: CartPolePOMDP + WeightedParticleBelief with N=100 particles.
+    When: belief.update(action, observation, pomdp) is called repeatedly.
+    Then: Execution time is recorded.
+
+    Test type: performance
+    """
+    env = CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    particles = list(_cartpole_initial_particles(env, _N_PARTICLES))
+    log_weights = np.log(np.ones(_N_PARTICLES) / _N_PARTICLES)
+    belief = WeightedParticleBelief(particles=particles, log_weights=log_weights)
+    action = env.get_actions()[0]
+    observation = env.initial_observation_dist().sample(n_samples=1)[0]
+
+    def run():
+        return belief.update(action=action, observation=observation, pomdp=env)
+
+    benchmark(run)
+
+
+@pytest.mark.benchmark(group="belief-update-cp-vectorized-numpy")
+def test_bench_cp_vectorized_belief_update(benchmark):
+    """Benchmark VectorizedWeightedParticleBelief.update on CartPole (numpy).
+
+    Purpose: Measures the explicit vectorized belief path on CartPole. The
+    updater (CartPoleVectorizedUpdater) implements batch_transition and
+    batch_observation_log_likelihood in numpy -- no C++ involved.
+
+    Given: CartPolePOMDP + VectorizedWeightedParticleBelief with N=100.
+    When: belief.update(action, observation, pomdp) is called repeatedly.
+    Then: Execution time is recorded.
+
+    Test type: performance
+    """
+    env = CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    updater = CartPoleVectorizedUpdater.from_environment(env)
+    particles = np.array(_cartpole_initial_particles(env, _N_PARTICLES))
+    log_weights = np.log(np.ones(_N_PARTICLES) / _N_PARTICLES)
+    belief = VectorizedWeightedParticleBelief(
+        particles=particles,
+        log_weights=log_weights,
+        updater=updater,
+    )
+    action = env.get_actions()[0]
+    observation = env.initial_observation_dist().sample(n_samples=1)[0]
+
+    def run():
+        return belief.update(action=action, observation=observation, pomdp=env)
+
+    benchmark(run)

--- a/POMDPPlanners/tests/test_core/test_belief/belief_equivalence_utils.py
+++ b/POMDPPlanners/tests/test_core/test_belief/belief_equivalence_utils.py
@@ -52,6 +52,7 @@ def assert_update_particles_match(
     pomdp: Environment,
     atol: float = 1e-10,
     seed: Optional[int] = None,
+    seed_fn: Optional[Callable[[int], None]] = None,
     particle_to_array: Optional[ParticleToArray] = None,
 ) -> BeliefPair:
     """Run one update on both beliefs and assert next particles agree.
@@ -74,7 +75,7 @@ def assert_update_particles_match(
     Returns:
         The updated ``(base, vec)`` belief pair so callers can chain asserts.
     """
-    base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed)
+    base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed, seed_fn)
     _check_particles(base_next, vec_next, atol=atol, particle_to_array=particle_to_array)
     return base_next, vec_next
 
@@ -88,6 +89,7 @@ def assert_update_weights_match(
     atol: float = 1e-6,
     significance_threshold: Optional[float] = None,
     seed: Optional[int] = None,
+    seed_fn: Optional[Callable[[int], None]] = None,
 ) -> BeliefPair:
     """Run one update on both beliefs and assert normalized weights agree.
 
@@ -112,7 +114,7 @@ def assert_update_weights_match(
     Returns:
         The updated ``(base, vec)`` belief pair.
     """
-    base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed)
+    base_next, vec_next = _run_updates(base, vec, action, observation, pomdp, seed, seed_fn)
     _check_weights(base_next, vec_next, atol=atol, significance_threshold=significance_threshold)
     return base_next, vec_next
 
@@ -410,12 +412,14 @@ def _run_updates(
     observation: Any,
     pomdp: Environment,
     seed: Optional[int],
+    seed_fn: Optional[Callable[[int], None]] = None,
 ) -> BeliefPair:
+    effective_seed_fn = seed_fn if seed_fn is not None else np.random.seed
     if seed is not None:
-        np.random.seed(seed)
+        effective_seed_fn(seed)
     vec_next = vec.update(action=action, observation=observation, pomdp=pomdp)
     if seed is not None:
-        np.random.seed(seed)
+        effective_seed_fn(seed)
     base_next = base.update(action=action, observation=observation, pomdp=pomdp)
     return base_next, vec_next
 

--- a/POMDPPlanners/tests/test_core/test_belief/vectorized_updater_test_utils.py
+++ b/POMDPPlanners/tests/test_core/test_belief/vectorized_updater_test_utils.py
@@ -26,6 +26,7 @@ def assert_batch_transition_matches_loop(
     per_particle_transition_fn: Callable[[np.ndarray, Any], np.ndarray],
     atol: float = 1e-10,
     seed: Optional[int] = None,
+    seed_fn: Optional[Callable[[int], None]] = None,
     err_msg: str = "",
 ) -> None:
     """Assert that batch_transition matches a per-particle transition loop.
@@ -37,13 +38,20 @@ def assert_batch_transition_matches_loop(
         per_particle_transition_fn: Callable(particle_1d, action) -> next_state_1d
             that wraps the environment's per-particle transition logic.
         atol: Absolute tolerance for comparison.
-        seed: If provided, seeds np.random before each path so stochastic
+        seed: If provided, the RNG is seeded before each path so stochastic
             transitions consume the same random sequence.
+        seed_fn: Callable used to seed the RNG. Defaults to ``np.random.seed``.
+            Envs whose updater draws noise from a non-numpy RNG (e.g.
+            MountainCar's native C++ extension) should pass their own seeder,
+            e.g. ``_native.set_seed``.
         err_msg: Optional message appended on failure.
     """
-    vectorized_result = _run_vectorized_transition(updater, particles, action, seed)
+    effective_seed_fn = seed_fn if seed_fn is not None else np.random.seed
+    vectorized_result = _run_vectorized_transition(
+        updater, particles, action, seed, effective_seed_fn
+    )
     per_particle_result = _run_per_particle_transition(
-        particles, action, per_particle_transition_fn, seed
+        particles, action, per_particle_transition_fn, seed, effective_seed_fn
     )
     np.testing.assert_allclose(vectorized_result, per_particle_result, atol=atol, err_msg=err_msg)
 
@@ -100,9 +108,10 @@ def _run_vectorized_transition(
     particles: np.ndarray,
     action: Any,
     seed: Optional[int],
+    seed_fn: Callable[[int], None],
 ) -> np.ndarray:
     if seed is not None:
-        np.random.seed(seed)
+        seed_fn(seed)
     return updater.batch_transition(particles, action)
 
 
@@ -111,9 +120,10 @@ def _run_per_particle_transition(
     action: Any,
     per_particle_fn: Callable[[np.ndarray, Any], np.ndarray],
     seed: Optional[int],
+    seed_fn: Callable[[int], None],
 ) -> np.ndarray:
     if seed is not None:
-        np.random.seed(seed)
+        seed_fn(seed)
     n = len(particles)
     result = np.empty_like(particles)
     for i in range(n):

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py
@@ -5,6 +5,8 @@ log-likelihood methods, including an equivalence test that verifies
 the vectorized results match the per-particle loop.
 """
 
+import math
+
 import numpy as np
 import pytest
 
@@ -12,7 +14,7 @@ from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
 from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
     VectorizedWeightedParticleBelief,
 )
-from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
+from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP, _native
 from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp_beliefs import (
     CartPoleVectorizedUpdater,
 )
@@ -120,20 +122,21 @@ class TestBatchTransition:
         """Test that batch_transition is deterministic under a fixed seed.
 
         Purpose: Validates that the stochastic batch_transition produces
-                 identical output when the global numpy RNG is seeded
-                 identically before each call.
+                 identical output when the module-level C++ RNG (now the
+                 source of randomness for the updater) is seeded identically
+                 before each call.
 
-        Given: A set of particles and an action, with np.random.seed fixed
-               before each call.
+        Given: A set of particles and an action, with ``_native.set_seed``
+               fixed before each call.
         When: batch_transition is called twice.
         Then: Both results are identical.
 
         Test type: unit
         """
         particles = np.array([[0.0, 0.0, 0.1, 0.0], [0.01, -0.02, 0.05, 0.1]])
-        np.random.seed(7)
+        _native.set_seed(7)
         result_a = updater.batch_transition(particles, action=1)
-        np.random.seed(7)
+        _native.set_seed(7)
         result_b = updater.batch_transition(particles, action=1)
         np.testing.assert_array_equal(result_a, result_b)
 
@@ -150,8 +153,6 @@ class TestBatchTransition:
 
         Test type: unit
         """
-        import math
-
         state = np.array([[0.0, 0.0, 0.1, 0.0]])
         # pylint: disable=protected-access
         result = updater._deterministic_next_state(state, action=1)
@@ -275,8 +276,8 @@ class TestConfigId:
         """
         u1 = CartPoleVectorizedUpdater.from_environment(env)
         u2 = CartPoleVectorizedUpdater(
-            state_transition_dist=env._state_transition_dist,
-            obs_dist=env._obs_dist,
+            state_transition_dist=env._state_transition_dist,  # pylint: disable=protected-access
+            obs_dist=env._obs_dist,  # pylint: disable=protected-access
             force_mag=env.force_mag * 2,
             gravity=env.gravity,
             masscart=env.masscart,
@@ -322,6 +323,7 @@ class TestEquivalenceWithPerParticleLoop:
             action=1,
             per_particle_transition_fn=per_particle_fn,
             seed=999,
+            seed_fn=_native.set_seed,
         )
 
     def test_batch_observation_log_likelihood_matches_per_particle_loop(self, env, updater):
@@ -365,10 +367,12 @@ class TestBeliefEquivalenceWithBaseline:
 
         Purpose: Validates that VectorizedWeightedParticleBelief.update and
             WeightedParticleBelief.update agree on next-state particles once
-            the vectorized updater mirrors the standard transition noise.
+            both paths route through the shared pomdp_native batch methods
+            (and therefore share the module-level C++ RNG).
 
         Given: 60 aligned particles.
-        When: Both beliefs are updated with action=1 under a shared seed.
+        When: Both beliefs are updated with action=1 under a shared seed
+            applied via ``_native.set_seed``.
         Then: Next particles agree within floating-point tolerance.
 
         Test type: integration
@@ -376,7 +380,13 @@ class TestBeliefEquivalenceWithBaseline:
         base, vec = _make_aligned_beliefs(updater)
         obs = np.array([0.01, 0.0, 0.02, 0.0])
         assert_update_particles_match(
-            base=base, vec=vec, action=1, observation=obs, pomdp=env, seed=999
+            base=base,
+            vec=vec,
+            action=1,
+            observation=obs,
+            pomdp=env,
+            seed=999,
+            seed_fn=_native.set_seed,
         )
 
     def test_update_weights_match(self, env, updater):
@@ -400,6 +410,7 @@ class TestBeliefEquivalenceWithBaseline:
             pomdp=env,
             atol=1e-6,
             seed=999,
+            seed_fn=_native.set_seed,
         )
 
     def test_sample_distributions_match_post_update(self, env, updater):
@@ -407,7 +418,9 @@ class TestBeliefEquivalenceWithBaseline:
 
         Purpose: Validates sample() unbiasedness and cross-belief agreement.
 
-        Given: 60 aligned particles; one update step seeded identically.
+        Given: 60 aligned particles; one update step seeded identically
+            via ``_native.set_seed`` (for the C++ transition batch) and
+            ``np.random.seed`` (for particle resampling -- still numpy).
         When: 20,000 samples are drawn from each belief.
         Then: Empirical histograms agree and each matches its normalized_weights.
 
@@ -415,9 +428,9 @@ class TestBeliefEquivalenceWithBaseline:
         """
         base, vec = _make_aligned_beliefs(updater)
         obs = np.array([0.01, 0.0, 0.02, 0.0])
-        np.random.seed(999)
+        _native.set_seed(999)
         vec = vec.update(action=1, observation=obs, pomdp=env)
-        np.random.seed(999)
+        _native.set_seed(999)
         base = base.update(action=1, observation=obs, pomdp=env)
 
         assert_sample_distributions_match(

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_native_equivalence.py
@@ -1,0 +1,445 @@
+"""Numerical equivalence tests for the native CartPole sampling extension.
+
+Verifies that the C++ ``_native`` sampling / probability code matches the
+Python reference (``CovarianceParameterizedMultivariateNormal``) up to
+statistical noise in the samples and up to floating-point tolerance in
+the PDF. Complements ``test_cartpole_pomdp.py`` which exercises the
+shipped API; this module focuses on the port-specific invariants.
+Generic assertion mechanics live in ``_native_parity.py`` so other native
+env ports can reuse them.
+"""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.environment import ObservationModel, StateTransitionModel
+from POMDPPlanners.environments.cartpole_pomdp import (
+    CartPoleObservation,
+    CartPolePOMDP,
+    CartPoleStateTransition,
+    _native,
+)
+from POMDPPlanners.tests.test_environments import _native_parity
+from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
+
+
+@pytest.fixture(name="env")
+def _env_fixture():
+    noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
+    return CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
+
+
+@pytest.fixture(name="transition")
+def _transition_fixture(env):
+    state = np.array([0.0, 0.0, 0.05, 0.0])
+    return env.state_transition_model(state=state, action=1)
+
+
+@pytest.fixture(name="observation")
+def _observation_fixture(env):
+    next_state = np.array([0.01, 0.0, 0.05, 0.0])
+    return env.observation_model(next_state=next_state, action=1)
+
+
+# ---------------------------------------------------------------------------
+# ABC / typing contract
+# ---------------------------------------------------------------------------
+
+
+def test_transition_is_registered_as_state_transition_model(transition):
+    """Shim passes isinstance check for StateTransitionModel after register().
+
+    Purpose: Validates the ABC virtual-subclass registration applied in the
+    Python shim so downstream polymorphic callers see the C++ class as a
+    valid StateTransitionModel.
+
+    Given: A CartPoleStateTransition produced by CartPolePOMDP's factory.
+    When: isinstance is checked against StateTransitionModel.
+    Then: It returns True.
+
+    Test type: unit
+    """
+    _native_parity.assert_abc_registration(transition, StateTransitionModel)
+
+
+def test_observation_is_registered_as_observation_model(observation):
+    """Shim passes isinstance check for ObservationModel after register().
+
+    Purpose: Same as the transition case, for the observation model.
+
+    Given: A CartPoleObservation produced by CartPolePOMDP's factory.
+    When: isinstance is checked against ObservationModel.
+    Then: It returns True.
+
+    Test type: unit
+    """
+    _native_parity.assert_abc_registration(observation, ObservationModel)
+
+
+def test_transition_is_not_abstract():
+    """CartPoleStateTransition is instantiable (no unresolved abstract methods).
+
+    Purpose: Guards against ABC.register masking missing slot implementations
+    on the C++ side.
+
+    Given: The CartPoleStateTransition class object.
+    When: __abstractmethods__ is inspected.
+    Then: The set is empty.
+
+    Test type: unit
+    """
+    abstract_methods = getattr(CartPoleStateTransition, "__abstractmethods__", frozenset())
+    assert abstract_methods == frozenset()
+
+
+def test_observation_is_not_abstract():
+    """CartPoleObservation is instantiable (no unresolved abstract methods).
+
+    Purpose: Guards against ABC.register masking missing slot implementations
+    on the C++ side.
+
+    Given: The CartPoleObservation class object.
+    When: __abstractmethods__ is inspected.
+    Then: The set is empty.
+
+    Test type: unit
+    """
+    abstract_methods = getattr(CartPoleObservation, "__abstractmethods__", frozenset())
+    assert abstract_methods == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Sample distribution matches the Gaussian spec
+# ---------------------------------------------------------------------------
+
+
+def test_transition_sample_empirical_moments_match_spec(env):
+    """Native transition samples have the documented Gaussian distribution.
+
+    Purpose: Validates that 200k samples from the C++ sampler have the
+    theoretical mean (deterministic next state) and covariance (the
+    declared process noise), since the C++ RNG cannot be compared
+    bit-for-bit against numpy's.
+
+    Given: A CartPoleStateTransition from an interior state with action=1
+        (no boundary effects).
+    When: 200,000 samples are drawn via the C++ path.
+    Then: The empirical mean matches the deterministic next state within
+        5e-3, and the empirical covariance matches the configured process
+        noise within a Frobenius-norm tolerance of 1e-5.
+
+    Test type: integration
+    """
+    state = np.array([0.0, 0.0, 0.05, 0.0])
+    transition = env.state_transition_model(state=state, action=1)
+    det = np.asarray(
+        transition._compute_deterministic_next_state()  # pylint: disable=protected-access
+    )
+
+    _native_parity.assert_sample_moments_match(
+        model=transition,
+        seed_fn=_native.set_seed,
+        expected_mean=det,
+        expected_cov=env.state_transition_cov,
+        n_samples=200_000,
+        seed=12345,
+        mean_atol=5e-3,
+        cov_frobenius_atol=1e-5,
+    )
+
+
+def test_observation_sample_empirical_moments_match_spec(env):
+    """Native observation samples match the documented observation noise.
+
+    Purpose: Validates that 200k observation samples have the theoretical
+    mean (the input next_state) and covariance (the declared observation
+    noise).
+
+    Given: A CartPoleObservation with a fixed next_state.
+    When: 200,000 samples are drawn via the C++ path.
+    Then: The empirical mean matches the next_state within 5e-3, and the
+        empirical covariance matches the observation covariance within
+        Frobenius-norm 1e-2.
+
+    Test type: integration
+    """
+    next_state = np.array([0.05, 0.1, -0.02, 0.0])
+    observation_model = env.observation_model(next_state=next_state, action=0)
+
+    _native_parity.assert_sample_moments_match(
+        model=observation_model,
+        seed_fn=_native.set_seed,
+        expected_mean=next_state,
+        expected_cov=env.noise_cov,
+        n_samples=200_000,
+        seed=7777,
+        mean_atol=5e-3,
+        cov_frobenius_atol=1e-2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# probability() bit-exactness vs the Python reference
+# ---------------------------------------------------------------------------
+
+
+def test_transition_probability_matches_python_reference_on_grid(env):
+    """C++ probability() matches CovarianceParameterizedMultivariateNormal.pdf.
+
+    Purpose: Validates that the C++ PDF computation agrees numerically with
+    the Python reference on a deterministic grid.
+
+    Given: A 1000-point grid of candidate next-states around the
+        deterministic transition target, plus the Python reference
+        distribution constructed from the same covariance.
+    When: probability(grid) is called on both implementations.
+    Then: Outputs agree to absolute tolerance 1e-6 (PDF values are large
+        relative to the log-pdf difference tolerance).
+
+    Test type: unit
+    """
+    state = np.array([0.0, 0.0, 0.05, 0.0])
+    transition = env.state_transition_model(state=state, action=1)
+    det = np.asarray(
+        transition._compute_deterministic_next_state()  # pylint: disable=protected-access
+    )
+
+    rng = np.random.default_rng(42)
+    offsets = rng.normal(size=(1000, 4)) * np.array([0.005, 0.005, 0.002, 0.005])
+    grid = det[np.newaxis, :] + offsets
+
+    py_ref = CovarianceParameterizedMultivariateNormal(env.state_transition_cov)
+    _native_parity.assert_logpdf_bitwise(
+        model=transition,
+        reference_dist=py_ref,
+        mean=det,
+        points=grid,
+        atol=1e-6,
+    )
+
+
+def test_observation_probability_matches_python_reference_on_grid(env):
+    """C++ observation probability() matches the Python reference on a grid.
+
+    Purpose: Same as the transition case, for the observation model.
+
+    Given: A 1000-point grid of candidate observations around the true state.
+    When: probability(grid) is called on both C++ and Python reference.
+    Then: Outputs agree to absolute tolerance 1e-10.
+
+    Test type: unit
+    """
+    next_state = np.array([0.02, 0.05, -0.01, 0.1])
+    observation_model = env.observation_model(next_state=next_state, action=1)
+
+    rng = np.random.default_rng(4242)
+    offsets = rng.normal(size=(1000, 4)) * np.array([0.1, 0.1, 0.05, 0.1])
+    grid = next_state[np.newaxis, :] + offsets
+
+    py_ref = CovarianceParameterizedMultivariateNormal(env.noise_cov)
+    _native_parity.assert_logpdf_bitwise(
+        model=observation_model,
+        reference_dist=py_ref,
+        mean=next_state,
+        points=grid,
+        atol=1e-10,
+    )
+
+
+def test_transition_probability_accepts_list_and_ndarray_inputs(transition):
+    """probability() accepts both a list of 1-D arrays and a 2-D ndarray.
+
+    Purpose: Validates the Python-side input flexibility of the C++ binding
+    (matches the pre-port duck-typed contract).
+
+    Given: A list of three 1-D numpy arrays and the equivalent stacked 2-D
+        array.
+    When: probability() is called with each form.
+    Then: Outputs are identical.
+
+    Test type: unit
+    """
+    list_values = [
+        np.array([0.0, 0.0, 0.05, 0.0]),
+        np.array([0.001, -0.002, 0.048, 0.003]),
+        np.array([-0.001, 0.003, 0.052, -0.002]),
+    ]
+    array_values = np.stack(list_values, axis=0)
+
+    from_list = transition.probability(list_values)
+    from_array = transition.probability(array_values)
+
+    np.testing.assert_array_equal(from_list, from_array)
+
+
+# ---------------------------------------------------------------------------
+# Determinism under explicit seeding
+# ---------------------------------------------------------------------------
+
+
+def test_sample_is_deterministic_under_set_seed(env):
+    """Repeated set_seed + sample yields identical samples.
+
+    Purpose: Validates the determinism path used by reproducible tests.
+
+    Given: Two CartPoleStateTransition instances sampled under the same seed.
+    When: _native.set_seed(seed) is called before each, followed by sample(50).
+    Then: The two sample sequences are elementwise identical.
+
+    Test type: unit
+    """
+    state = np.array([0.01, 0.005, 0.03, -0.01])
+    transition = env.state_transition_model(state=state, action=1)
+    _native_parity.assert_determinism_under_seed(
+        model=transition,
+        seed_fn=_native.set_seed,
+        n_samples=50,
+        seed=2024,
+    )
+
+
+def test_sample_returns_list_of_1d_ndarrays(transition):
+    """sample() preserves the pre-port List[np.ndarray] contract.
+
+    Purpose: Guards against accidental API drift (many call sites index
+    the returned list with ``[0]`` or iterate it).
+
+    Given: A CartPoleStateTransition.
+    When: sample(3) is called.
+    Then: The return value is a list of exactly three 1-D ndarrays of
+        length 4.
+
+    Test type: unit
+    """
+    _native_parity.assert_sample_shape_contract(
+        model=transition,
+        seed_fn=_native.set_seed,
+        n_samples=3,
+        expected_dim=4,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch entry points
+# ---------------------------------------------------------------------------
+
+
+def test_transition_batch_sample_matches_per_particle_sample(env):
+    """batch_sample(P) is bit-identical to sample(1) per row under fixed seed.
+
+    Purpose: Validates that the TransitionModelCpp<Dim>.batch_sample produces
+    the same noise sequence as N per-particle sample(1) calls when both
+    consume the same module-level C++ RNG seeded once.
+
+    Given: 64 particles spanning a range of CartPole states.
+    When: batch_sample runs under seed=777; then for each particle a fresh
+        CartPoleStateTransition is built and sample(1) is called in the same
+        order under the same seed.
+    Then: The two (64, 4) arrays are array_equal.
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(123)
+    particles = np.column_stack(
+        [
+            rng.uniform(-0.05, 0.05, 64),
+            rng.uniform(-0.05, 0.05, 64),
+            rng.uniform(-0.1, 0.1, 64),
+            rng.uniform(-0.05, 0.05, 64),
+        ]
+    )
+    action = 1
+
+    _native.set_seed(777)
+    transition = env.state_transition_model(state=particles[0], action=action)
+    batch_result = transition.batch_sample(particles)
+
+    _native.set_seed(777)
+    per_particle_rows = []
+    for row in particles:
+        model = env.state_transition_model(state=row, action=action)
+        per_particle_rows.append(model.sample(1)[0])
+    per_particle_result = np.stack(per_particle_rows, axis=0)
+
+    np.testing.assert_array_equal(batch_result, per_particle_result)
+
+
+def test_observation_batch_log_likelihood_matches_per_particle(env):
+    """batch_log_likelihood matches np.log(probability([observation])) per row.
+
+    Purpose: Validates the observation batch path against the per-particle
+    reference (C++ probability() uses the same log_pdf internally, then
+    exp's it; we take log to invert).
+
+    Given: 64 random next-state particles and a single observation.
+    When: batch_log_likelihood(next_particles, observation) is called, and
+        for each particle a fresh CartPoleObservation is built and
+        probability([observation]) is computed.
+    Then: The batch log-likelihoods equal np.log of the per-particle
+        probabilities within atol=1e-12.
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(456)
+    next_particles = np.column_stack(
+        [
+            rng.uniform(-0.1, 0.1, 64),
+            rng.uniform(-0.1, 0.1, 64),
+            rng.uniform(-0.15, 0.15, 64),
+            rng.uniform(-0.1, 0.1, 64),
+        ]
+    )
+    observation = np.array([0.02, 0.0, -0.01, 0.0])
+    action = 0
+
+    obs_model = env.observation_model(next_state=next_particles[0], action=action)
+    batch_log_ll = obs_model.batch_log_likelihood(next_particles, observation)
+
+    per_particle_log_ll = np.empty(len(next_particles))
+    for i, next_state in enumerate(next_particles):
+        model = env.observation_model(next_state=next_state, action=action)
+        per_particle_log_ll[i] = np.log(model.probability([observation])[0])
+
+    np.testing.assert_allclose(batch_log_ll, per_particle_log_ll, atol=1e-12, rtol=0.0)
+
+
+def test_transition_batch_sample_shape_contract(env):
+    """batch_sample returns a 2-D ndarray matching the input shape.
+
+    Purpose: Guards the shape contract used by belief-level callers.
+
+    Given: A CartPoleStateTransition and a (37, 4) particles ndarray.
+    When: batch_sample is called.
+    Then: The result is an ndarray of shape (37, 4) and dtype float64.
+
+    Test type: unit
+    """
+    state = np.array([0.0, 0.0, 0.05, 0.0])
+    transition = env.state_transition_model(state=state, action=1)
+    particles = np.zeros((37, 4), dtype=np.float64)
+    _native.set_seed(0)
+    result = transition.batch_sample(particles)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (37, 4)
+    assert result.dtype == np.float64
+
+
+def test_observation_batch_log_likelihood_shape_contract(env):
+    """batch_log_likelihood returns a 1-D ndarray of length N.
+
+    Purpose: Guards the shape contract used by belief-level callers.
+
+    Given: A CartPoleObservation, 37 next-particles, and one observation.
+    When: batch_log_likelihood is called.
+    Then: The result is an ndarray of shape (37,) and dtype float64.
+
+    Test type: unit
+    """
+    next_state = np.array([0.0, 0.0, 0.05, 0.0])
+    obs_model = env.observation_model(next_state=next_state, action=1)
+    next_particles = np.zeros((37, 4), dtype=np.float64)
+    observation = np.array([0.0, 0.0, 0.05, 0.0])
+    result = obs_model.batch_log_likelihood(next_particles, observation)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (37,)
+    assert result.dtype == np.float64

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
@@ -12,7 +12,7 @@ from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
 from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
     VectorizedWeightedParticleBelief,
 )
-from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP
+from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP, _native
 from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp_beliefs import (
     MountainCarVectorizedUpdater,
 )
@@ -125,20 +125,21 @@ class TestBatchTransition:
         """Test that batch_transition is deterministic under a fixed seed.
 
         Purpose: Validates that the stochastic batch_transition produces
-                 identical output when the global numpy RNG is seeded
+                 identical output when the module-level C++ RNG (now the
+                 source of randomness for the updater) is seeded
                  identically before each call.
 
-        Given: A set of particles and an action, with np.random.seed fixed
-               before each call.
+        Given: A set of particles and an action, with ``_native.set_seed``
+               fixed before each call.
         When: batch_transition is called twice.
         Then: Both results are identical.
 
         Test type: unit
         """
         particles = np.array([[-0.5, 0.0], [-0.6, 0.01]])
-        np.random.seed(7)
+        _native.set_seed(7)
         result_a = updater.batch_transition(particles, action=1)
-        np.random.seed(7)
+        _native.set_seed(7)
         result_b = updater.batch_transition(particles, action=1)
         np.testing.assert_array_equal(result_a, result_b)
 
@@ -305,6 +306,7 @@ class TestConfigId:
         Test type: unit
         """
         u1 = MountainCarVectorizedUpdater.from_environment(env)
+        # pylint: disable=protected-access
         u2 = MountainCarVectorizedUpdater(
             state_transition_dist=env._state_transition_dist,
             obs_dist=env._obs_dist,
@@ -314,6 +316,7 @@ class TestConfigId:
             min_position=env.min_position,
             max_position=env.max_position,
         )
+        # pylint: enable=protected-access
         assert u1.config_id != u2.config_id
 
 

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
@@ -325,27 +325,18 @@ class TestConfigId:
 # ---------------------------------------------------------------------------
 
 
-_CPP_RNG_SKIP_REASON = (
-    "Bit-exact equivalence between the vectorized numpy path and the per-particle "
-    "path is no longer achievable: MountainCarTransition.sample() now uses the "
-    "_native C++ std::mt19937_64 RNG while MountainCarVectorizedUpdater.batch_transition "
-    "still consumes numpy's RNG. A follow-up can route batch_transition through "
-    "_native to restore cross-path bit-exactness; distributional correctness of "
-    "each path is still covered by the other tests in this module."
-)
-
-
 class TestBeliefEquivalenceWithBaseline:
-    @pytest.mark.skip(reason=_CPP_RNG_SKIP_REASON)
     def test_update_particles_match(self, env, updater):
         """Test vectorized belief update produces identical next particles.
 
         Purpose: Validates that VectorizedWeightedParticleBelief.update and
             WeightedParticleBelief.update agree on next-state particles once
-            the vectorized updater mirrors the standard transition noise.
+            both paths route through the shared pomdp_native batch methods
+            (and therefore share the module-level C++ RNG).
 
         Given: 60 aligned particles.
-        When: Both beliefs are updated with action=1 under a shared seed.
+        When: Both beliefs are updated with action=1 under a shared seed
+            applied via ``_native.set_seed``.
         Then: Next particles agree within floating-point tolerance.
 
         Test type: integration
@@ -353,10 +344,15 @@ class TestBeliefEquivalenceWithBaseline:
         base, vec = _make_aligned_beliefs(updater)
         obs = np.array([-0.5, 0.0])
         assert_update_particles_match(
-            base=base, vec=vec, action=1, observation=obs, pomdp=env, seed=999
+            base=base,
+            vec=vec,
+            action=1,
+            observation=obs,
+            pomdp=env,
+            seed=999,
+            seed_fn=_native.set_seed,
         )
 
-    @pytest.mark.skip(reason=_CPP_RNG_SKIP_REASON)
     def test_update_weights_match(self, env, updater):
         """Test vectorized and baseline beliefs produce identical normalized weights.
 
@@ -378,15 +374,17 @@ class TestBeliefEquivalenceWithBaseline:
             pomdp=env,
             atol=1e-6,
             seed=999,
+            seed_fn=_native.set_seed,
         )
 
-    @pytest.mark.skip(reason=_CPP_RNG_SKIP_REASON)
     def test_sample_distributions_match_post_update(self, env, updater):
         """Test sample() on both beliefs draws unbiased from normalized_weights.
 
         Purpose: Validates sample() unbiasedness and cross-belief agreement.
 
-        Given: 60 aligned particles; one update step seeded identically.
+        Given: 60 aligned particles; one update step seeded identically
+            via ``_native.set_seed`` (for the C++ transition batch) and
+            ``np.random.seed`` (for particle resampling -- still numpy).
         When: 20,000 samples are drawn from each belief.
         Then: Empirical histograms agree and each matches its normalized_weights.
 
@@ -394,9 +392,9 @@ class TestBeliefEquivalenceWithBaseline:
         """
         base, vec = _make_aligned_beliefs(updater)
         obs = np.array([-0.5, 0.0])
-        np.random.seed(999)
+        _native.set_seed(999)
         vec = vec.update(action=1, observation=obs, pomdp=env)
-        np.random.seed(999)
+        _native.set_seed(999)
         base = base.update(action=1, observation=obs, pomdp=env)
 
         assert_sample_distributions_match(
@@ -415,13 +413,12 @@ class TestBeliefEquivalenceWithBaseline:
 
 
 class TestEquivalenceWithPerParticleLoop:
-    @pytest.mark.skip(reason=_CPP_RNG_SKIP_REASON)
     def test_batch_transition_matches_per_particle_loop(self, env, updater):
         """Test vectorized batch_transition matches per-particle state_transition_model.sample.
 
         Purpose: Verifies that batch_transition produces the same stochastic
                  next states as the environment's state_transition_model.sample
-                 when the global RNG is seeded identically on both paths.
+                 when the shared C++ RNG is seeded identically on both paths.
 
         Given: A set of particles, an action, and a fixed random seed.
         When: batch_transition is called, and the same transitions are computed
@@ -447,6 +444,7 @@ class TestEquivalenceWithPerParticleLoop:
             action=1,
             per_particle_transition_fn=per_particle_fn,
             seed=999,
+            seed_fn=_native.set_seed,
         )
 
     def test_batch_observation_log_likelihood_matches_per_particle_loop(self, env, updater):

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_native_equivalence.py
@@ -312,3 +312,123 @@ def test_sample_returns_list_of_1d_ndarrays(transition):
         n_samples=3,
         expected_dim=2,
     )
+
+
+# ---------------------------------------------------------------------------
+# Batch entry points
+# ---------------------------------------------------------------------------
+
+
+def test_transition_batch_sample_matches_per_particle_sample(env):
+    """batch_sample(P) is bit-identical to sample(1) per row under fixed seed.
+
+    Purpose: Validates that the new TransitionModelCpp<Dim>.batch_sample
+    produces the same noise sequence as N per-particle sample(1) calls when
+    both consume the same module-level C++ RNG seeded once.
+
+    Given: 64 particles spanning the valid MountainCar state range.
+    When: batch_sample runs under seed=777; then for each particle a fresh
+        MountainCarTransition is built and sample(1) is called in the same
+        order under the same seed.
+    Then: The two (64, 2) arrays are array_equal.
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(123)
+    particles = np.column_stack(
+        [
+            rng.uniform(-1.0, 0.5, 64),
+            rng.uniform(-0.05, 0.05, 64),
+        ]
+    )
+    action = 1
+
+    _native.set_seed(777)
+    transition = env.state_transition_model(state=(-0.5, 0.0), action=action)
+    batch_result = transition.batch_sample(particles)
+
+    _native.set_seed(777)
+    per_particle_rows = []
+    for row in particles:
+        model = env.state_transition_model(state=tuple(row.tolist()), action=action)
+        per_particle_rows.append(model.sample(1)[0])
+    per_particle_result = np.stack(per_particle_rows, axis=0)
+
+    np.testing.assert_array_equal(batch_result, per_particle_result)
+
+
+def test_observation_batch_log_likelihood_matches_per_particle(env):
+    """batch_log_likelihood matches np.log(probability([observation])) per row.
+
+    Purpose: Validates the observation batch path against the per-particle
+    reference (C++ probability() uses the same log_pdf internally, then
+    exp's it; we take log to invert).
+
+    Given: 64 random next-state particles and a single observation.
+    When: batch_log_likelihood(next_particles, observation) is called, and
+        for each particle a fresh MountainCarObservation is built and
+        probability([observation]) is computed.
+    Then: The batch log-likelihoods equal np.log of the per-particle
+        probabilities within atol=1e-12.
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(456)
+    next_particles = np.column_stack(
+        [
+            rng.uniform(-1.0, 0.5, 64),
+            rng.uniform(-0.05, 0.05, 64),
+        ]
+    )
+    observation = np.array([-0.3, 0.015])
+    action = 0
+
+    obs_model = env.observation_model(next_state=(-0.5, 0.0), action=action)
+    batch_log_ll = obs_model.batch_log_likelihood(next_particles, observation)
+
+    per_particle_log_ll = np.empty(len(next_particles))
+    for i, next_state in enumerate(next_particles):
+        model = env.observation_model(next_state=tuple(next_state.tolist()), action=action)
+        per_particle_log_ll[i] = np.log(model.probability([observation])[0])
+
+    np.testing.assert_allclose(batch_log_ll, per_particle_log_ll, atol=1e-12, rtol=0.0)
+
+
+def test_transition_batch_sample_shape_contract(env):
+    """batch_sample returns a 2-D ndarray matching the input shape.
+
+    Purpose: Guards the shape contract used by belief-level callers.
+
+    Given: A MountainCarTransition and a (37, 2) particles ndarray.
+    When: batch_sample is called.
+    Then: The result is an ndarray of shape (37, 2) and dtype float64.
+
+    Test type: unit
+    """
+    transition = env.state_transition_model(state=(-0.5, 0.0), action=1)
+    particles = np.zeros((37, 2), dtype=np.float64)
+    _native.set_seed(0)
+    result = transition.batch_sample(particles)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (37, 2)
+    assert result.dtype == np.float64
+
+
+def test_observation_batch_log_likelihood_shape_contract(env):
+    """batch_log_likelihood returns a 1-D ndarray of length N.
+
+    Purpose: Guards the shape contract used by belief-level callers.
+
+    Given: A MountainCarObservation, 37 next-particles, and one observation.
+    When: batch_log_likelihood is called.
+    Then: The result is an ndarray of shape (37,) and dtype float64.
+
+    Test type: unit
+    """
+    obs_model = env.observation_model(next_state=(-0.5, 0.0), action=1)
+    next_particles = np.zeros((37, 2), dtype=np.float64)
+    observation = np.array([-0.5, 0.0])
+    result = obs_model.batch_log_likelihood(next_particles, observation)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (37,)
+    assert result.dtype == np.float64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ persistent = true
 extension-pkg-allow-list = [
     "POMDPPlanners.core._native",
     "POMDPPlanners.environments.mountain_car_pomdp._native",
+    "POMDPPlanners.environments.cartpole_pomdp._native",
 ]
 
 [tool.pylint.messages_control]

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,10 @@ ext_modules = [
         name="POMDPPlanners.environments.mountain_car_pomdp._native",
         sources=["POMDPPlanners/environments/mountain_car_pomdp/_cpp/mountain_car.cpp"],
     ),
+    _make_ext(
+        name="POMDPPlanners.environments.cartpole_pomdp._native",
+        sources=["POMDPPlanners/environments/cartpole_pomdp/_cpp/cartpole.cpp"],
+    ),
 ]
 
 setup(ext_modules=ext_modules, cmdclass={"build_ext": build_ext})


### PR DESCRIPTION
## Summary

Ports the `CartPolePOMDP` transition + observation models onto the shared `pomdp_native::TransitionModelCpp<4>` / `ObservationModelCpp<4>` bases (PR #81 / #82). CartPole fits the Gaussian infrastructure cleanly: 4D continuous state (cart pos/vel, pole angle/ang-vel), Gaussian process + observation noise, no state-dependent covariance.

- New `POMDPPlanners/environments/cartpole_pomdp/_cpp/cartpole.cpp` pybind11 extension. State dimension = 4. Physics (kinematics integrator with gravity, pole inertia, force from action) lives in `compute_mean_from_state`. No `post_sample_transform` needed.
- Python shim: `cartpole_pomdp.py`'s model classes inherit `_native.<Foo>Cpp` and register against `StateTransitionModel` / `ObservationModel` ABCs.
- `CartPoleVectorizedUpdater.batch_transition` / `batch_observation_log_likelihood` delegate to `_native.batch_sample` / `batch_log_likelihood`.
- `_native.pyi`, `setup.py`, `pyproject.toml` wired up.
- Native parity tests at `tests/test_environments/test_cartpole_pomdp_native_equivalence.py` (15 cases: ABC, moments, PDF, determinism, batch parity, shape contracts).
- 4 benchmark cases (`cp-generic-python`, `cp-vectorized-numpy`, `cp-generic-cpp`, `cp-vectorized-cpp`) landed together in `test_benchmark_particle_belief_update.py` — all 4 run in the same commit so the comparison is apples-to-apples under one hardware snapshot.
- CartPole belief tests updated to route seeding through `_native.set_seed` since sampling now runs on the C++ RNG.

## Benchmark (N=100 particles, median)

| Case | Backend | Median | Speedup vs Python baseline |
|---|---|---:|---:|
| `cp-generic-python` | Python per-particle (pre-port) | 2026 µs | 1× baseline |
| `cp-generic-cpp` | C++ auto-dispatch (post-port) | 45.7 µs | **44.3× faster** |
| `cp-vectorized-numpy` | numpy updater (pre-port) | 107.2 µs | 18.9× faster |
| `cp-vectorized-cpp` | C++ updater (post-port) | 27.8 µs | 72.9× faster |

Three comparisons:

1. **cp-generic-cpp vs cp-vectorized-cpp** — 1.64× overhead from auto-dispatch's list↔ndarray conversion.
2. **cp-generic-python vs cp-vectorized-numpy** — 18.9× baseline vectorization gain.
3. **cp-generic-cpp vs cp-generic-python** — **44.3× headline** speedup from the native port.

## Verification

- `pip install -e . --no-deps` — builds cleanly.
- `pyright`: 0 errors / 0 warnings on all touched Python / test files.
- `pylint`: 10.00 / 10 on all touched files.
- `pytest POMDPPlanners/tests/test_environments/test_cartpole_pomdp_native_equivalence.py`: 15 / 15 pass.
- `pytest POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py`: 14 / 14 pass.
- `pytest POMDPPlanners/tests/`: **2909 passed, 10 pre-existing skips, 0 failures**.

## Commits

- `848f74b` Port CartPole native extension onto pomdp_native shared core
- `a26e75a` Route CartPole Python models and updater through native core
- `d79d82e` Add CartPole native equivalence tests and benchmark cases

## Test plan

- [ ] CI green on `refactor/cartpole-native-batch`
- [ ] Reviewer spot-checks the cart-pole kinematics integrator in C++ against the numpy updater