### PR TITLE
Add direct sample_next_state / sample_observation API to all envs

### DIFF
--- a/POMDPPlanners/core/belief/particle_beliefs.py
+++ b/POMDPPlanners/core/belief/particle_beliefs.py
@@ -59,8 +59,8 @@ class UnweightedParticleBelief(Belief):
         for _ in range(self.num_particles):
             # Sample a particle and simulate its transition
             s = random.choice(self.particles)
-            next_s = pomdp.state_transition_model(state=s, action=action).sample()[0]
-            obs = pomdp.observation_model(next_state=next_s, action=action).sample()[0]
+            next_s = pomdp.sample_next_state(state=s, action=action)
+            obs = pomdp.sample_observation(next_state=next_s, action=action)
             if pomdp.is_equal_observation(obs, observation):
                 new_particles.append(next_s)
 
@@ -87,8 +87,8 @@ class UnweightedParticleBelief(Belief):
             s = self._reinvigoration_pertubation(
                 action=action, observation=observation, pomdp=pomdp
             )
-            next_s = pomdp.state_transition_model(state=s, action=action).sample()[0]
-            obs = pomdp.observation_model(next_state=next_s, action=action).sample()[0]
+            next_s = pomdp.sample_next_state(state=s, action=action)
+            obs = pomdp.sample_observation(next_state=next_s, action=action)
             if pomdp.is_equal_observation(obs, observation):
                 return next_s
 
@@ -284,8 +284,7 @@ class WeightedParticleBelief(Belief):
         # Fallback: per-particle Python loop. Byte-identical to pre-Layer-2
         # behaviour for envs without native batch support.
         next_particles = [
-            pomdp.state_transition_model(state=particle, action=action).sample()[0]
-            for particle in self.particles
+            pomdp.sample_next_state(state=particle, action=action) for particle in self.particles
         ]
         probs = np.array(
             [

--- a/POMDPPlanners/core/environment.py
+++ b/POMDPPlanners/core/environment.py
@@ -566,6 +566,40 @@ class Environment(ABC):
             This is particularly important for discrete observation spaces.
         """
 
+    def sample_next_state(self, state: Any, action: Any) -> Any:
+        """Sample a single next state for ``(state, action)``.
+
+        Hot-path entry point used by MCTS planners. The default delegates to
+        ``state_transition_model(state, action).sample()[0]``; subclasses may
+        override to skip the per-call wrapper allocation while preserving the
+        same RNG draw sequence.
+
+        Args:
+            state: Current state.
+            action: Action to execute.
+
+        Returns:
+            A sampled next state.
+        """
+        return self.state_transition_model(state=state, action=action).sample()[0]
+
+    def sample_observation(self, next_state: Any, action: Any) -> Any:
+        """Sample a single observation for ``(next_state, action)``.
+
+        Hot-path entry point used by MCTS planners. The default delegates to
+        ``observation_model(next_state, action).sample()[0]``; subclasses may
+        override to skip the per-call wrapper allocation while preserving the
+        same RNG draw sequence.
+
+        Args:
+            next_state: State after the action was executed.
+            action: Action that was executed.
+
+        Returns:
+            A sampled observation.
+        """
+        return self.observation_model(next_state=next_state, action=action).sample()[0]
+
     def sample_next_step(self, state: Any, action: Any) -> Tuple[Any, Any, float]:
         """Sample a complete state transition step.
 
@@ -582,8 +616,8 @@ class Environment(ABC):
                 - next_observation: Sampled observation
                 - reward: Immediate reward
         """
-        next_state = self.state_transition_model(state=state, action=action).sample()[0]
-        next_observation = self.observation_model(next_state=next_state, action=action).sample()[0]
+        next_state = self.sample_next_state(state=state, action=action)
+        next_observation = self.sample_observation(next_state=next_state, action=action)
         reward = self.reward(state=state, action=action)
 
         return next_state, next_observation, reward

--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
@@ -361,6 +361,37 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
             next_state=next_state, action=action, obs_dist=self._obs_dist
         )
 
+    # ── Hot-path sampling overrides ─────────────────────────────────
+    # The Python wrappers above only forward arguments to the native
+    # C++ constructor and keep a reference to the dist object. Skip
+    # the wrapper subclass and build the native kernel directly so
+    # ``sample()`` produces a byte-identical RNG draw to the legacy
+    # path.
+
+    def sample_next_state(self, state: np.ndarray, action: int) -> NDArray[np.float64]:
+        kernel = _native.CartPoleTransitionCpp(
+            state=state,
+            action=action,
+            force_mag=self.force_mag,
+            total_mass=self.total_mass,
+            polemass_length=self.polemass_length,
+            gravity=self.gravity,
+            length=self.length,
+            kinematics_integrator=self.kinematics_integrator,
+            tau=self.tau,
+            masspole=self.masspole,
+            covariance=self._state_transition_dist.covariance,
+        )
+        return kernel.sample()[0]
+
+    def sample_observation(self, next_state: np.ndarray, action: int) -> NDArray[np.float64]:
+        kernel = _native.CartPoleObservationCpp(
+            next_state=next_state,
+            action=action,
+            covariance=self._obs_dist.covariance,
+        )
+        return kernel.sample()[0]
+
     def reward(self, state: np.ndarray, action: int) -> float:
         terminated = self.is_terminal(state)
 

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -365,6 +365,39 @@ class ContinuousLaserTagPOMDP(Environment):
             opponent_radius=self.opponent_radius,
         )
 
+    # ── Hot-path sampling overrides ─────────────────────────────────
+    # The default base-class implementations build a Python wrapper subclass
+    # per call which only stores a few attributes; the actual RNG draw lives
+    # in the C++ _native kernel. These overrides construct the native kernel
+    # directly to skip the Python wrapper allocation, producing byte-identical
+    # RNG draws (same module-level RNG, same call sequence).
+
+    def sample_next_state(self, state: np.ndarray, action: np.ndarray) -> np.ndarray:
+        kernel = _native.ContinuousLaserTagTransitionCpp(
+            state=state,
+            action=np.asarray(action, dtype=float),
+            robot_covariance=self._robot_transition_dist.covariance,
+            opponent_covariance=self._opponent_transition_dist.covariance,
+            pursuit_speed=self.pursuit_speed,
+            walls=self._walls,
+            grid_size=self._grid_size,
+            robot_radius=self.robot_radius,
+            opponent_radius=self.opponent_radius,
+            tag_radius=self.tag_radius,
+        )
+        return kernel.sample(1)[0]
+
+    def sample_observation(self, next_state: np.ndarray, action: np.ndarray) -> Any:
+        kernel = _native.ContinuousLaserTagObservationCpp(
+            next_state=next_state,
+            action=np.asarray(action, dtype=float),
+            measurement_noise=self.measurement_noise,
+            walls=self._walls,
+            grid_size=self._grid_size,
+            opponent_radius=self.opponent_radius,
+        )
+        return kernel.sample(1)[0]
+
     def reward(self, state: np.ndarray, action: np.ndarray) -> float:
         if bool(state[4]):
             return 0.0
@@ -682,6 +715,12 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
 
     def observation_model(self, next_state: np.ndarray, action: Any) -> ObservationModel:
         return super().observation_model(next_state, self.action_to_vector[action])
+
+    def sample_next_state(self, state: np.ndarray, action: Any) -> np.ndarray:
+        return super().sample_next_state(state, self.action_to_vector[action])
+
+    def sample_observation(self, next_state: np.ndarray, action: Any) -> Any:
+        return super().sample_observation(next_state, self.action_to_vector[action])
 
     def reward(self, state: np.ndarray, action: Any) -> float:
         return super().reward(state, self.action_to_vector[action])

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -43,6 +43,19 @@ from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_visualizer import (  #
 )
 
 
+# 8-directional laser measurements: N, NE, E, SE, S, SW, W, NW (matches LaserTagObservation)
+_LASER_DIRECTIONS: List[Tuple[int, int]] = [
+    (-1, 0),
+    (-1, 1),
+    (0, 1),
+    (1, 1),
+    (1, 0),
+    (1, -1),
+    (0, -1),
+    (-1, -1),
+]
+
+
 class LaserTagPOMDPMetrics(Enum):
     """Metric names for LaserTag POMDP environment."""
 
@@ -752,6 +765,172 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             floor_shape=self.floor_shape,
             walls=self.walls,
         )
+
+    # ── Hot-path sampling overrides ─────────────────────────────────
+    # Inline the body of LaserTagStateTransition.sample()/LaserTagObservation.sample()
+    # for n_samples=1 to skip the per-call wrapper allocation. Preserves the
+    # exact sequence of np.random.* calls so seeded behavior is identical.
+
+    def _is_valid_position_inline(self, pos: Tuple[int, int]) -> bool:
+        row, col = pos
+        return (
+            0 <= row < self.floor_shape[0]
+            and 0 <= col < self.floor_shape[1]
+            and pos not in self.walls
+        )
+
+    def sample_next_state(self, state: np.ndarray, action: int) -> np.ndarray:
+        # _get_actual_action: matches LaserTagStateTransition._get_actual_action
+        if action == 4:
+            actual_action = action
+        else:
+            if np.random.random() < self.transition_error_prob:
+                available_actions = [a for a in [0, 1, 2, 3] if a != action]
+                actual_action = int(np.random.choice(available_actions))
+            else:
+                actual_action = action
+
+        # _get_robot_next_position(actual_action)
+        robot_current = (int(state[0]), int(state[1]))
+        if actual_action == 4:
+            robot_next = robot_current
+        else:
+            dr, dc = self._action_directions[actual_action]
+            cand = (robot_current[0] + dr, robot_current[1] + dc)
+            robot_next = cand if self._is_valid_position_inline(cand) else robot_current
+
+        opponent_current = (int(state[2]), int(state[3]))
+
+        # Tag at same cell → terminal
+        if actual_action == 4 and robot_current == opponent_current:
+            return np.array(
+                [
+                    float(robot_next[0]),
+                    float(robot_next[1]),
+                    float(opponent_current[0]),
+                    float(opponent_current[1]),
+                    1.0,
+                ]
+            )
+
+        # Regular transition: build opponent move distribution then draw
+        opp_moves = self._opponent_move_probabilities_inline(state, robot_next)
+        positions, probabilities = zip(*opp_moves)
+        opp_indices = np.random.choice(len(positions), size=1, p=probabilities)
+        opp_next_pos = positions[opp_indices[0]]
+        return np.array(
+            [
+                float(robot_next[0]),
+                float(robot_next[1]),
+                float(opp_next_pos[0]),
+                float(opp_next_pos[1]),
+                0.0,
+            ]
+        )
+
+    def _opponent_move_probabilities_inline(
+        self, state: np.ndarray, robot_pos: Tuple[int, int]
+    ) -> List[Tuple[Tuple[int, int], float]]:
+        # Mirror of LaserTagStateTransition._get_opponent_move_probabilities,
+        # but operating on a state ndarray rather than self.state.
+        current_opp = (int(state[2]), int(state[3]))
+        robot_row, robot_col = robot_pos
+        opp_row, opp_col = current_opp
+
+        x_moves = self._directional_moves_inline(opp_col, robot_col, opp_row, True)
+        y_moves = self._directional_moves_inline(opp_row, robot_row, opp_col, False)
+
+        move_probs = x_moves + y_moves + [(current_opp, 0.2)]
+        actual_total = sum(prob for _, prob in move_probs if prob > 0)
+        if actual_total < 1.0:
+            stay_index = len(move_probs) - 1
+            current_pos, current_stay_prob = move_probs[stay_index]
+            move_probs[stay_index] = (current_pos, current_stay_prob + (1.0 - actual_total))
+        return [(pos, prob) for pos, prob in move_probs if prob > 0]
+
+    def _directional_moves_inline(
+        self, opponent_coord: int, robot_coord: int, fixed_coord: int, is_horizontal: bool
+    ) -> List[Tuple[Tuple[int, int], float]]:
+        if robot_coord > opponent_coord:
+            toward_pos = (
+                (fixed_coord, opponent_coord + 1)
+                if is_horizontal
+                else (opponent_coord + 1, fixed_coord)
+            )
+            away_pos = (
+                (fixed_coord, opponent_coord - 1)
+                if is_horizontal
+                else (opponent_coord - 1, fixed_coord)
+            )
+            toward_prob, away_prob = 0.4, 0.0
+        elif robot_coord < opponent_coord:
+            toward_pos = (
+                (fixed_coord, opponent_coord - 1)
+                if is_horizontal
+                else (opponent_coord - 1, fixed_coord)
+            )
+            away_pos = (
+                (fixed_coord, opponent_coord + 1)
+                if is_horizontal
+                else (opponent_coord + 1, fixed_coord)
+            )
+            toward_prob, away_prob = 0.4, 0.0
+        else:
+            toward_pos = (
+                (fixed_coord, opponent_coord + 1)
+                if is_horizontal
+                else (opponent_coord + 1, fixed_coord)
+            )
+            away_pos = (
+                (fixed_coord, opponent_coord - 1)
+                if is_horizontal
+                else (opponent_coord - 1, fixed_coord)
+            )
+            toward_prob, away_prob = 0.2, 0.2
+
+        moves: List[Tuple[Tuple[int, int], float]] = []
+        if self._is_valid_position_inline(toward_pos):
+            moves.append((toward_pos, toward_prob))
+        if self._is_valid_position_inline(away_pos):
+            moves.append((away_pos, away_prob))
+        return moves
+
+    def sample_observation(self, next_state: np.ndarray, action: int) -> Tuple[float, ...]:
+        if bool(next_state[4]):
+            return (-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0)
+
+        robot_pos = (int(next_state[0]), int(next_state[1]))
+        opp_pos = (int(next_state[2]), int(next_state[3]))
+        # Compute true 8-direction laser measurements (no RNG)
+        true_measurements = [
+            self._laser_distance_inline(robot_pos, direction, opp_pos)
+            for direction in _LASER_DIRECTIONS
+        ]
+        # Add Gaussian noise to each measurement (8 np.random.normal draws, in order)
+        noisy: List[float] = []
+        for true_measure in true_measurements:
+            noise = np.random.normal(0, self.measurement_noise)
+            noisy.append(max(0.0, true_measure + noise))
+        return tuple(noisy)
+
+    def _laser_distance_inline(
+        self,
+        robot_pos: Tuple[int, int],
+        direction: Tuple[int, int],
+        opp_pos: Tuple[int, int],
+    ) -> float:
+        row, col = robot_pos
+        dr, dc = direction
+        distance = 0.0
+        while True:
+            row += dr
+            col += dc
+            distance += 1.0
+            if row < 0 or row >= self.floor_shape[0] or col < 0 or col >= self.floor_shape[1]:
+                break
+            if (row, col) in self.walls or (row, col) == opp_pos:
+                break
+        return distance - 1.0
 
     def _is_in_dangerous_area(self, position: Tuple[int, int]) -> bool:
         """Check if a position is within any dangerous area.

--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
@@ -417,6 +417,39 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
             )
         raise ValueError(f"Unknown observation model type: {self.observation_model_type}")
 
+    # ── Hot-path sampling overrides ─────────────────────────────────
+    # The default base-class implementations build a Python-wrapper
+    # subclass per call (np.asarray(...).ravel() x2, side-attribute
+    # storage). The actual RNG draw lives entirely inside the C++
+    # _native.ContinuousLightDark{Transition,Observation}Cpp.sample()
+    # method. These overrides skip the Python subclass, construct the
+    # native kernel directly, and produce byte-identical RNG draws.
+
+    def sample_next_state(self, state: np.ndarray, action: np.ndarray) -> np.ndarray:
+        kernel = _native.ContinuousLightDarkTransitionCpp(
+            state=state,
+            action=action,
+            covariance=self._state_transition_dist.covariance,
+        )
+        return kernel.sample()[0]
+
+    def sample_observation(self, next_state: np.ndarray, action: np.ndarray) -> Any:
+        if self.observation_model_type == ObservationModelType.NORMAL_NOISE:
+            kernel = _native.ContinuousLightDarkObservationCpp(
+                next_state=next_state,
+                action=action,
+                covariance_near=self._obs_dist_near_beacon.covariance,
+                covariance_far=self._obs_dist_far_from_beacon.covariance,
+                beacons=self.beacons,
+                beacon_radius=float(self.beacon_radius),
+                grid_size=float(self.grid_size),
+            )
+            return kernel.sample()[0]
+        # NoObsInDark and DistanceBased models have Python-side sampling
+        # logic in their wrappers; fall back to the default base-class
+        # path which goes through observation_model(...).sample()[0].
+        return super().sample_observation(next_state=next_state, action=action)
+
     def reward(self, state: np.ndarray, action: np.ndarray) -> float:
         return self.reward_model.compute_reward(state, action)
 
@@ -648,11 +681,13 @@ class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, Discrete
         )
 
         self.actions = ["up", "down", "right", "left"]
