### PR TITLE
Use lazy CDF in WeightedParticleBelief.sample for O(log K) sampling

### DIFF
--- a/POMDPPlanners/core/belief/particle_beliefs.py
+++ b/POMDPPlanners/core/belief/particle_beliefs.py
@@ -178,6 +178,12 @@ class WeightedParticleBelief(Belief):
 
         self.eps = 1e-10
 
+        # Lazy cumulative-weight CDF. Built on first `sample()` call and
+        # cached thereafter; skipped entirely for beliefs that are never
+        # sampled (e.g. intermediate update() instances used only for
+        # weight propagation).
+        self._cdf: Optional[List[float]] = None
+
     def to_dict(self) -> dict:
         """Convert the belief to a dictionary for serialization.
 
@@ -354,10 +360,15 @@ class WeightedParticleBelief(Belief):
 
     def sample(self):
         """Sample a particle from the belief."""
-        idx = np.random.choice(len(self.particles), p=self.normalized_weights)
-        particle = self.particles[idx]
-
-        return particle
+        cdf = self._cdf
+        if cdf is None:
+            cdf = np.cumsum(self.normalized_weights).tolist()
+            self._cdf = cdf
+        target = random.random() * cdf[-1]
+        idx = bisect.bisect_left(cdf, target)
+        if idx >= len(self.particles):
+            idx = len(self.particles) - 1
+        return self.particles[idx]
 
 
 class WeightedParticleBeliefReinvigoration(WeightedParticleBelief, ABC):

--- a/POMDPPlanners/tests/benchmarks/test_benchmark_weighted_particle_belief_sample.py
+++ b/POMDPPlanners/tests/benchmarks/test_benchmark_weighted_particle_belief_sample.py
@@ -1,0 +1,109 @@
+"""Benchmarks for ``WeightedParticleBelief.sample``.
+
+Compares the **lazy-CDF** implementation (``bisect_left`` on a cached
+cumulative-weight list, O(log K) per call after the first) against an
+inlined **Python-reference** that mirrors the pre-optimization path
+(``np.random.choice`` with a probability vector, O(K) per call). The
+reference lives in this test file so it keeps running the baseline code
+path even after the shipped ``sample`` has been replaced.
+
+Cases:
+
+| case                              | impl     | N              | metric |
+|-----------------------------------|----------|----------------|--------|
+| sample-cached-cdf                 | new      | 200/500/1k/2k  | ops/s  |
+| sample-np-choice-ref              | baseline | 200/500/1k/2k  | ops/s  |
+| sample-first-call-cdf             | new      | 200/500/1k/2k  | ops/s  |
+
+``sample-cached-cdf`` benchmarks steady-state sampling on a belief whose
+CDF has already been built (the common case inside MCTS rollouts). The
+``sample-first-call-cdf`` case rebuilds a fresh belief per round to
+capture the one-time CDF construction cost.
+
+Run::
+
+    pytest POMDPPlanners/tests/benchmarks/test_benchmark_weighted_particle_belief_sample.py \\
+        --benchmark-only -v
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any, List, Tuple
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
+
+N_VALUES = [200, 500, 1000, 2000]
+
+
+def _generate_particles(n: int, dim: int = 2, seed: int = 123) -> Tuple[List[Any], np.ndarray]:
+    rng = np.random.default_rng(seed)
+    particles: List[Any] = [rng.standard_normal(dim) for _ in range(n)]
+    log_weights = rng.uniform(-2.0, 2.0, size=n)
+    return particles, log_weights
+
+
+class _PyRefBelief:
+    """Python-reference mirroring the pre-optimization ``sample`` path.
+
+    Inlined so the benchmark keeps exercising the ``np.random.choice``
+    baseline even after the shipped ``WeightedParticleBelief.sample`` has
+    been migrated to the lazy-CDF + ``bisect_left`` implementation.
+    """
+
+    def __init__(self, particles: List[Any], log_weights: np.ndarray) -> None:
+        self.particles = particles
+        weights = np.exp(log_weights - np.max(log_weights))
+        self.normalized_weights = weights / np.sum(weights)
+
+    def sample(self) -> Any:
+        idx = np.random.choice(len(self.particles), p=self.normalized_weights)
+        return self.particles[idx]
+
+
+# ---------------------------------------------------------------------------
+# steady-state sampling (CDF cached)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="sample-cached-cdf")
+@pytest.mark.parametrize("n", N_VALUES)
+def test_benchmark_sample_cached_cdf(benchmark, n: int) -> None:
+    """New sample(): cached-CDF draw on a pre-built belief."""
+    particles, log_weights = _generate_particles(n)
+    belief = WeightedParticleBelief(particles=particles, log_weights=log_weights)
+    belief.sample()  # prime the CDF so the benchmark measures steady state
+    random.seed(42)
+    benchmark(belief.sample)
+
+
+@pytest.mark.benchmark(group="sample-np-choice-ref")
+@pytest.mark.parametrize("n", N_VALUES)
+def test_benchmark_sample_np_choice_ref(benchmark, n: int) -> None:
+    """Baseline sample(): ``np.random.choice`` O(K) draw."""
+    particles, log_weights = _generate_particles(n)
+    belief = _PyRefBelief(particles, log_weights)
+    np.random.seed(42)
+    benchmark(belief.sample)
+
+
+# ---------------------------------------------------------------------------
+# first-call sampling (fresh belief each round, measures CDF build + draw)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="sample-first-call-cdf")
+@pytest.mark.parametrize("n", N_VALUES)
+def test_benchmark_sample_first_call_cdf(benchmark, n: int) -> None:
+    """New sample(): fresh belief per round -- one-time CDF build + draw."""
+    particles, log_weights = _generate_particles(n)
+
+    def _run() -> None:
+        belief = WeightedParticleBelief(particles=particles, log_weights=log_weights)
+        belief.sample()
+
+    random.seed(42)
+    benchmark(_run)


