### PR TITLE
fix(docker): install g++ for C++ extension build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,13 @@
 # Use a standard Python base image (for example, python:3.10-slim) as the base.
 FROM python:3.10-slim AS base
 
+RUN apt-get update && apt-get install -y --no-install-recommends libatomic1 g++ \
+    && rm -rf /var/lib/apt/lists/*
+
 # Test stage
 FROM base AS test
 
 WORKDIR /app
-
-RUN apt-get update && apt-get install -y libatomic1 && rm -rf /var/lib/apt/lists/*
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- `docker/Dockerfile` fails at `pip install -e .` because `python:3.10-slim` has no C++ compiler, and the `POMDPPlanners.core._native` extension needs one to build.
- Move the apt-get step into the shared `base` stage and add `g++` alongside `libatomic1`, so both the `test` and production stages can build the editable install.
- Matches the setup already in `docker/Dockerfile.base` and `docker/Dockerfile.ci`.

## Error this fixes
```
building 'POMDPPlanners.core._native' extension
...
error: command 'g++' failed: No such file or directory
ERROR: Failed building editable for POMDPPlanners
```

## Test plan
- [ ] `docker build -f docker/Dockerfile --target test .` completes successfully
- [ ] `docker build -f docker/Dockerfile .` (production stage) completes successfully
- [ ] Remote CI build step that previously failed at `pip install -e .` now passes