+        # Cache action vectors as contiguous float64 ndarrays so the hot
+        # path can skip np.asarray(...).ravel() conversions.
         self.action_to_vector = {
-            "up": np.array([0, 1]),
-            "down": np.array([0, -1]),
-            "right": np.array([1, 0]),
-            "left": np.array([-1, 0]),
+            "up": np.ascontiguousarray([0.0, 1.0], dtype=np.float64),
+            "down": np.ascontiguousarray([0.0, -1.0], dtype=np.float64),
+            "right": np.ascontiguousarray([1.0, 0.0], dtype=np.float64),
+            "left": np.ascontiguousarray([-1.0, 0.0], dtype=np.float64),
         }
 
     def get_actions(self) -> List[Any]:
@@ -672,6 +707,12 @@ class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, Discrete
 
     def reward_batch(self, states: Union[np.ndarray, Sequence[Any]], action: Any) -> np.ndarray:
         return super().reward_batch(np.asarray(states), self.action_to_vector[action])
+
+    def sample_next_state(self, state: np.ndarray, action: Any) -> np.ndarray:
+        return super().sample_next_state(state, self.action_to_vector[action])
+
+    def sample_observation(self, next_state: np.ndarray, action: Any) -> Any:
+        return super().sample_observation(next_state, self.action_to_vector[action])
 
     def __eq__(self, other):
         if not isinstance(other, ContinuousLightDarkPOMDPDiscreteActions):

--- a/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
@@ -182,6 +182,9 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
         # Precompute transition cumulative sums per action for bisect sampling
         self._transition_probs = {}
         self._transition_cum: dict[str, list[float]] = {}
+        # Wrapper-equivalent cumulative-probability arrays for np.searchsorted
+        # (matches DiscreteDistribution(values, probs)._cumprobs = np.cumsum(probs))
+        self._transition_cumprobs_np: dict[str, np.ndarray] = {}
         for i, act in enumerate(self.actions):
             probs = np.ones(n_actions) * (self.transition_error_prob / (n_actions - 1))
             probs[i] = 1 - self.transition_error_prob
@@ -193,6 +196,7 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
                 running += float(p)
                 cum.append(running)
             self._transition_cum[act] = cum
+            self._transition_cumprobs_np[act] = np.cumsum(probs)
 
         # Precompute action vectors as a list for index-based access
         self._action_vectors = [self.action_to_vector[a] for a in self.actions]
@@ -213,6 +217,9 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
 
         self._obs_cum_near = list(np.cumsum(obs_probs_near))
         self._obs_cum_far = list(np.cumsum(obs_probs_far))
+        # Wrapper-equivalent np.cumsum arrays for np.searchsorted RNG path
+        self._obs_cumprobs_near_np = np.cumsum(obs_probs_near)
+        self._obs_cumprobs_far_np = np.cumsum(obs_probs_far)
 
         # Precompute reward helpers: obstacle positions as set of tuples for O(1) lookup
         self._obstacle_tuples = {
@@ -276,6 +283,45 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
             reward += self.obstacle_reward
 
         return reward
+
+    def sample_next_state(self, state: np.ndarray, action: Any) -> np.ndarray:
+        # Inlined wrapper-equivalent of
+        # state_transition_model(state, action).sample()[0].
+        # Wrapper builds DiscreteDistribution(values, probs) with
+        # _cumprobs = np.cumsum(probs); .sample() does
+        # idx = int(np.searchsorted(_cumprobs, np.random.rand())) clamped
+        # to len(values)-1. Same RNG draw is preserved here.
+        cumprobs = self._transition_cumprobs_np[action]
+        idx = int(np.searchsorted(cumprobs, np.random.rand()))
+        if idx >= self._n_actions:
+            idx = self._n_actions - 1
+        return state + self._action_vectors[idx]
+
+    def sample_observation(self, next_state: np.ndarray, action: Any) -> Any:
+        # Only the NORMAL observation model is inlined — it is the only
+        # path with no early-exit "None" branch and matches the wrapper's
+        # RNG sequence exactly. Other model types fall back to the base
+        # class default (observation_model(...).sample()[0]).
+        if self.observation_model_type != ObservationModelType.NORMAL:
+            return super().sample_observation(next_state=next_state, action=action)
+
+        # Wrapper-equivalent near-beacon check (BaseDiscreteLightDarkObservationModel._near_beacon):
+        # distances = np.linalg.norm(beacons - next_state[:, None], axis=0)
+        # near_beacon = float(np.min(distances)) < beacon_radius.
+        distances = np.linalg.norm(self.beacons - next_state[:, np.newaxis], axis=0)
+        near_beacon = float(np.min(distances)) < self.beacon_radius
+
+        cumprobs = self._obs_cumprobs_near_np if near_beacon else self._obs_cumprobs_far_np
+        # Wrapper builds values = [next_state + dir for dir in dirs] + [next_state],
+        # then DiscreteDistribution.sample() draws np.random.rand() and
+        # np.searchsorted; same draw replicated here.
+        idx = int(np.searchsorted(cumprobs, np.random.rand()))
+        n_obs = self._n_obs_values
+        if idx >= n_obs:
+            idx = n_obs - 1
+        if idx < self._n_actions:
+            return next_state + self._action_vectors[idx]
+        return next_state
 
     def state_transition_model(self, state: np.ndarray, action: Any) -> StateTransitionModel:
         action_index = self.actions.index(action)

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
@@ -314,6 +314,36 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
             next_state=next_state, action=action, obs_dist=self._obs_dist
         )
 
+    # ── Hot-path sampling overrides ─────────────────────────────────
+    # The Python wrappers above only forward arguments to the native
+    # C++ constructor and keep a reference to the dist object. Skip
+    # the wrapper subclass and build the native kernel directly so
+    # ``sample()`` produces a byte-identical RNG draw to the legacy
+    # path.
+
+    def sample_next_state(self, state: Tuple[float, float], action: int) -> NDArray[np.float64]:
+        kernel = _native.MountainCarTransitionCpp(
+            state=state,
+            action=action,
+            power=self.power,
+            gravity=self.gravity,
+            max_speed=self.max_speed,
+            min_position=self.min_position,
+            max_position=self.max_position,
+            covariance=self._state_transition_dist.covariance,
+        )
+        return kernel.sample()[0]
+
+    def sample_observation(
+        self, next_state: Tuple[float, float], action: int
+    ) -> NDArray[np.float64]:
+        kernel = _native.MountainCarObservationCpp(
+            next_state=next_state,
+            action=action,
+            covariance=self._obs_dist.covariance,
+        )
+        return kernel.sample()[0]
+
     def reward(self, state: Tuple[float, float], action: int) -> float:
         position, _ = state
 

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -618,6 +618,33 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         """Get observation model."""
         return PacManObservationModel(self._require_state_array(next_state), action, self)
 
+    # ── Hot-path sampling overrides ─────────────────────────────────
+    # The default base-class implementations build a Python wrapper
+    # subclass per call (``PacManStateTransitionModel`` /
+    # ``PacManObservationModel``) that forwards to the native C++
+    # kernel. The overrides below construct the native kernel directly
+    # and skip the wrapper allocation, while preserving the identical
+    # kernel-construction sequence and arguments.
+
+    def sample_next_state(self, state: np.ndarray, action: int) -> np.ndarray:
+        kernel = _native.PacManTransitionCpp(
+            state=self._require_state_array(state),
+            action=int(action),
+            **self.get_transition_cpp_ctor_kwargs(),
+            patrol_dir_state=self.ghost_patrol_directions,
+        )
+        return kernel.sample()[0]
+
+    def sample_observation(
+        self, next_state: np.ndarray, action: int
+    ) -> Tuple[Tuple[int, int], ...]:
+        kernel = _native.PacManObservationCpp(
+            next_state=self._require_state_array(next_state),
+            action=int(action),
+            **self.get_observation_cpp_ctor_kwargs(),
+        )
+        return self.array_to_observation(kernel.sample()[0])
+
     def reward(self, state: np.ndarray, action: int) -> float:
         """Calculate immediate reward."""
         state = self._require_state_array(state)

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -362,6 +362,37 @@ class ContinuousPushPOMDP(Environment):
             grid_size=self.grid_size,
         )
 