### PR DESCRIPTION
## Summary

- Build the cumulative-weight CDF on first call to `WeightedParticleBelief.sample()` and cache it on the instance; subsequent draws go through `bisect.bisect_left` instead of `np.random.choice(..., p=normalized_weights)` which rebuilt the CDF internally on every call.
- Beliefs that are never sampled (e.g. intermediate `update()` instances used only for weight propagation) pay **zero** extra cost — the CDF is only materialized on the first `sample()`.
- Mirrors the pattern landed in #92 for `WeightedParticleBeliefStateUpdate.sample` and the approach in `DiscreteDistribution.sample`.

## Benchmarks

### Micro-benchmark — `sample()` ops/s on a pre-built belief (CDF cached)

| N    | before (`np.random.choice`) | after (cached CDF) | speedup |
|------|-----------------------------|--------------------|---------|
| 200  | ~110 Kops/s                 | ~3.80 Mops/s       | **~35x** |
| 500  |  ~92 Kops/s                 | ~4.20 Mops/s       | **~46x** |
| 1000 |  ~72 Kops/s                 | ~3.92 Mops/s       | **~55x** |
| 2000 |  ~51 Kops/s                 | ~3.75 Mops/s       | **~73x** |

Speedup grows with `K` because the baseline is O(K) per call while the cached-CDF path is O(log K) + small constant.

### End-to-end — PFT-DPW sims/sec on `ContinuousLightDarkPOMDPDiscreteActions`

1s budget × 20 beliefs × 200 particles, `k_a=k_o=10`, `alpha=0.5`, `depth=20`, `c=1.0`:

| metric | before | after | Δ |
|---|---|---|---|
| median sims/sec | 1,976 | **2,162** | **+9.4%** |
| mean sims/sec   | 1,936 | **2,117** | **+9.4%** |
| min             | 1,612 | 1,759 | +9.1% |
| max             | 2,019 | 2,197 | +8.8% |

Real-world gain is smaller than the micro-benchmark speedup because `sample()` is one of many hot paths inside a PFT-DPW simulation (transition/observation models, belief updates, rollout policy, tree bookkeeping).

## Test plan

- [x] `pyright` — 0 errors, 0 warnings on changed files
- [x] `pylint` — 10.00/10 on changed files
- [x] Micro-benchmark added at `POMDPPlanners/tests/benchmarks/test_benchmark_weighted_particle_belief_sample.py` (parametrized N ∈ {200, 500, 1000, 2000}; includes an inlined `_PyRefBelief` that keeps the `np.random.choice` baseline runnable after this lands)
- [ ] CI green on the new branch