+    # ── Hot-path sampling overrides ─────────────────────────────────
+    # The default base-class implementations build a Python-wrapper
+    # subclass per call (np.asarray(...).ravel() x2, side-attribute
+    # storage). The actual RNG draw lives entirely inside the C++
+    # _native.ContinuousPush{Transition,Observation}Cpp.sample() method.
+    # These overrides skip the Python subclass, construct the native
+    # kernel directly, and produce byte-identical RNG draws.
+
+    def sample_next_state(self, state: np.ndarray, action: np.ndarray) -> np.ndarray:
+        kernel = _native.ContinuousPushTransitionCpp(
+            state=state,
+            action=action,
+            grid_size=float(self.grid_size),
+            push_threshold=float(self.push_threshold),
+            friction_coefficient=float(self.friction_coefficient),
+            max_push=float(self.max_push),
+            robot_radius=float(self.robot_radius),
+            obstacles=self.obstacles,
+            covariance=self._state_transition_dist.covariance,
+        )
+        return kernel.sample()[0]
+
+    def sample_observation(self, next_state: np.ndarray, action: np.ndarray) -> Any:
+        kernel = _native.ContinuousPushObservationCpp(
+            next_state=next_state,
+            action=action,
+            observation_noise=float(self.observation_noise),
+            grid_size=float(self.grid_size),
+        )
+        return kernel.sample()[0]
+
     def reward(self, state: np.ndarray, action: np.ndarray) -> float:
         action = np.asarray(action, dtype=float)
         next_state = self._sample_transition(state, action)
@@ -629,11 +660,13 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
         )
 
         self.actions = ["up", "down", "right", "left"]
+        # Cache action vectors as contiguous float64 ndarrays so the hot
+        # path can skip np.asarray(...).ravel() conversions.
         self.action_to_vector = {
-            "up": np.array([0.0, 1.0]),
-            "down": np.array([0.0, -1.0]),
-            "right": np.array([1.0, 0.0]),
-            "left": np.array([-1.0, 0.0]),
+            "up": np.ascontiguousarray([0.0, 1.0], dtype=np.float64),
+            "down": np.ascontiguousarray([0.0, -1.0], dtype=np.float64),
+            "right": np.ascontiguousarray([1.0, 0.0], dtype=np.float64),
+            "left": np.ascontiguousarray([-1.0, 0.0], dtype=np.float64),
         }
 
     def get_actions(self) -> List[str]:
@@ -654,3 +687,9 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
         if isinstance(action, str):
             action = self.action_to_vector[action]
         return super().reward_batch(np.asarray(states), action)
+
+    def sample_next_state(self, state: np.ndarray, action: Any) -> np.ndarray:
+        return super().sample_next_state(state, self.action_to_vector[action])
+
+    def sample_observation(self, next_state: np.ndarray, action: Any) -> Any:
+        return super().sample_observation(next_state, self.action_to_vector[action])

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -617,10 +617,107 @@ class PushPOMDP(DiscreteActionsEnvironment):
         )
 
     def sample_next_step(self, state: Any, action: Any) -> Tuple[Any, Any, float]:
-        next_state = self.state_transition_model(state=state, action=action).sample()[0]
-        next_observation = self.observation_model(next_state=next_state, action=action).sample()[0]
+        next_state = self.sample_next_state(state=state, action=action)
+        next_observation = self.sample_observation(next_state=next_state, action=action)
         r = self._reward_from_next_state(state, action, next_state)
         return next_state, next_observation, r
+
+    # ── Hot-path sampling overrides ─────────────────────────────────
+    # The default base-class implementations build a PushStateTransition /
+    # PushObservation wrapper per call (constructor work, slicing, and a
+    # Python ``sample()`` loop). These overrides inline the wrapper body so
+    # the wrapper allocation is skipped while the np.random.* call sequence
+    # remains byte-identical with the wrapper path.
+
+    def sample_next_state(self, state: np.ndarray, action: str) -> np.ndarray:
+        # Inline of PushStateTransition._get_actual_action() then
+        # _compute_next_state_for_action(). RNG order: one np.random.random()
+        # call, optionally one np.random.choice() call on error_actions.
+        if self.transition_error_prob > 0.0 and np.random.random() < self.transition_error_prob:
+            error_actions = [a for a in self.actions if a != action]
+            actual_action = np.random.choice(error_actions)
+        else:
+            actual_action = action
+
+        dx, dy = PushStateTransition._ACTION_TO_DXY[
+            actual_action
+        ]  # pylint: disable=protected-access
+
+        # Extract scalar positions from the 6-D state.
+        rx, ry = float(state[0]), float(state[1])
+        ox, oy = float(state[2]), float(state[3])
+        tx, ty = float(state[4]), float(state[5])
+
+        # Intended new robot position; obstacle collision blocks movement.
+        irx, iry = rx + dx, ry + dy
+        if self._is_colliding_with_obstacle_scalar(irx, iry):
+            nrx, nry = rx, ry
+        else:
+            nrx, nry = irx, iry
+
+        # Push if robot is within push_threshold of the object.
+        ddx, ddy = nrx - ox, nry - oy
+        dist_sq = ddx * ddx + ddy * ddy
+        push_threshold_sq = self.push_threshold * self.push_threshold
+
+        if dist_sq < push_threshold_sq:
+            push_scale = 1.0 - self.friction_coefficient
+            iox = ox + dx * push_scale
+            ioy = oy + dy * push_scale
+            if self._is_colliding_with_obstacle_scalar(iox, ioy):
+                nox, noy = ox, oy
+            else:
+                nox, noy = iox, ioy
+        else:
+            nox, noy = ox, oy
+
+        # Clip to grid bounds.
+        gmax = self.grid_size - 1
+        nrx = max(0.0, min(nrx, gmax))
+        nry = max(0.0, min(nry, gmax))
+        nox = max(0.0, min(nox, gmax))
+        noy = max(0.0, min(noy, gmax))
+
+        result = np.empty(6)
+        result[0] = nrx
+        result[1] = nry
+        result[2] = nox
+        result[3] = noy
+        result[4] = tx
+        result[5] = ty
+        return result
+
+    def _is_colliding_with_obstacle_scalar(self, pos_x: float, pos_y: float) -> bool:
+        if not self.obstacles:
+            return False
+        obs_r_sq = self.obstacle_radius * self.obstacle_radius
+        for obs_x, obs_y in self.obstacles:
+            ddx = pos_x - obs_x
+            ddy = pos_y - obs_y
+            if ddx * ddx + ddy * ddy <= obs_r_sq:
+                return True
+        return False
+
+    def sample_observation(self, next_state: np.ndarray, action: str) -> np.ndarray:
+        # Inline of PushObservation.sample(1): two np.random.normal(0, sigma)
+        # draws, clamped to [0, grid_size - 1]. RNG order matches the wrapper.
+        gmax = self.grid_size - 1
+        rx, ry = float(next_state[0]), float(next_state[1])
+        ox, oy = float(next_state[2]), float(next_state[3])
+        tx, ty = float(next_state[4]), float(next_state[5])
+        noise_std = self.observation_noise
+
+        nox = max(0.0, min(ox + np.random.normal(0, noise_std), gmax))
+        noy = max(0.0, min(oy + np.random.normal(0, noise_std), gmax))
+
+        observation = np.empty(6)
+        observation[0] = rx
+        observation[1] = ry
+        observation[2] = nox
+        observation[3] = noy
+        observation[4] = tx
+        observation[5] = ty
+        return observation
 
     def reward(self, state: np.ndarray, action: str) -> float:
         # Compute next state to evaluate reward based on action result

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -297,6 +297,11 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):
         # Validate parameters
         self._validate_parameters()
 
+        # Cached int32 rock positions array; identical to what the per-call
+        # wrappers build via ``np.asarray(...)``. Reused on the hot-path
+        # native-kernel sample overrides to skip the per-call allocation.
+        self._rock_positions_int32 = np.asarray(self.rock_positions, dtype=np.int32)
+
         # Define actions: 0=sample, 1=north, 2=east, 3=south, 4=west, 5+=check_rock_i
         self.action_names = ["sample", "north", "east", "south", "west"]
         self.action_names.extend([f"check_rock_{i}" for i in range(len(self.rock_positions))])
@@ -398,12 +403,44 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):
 
         return total_reward
 
+    # ── Hot-path sampling overrides ─────────────────────────────────
+    # The default base-class implementations build a Python wrapper
+    # (``RockSampleStateTransitionModel`` / ``RockSampleObservationModel``)
+    # per call, which forwards to the native C++ kernel. The overrides
+    # below construct the native kernel directly, skipping the wrapper
+    # allocation while preserving the identical kernel-construction
+    # sequence and arguments.
+
+    def sample_next_state(self, state: RockSampleState, action: int) -> RockSampleState:
+        kernel = _native.RockSampleTransitionCpp(
+            state=np.asarray(state, dtype=float),
+            action=int(action),
+            map_rows=self.map_size[0],
+            map_cols=self.map_size[1],
+            num_rocks=len(self.rock_positions),
+            rock_positions=self._rock_positions_int32,
+            sensor_efficiency=self.sensor_efficiency,
+        )
+        return kernel.sample()[0]
+
+    def sample_observation(self, next_state: RockSampleState, action: int) -> str:
+        kernel = _native.RockSampleObservationCpp(
+            next_state=np.asarray(next_state, dtype=float),
+            action=int(action),
+            map_rows=self.map_size[0],
+            map_cols=self.map_size[1],
+            num_rocks=len(self.rock_positions),
+            rock_positions=self._rock_positions_int32,
+            sensor_efficiency=self.sensor_efficiency,
+        )
+        return _OBS_CODE_TO_STR[kernel.sample()[0]]
+
     def sample_next_step(
         self, state: RockSampleState, action: int
     ) -> Tuple[RockSampleState, str, float]:
         """Override to avoid reward() recomputing next state."""
-        next_state = self.state_transition_model(state, action).sample()[0]
-        observation = self.observation_model(next_state, action).sample()[0]
+        next_state = self.sample_next_state(state=state, action=action)
+        observation = self.sample_observation(next_state=next_state, action=action)
         reward = self._reward_from_next_state(state, action, next_state)
         return next_state, observation, reward
 

--- a/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
+++ b/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
@@ -350,6 +350,14 @@ class SafeAntVelocityPOMDP(DiscreteActionsEnvironment):
             use_queue_logger=use_queue_logger,
         )
 
+        # Cached observation covariance — built once from env params; identical
+        # to what the per-call observation wrapper builds via
+        # ``_build_safe_ant_obs_covariance``. Reused on the hot-path native-
+        # kernel observation override to skip the per-call allocation.
+        self._observation_covariance = _build_safe_ant_obs_covariance(
+            position_noise, velocity_noise
+        )
+
     def state_transition_model(self, state: np.ndarray, action: int) -> StateTransitionModel:
         return SafeAntVelocityStateTransition(  # pyright: ignore[reportReturnType]
             state=state,
@@ -522,11 +530,39 @@ class SafeAntVelocityPOMDP(DiscreteActionsEnvironment):
             ),
         ]
 
+    # ── Hot-path sampling overrides ─────────────────────────────────
+    # The default base-class implementations build a Python wrapper
+    # subclass per call (``SafeAntVelocityStateTransition`` /
+    # ``SafeAntVelocityObservation``) that forwards to the native C++
+    # kernel. The overrides below construct the native kernel directly
+    # and skip the wrapper allocation, while preserving the identical
+    # kernel-construction sequence and arguments.
+
+    def sample_next_state(self, state: np.ndarray, action: int) -> np.ndarray:
+        kernel = _native.SafeAntVelocityTransitionCpp(
+            state=state,
+            action=action,
+            dt=self.dt,
+            mass=self.mass,
+            damping=self.damping,
+            max_force=self.max_force,
+            force_scales=DEFAULT_FORCE_SCALES,
+        )
+        return kernel.sample()[0]
+
+    def sample_observation(self, next_state: np.ndarray, action: int) -> np.ndarray:
+        kernel = _native.SafeAntVelocityObservationCpp(
+            next_state=next_state,
+            action=action,
+            covariance=self._observation_covariance,
+        )
+        return kernel.sample()[0]
+
     def sample_next_step(
         self, state: np.ndarray, action: int
     ) -> Tuple[np.ndarray, np.ndarray, float]:
-        next_state = self.state_transition_model(state=state, action=action).sample()[0]
-        next_observation = self.observation_model(next_state=next_state, action=action).sample()[0]
+        next_state = self.sample_next_state(state=state, action=action)
+        next_observation = self.sample_observation(next_state=next_state, action=action)
         reward = self.reward(state=next_state, action=action)
 
         return next_state, next_observation, reward

--- a/POMDPPlanners/environments/sanity_pomdp.py
+++ b/POMDPPlanners/environments/sanity_pomdp.py
@@ -333,6 +333,17 @@ class SanityPOMDP(DiscreteActionsEnvironment):
     def observation_model(self, next_state: int, action: int) -> SanityObservationModel:
         return SanityObservationModel(next_state, action)
 
+    # ── Hot-path sampling overrides ─────────────────────────────────
+    # Inline the wrapper's sample() body. Both transitions and
+    # observations are deterministic, so no RNG draws occur and the
+    # behavior is byte-identical to the wrapper-based path.
+
+    def sample_next_state(self, state: int, action: int) -> int:
+        return 0 if action == 0 else 1
+
+    def sample_observation(self, next_state: int, action: int) -> int:
+        return next_state
+
     def reward(self, state: int, action: int) -> float:
         # Higher reward for being in good state (0)
         next_state = self.state_transition_model(state, action).sample()[0]

--- a/POMDPPlanners/environments/tiger_pomdp.py
+++ b/POMDPPlanners/environments/tiger_pomdp.py
@@ -273,6 +273,22 @@ class TigerPOMDP(DiscreteActionsEnvironment):
     def observation_model(self, next_state: str, action: str) -> ObservationModel:
         return TigerObservation(next_state=next_state, action=action)
 
+    # ── Hot-path sampling overrides ─────────────────────────────────
+    # Inline the wrapper's sample() body to skip per-call wrapper
+    # allocation. The RNG draw sequence is preserved bit-for-bit.
+
+    def sample_next_state(self, state: str, action: str) -> str:
+        if action in ("open_left", "open_right"):
+            return str(np.random.choice(STATES))
+        return state
+
+    def sample_observation(self, next_state: str, action: str) -> str:
+        if action == "listen":
+            if next_state == "tiger_left":
+                return "hear_left" if np.random.random() < 0.85 else "hear_right"
+            return "hear_right" if np.random.random() < 0.85 else "hear_left"
+        return "hear_nothing"
+
     def reward(self, state: str, action: str) -> float:
         if action == "listen":
             return -1.0  # Cost of listening

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
@@ -848,3 +848,89 @@ def test_reward_batch_matches_scalar_reward():
     single = env.reward_batch(states[:1], action)
     assert single.shape == (1,)
     assert single[0] == env.reward(states[0], action)
+
+
+def test_sample_next_state_rng_pinned_equivalence(base_cartpole_environment):
+    """Test that sample_next_state matches state_transition_model().sample()[0] under fixed RNG.
+
+    Purpose: Validates that the sample_next_state override produces byte-identical results
+        to the wrapper-based path when both use the same native RNG seed.
+
+    Given: A CartPolePOMDP environment and (state, action) pairs covering both actions and
+        a range of state vectors near and away from the equilibrium, with the native module
+        RNG and Python np.random/random seeded identically before each pair of draws
+    When: A sample is drawn through state_transition_model(s, a).sample()[0] and again
+        through env.sample_next_state(s, a) after re-seeding
+    Then: The two draws produce arrays equal element-wise across all combinations
+
+    Test type: unit
+    """
+    from POMDPPlanners.environments.cartpole_pomdp import (  # pylint: disable=import-outside-toplevel
+        _native,
+    )
+
+    env = base_cartpole_environment
+    cases = [
+        (np.array([0.0, 0.0, 0.0, 0.0]), 0),
+        (np.array([0.0, 0.0, 0.0, 0.0]), 1),
+        (np.array([0.1, 0.05, 0.02, -0.1]), 1),
+        (np.array([-0.1, -0.05, -0.02, 0.1]), 0),
+        (np.array([0.5, 0.2, 0.05, 0.0]), 1),
+    ]
+    for state, action in cases:
+        _native.set_seed(2024)
+        np.random.seed(2024)
+        random.seed(2024)
+        wrapper_sample = env.state_transition_model(state=state, action=action).sample()[0]
+        _native.set_seed(2024)
+        np.random.seed(2024)
+        random.seed(2024)
+        direct_sample = env.sample_next_state(state=state, action=action)
+        np.testing.assert_array_equal(
+            wrapper_sample,
+            direct_sample,
+            err_msg=f"sample_next_state mismatch for ({state.tolist()}, {action})",
+        )
+
+
+def test_sample_observation_rng_pinned_equivalence(base_cartpole_environment):
+    """Test that sample_observation matches observation_model().sample()[0] under fixed RNG.
+
+    Purpose: Validates that the sample_observation override produces byte-identical results
+        to the wrapper-based path when both use the same native RNG seed.
+
+    Given: A CartPolePOMDP environment and (next_state, action) pairs covering both actions
+        across a range of state vectors, with the native module RNG and Python
+        np.random/random seeded identically before each pair of draws
+    When: An observation is drawn through observation_model(ns, a).sample()[0] and again
+        through env.sample_observation(ns, a) after re-seeding
+    Then: The two draws produce arrays equal element-wise across all combinations
+
+    Test type: unit
+    """
+    from POMDPPlanners.environments.cartpole_pomdp import (  # pylint: disable=import-outside-toplevel
+        _native,
+    )
+
+    env = base_cartpole_environment
+    cases = [
+        (np.array([0.0, 0.0, 0.0, 0.0]), 0),
+        (np.array([0.0, 0.0, 0.0, 0.0]), 1),
+        (np.array([0.1, 0.05, 0.02, -0.1]), 1),
+        (np.array([-0.1, -0.05, -0.02, 0.1]), 0),
+        (np.array([0.5, 0.2, 0.05, 0.0]), 1),
+    ]
+    for next_state, action in cases:
+        _native.set_seed(99)
+        np.random.seed(99)
+        random.seed(99)
+        wrapper_obs = env.observation_model(next_state=next_state, action=action).sample()[0]
+        _native.set_seed(99)
+        np.random.seed(99)
+        random.seed(99)
+        direct_obs = env.sample_observation(next_state=next_state, action=action)
+        np.testing.assert_array_equal(
+            wrapper_obs,
+            direct_obs,
+            err_msg=f"sample_observation mismatch for ({next_state.tolist()}, {action})",
+        )

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
@@ -12,6 +12,7 @@ import pytest
 from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.core.policy import PolicyRunData
 from POMDPPlanners.core.simulation import History, StepData
+from POMDPPlanners.environments.laser_tag_pomdp import _native
 from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_pomdp import (
     ContinuousLaserTagPOMDP,
     ContinuousLaserTagPOMDPDiscreteActions,
@@ -1000,3 +1001,108 @@ class TestEnvironmentRegistry:
 
         env_d = get_environment("ContinuousLaserTagPOMDPDiscreteActions", discount_factor=0.95)
         assert isinstance(env_d, ContinuousLaserTagPOMDPDiscreteActions)
+
+
+class TestContinuousLaserTagDirectSampleApiEquivalence:
+    """Equivalence tests for sample_next_state/sample_observation overrides.
+
+    The native C++ kernel uses a module-level RNG seeded via _native.set_seed.
+    Pinning that RNG before each draw produces byte-identical samples between
+    the wrapper and the override.
+    """
+
+    def test_sample_next_state_matches_wrapper_with_pinned_native_rng(self) -> None:
+        """Direct sample_next_state matches wrapper output under pinned _native RNG.
+
+        Purpose: Validates that ContinuousLaserTagPOMDP.sample_next_state
+            issues the same C++ RNG draws as the wrapper path.
+
+        Given: A ContinuousLaserTagPOMDP and a fixed (state, action) with the
+            module-level _native RNG seeded identically before each draw.
+        When: We draw via env.state_transition_model(s, a).sample(1)[0] and
+            via env.sample_next_state(s, a).
+        Then: The two next-state arrays are byte-equal.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([1.0, 0.0, 0.0])
+
+        _native.set_seed(2024)
+        np.random.seed(2024)
+        ns_wrap = env.state_transition_model(state, action).sample(n_samples=1)[0]
+
+        _native.set_seed(2024)
+        np.random.seed(2024)
+        ns_direct = env.sample_next_state(state, action)
+
+        assert np.array_equal(ns_wrap, ns_direct)
+
+    def test_sample_observation_matches_wrapper_with_pinned_native_rng(self) -> None:
+        """Direct sample_observation matches wrapper output under pinned _native RNG.
+
+        Purpose: Validates that ContinuousLaserTagPOMDP.sample_observation
+            issues the same C++ RNG draws as the wrapper path.
+
+        Given: A ContinuousLaserTagPOMDP and a fixed (next_state, action) with
+            _native RNG seeded identically before each draw.
+        When: We draw via env.observation_model(...).sample(1)[0] and via
+            env.sample_observation(...).
+        Then: The two observation arrays are byte-equal.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        next_state = np.array([4.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([1.0, 0.0, 0.0])
+
+        _native.set_seed(99)
+        np.random.seed(99)
+        o_wrap = env.observation_model(next_state, action).sample(n_samples=1)[0]
+
+        _native.set_seed(99)
+        np.random.seed(99)
+        o_direct = env.sample_observation(next_state, action)
+
+        assert np.array_equal(o_wrap, o_direct)
+
+    def test_discrete_actions_variant_translates_action_then_matches_wrapper(self) -> None:
+        """ContinuousLaserTagPOMDPDiscreteActions overrides translate the action and match.
+
+        Purpose: Validates that the discrete-actions subclass routes string
+            actions through action_to_vector before delegating to the parent
+            override, producing byte-identical samples to the wrapper.
+
+        Given: A ContinuousLaserTagPOMDPDiscreteActions and a fixed
+            (state, "up") with _native RNG seeded before each draw.
+        When: We draw via env.state_transition_model(...).sample(1)[0] and
+            via env.sample_next_state(...).
+        Then: The two next-state arrays are byte-equal.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDPDiscreteActions(
+            discount_factor=0.95, walls=[], dangerous_areas=[]
+        )
+        state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
+
+        _native.set_seed(11)
+        np.random.seed(11)
+        ns_wrap = env.state_transition_model(state, "up").sample(n_samples=1)[0]
+
+        _native.set_seed(11)
+        np.random.seed(11)
+        ns_direct = env.sample_next_state(state, "up")
+
+        assert np.array_equal(ns_wrap, ns_direct)
+
+        _native.set_seed(13)
+        np.random.seed(13)
+        o_wrap = env.observation_model(ns_wrap, "up").sample(n_samples=1)[0]
+
+        _native.set_seed(13)
+        np.random.seed(13)
+        o_direct = env.sample_observation(ns_wrap, "up")
+
+        assert np.array_equal(o_wrap, o_direct)

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -2049,6 +2049,117 @@ def test_metrics_confidence_intervals():
     verify_metrics_within_confidence_intervals(metrics)
 
 
+class TestLaserTagDirectSampleApiEquivalence:
+    """Equivalence tests for sample_next_state/sample_observation overrides.
+
+    Verifies that the env-level direct-sample overrides produce byte-identical
+    output to the wrapper path when seeded identically.
+    """
+
+    @pytest.mark.parametrize("action", [0, 1, 2, 3, 4])
+    def test_sample_next_state_matches_wrapper_with_pinned_rng(self, action: int) -> None:
+        """Direct sample_next_state matches wrapper.sample()[0] under pinned RNG.
+
+        Purpose: Validates that LaserTagPOMDP.sample_next_state inlines the
+            wrapper's RNG sequence exactly so seeded behavior is identical.
+
+        Given: A LaserTagPOMDP and a fixed (state, action). np.random and random
+            are seeded identically before each draw.
+        When: We draw via env.state_transition_model(s, a).sample()[0] and via
+            env.sample_next_state(s, a).
+        Then: The two next-state arrays are equal.
+
+        Test type: unit
+        """
+        env = LaserTagPOMDP(discount_factor=0.95, transition_error_prob=0.2)
+        state = np.array([3.0, 4.0, 5.0, 2.0, 0.0])
+
+        np.random.seed(123)
+        random.seed(123)
+        ns_wrap = env.state_transition_model(state, action).sample(n_samples=1)[0]
+
+        np.random.seed(123)
+        random.seed(123)
+        ns_direct = env.sample_next_state(state, action)
+
+        assert np.array_equal(ns_wrap, ns_direct)
+
+    def test_sample_next_state_terminal_tag_matches_wrapper(self) -> None:
+        """Terminal-tag transition matches wrapper output.
+
+        Purpose: Validates the tag-on-same-cell terminal branch of
+            sample_next_state matches the wrapper.
+
+        Given: A LaserTagPOMDP and a state where robot and opponent share a
+            cell, with action=Tag(4).
+        When: We draw via wrapper and via the override.
+        Then: Both produce the same terminal next state.
+
+        Test type: unit
+        """
+        env = LaserTagPOMDP(discount_factor=0.95)
+        state = np.array([3.0, 3.0, 3.0, 3.0, 0.0])
+
+        np.random.seed(0)
+        random.seed(0)
+        ns_wrap = env.state_transition_model(state, 4).sample(n_samples=1)[0]
+
+        np.random.seed(0)
+        random.seed(0)
+        ns_direct = env.sample_next_state(state, 4)
+
+        assert np.array_equal(ns_wrap, ns_direct)
+
+    @pytest.mark.parametrize("action", [0, 4])
+    def test_sample_observation_matches_wrapper_with_pinned_rng(self, action: int) -> None:
+        """Direct sample_observation matches wrapper.sample()[0] under pinned RNG.
+
+        Purpose: Validates that LaserTagPOMDP.sample_observation inlines the
+            wrapper's 8 np.random.normal draws in the same order.
+
+        Given: A LaserTagPOMDP and a fixed (next_state, action). RNG is seeded
+            identically before each draw.
+        When: We draw via env.observation_model(...).sample()[0] and via
+            env.sample_observation(...).
+        Then: The two observation tuples are equal.
+
+        Test type: unit
+        """
+        env = LaserTagPOMDP(discount_factor=0.95)
+        next_state = np.array([3.0, 4.0, 5.0, 2.0, 0.0])
+
+        np.random.seed(7)
+        random.seed(7)
+        o_wrap = env.observation_model(next_state, action).sample(n_samples=1)[0]
+
+        np.random.seed(7)
+        random.seed(7)
+        o_direct = env.sample_observation(next_state, action)
+
+        assert tuple(o_wrap) == tuple(o_direct)
+
+    def test_sample_observation_terminal_state_matches_wrapper(self) -> None:
+        """Terminal-state observation matches wrapper output.
+
+        Purpose: Validates terminal sentinel observation in sample_observation.
+
+        Given: A LaserTagPOMDP and a terminal next_state.
+        When: We draw via wrapper and via the override.
+        Then: Both produce the same terminal observation tuple.
+
+        Test type: unit
+        """
+        env = LaserTagPOMDP(discount_factor=0.95)
+        terminal_state = np.array([3.0, 3.0, 3.0, 3.0, 1.0])
+
+        np.random.seed(0)
+        o_wrap = env.observation_model(terminal_state, 4).sample(n_samples=1)[0]
+        np.random.seed(0)
+        o_direct = env.sample_observation(terminal_state, 4)
+
+        assert tuple(o_wrap) == tuple(o_direct)
+
+
 if __name__ == "__main__":
     # Run tests if script is executed directly
     pytest.main([__file__, "-v"])

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_pomdp.py
@@ -1577,3 +1577,142 @@ def test_reward_batch_matches_scalar(base_light_dark_environment):
     assert single.shape == (1,)
     np.random.seed(42)
     np.testing.assert_allclose(single[0], env.reward(states[0], action))
+
+
+def test_sample_next_state_matches_state_transition_model_wrapper(base_light_dark_environment):
+    """Pinned-seed equivalence: sample_next_state vs state_transition_model().sample()[0].
+
+    Purpose: Validates that the inlined sample_next_state override produces
+        byte-identical RNG draws to the wrapper-based state_transition_model
+        path (which goes through DiscreteDistribution.sample() and
+        np.searchsorted on np.cumsum(probs)).
+
+    Given: A DiscreteLightDarkPOMDP environment, a fixed list of (state, action)
+        pairs spanning all four actions, and identical numpy / random seeds.
+    When: A next-state is drawn first via env.state_transition_model(s, a).sample()[0]
+        and then via env.sample_next_state(s, a) under the same re-seeded RNG.
+    Then: For every (state, action) pair, both paths yield np.array_equal results.
+
+    Test type: unit
+    """
+    env = base_light_dark_environment
+    actions = env.get_actions()
+    test_pairs = [
+        (np.array([0, 5]), actions[0]),
+        (np.array([3, 3]), actions[1]),
+        (np.array([7, 2]), actions[2]),
+        (np.array([10, 10]), actions[3]),
+        (np.array([5, 5]), actions[0]),
+        (np.array([1, 8]), actions[2]),
+    ]
+    for state, action in test_pairs:
+        np.random.seed(12345)
+        random.seed(12345)
+        wrapper_next = env.state_transition_model(state, action).sample()[0]
+        np.random.seed(12345)
+        random.seed(12345)
+        direct_next = env.sample_next_state(state, action)
+        assert np.array_equal(wrapper_next, direct_next), (
+            f"Mismatch for state={state}, action={action}: "
+            f"wrapper={wrapper_next}, direct={direct_next}"
+        )
+
+
+def test_sample_observation_matches_observation_model_wrapper_normal():
+    """Pinned-seed equivalence: sample_observation vs observation_model().sample()[0].
+
+    Purpose: Validates that the inlined sample_observation override (NORMAL
+        observation model type) produces byte-identical RNG draws to the
+        wrapper-based observation_model path.
+
+    Given: A DiscreteLightDarkPOMDP env using ObservationModelType.NORMAL,
+        a fixed list of (next_state, action) pairs that include states both
+        near and far from beacons, and identical numpy / random seeds.
+    When: An observation is drawn first via
+        env.observation_model(ns, a).sample()[0] and then via
+        env.sample_observation(ns, a) under the same re-seeded RNG.
+    Then: For every (next_state, action) pair, both paths yield equal results
+        (np.array_equal for ndarray observations, equality for "None" strings).
+
+    Test type: unit
+    """
+    env = DiscreteLightDarkPOMDP(
+        discount_factor=0.95,
+        transition_error_prob=0.05,
+        observation_error_prob=0.05,
+        beacons=[(0, 0), (5, 5), (10, 10)],
+        beacon_radius=1.5,
+        grid_size=11,
+        observation_model_type=ObservationModelType.NORMAL,
+    )
+    test_pairs = [
+        (np.array([0, 0]), "up"),  # near beacon
+        (np.array([5, 5]), "down"),  # near beacon
+        (np.array([3, 3]), "right"),  # far from beacon
+        (np.array([7, 1]), "left"),  # far from beacon
+        (np.array([10, 10]), "up"),  # near beacon
+        (np.array([8, 4]), "down"),  # far from beacon
+    ]
+    for next_state, action in test_pairs:
+        np.random.seed(54321)
+        random.seed(54321)
+        wrapper_obs = env.observation_model(next_state, action).sample()[0]
+        np.random.seed(54321)
+        random.seed(54321)
+        direct_obs = env.sample_observation(next_state, action)
+        if isinstance(wrapper_obs, np.ndarray):
+            assert isinstance(direct_obs, np.ndarray)
+            assert np.array_equal(wrapper_obs, direct_obs), (
+                f"Mismatch for next_state={next_state}, action={action}: "
+                f"wrapper={wrapper_obs}, direct={direct_obs}"
+            )
+        else:
+            assert wrapper_obs == direct_obs
+
+
+def test_sample_observation_falls_back_for_non_normal_model_types():
+    """Non-NORMAL observation model types delegate to base-class default.
+
+    Purpose: Validates that when observation_model_type is NO_OBS_IN_DARK or
+        DISTANCE_BASED, sample_observation falls back to
+        observation_model(...).sample()[0] (the inline override only handles
+        the NORMAL path).
+
+    Given: DiscreteLightDarkPOMDP envs configured with NO_OBS_IN_DARK and
+        DISTANCE_BASED observation model types.
+    When: sample_observation is called under a pinned seed, and the wrapper
+        path is also called under the same pinned seed.
+    Then: The two paths produce equal observations for several (next_state,
+        action) pairs.
+
+    Test type: unit
+    """
+    for obs_type in (
+        ObservationModelType.NO_OBS_IN_DARK,
+        ObservationModelType.DISTANCE_BASED,
+    ):
+        env = DiscreteLightDarkPOMDP(
+            discount_factor=0.95,
+            transition_error_prob=0.05,
+            observation_error_prob=0.05,
+            beacons=[(0, 0), (5, 5), (10, 10)],
+            beacon_radius=1.5,
+            grid_size=11,
+            observation_model_type=obs_type,
+        )
+        for next_state, action in [
+            (np.array([0, 0]), "up"),
+            (np.array([3, 3]), "right"),
+            (np.array([5, 5]), "down"),
+        ]:
+            np.random.seed(7)
+            random.seed(7)
+            wrapper_obs = env.observation_model(next_state, action).sample()[0]
+            np.random.seed(7)
+            random.seed(7)
+            direct_obs = env.sample_observation(next_state, action)
+            if isinstance(wrapper_obs, np.ndarray):
+                assert isinstance(direct_obs, np.ndarray)
+                assert np.array_equal(wrapper_obs, direct_obs)
+            else:
+                assert wrapper_obs == direct_obs

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
@@ -1134,3 +1134,91 @@ def test_reward_batch_matches_scalar_reward():
     single = env.reward_batch(states[:1], action)
     assert single.shape == (1,)
     assert single[0] == env.reward(states[0], action)
+
+
+def test_sample_next_state_rng_pinned_equivalence(base_mountain_car_environment):
+    """Test that sample_next_state matches state_transition_model().sample()[0] under fixed RNG.
+
+    Purpose: Validates that the sample_next_state override produces byte-identical results
+        to the wrapper-based path when both use the same native RNG seed.
+
+    Given: A MountainCarPOMDP environment and (state, action) pairs covering the three
+        actions and a few representative positions/velocities, with the native module RNG
+        and Python-side np.random/random seeded identically before each pair of draws
+    When: A sample is drawn through state_transition_model(s, a).sample()[0] and again
+        through env.sample_next_state(s, a) after re-seeding
+    Then: The two draws produce arrays equal element-wise across all combinations
+
+    Test type: unit
+    """
+    from POMDPPlanners.environments.mountain_car_pomdp import (  # pylint: disable=import-outside-toplevel
+        _native,
+    )
+
+    env = base_mountain_car_environment
+    cases = [
+        ((-0.5, 0.0), -1),
+        ((-0.5, 0.0), 0),
+        ((-0.5, 0.0), 1),
+        ((0.0, 0.05), 1),
+        ((-1.0, -0.03), 0),
+        ((0.4, 0.04), -1),
+    ]
+    for state, action in cases:
+        _native.set_seed(2024)
+        np.random.seed(2024)
+        random.seed(2024)
+        wrapper_sample = env.state_transition_model(state=state, action=action).sample()[0]
+        _native.set_seed(2024)
+        np.random.seed(2024)
+        random.seed(2024)
+        direct_sample = env.sample_next_state(state=state, action=action)
+        np.testing.assert_array_equal(
+            wrapper_sample,
+            direct_sample,
+            err_msg=f"sample_next_state mismatch for ({state}, {action})",
+        )
+
+
+def test_sample_observation_rng_pinned_equivalence(base_mountain_car_environment):
+    """Test that sample_observation matches observation_model().sample()[0] under fixed RNG.
+
+    Purpose: Validates that the sample_observation override produces byte-identical results
+        to the wrapper-based path when both use the same native RNG seed.
+
+    Given: A MountainCarPOMDP environment and (next_state, action) pairs covering the three
+        actions and a range of positions/velocities, with the native module RNG and Python
+        np.random/random seeded identically before each pair of draws
+    When: An observation is drawn through observation_model(ns, a).sample()[0] and again
+        through env.sample_observation(ns, a) after re-seeding
+    Then: The two draws produce arrays equal element-wise across all combinations
+
+    Test type: unit
+    """
+    from POMDPPlanners.environments.mountain_car_pomdp import (  # pylint: disable=import-outside-toplevel
+        _native,
+    )
+
+    env = base_mountain_car_environment
+    cases = [
+        ((-0.5, 0.0), -1),
+        ((-0.5, 0.0), 0),
+        ((-0.5, 0.0), 1),
+        ((0.0, 0.05), 1),
+        ((-1.0, -0.03), 0),
+        ((0.4, 0.04), -1),
+    ]
+    for next_state, action in cases:
+        _native.set_seed(99)
+        np.random.seed(99)
+        random.seed(99)
+        wrapper_obs = env.observation_model(next_state=next_state, action=action).sample()[0]
+        _native.set_seed(99)
+        np.random.seed(99)
+        random.seed(99)
+        direct_obs = env.sample_observation(next_state=next_state, action=action)
+        np.testing.assert_array_equal(
+            wrapper_obs,
+            direct_obs,
+            err_msg=f"sample_observation mismatch for ({next_state}, {action})",
+        )

--- a/POMDPPlanners/tests/test_environments/test_pacman_native/test_pacman_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_native/test_pacman_native_equivalence.py
@@ -281,3 +281,84 @@ class TestAggressiveDistribution:
 
         # Probabilities should normalize over their support.
         assert math.isclose(float(probs.sum()), 1.0, abs_tol=1e-9)
+
+
+class TestSampleNextStateOverrideEquivalence:
+    """Hot-path overrides skip the Python wrapper but match it bit-exactly.
+
+    The new ``sample_next_state`` / ``sample_observation`` env-level
+    overrides construct the native C++ kernel directly, bypassing the
+    per-call ``PacManStateTransitionModel`` / ``PacManObservationModel``
+    wrapper allocation. Under a shared C++ RNG seed and the same
+    ``ghost_patrol_directions`` buffer state, both paths must produce
+    identical outputs.
+    """
+
+    def test_sample_next_state_matches_state_transition_model(self) -> None:
+        """Override sample_next_state matches state_transition_model.sample().
+
+        Purpose: Validates that ``PacManPOMDP.sample_next_state`` produces
+        the exact same next state as the legacy
+        ``state_transition_model(state, action).sample()[0]`` path under
+        a fixed C++ RNG seed and matching patrol-direction buffer state.
+
+        Given: A small env, a non-terminal state at the initial position,
+            and a sweep of all four discrete actions.
+        When: Both paths are invoked with ``_native.set_seed`` reset to
+            the same value and the env's ``ghost_patrol_directions``
+            buffer reset to zeros before each call.
+        Then: ``np.array_equal`` holds elementwise on the returned arrays.
+
+        Test type: integration
+        """
+        env = _build_env()
+        state = env.initial_state_dist().sample()[0]
+
+        for action in range(4):
+            env.ghost_patrol_directions[:] = 0
+            _native.set_seed(2024 + action)
+            via_wrapper = env.state_transition_model(state, action).sample()[0]
+
+            env.ghost_patrol_directions[:] = 0
+            _native.set_seed(2024 + action)
+            via_override = env.sample_next_state(state=state, action=action)
+
+            np.testing.assert_array_equal(via_wrapper, via_override)
+
+    def test_sample_observation_matches_observation_model(self) -> None:
+        """Override sample_observation matches observation_model.sample().
+
+        Purpose: Validates that ``PacManPOMDP.sample_observation``
+        (which constructs the native observation kernel directly) produces
+        the exact same tuple-of-(row, col) observation as the legacy
+        ``observation_model(...).sample()[0]`` path under a fixed C++ RNG
+        seed.
+
+        Given: A small env and a small set of representative next states
+            covering different ghost configurations.
+        When: Both paths are invoked with ``_native.set_seed`` reset to
+            the same value before each call.
+        Then: The two observations are equal.
+
+        Test type: integration
+        """
+        env = _build_env()
+        # Generate a few next-states by stepping the env from the initial
+        # state with different actions; this gives realistic non-terminal
+        # ghost positions to exercise the noise sampler over.
+        initial_state = env.initial_state_dist().sample()[0]
+        next_states = [initial_state]
+        env.ghost_patrol_directions[:] = 0
+        _native.set_seed(0)
+        for action in range(4):
+            next_states.append(env.state_transition_model(initial_state, action).sample()[0])
+
+        for i, next_state in enumerate(next_states):
+            for action in (0, 1, 2, 3):
+                _native.set_seed(7777 + i * 11 + action)
+                via_wrapper = env.observation_model(next_state, action).sample()[0]
+
+                _native.set_seed(7777 + i * 11 + action)
+                via_override = env.sample_observation(next_state=next_state, action=action)
+
+                assert via_wrapper == via_override

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
@@ -646,3 +646,199 @@ class TestContinuousPushPOMDPDiscreteActions:
 
         ns_down = env.sample_next_step(state, "down")[0]
         assert ns_down[1] < state[1]
+
+
+# ------------------------------------------------------------------
+# Hot-path sampling override equivalence
+# ------------------------------------------------------------------
+
+
+class TestSampleHotPathOverridesEquivalence:
+    """Pinned-seed equivalence for the C++-kernel sampling overrides.
+
+    Both ``state_transition_model(...).sample()[0]`` (the wrapper path) and
+    ``sample_next_state(...)`` (the override) construct the same underlying
+    ``_native.ContinuousPushTransitionCpp`` kernel and consume the same
+    module-level RNG seeded via ``_native.set_seed``. They must therefore
+    produce byte-identical samples. Same argument for the observation pair.
+    """
+
+    def test_sample_next_state_matches_state_transition_model_wrapper(self):
+        """Pinned-seed equivalence: sample_next_state vs wrapper path.
+
+        Purpose: Validates that the inlined sample_next_state override (which
+            constructs ``_native.ContinuousPushTransitionCpp`` directly) is
+            byte-identical to the ``ContinuousPushStateTransitionModel`` wrapper
+            ``.sample()[0]`` call under the same _native.set_seed().
+
+        Given: A ContinuousPushPOMDP env with non-trivial state-transition
+            covariance, several (state, action) pairs covering both
+            object-far-from-robot and object-within-push-threshold regimes,
+            and identical ``_native.set_seed`` before each path.
+        When: env.state_transition_model(s, a).sample()[0] and
+            env.sample_next_state(s, a) are each called under the same
+            re-seeded native RNG.
+        Then: For every pair, both paths yield np.array_equal next-states.
+
+        Test type: unit
+        """
+        from POMDPPlanners.environments.push_pomdp import (
+            _native,
+        )  # pylint: disable=import-outside-toplevel
+
+        env = ContinuousPushPOMDP(
+            discount_factor=0.99,
+            state_transition_cov_matrix=np.eye(2) * 0.01,
+            robot_radius=0.3,
+        )
+        test_pairs = [
+            (np.array([2.0, 3.0, 7.0, 7.0, 8.0, 8.0]), np.array([1.0, 0.0])),
+            (np.array([2.5, 3.1, 3.0, 3.0, 8.0, 8.0]), np.array([1.0, 0.0])),  # push range
+            (np.array([0.5, 0.5, 5.0, 5.0, 8.0, 8.0]), np.array([-2.0, 0.0])),  # wall
+            (np.array([5.0, 5.0, 5.5, 5.0, 8.0, 8.0]), np.array([0.5, 0.5])),  # push diag
+            (np.array([8.0, 8.0, 8.5, 7.5, 8.0, 8.0]), np.array([1.0, -1.0])),
+        ]
+        for state, action in test_pairs:
+            for seed in (12345, 67890, 314159):
+                _native.set_seed(seed)
+                wrapper_next = env.state_transition_model(state, action).sample()[0]
+                _native.set_seed(seed)
+                direct_next = env.sample_next_state(state, action)
+                np.testing.assert_array_equal(
+                    wrapper_next,
+                    direct_next,
+                    err_msg=(
+                        f"Mismatch for state={state}, action={action}, seed={seed}: "
+                        f"wrapper={wrapper_next}, direct={direct_next}"
+                    ),
+                )
+
+    def test_sample_observation_matches_observation_model_wrapper(self):
+        """Pinned-seed equivalence: sample_observation vs wrapper path.
+
+        Purpose: Validates that the inlined sample_observation override (which
+            constructs ``_native.ContinuousPushObservationCpp`` directly) is
+            byte-identical to the ``ContinuousPushObservationModel`` wrapper
+            ``.sample()[0]`` call under the same _native.set_seed().
+
+        Given: A ContinuousPushPOMDP env, several (next_state, action) pairs
+            spanning interior and boundary positions, and identical
+            ``_native.set_seed`` before each path.
+        When: env.observation_model(ns, a).sample()[0] and
+            env.sample_observation(ns, a) are each called under the same
+            re-seeded native RNG.
+        Then: For every pair, both paths yield np.array_equal observations.
+
+        Test type: unit
+        """
+        from POMDPPlanners.environments.push_pomdp import (
+            _native,
+        )  # pylint: disable=import-outside-toplevel
+
+        env = ContinuousPushPOMDP(
+            discount_factor=0.99,
+            observation_noise=0.3,
+            robot_radius=0.3,
+        )
+        test_pairs = [
+            (np.array([2.0, 3.0, 2.8, 3.2, 8.0, 8.0]), np.array([1.0, 0.0])),
+            (np.array([5.0, 5.0, 5.0, 5.0, 8.0, 8.0]), np.array([0.0, 0.0])),
+            (np.array([0.0, 0.0, 0.1, 0.0, 8.0, 8.0]), np.array([1.0, 1.0])),
+            (np.array([9.0, 9.0, 8.9, 9.0, 8.0, 8.0]), np.array([-1.0, 0.0])),
+        ]
+        for next_state, action in test_pairs:
+            for seed in (54321, 24680, 271828):
+                _native.set_seed(seed)
+                wrapper_obs = env.observation_model(next_state, action).sample()[0]
+                _native.set_seed(seed)
+                direct_obs = env.sample_observation(next_state, action)
+                np.testing.assert_array_equal(
+                    wrapper_obs,
+                    direct_obs,
+                    err_msg=(
+                        f"Mismatch for next_state={next_state}, action={action}, seed={seed}: "
+                        f"wrapper={wrapper_obs}, direct={direct_obs}"
+                    ),
+                )
+
+    def test_discrete_actions_sample_next_state_uses_action_to_vector(self):
+        """Discrete-actions wrapper resolves str action via action_to_vector and matches.
+
+        Purpose: Validates that ContinuousPushPOMDPDiscreteActions.sample_next_state
+            looks up the cached action vector and produces the same result as
+            calling the parent override with that vector directly.
+
+        Given: A ContinuousPushPOMDPDiscreteActions env, a single state, and
+            identical ``_native.set_seed`` before each path.
+        When: For each str action, env.sample_next_state(state, str_action) is
+            compared against env.sample_next_state(state, action_to_vector[a])
+            via super() (i.e. the continuous parent's override).
+        Then: Both paths produce np.array_equal next-states.
+
+        Test type: unit
+        """
+        from POMDPPlanners.environments.push_pomdp import (
+            _native,
+        )  # pylint: disable=import-outside-toplevel
+
+        env = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99,
+            state_transition_cov_matrix=np.eye(2) * 0.01,
+        )
+        state = np.array([5.0, 5.0, 5.5, 5.0, 9.0, 9.0])
+        for str_action in env.get_actions():
+            vec = env.action_to_vector[str_action]
+            _native.set_seed(2024)
+            via_str = env.sample_next_state(state, str_action)
+            _native.set_seed(2024)
+            via_vec = ContinuousPushPOMDP.sample_next_state(env, state, vec)
+            np.testing.assert_array_equal(via_str, via_vec)
+
+    def test_discrete_actions_sample_observation_uses_action_to_vector(self):
+        """Discrete-actions wrapper sample_observation resolves str via action_to_vector.
+
+        Purpose: Same as sample_next_state, for the observation override.
+
+        Given: A ContinuousPushPOMDPDiscreteActions env, a single next_state,
+            and identical ``_native.set_seed`` before each path.
+        When: For each str action, env.sample_observation(ns, str_action) is
+            compared against ContinuousPushPOMDP.sample_observation(env, ns,
+            action_to_vector[str_action]).
+        Then: Both paths produce np.array_equal observations.
+
+        Test type: unit
+        """
+        from POMDPPlanners.environments.push_pomdp import (
+            _native,
+        )  # pylint: disable=import-outside-toplevel
+
+        env = ContinuousPushPOMDPDiscreteActions(discount_factor=0.99)
+        next_state = np.array([5.0, 5.0, 5.5, 5.0, 9.0, 9.0])
+        for str_action in env.get_actions():
+            vec = env.action_to_vector[str_action]
+            _native.set_seed(2024)
+            via_str = env.sample_observation(next_state, str_action)
+            _native.set_seed(2024)
+            via_vec = ContinuousPushPOMDP.sample_observation(env, next_state, vec)
+            np.testing.assert_array_equal(via_str, via_vec)
+
+    def test_discrete_actions_action_to_vector_is_contiguous_float64(self):
+        """action_to_vector entries are contiguous float64 ndarrays.
+
+        Purpose: Guards the cache contract that lets the hot path skip
+            ``np.asarray(...).ravel()`` conversions inside the C++ kernel
+            constructor.
+
+        Given: A ContinuousPushPOMDPDiscreteActions env.
+        When: action_to_vector entries are inspected.
+        Then: Each value is a 1-D ndarray of shape (2,), dtype float64, and
+            C-contiguous.
+
+        Test type: unit
+        """
+        env = ContinuousPushPOMDPDiscreteActions(discount_factor=0.99)
+        for action_name, vec in env.action_to_vector.items():
+            assert isinstance(vec, np.ndarray), action_name
+            assert vec.dtype == np.float64, action_name
+            assert vec.shape == (2,), action_name
+            assert vec.flags["C_CONTIGUOUS"], action_name

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
@@ -1296,3 +1296,106 @@ class TestSampleNextStepEquivalence:
                     f"reward mismatch for action={action}, seed={seed}: "
                     f"{opt_reward} != {base_reward}"
                 )
+
+
+class TestSampleHotPathOverridesEquivalence:
+    """Pinned-seed equivalence between hot-path overrides and the wrapper path."""
+
+    def test_sample_next_state_matches_state_transition_model_wrapper(self):
+        """Pinned-seed equivalence: sample_next_state vs state_transition_model().sample()[0].
+
+        Purpose: Validates that the inlined sample_next_state override produces
+            byte-identical RNG draws to the wrapper-based state_transition_model
+            path. Both consume np.random.random() (then optionally
+            np.random.choice() on the error-action list) in the same order, so
+            under a pinned seed the two paths must yield equal next-states.
+
+        Given: A PushPOMDP with non-zero transition_error_prob (so the
+            np.random.choice branch is exercised), a list of (state, action)
+            pairs covering all four actions in mixed obstacle / push regimes,
+            and identical numpy / random seeds before each path.
+        When: env.state_transition_model(s, a).sample()[0] and
+            env.sample_next_state(s, a) are each called under the same seeded
+            RNG.
+        Then: For every (state, action) pair, both paths yield np.array_equal
+            results.
+
+        Test type: unit
+        """
+        env = PushPOMDP(
+            discount_factor=0.95,
+            grid_size=10,
+            push_threshold=1.0,
+            friction_coefficient=0.3,
+            observation_noise=0.1,
+            obstacles=[(3.0, 3.0), (7.0, 7.0)],
+            obstacle_radius=0.5,
+            transition_error_prob=0.2,
+        )
+        actions = env.get_actions()
+        test_pairs = [
+            (np.array([1.0, 1.0, 5.0, 5.0, 9.0, 9.0]), actions[0]),
+            (np.array([2.0, 3.0, 2.5, 3.0, 9.0, 9.0]), actions[1]),  # close to obj
+            (np.array([3.5, 3.0, 6.0, 6.0, 9.0, 9.0]), actions[2]),  # near obstacle
+            (np.array([0.0, 0.0, 1.0, 0.5, 9.0, 9.0]), actions[3]),  # corner
+            (np.array([8.0, 8.0, 7.5, 7.5, 9.0, 9.0]), actions[0]),  # near obstacle (7,7)
+            (np.array([5.0, 5.0, 5.5, 5.0, 9.0, 9.0]), actions[2]),  # close to obj
+        ]
+        for state, action in test_pairs:
+            for seed in (12345, 67890, 314159):
+                np.random.seed(seed)
+                random.seed(seed)
+                wrapper_next = env.state_transition_model(state, action).sample()[0]
+                np.random.seed(seed)
+                random.seed(seed)
+                direct_next = env.sample_next_state(state, action)
+                assert np.array_equal(wrapper_next, direct_next), (
+                    f"Mismatch for state={state}, action={action}, seed={seed}: "
+                    f"wrapper={wrapper_next}, direct={direct_next}"
+                )
+
+    def test_sample_observation_matches_observation_model_wrapper(self):
+        """Pinned-seed equivalence: sample_observation vs observation_model().sample()[0].
+
+        Purpose: Validates that the inlined sample_observation override produces
+            byte-identical RNG draws to the wrapper-based observation_model
+            path. Both consume two np.random.normal(0, sigma) draws in the same
+            order, so under a pinned seed the two paths must yield equal
+            observations (including the grid-clamp boundary cases).
+
+        Given: A PushPOMDP env, a list of (next_state, action) pairs spanning
+            mid-grid and edge / corner positions (so both unclamped and clamped
+            branches of max(0, min(.., gmax)) are exercised), and identical
+            numpy / random seeds before each path.
+        When: env.observation_model(ns, a).sample()[0] and
+            env.sample_observation(ns, a) are each called under the same seeded
+            RNG.
+        Then: For every (next_state, action) pair, both paths yield
+            np.array_equal observations.
+
+        Test type: unit
+        """
+        env = PushPOMDP(
+            discount_factor=0.95,
+            grid_size=10,
+            observation_noise=0.5,
+        )
+        test_pairs = [
+            (np.array([5.0, 5.0, 4.5, 5.5, 9.0, 9.0]), "up"),
+            (np.array([2.0, 7.0, 1.5, 6.5, 9.0, 9.0]), "down"),
+            (np.array([0.0, 0.0, 0.1, 0.0, 9.0, 9.0]), "right"),  # corner clamp
+            (np.array([9.0, 9.0, 8.9, 9.0, 9.0, 9.0]), "left"),  # opposite corner
+            (np.array([3.0, 3.0, 3.0, 3.0, 9.0, 9.0]), "up"),
+        ]
+        for next_state, action in test_pairs:
+            for seed in (54321, 24680, 271828):
+                np.random.seed(seed)
+                random.seed(seed)
+                wrapper_obs = env.observation_model(next_state, action).sample()[0]
+                np.random.seed(seed)
+                random.seed(seed)
+                direct_obs = env.sample_observation(next_state, action)
+                assert np.array_equal(wrapper_obs, direct_obs), (
+                    f"Mismatch for next_state={next_state}, action={action}, seed={seed}: "
+                    f"wrapper={wrapper_obs}, direct={direct_obs}"
+                )

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_native_equivalence.py
@@ -654,3 +654,97 @@ def test_batch_transition_full_parity_against_updater(env: RockSamplePOMDP, acti
         action=action,
         per_particle_transition_fn=per_particle,
     )
+
+
+# ---------------------------------------------------------------------------
+# 20. Hot-path sample_next_state / sample_observation overrides
+#     (skip Python wrapper, route directly to native kernel)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "robot_pos,action,rocks",
+    [
+        ((0, 0), 1, (True, True, False, True)),  # north move
+        ((2, 2), 2, (False, True, True, False)),  # east move
+        ((3, 3), 5, (True, False, False, True)),  # check rock 0 from far
+        ((1, 1), 5, (True, True, True, True)),  # check rock 0 colocated
+        ((4, 4), 0, (False, True, False, True)),  # sample at empty cell
+    ],
+)
+def test_sample_next_state_override_matches_wrapper(
+    env: RockSamplePOMDP,
+    robot_pos: Tuple[int, int],
+    action: int,
+    rocks: Tuple[bool, ...],
+) -> None:
+    """Override sample_next_state matches the per-call wrapper bit-exactly.
+
+    Purpose: Validates that ``RockSamplePOMDP.sample_next_state`` (which
+    constructs the native kernel directly, skipping the Python wrapper)
+    produces the exact same next state as the legacy
+    ``state_transition_model(state, action).sample()[0]`` path under a
+    fixed C++ RNG seed.
+
+    Given: The shared RockSample env fixture and a parametrized
+        ``(robot_pos, action, rocks)`` triple covering movement, check,
+        and sample actions.
+    When: Both paths are invoked with ``_native.set_seed`` reset to the
+        same value before each call.
+    Then: ``np.array_equal`` holds elementwise on the returned arrays.
+
+    Test type: integration
+    """
+    state = _state(robot_pos[0], robot_pos[1], rocks)
+
+    _native.set_seed(2024)
+    via_wrapper = env.state_transition_model(state, action).sample()[0]
+
+    _native.set_seed(2024)
+    via_override = env.sample_next_state(state=state, action=action)
+
+    assert np.array_equal(via_wrapper, via_override)
+
+
+@pytest.mark.parametrize(
+    "robot_pos,action,rocks",
+    [
+        ((1, 1), 5, (True, True, False, True)),  # check rock 0 colocated
+        ((0, 0), 5, (True, False, True, False)),  # check rock 0 from corner
+        ((3, 3), 6, (False, True, False, True)),  # check rock 1 colocated
+        ((6, 2), 8, (True, True, True, False)),  # check rock 3 colocated
+        ((2, 2), 2, (True, True, True, True)),  # movement -> none
+    ],
+)
+def test_sample_observation_override_matches_wrapper(
+    env: RockSamplePOMDP,
+    robot_pos: Tuple[int, int],
+    action: int,
+    rocks: Tuple[bool, ...],
+) -> None:
+    """Override sample_observation matches the per-call wrapper bit-exactly.
+
+    Purpose: Validates that ``RockSamplePOMDP.sample_observation`` (which
+    constructs the native observation kernel directly, skipping the
+    Python wrapper) produces the exact same string observation as the
+    legacy ``observation_model(...).sample()[0]`` path under a fixed
+    C++ RNG seed.
+
+    Given: The shared env fixture plus a parametrized
+        ``(robot_pos, action, rocks)`` triple covering check actions
+        across distances and a movement action.
+    When: Both paths are invoked with ``_native.set_seed`` reset to the
+        same value before each call.
+    Then: The two string observations are equal.
+
+    Test type: integration
+    """
+    next_state = _state(robot_pos[0], robot_pos[1], rocks)
+
+    _native.set_seed(7777)
+    via_wrapper = env.observation_model(next_state, action).sample()[0]
+
+    _native.set_seed(7777)
+    via_override = env.sample_observation(next_state=next_state, action=action)
+
+    assert via_wrapper == via_override

--- a/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_native_equivalence.py
@@ -461,3 +461,79 @@ def test_observation_probability_accepts_list_and_ndarray_inputs(observation):
     from_array = observation.probability(array_values)
 
     np.testing.assert_array_equal(from_list, from_array)
+
+
+# ---------------------------------------------------------------------------
+# Hot-path sample_next_state / sample_observation overrides
+# (skip Python wrapper, route directly to native kernel)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state,action",
+    [
+        (np.array([0.0, 0.0, 0.0, 0.0]), 0),  # zero force -> deterministic
+        (np.array([0.5, -0.2, 1.0, 0.5]), 1),
+        (np.array([-0.3, 0.4, 0.7, -0.6]), 2),
+        (np.array([0.1, 0.1, 1.5, 0.8]), 3),
+    ],
+)
+def test_sample_next_state_override_matches_wrapper(env, state, action):
+    """Override sample_next_state matches the per-call wrapper bit-exactly.
+
+    Purpose: Validates that ``SafeAntVelocityPOMDP.sample_next_state``
+    (which constructs the native transition kernel directly, skipping the
+    Python wrapper) produces the exact same next state as the legacy
+    ``state_transition_model(state, action).sample()[0]`` path under a
+    fixed C++ RNG seed.
+
+    Given: The shared SafeAnt env fixture and a parametrized
+        ``(state, action)`` pair covering zero-force and varied-force
+        regimes.
+    When: Both paths are invoked with ``_native.set_seed`` reset to the
+        same value before each call.
+    Then: ``np.array_equal`` holds elementwise on the returned arrays.
+
+    Test type: integration
+    """
+    _native.set_seed(2024)
+    via_wrapper = env.state_transition_model(state=state, action=action).sample()[0]
+
+    _native.set_seed(2024)
+    via_override = env.sample_next_state(state=state, action=action)
+
+    np.testing.assert_array_equal(via_wrapper, via_override)
+
+
+@pytest.mark.parametrize(
+    "next_state,action",
+    [
+        (np.array([0.0, 0.0, 0.0, 0.0]), 0),
+        (np.array([0.5, -0.2, 1.0, 0.5]), 1),
+        (np.array([-0.3, 0.4, 0.7, -0.6]), 2),
+        (np.array([0.1, 0.1, 1.5, 0.8]), 3),
+    ],
+)
+def test_sample_observation_override_matches_wrapper(env, next_state, action):
+    """Override sample_observation matches the per-call wrapper bit-exactly.
+
+    Purpose: Validates that ``SafeAntVelocityPOMDP.sample_observation``
+    (which constructs the native observation kernel directly, skipping
+    the Python wrapper) produces the exact same observation as the legacy
+    ``observation_model(...).sample()[0]`` path under a fixed C++ RNG seed.
+
+    Given: The shared env fixture plus a parametrized
+        ``(next_state, action)`` pair.
+    When: Both paths are invoked with ``_native.set_seed`` reset to the
+        same value before each call.
+    Then: ``np.array_equal`` holds elementwise.
+
+    Test type: integration
+    """
+    _native.set_seed(7777)
+    via_wrapper = env.observation_model(next_state=next_state, action=action).sample()[0]
+
+    _native.set_seed(7777)
+    via_override = env.sample_observation(next_state=next_state, action=action)
+
+    np.testing.assert_array_equal(via_wrapper, via_override)

--- a/POMDPPlanners/tests/test_environments/test_sanity_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_sanity_pomdp.py
@@ -851,3 +851,61 @@ class TestSanityPOMDPIntegration:
             assert next_state == 1
             assert next_observation == 1
             assert reward == 0.0
+
+
+def test_sample_next_state_rng_pinned_equivalence(sanity_pomdp):
+    """Test that sample_next_state matches state_transition_model().sample()[0] under fixed RNG.
+
+    Purpose: Validates that the sample_next_state override produces byte-identical results
+        to the wrapper-based path when both are seeded identically.
+
+    Given: A SanityPOMDP environment and the four (state, action) combinations covering
+        the full discrete state-action space, with both np.random and random pinned
+    When: A sample is drawn through state_transition_model(s, a).sample()[0] and again through
+        env.sample_next_state(s, a) after re-seeding
+    Then: The two draws are equal across all (state, action) combinations
+
+    Test type: unit
+    """
+    cases = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    for state, action in cases:
+        np.random.seed(123)
+        random.seed(123)
+        wrapper_sample = sanity_pomdp.state_transition_model(state=state, action=action).sample()[0]
+        np.random.seed(123)
+        random.seed(123)
+        direct_sample = sanity_pomdp.sample_next_state(state=state, action=action)
+        assert wrapper_sample == direct_sample, (
+            f"sample_next_state mismatch for ({state}, {action}): "
+            f"{wrapper_sample} vs {direct_sample}"
+        )
+
+
+def test_sample_observation_rng_pinned_equivalence(sanity_pomdp):
+    """Test that sample_observation matches observation_model().sample()[0] under fixed RNG.
+
+    Purpose: Validates that the sample_observation override produces byte-identical results
+        to the wrapper-based path when both are seeded identically.
+
+    Given: A SanityPOMDP environment and the four (next_state, action) combinations
+        covering the full discrete state-action space, with both np.random and random pinned
+    When: An observation is drawn through observation_model(ns, a).sample()[0] and again
+        through env.sample_observation(ns, a) after re-seeding
+    Then: The two draws are equal across all (next_state, action) combinations
+
+    Test type: unit
+    """
+    cases = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    for next_state, action in cases:
+        np.random.seed(7)
+        random.seed(7)
+        wrapper_obs = sanity_pomdp.observation_model(next_state=next_state, action=action).sample()[
+            0
+        ]
+        np.random.seed(7)
+        random.seed(7)
+        direct_obs = sanity_pomdp.sample_observation(next_state=next_state, action=action)
+        assert wrapper_obs == direct_obs, (
+            f"sample_observation mismatch for ({next_state}, {action}): "
+            f"{wrapper_obs} vs {direct_obs}"
+        )

--- a/POMDPPlanners/tests/test_environments/test_tiger_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_tiger_pomdp.py
@@ -694,3 +694,73 @@ def test_metric_name_consistency(tiger_pomdp):
 
     # Verify consistency using reusable utility function
     verify_environment_metric_consistency(tiger_pomdp, histories)
+
+
+def test_sample_next_state_rng_pinned_equivalence(tiger_pomdp):
+    """Test that sample_next_state matches state_transition_model().sample()[0] under fixed RNG.
+
+    Purpose: Validates that the sample_next_state override produces byte-identical results
+        to the wrapper-based path when both are seeded identically.
+
+    Given: A TigerPOMDP environment and a list of (state, action) pairs covering listen and
+        both open actions, with both np.random and random pinned to the same seed
+    When: A sample is drawn through state_transition_model(s, a).sample()[0] and again through
+        env.sample_next_state(s, a) after re-seeding
+    Then: The two draws are equal across all (state, action) combinations
+
+    Test type: unit
+    """
+    cases = [
+        ("tiger_left", "listen"),
+        ("tiger_right", "listen"),
+        ("tiger_left", "open_left"),
+        ("tiger_left", "open_right"),
+        ("tiger_right", "open_left"),
+        ("tiger_right", "open_right"),
+    ]
+    for state, action in cases:
+        np.random.seed(123)
+        random.seed(123)
+        wrapper_sample = tiger_pomdp.state_transition_model(state=state, action=action).sample()[0]
+        np.random.seed(123)
+        random.seed(123)
+        direct_sample = tiger_pomdp.sample_next_state(state=state, action=action)
+        assert wrapper_sample == direct_sample, (
+            f"sample_next_state mismatch for ({state!r}, {action!r}): "
+            f"{wrapper_sample!r} vs {direct_sample!r}"
+        )
+
+
+def test_sample_observation_rng_pinned_equivalence(tiger_pomdp):
+    """Test that sample_observation matches observation_model().sample()[0] under fixed RNG.
+
+    Purpose: Validates that the sample_observation override produces byte-identical results
+        to the wrapper-based path when both are seeded identically.
+
+    Given: A TigerPOMDP environment and (next_state, action) pairs spanning listen and open
+        actions, with both np.random and random pinned to the same seed
+    When: An observation is drawn through observation_model(ns, a).sample()[0] and again
+        through env.sample_observation(ns, a) after re-seeding
+    Then: The two draws are equal across all (next_state, action) combinations
+
+    Test type: unit
+    """
+    cases = [
+        ("tiger_left", "listen"),
+        ("tiger_right", "listen"),
+        ("tiger_left", "open_left"),
+        ("tiger_right", "open_right"),
+    ]
+    for next_state, action in cases:
+        np.random.seed(7)
+        random.seed(7)
+        wrapper_obs = tiger_pomdp.observation_model(next_state=next_state, action=action).sample()[
+            0
+        ]
+        np.random.seed(7)
+        random.seed(7)
+        direct_obs = tiger_pomdp.sample_observation(next_state=next_state, action=action)
+        assert wrapper_obs == direct_obs, (
+            f"sample_observation mismatch for ({next_state!r}, {action!r}): "
+            f"{wrapper_obs!r} vs {direct_obs!r}"
+        )

--- a/bench_env_sample_direct_api.md
+++ b/bench_env_sample_direct_api.md
@@ -1,0 +1,68 @@
+# env-sample-direct-api: bench summary
+
+Baseline = `develop` HEAD (`1bfaa24`), per-step factory + wrapper allocation.
+After = same HEAD + this branch's per-env `sample_next_state` / `sample_observation`
+overrides that bypass the Python wrapper subclass and go straight to the
+sampling math (or native C++ kernel).
+
+Settings: 100-particle initial belief, `_simulate_path` driven on a fresh
+`BeliefNode` per repeat, 1.0 s budget, median of N trials.
+
+## POMCPOW (sims/sec, median)
+
+| Env                                | Before  | After   | Δ       |
+| ---------------------------------- | ------: | ------: | ------: |
+| Tiger                              |  7,218  |  7,827  |  +8.4%  |
+| Sanity                             | 10,240  | 11,160  |  +9.0%  |
+| MountainCar                        |  9,939  |  9,872  |  -0.7%  |
+| CartPole                           |  9,728  |  9,827  |  +1.0%  |
+| DiscreteLightDark                  |  2,330  |  2,339  |  +0.4%  |
+| ContinuousLightDarkDiscreteActions |  7,680  |  8,499  | +10.7%  |
+| ContinuousLightDark                |  4,175  |  4,142  |  -0.8%  |
+| LaserTag                           |  2,494  |  2,674  |  +7.2%  |
+| ContinuousLaserTag                 |  4,010  |  4,018  |  +0.2%  |
+| Push                               |  6,527  |  6,515  |  -0.2%  |
+| ContinuousPush                     |  3,162  |  3,197  |  +1.1%  |
+| RockSample                         |  7,258  |  7,736  |  +6.6%  |
+| SafetyAnt                          |  7,199  |  7,510  |  +4.3%  |
+| Pacman                             |  5,563  |  5,362  |  -3.6%  |
+
+## PFT-DPW (sims/sec, median)
+
+| Env                                |  Before |  After  |    Δ     |
+| ---------------------------------- | ------: | ------: | -------: |
+| Tiger                              |  1,480  |  1,687  |  +14.0%  |
+| Sanity                             |  4,240  |  4,961  |  +17.0%  |
+| MountainCar                        |  3,863  |  4,166  |   +7.8%  |
+| CartPole                           |  3,842  |  4,400  |  +14.5%  |
+| DiscreteLightDark                  |  279    |  357    |  +28.1%  |
+| ContinuousLightDarkDiscreteActions |  2,537  |  3,115  |  +22.8%  |
+| ContinuousLightDark                |  1,933  |  2,151  |  +11.3%  |
+| LaserTag                           |  193    |  235    |  +21.8%  |
+| ContinuousLaserTag                 |  1,639  |  1,763  |   +7.6%  |
+| Push                               |  687    |  795    |  +15.7%  |
+| ContinuousPush                     |  692    |  746    |   +7.8%  |
+| RockSample                         |  1,023  |  1,069  |   +4.5%  |
+| SafetyAnt                          |  2,505  |  3,417  |  +36.4%  |
+| Pacman                             |  2,193  |  2,261  |   +3.1%  |
+
+## Why PFT-DPW gains more than POMCPOW
+
+PFT-DPW does a `belief.update()` per tree expansion which iterates particles
+through `pomdp.sample_next_state(state=particle, action=action)` — exactly
+the path the new overrides skip. POMCPOW's hot path samples one state per
+sim, so it benefits primarily from the env-side wrapper-allocation savings
+inside `sample_next_step`, which is a smaller share of its total runtime.
+
+## Behavior preservation
+
+Every modified env carries an RNG-pinned (or, for envs with non-reproducible
+native RNG, statistical) equivalence test that compares the wrapper-path
+draw to the new direct-path draw under identical seeds. All env test suites
+pass:
+
+- LightDark (Continuous + Discrete + DiscreteActions): 53 + 44 = 97 tests
+- LaserTag (Continuous + Discrete): 184 tests
+- Push (Continuous + Discrete): 151 tests
+- Tiger, Sanity, MountainCar, CartPole: 144 tests
+- RockSample, SafetyAnt, Pacman: 319 tests


### PR DESCRIPTION
## Summary

- Adds two hot-path methods on `Environment` (`sample_next_state`, `sample_observation`) with default impls going through the existing factory + `.sample()` so envs that don't override see no behavior change.
- Reroutes `Environment.sample_next_step` and `WeightedParticleBelief` / `UnweightedParticleBelief` per-particle simulate calls through the new methods. Planners (POMCPOW, PFT-DPW, ICVaR variants, BetaZero, ConstrainedZero) inherit the speedup automatically via their existing `sample_next_step` / `belief.update()` calls.
- All **14 environments** override the new methods to skip the per-step Python-wrapper-subclass allocation. Wrapper classes themselves are **untouched** — still returned by factories for callers that need a `Distribution` object.

## Behavior preservation

Every modified env carries a pinned-seed (or statistical, where native C++ RNG is non-reproducible from Python) equivalence test that compares the wrapper-path draw to the new direct-path draw. Tests:
- **1036 env tests pass** (53 + 44 LightDark; 184 LaserTag; 151 Push; 144 Tiger/Sanity/MountainCar/CartPole; 319 RockSample/SafetyAnt/Pacman; 141 supporting fixtures)
- **44 POMCPOW + PFT-DPW arena planner tests pass** (post-merge with `develop`'s arena migration)

## Bench results (sims/sec, median, 1.0 s × 3 trials, 100 particles)

### PFT-DPW — gains across all 14 envs

| Env | Before | After | Δ |
|---|---:|---:|---:|
| SafetyAnt | 2,505 | 3,417 | **+36.4%** |
| DiscreteLightDark | 279 | 357 | **+28.1%** |
| ContinuousLightDarkDiscreteActions | 2,537 | 3,115 | **+22.8%** |
| LaserTag | 193 | 235 | **+21.8%** |
| Sanity | 4,240 | 4,961 | +17.0% |
| Push | 687 | 795 | +15.7% |
| CartPole | 3,842 | 4,400 | +14.5% |
| Tiger | 1,480 | 1,687 | +14.0% |
| ContinuousLightDark | 1,933 | 2,151 | +11.3% |
| ContinuousPush | 692 | 746 | +7.8% |
| MountainCar | 3,863 | 4,166 | +7.8% |
| ContinuousLaserTag | 1,639 | 1,763 | +7.6% |
| RockSample | 1,023 | 1,069 | +4.5% |
| Pacman | 2,193 | 2,261 | +3.1% |

### POMCPOW — more modest, hot path samples one state/sim

| Env | Before | After | Δ |
|---|---:|---:|---:|
| ContinuousLightDarkDiscreteActions | 7,680 | 8,499 | **+10.7%** |
| Sanity | 10,240 | 11,160 | +9.0% |
| Tiger | 7,218 | 7,827 | +8.4% |
| LaserTag | 2,494 | 2,674 | +7.2% |
| RockSample | 7,258 | 7,736 | +6.6% |
| SafetyAnt | 7,199 | 7,510 | +4.3% |
| Pacman | 5,563 | 5,362 | -3.6% |
| Other 7 envs | — | — | flat (±1-3% noise band) |

PFT-DPW sees larger gains because it runs `belief.update()` per tree-expansion, which iterates particles through `pomdp.sample_next_state(particle, action)` — exactly the path the new overrides skip. POMCPOW's hot path samples one state per sim, so the env-ctor share is smaller.

## Implementation notes per env class

| Env type | Strategy |
|---|---|
| Pure-Python wrappers (Tiger, Sanity, MountainCar, CartPole, DiscreteLightDark, LaserTag, Push, Pacman) | Inline wrapper `__init__` + `.sample()` body into env method. Same `np.random`/`random` call sequence — byte-identical seeded behavior. |
| pybind11/native-backed (ContinuousLightDark, ContinuousPush, ContinuousLaserTag, RockSample, SafetyAnt) | Construct `_native.<Env>{Transition,Observation}Cpp` directly in env method, skipping the Python subclass allocation + redundant `np.asarray(...).ravel()` conversions. |
| Discrete-actions wrappers (ContinuousLightDarkPOMDPDiscreteActions, ContinuousPushPOMDPDiscreteActions) | Cache `action_to_vector` as contiguous `float64` ndarrays once at `__init__`; overrides delegate to super with the cached vector. |

## Test plan

- [x] All env test suites pass (1036 tests)
- [x] POMCPOW + PFT-DPW arena tests pass (44 tests)
- [x] Pinned-seed / statistical equivalence tests added per env
- [x] black + pylint + pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)