### PR TITLE
PR-A: Add batched sampling + log-probability API to Environment

### DIFF
--- a/POMDPPlanners/core/environment.py
+++ b/POMDPPlanners/core/environment.py
@@ -566,39 +566,104 @@ class Environment(ABC):
             This is particularly important for discrete observation spaces.
         """
 
-    def sample_next_state(self, state: Any, action: Any) -> Any:
-        """Sample a single next state for ``(state, action)``.
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> Any:
+        """Sample one or more next states for ``(state, action)``.
 
-        Hot-path entry point used by MCTS planners. The default delegates to
-        ``state_transition_model(state, action).sample()[0]``; subclasses may
-        override to skip the per-call wrapper allocation while preserving the
-        same RNG draw sequence.
+        Hot-path entry point used by MCTS planners and by particle filters.
+        The default delegates to
+        ``state_transition_model(state, action).sample(n_samples)``; subclasses
+        may override to skip the per-call wrapper allocation while preserving
+        the same RNG draw sequence.
 
         Args:
             state: Current state.
             action: Action to execute.
+            n_samples: Number of samples to draw. Defaults to 1.
 
         Returns:
-            A sampled next state.
+            When ``n_samples == 1``: a single next state of the env's
+            native type.
+            When ``n_samples > 1``: an array-like of length ``n_samples``.
+            Numeric envs return ``np.ndarray`` of shape ``(n_samples, *dim)``;
+            structured envs (Tiger, Pacman, Sanity) return a
+            ``List[T]`` of length ``n_samples``.
         """
-        return self.state_transition_model(state=state, action=action).sample()[0]
+        samples = self.state_transition_model(state=state, action=action).sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return samples
 
-    def sample_observation(self, next_state: Any, action: Any) -> Any:
-        """Sample a single observation for ``(next_state, action)``.
+    def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> Any:
+        """Sample one or more observations for ``(next_state, action)``.
 
-        Hot-path entry point used by MCTS planners. The default delegates to
-        ``observation_model(next_state, action).sample()[0]``; subclasses may
-        override to skip the per-call wrapper allocation while preserving the
-        same RNG draw sequence.
+        Hot-path entry point used by MCTS planners and by particle filters.
+        The default delegates to
+        ``observation_model(next_state, action).sample(n_samples)``;
+        subclasses may override to skip the per-call wrapper allocation while
+        preserving the same RNG draw sequence.
 
         Args:
             next_state: State after the action was executed.
             action: Action that was executed.
+            n_samples: Number of samples to draw. Defaults to 1.
 
         Returns:
-            A sampled observation.
+            When ``n_samples == 1``: a single observation of the env's
+            native type.
+            When ``n_samples > 1``: an array-like of length ``n_samples``.
+            Numeric envs return ``np.ndarray`` of shape ``(n_samples, *dim)``;
+            structured envs return a ``List[T]`` of length ``n_samples``.
         """
-        return self.observation_model(next_state=next_state, action=action).sample()[0]
+        samples = self.observation_model(next_state=next_state, action=action).sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return samples
+
+    def transition_log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+        """Log-probability of each candidate next state under ``(state, action)``.
+
+        The default delegates to
+        ``np.log(state_transition_model(state, action).probability(next_states))``;
+        subclasses may override for vectorized native paths.
+
+        Args:
+            state: Current state.
+            action: Action that was executed.
+            next_states: A sequence (length N) or batch ndarray (shape ``(N, *dim)``)
+                of candidate next states.
+
+        Returns:
+            ndarray of shape ``(N,)`` with log-probabilities (or log-PDFs for
+            continuous envs).
+        """
+        probs = np.asarray(
+            self.state_transition_model(state=state, action=action).probability(next_states)
+        )
+        return np.log(probs + 1e-300)
+
+    def observation_log_probability(
+        self, next_state: Any, action: Any, observations: Any
+    ) -> np.ndarray:
+        """Log-probability of each candidate observation under ``(next_state, action)``.
+
+        The default delegates to
+        ``np.log(observation_model(next_state, action).probability(observations))``;
+        subclasses may override for vectorized native paths.
+
+        Args:
+            next_state: State after the action was executed.
+            action: Action that was executed.
+            observations: A sequence (length N) or batch ndarray (shape ``(N, *dim)``)
+                of candidate observations.
+
+        Returns:
+            ndarray of shape ``(N,)`` with log-probabilities (or log-PDFs for
+            continuous envs).
+        """
+        probs = np.asarray(
+            self.observation_model(next_state=next_state, action=action).probability(observations)
+        )
+        return np.log(probs + 1e-300)
 
     def sample_next_step(self, state: Any, action: Any) -> Tuple[Any, Any, float]:
         """Sample a complete state transition step.

--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
@@ -368,7 +368,9 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
     # ``sample()`` produces a byte-identical RNG draw to the legacy
     # path.
 
-    def sample_next_state(self, state: np.ndarray, action: int) -> NDArray[np.float64]:
+    def sample_next_state(
+        self, state: np.ndarray, action: int, n_samples: int = 1
+    ) -> NDArray[np.float64]:
         kernel = _native.CartPoleTransitionCpp(
             state=state,
             action=action,
@@ -382,15 +384,59 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
             masspole=self.masspole,
             covariance=self._state_transition_dist.covariance,
         )
-        return kernel.sample()[0]
+        samples = kernel.sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return np.asarray(samples)
 
-    def sample_observation(self, next_state: np.ndarray, action: int) -> NDArray[np.float64]:
+    def sample_observation(
+        self, next_state: np.ndarray, action: int, n_samples: int = 1
+    ) -> NDArray[np.float64]:
         kernel = _native.CartPoleObservationCpp(
             next_state=next_state,
             action=action,
             covariance=self._obs_dist.covariance,
         )
-        return kernel.sample()[0]
+        samples = kernel.sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return np.asarray(samples)
+
+    def transition_log_probability(
+        self,
+        state: np.ndarray,
+        action: int,
+        next_states: Union[Sequence[Any], np.ndarray],
+    ) -> np.ndarray:
+        kernel = _native.CartPoleTransitionCpp(
+            state=state,
+            action=action,
+            force_mag=self.force_mag,
+            total_mass=self.total_mass,
+            polemass_length=self.polemass_length,
+            gravity=self.gravity,
+            length=self.length,
+            kinematics_integrator=self.kinematics_integrator,
+            tau=self.tau,
+            masspole=self.masspole,
+            covariance=self._state_transition_dist.covariance,
+        )
+        probs = np.asarray(kernel.probability(next_states))
+        return np.log(probs + 1e-300)
+
+    def observation_log_probability(
+        self,
+        next_state: np.ndarray,
+        action: int,
+        observations: Union[Sequence[Any], np.ndarray],
+    ) -> np.ndarray:
+        kernel = _native.CartPoleObservationCpp(
+            next_state=next_state,
+            action=action,
+            covariance=self._obs_dist.covariance,
+        )
+        probs = np.asarray(kernel.probability(observations))
+        return np.log(probs + 1e-300)
 
     def reward(self, state: np.ndarray, action: int) -> float:
         terminated = self.is_terminal(state)

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -372,7 +372,7 @@ class ContinuousLaserTagPOMDP(Environment):
     # directly to skip the Python wrapper allocation, producing byte-identical
     # RNG draws (same module-level RNG, same call sequence).
 
-    def sample_next_state(self, state: np.ndarray, action: np.ndarray) -> np.ndarray:
+    def sample_next_state(self, state: np.ndarray, action: np.ndarray, n_samples: int = 1) -> Any:
         kernel = _native.ContinuousLaserTagTransitionCpp(
             state=state,
             action=np.asarray(action, dtype=float),
@@ -385,9 +385,14 @@ class ContinuousLaserTagPOMDP(Environment):
             opponent_radius=self.opponent_radius,
             tag_radius=self.tag_radius,
         )
-        return kernel.sample(1)[0]
+        samples = kernel.sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return samples
 
-    def sample_observation(self, next_state: np.ndarray, action: np.ndarray) -> Any:
+    def sample_observation(
+        self, next_state: np.ndarray, action: np.ndarray, n_samples: int = 1
+    ) -> Any:
         kernel = _native.ContinuousLaserTagObservationCpp(
             next_state=next_state,
             action=np.asarray(action, dtype=float),
@@ -396,7 +401,44 @@ class ContinuousLaserTagPOMDP(Environment):
             grid_size=self._grid_size,
             opponent_radius=self.opponent_radius,
         )
-        return kernel.sample(1)[0]
+        samples = kernel.sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return samples
+
+    def transition_log_probability(
+        self, state: np.ndarray, action: np.ndarray, next_states: Any
+    ) -> np.ndarray:
+        kernel = _native.ContinuousLaserTagTransitionCpp(
+            state=state,
+            action=np.asarray(action, dtype=float),
+            robot_covariance=self._robot_transition_dist.covariance,
+            opponent_covariance=self._opponent_transition_dist.covariance,
+            pursuit_speed=self.pursuit_speed,
+            walls=self._walls,
+            grid_size=self._grid_size,
+            robot_radius=self.robot_radius,
+            opponent_radius=self.opponent_radius,
+            tag_radius=self.tag_radius,
+        )
+        probs = np.asarray(kernel.probability(next_states))
+        with np.errstate(divide="ignore"):
+            return np.log(probs)
+
+    def observation_log_probability(
+        self, next_state: np.ndarray, action: np.ndarray, observations: Any
+    ) -> np.ndarray:
+        kernel = _native.ContinuousLaserTagObservationCpp(
+            next_state=next_state,
+            action=np.asarray(action, dtype=float),
+            measurement_noise=self.measurement_noise,
+            walls=self._walls,
+            grid_size=self._grid_size,
+            opponent_radius=self.opponent_radius,
+        )
+        probs = np.asarray(kernel.probability(observations))
+        with np.errstate(divide="ignore"):
+            return np.log(probs)
 
     def reward(self, state: np.ndarray, action: np.ndarray) -> float:
         if bool(state[4]):
@@ -716,11 +758,25 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
     def observation_model(self, next_state: np.ndarray, action: Any) -> ObservationModel:
         return super().observation_model(next_state, self.action_to_vector[action])
 
-    def sample_next_state(self, state: np.ndarray, action: Any) -> np.ndarray:
-        return super().sample_next_state(state, self.action_to_vector[action])
+    def sample_next_state(self, state: np.ndarray, action: Any, n_samples: int = 1) -> Any:
+        return super().sample_next_state(state, self.action_to_vector[action], n_samples=n_samples)
 
-    def sample_observation(self, next_state: np.ndarray, action: Any) -> Any:
-        return super().sample_observation(next_state, self.action_to_vector[action])
+    def sample_observation(self, next_state: np.ndarray, action: Any, n_samples: int = 1) -> Any:
+        return super().sample_observation(
+            next_state, self.action_to_vector[action], n_samples=n_samples
+        )
+
+    def transition_log_probability(
+        self, state: np.ndarray, action: Any, next_states: Any
+    ) -> np.ndarray:
+        return super().transition_log_probability(state, self.action_to_vector[action], next_states)
+
+    def observation_log_probability(
+        self, next_state: np.ndarray, action: Any, observations: Any
+    ) -> np.ndarray:
+        return super().observation_log_probability(
+            next_state, self.action_to_vector[action], observations
+        )
 
     def reward(self, state: np.ndarray, action: Any) -> float:
         return super().reward(state, self.action_to_vector[action])

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -779,7 +779,7 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             and pos not in self.walls
         )
 
-    def sample_next_state(self, state: np.ndarray, action: int) -> np.ndarray:
+    def sample_next_state(self, state: np.ndarray, action: int, n_samples: int = 1) -> Any:
         # _get_actual_action: matches LaserTagStateTransition._get_actual_action
         if action == 4:
             actual_action = action
@@ -801,9 +801,9 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
 
         opponent_current = (int(state[2]), int(state[3]))
 
-        # Tag at same cell → terminal
+        # Tag at same cell → terminal: no extra RNG draws regardless of n_samples
         if actual_action == 4 and robot_current == opponent_current:
-            return np.array(
+            terminal_array = np.array(
                 [
                     float(robot_next[0]),
                     float(robot_next[1]),
@@ -812,21 +812,42 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
                     1.0,
                 ]
             )
+            if n_samples == 1:
+                return terminal_array
+            return [terminal_array.copy() for _ in range(n_samples)]
 
-        # Regular transition: build opponent move distribution then draw
+        # Regular transition: build opponent move distribution then draw indices
+        # in a single np.random.choice call (matches the wrapper's RNG draw order
+        # for any n_samples).
         opp_moves = self._opponent_move_probabilities_inline(state, robot_next)
         positions, probabilities = zip(*opp_moves)
-        opp_indices = np.random.choice(len(positions), size=1, p=probabilities)
-        opp_next_pos = positions[opp_indices[0]]
-        return np.array(
-            [
-                float(robot_next[0]),
-                float(robot_next[1]),
-                float(opp_next_pos[0]),
-                float(opp_next_pos[1]),
-                0.0,
-            ]
-        )
+        opp_indices = np.random.choice(len(positions), size=n_samples, p=probabilities)
+        if n_samples == 1:
+            opp_next_pos = positions[opp_indices[0]]
+            return np.array(
+                [
+                    float(robot_next[0]),
+                    float(robot_next[1]),
+                    float(opp_next_pos[0]),
+                    float(opp_next_pos[1]),
+                    0.0,
+                ]
+            )
+        samples: List[np.ndarray] = []
+        for idx in opp_indices:
+            opp_next_pos = positions[idx]
+            samples.append(
+                np.array(
+                    [
+                        float(robot_next[0]),
+                        float(robot_next[1]),
+                        float(opp_next_pos[0]),
+                        float(opp_next_pos[1]),
+                        0.0,
+                    ]
+                )
+            )
+        return samples
 
     def _opponent_move_probabilities_inline(
         self, state: np.ndarray, robot_pos: Tuple[int, int]
@@ -895,9 +916,12 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             moves.append((away_pos, away_prob))
         return moves
 
-    def sample_observation(self, next_state: np.ndarray, action: int) -> Tuple[float, ...]:
+    def sample_observation(self, next_state: np.ndarray, action: int, n_samples: int = 1) -> Any:
         if bool(next_state[4]):
-            return (-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0)
+            terminal_obs = (-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0)
+            if n_samples == 1:
+                return terminal_obs
+            return [terminal_obs] * n_samples
 
         robot_pos = (int(next_state[0]), int(next_state[1]))
         opp_pos = (int(next_state[2]), int(next_state[3]))
@@ -906,12 +930,41 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             self._laser_distance_inline(robot_pos, direction, opp_pos)
             for direction in _LASER_DIRECTIONS
         ]
-        # Add Gaussian noise to each measurement (8 np.random.normal draws, in order)
-        noisy: List[float] = []
-        for true_measure in true_measurements:
-            noise = np.random.normal(0, self.measurement_noise)
-            noisy.append(max(0.0, true_measure + noise))
-        return tuple(noisy)
+        # Add Gaussian noise to each measurement (8 np.random.normal draws per
+        # sample, in dir order — matches wrapper's RNG draw sequence).
+        if n_samples == 1:
+            noisy: List[float] = []
+            for true_measure in true_measurements:
+                noise = np.random.normal(0, self.measurement_noise)
+                noisy.append(max(0.0, true_measure + noise))
+            return tuple(noisy)
+
+        samples: List[Tuple[float, ...]] = []
+        for _ in range(n_samples):
+            noisy_inner: List[float] = []
+            for true_measure in true_measurements:
+                noise = np.random.normal(0, self.measurement_noise)
+                noisy_inner.append(max(0.0, true_measure + noise))
+            samples.append(tuple(noisy_inner))
+        return samples
+
+    def transition_log_probability(
+        self, state: np.ndarray, action: int, next_states: Any
+    ) -> np.ndarray:
+        probs = np.asarray(
+            self.state_transition_model(state=state, action=action).probability(next_states)
+        )
+        with np.errstate(divide="ignore"):
+            return np.log(probs)
+
+    def observation_log_probability(
+        self, next_state: np.ndarray, action: int, observations: Any
+    ) -> np.ndarray:
+        probs = np.asarray(
+            self.observation_model(next_state=next_state, action=action).probability(observations)
+        )
+        with np.errstate(divide="ignore"):
+            return np.log(probs)
 
     def _laser_distance_inline(
         self,

--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
@@ -425,15 +425,21 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
     # method. These overrides skip the Python subclass, construct the
     # native kernel directly, and produce byte-identical RNG draws.
 
-    def sample_next_state(self, state: np.ndarray, action: np.ndarray) -> np.ndarray:
+    def sample_next_state(
+        self, state: np.ndarray, action: np.ndarray, n_samples: int = 1
+    ) -> np.ndarray:
         kernel = _native.ContinuousLightDarkTransitionCpp(
             state=state,
             action=action,
             covariance=self._state_transition_dist.covariance,
         )
-        return kernel.sample()[0]
+        if n_samples == 1:
+            return kernel.sample()[0]
+        return np.asarray(kernel.sample(n_samples), dtype=np.float64)
 
-    def sample_observation(self, next_state: np.ndarray, action: np.ndarray) -> Any:
+    def sample_observation(
+        self, next_state: np.ndarray, action: np.ndarray, n_samples: int = 1
+    ) -> Any:
         if self.observation_model_type == ObservationModelType.NORMAL_NOISE:
             kernel = _native.ContinuousLightDarkObservationCpp(
                 next_state=next_state,
@@ -444,11 +450,52 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
                 beacon_radius=float(self.beacon_radius),
                 grid_size=float(self.grid_size),
             )
-            return kernel.sample()[0]
+            if n_samples == 1:
+                return kernel.sample()[0]
+            return np.asarray(kernel.sample(n_samples), dtype=np.float64)
         # NoObsInDark and DistanceBased models have Python-side sampling
         # logic in their wrappers; fall back to the default base-class
-        # path which goes through observation_model(...).sample()[0].
-        return super().sample_observation(next_state=next_state, action=action)
+        # path which goes through observation_model(...).sample().
+        return super().sample_observation(next_state=next_state, action=action, n_samples=n_samples)
+
+    def transition_log_probability(
+        self, state: np.ndarray, action: np.ndarray, next_states: Any
+    ) -> np.ndarray:
+        kernel = _native.ContinuousLightDarkTransitionCpp(
+            state=state,
+            action=action,
+            covariance=self._state_transition_dist.covariance,
+        )
+        next_states_array = np.asarray(next_states, dtype=np.float64)
+        if next_states_array.ndim == 1:
+            next_states_array = next_states_array.reshape(1, -1)
+        probs = np.asarray(kernel.probability(next_states_array), dtype=np.float64)
+        return np.log(probs + 1e-300)
+
+    def observation_log_probability(
+        self, next_state: np.ndarray, action: np.ndarray, observations: Any
+    ) -> np.ndarray:
+        if self.observation_model_type == ObservationModelType.NORMAL_NOISE:
+            kernel = _native.ContinuousLightDarkObservationCpp(
+                next_state=next_state,
+                action=action,
+                covariance_near=self._obs_dist_near_beacon.covariance,
+                covariance_far=self._obs_dist_far_from_beacon.covariance,
+                beacons=self.beacons,
+                beacon_radius=float(self.beacon_radius),
+                grid_size=float(self.grid_size),
+            )
+            obs_array = np.asarray(observations, dtype=np.float64)
+            if obs_array.ndim == 1:
+                obs_array = obs_array.reshape(1, -1)
+            probs = np.asarray(kernel.probability(obs_array), dtype=np.float64)
+            return np.log(probs + 1e-300)
+        # NoObsInDark and DistanceBased models accept "None" string
+        # observations; defer to the base-class path which goes through
+        # observation_model(...).probability().
+        return super().observation_log_probability(
+            next_state=next_state, action=action, observations=observations
+        )
 
     def reward(self, state: np.ndarray, action: np.ndarray) -> float:
         return self.reward_model.compute_reward(state, action)
@@ -708,11 +755,25 @@ class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, Discrete
     def reward_batch(self, states: Union[np.ndarray, Sequence[Any]], action: Any) -> np.ndarray:
         return super().reward_batch(np.asarray(states), self.action_to_vector[action])
 
-    def sample_next_state(self, state: np.ndarray, action: Any) -> np.ndarray:
-        return super().sample_next_state(state, self.action_to_vector[action])
+    def sample_next_state(self, state: np.ndarray, action: Any, n_samples: int = 1) -> np.ndarray:
+        return super().sample_next_state(state, self.action_to_vector[action], n_samples=n_samples)
 
-    def sample_observation(self, next_state: np.ndarray, action: Any) -> Any:
-        return super().sample_observation(next_state, self.action_to_vector[action])
+    def sample_observation(self, next_state: np.ndarray, action: Any, n_samples: int = 1) -> Any:
+        return super().sample_observation(
+            next_state, self.action_to_vector[action], n_samples=n_samples
+        )
+
+    def transition_log_probability(
+        self, state: np.ndarray, action: Any, next_states: Any
+    ) -> np.ndarray:
+        return super().transition_log_probability(state, self.action_to_vector[action], next_states)
+
+    def observation_log_probability(
+        self, next_state: np.ndarray, action: Any, observations: Any
+    ) -> np.ndarray:
+        return super().observation_log_probability(
+            next_state, self.action_to_vector[action], observations
+        )
 
     def __eq__(self, other):
         if not isinstance(other, ContinuousLightDarkPOMDPDiscreteActions):

--- a/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
@@ -284,7 +284,7 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
 
         return reward
 
-    def sample_next_state(self, state: np.ndarray, action: Any) -> np.ndarray:
+    def sample_next_state(self, state: np.ndarray, action: Any, n_samples: int = 1) -> Any:
         # Inlined wrapper-equivalent of
         # state_transition_model(state, action).sample()[0].
         # Wrapper builds DiscreteDistribution(values, probs) with
@@ -292,18 +292,29 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
         # idx = int(np.searchsorted(_cumprobs, np.random.rand())) clamped
         # to len(values)-1. Same RNG draw is preserved here.
         cumprobs = self._transition_cumprobs_np[action]
-        idx = int(np.searchsorted(cumprobs, np.random.rand()))
-        if idx >= self._n_actions:
-            idx = self._n_actions - 1
-        return state + self._action_vectors[idx]
+        if n_samples == 1:
+            idx = int(np.searchsorted(cumprobs, np.random.rand()))
+            if idx >= self._n_actions:
+                idx = self._n_actions - 1
+            return state + self._action_vectors[idx]
+        # Vectorize: draw N uniforms and N searchsorted calls, then
+        # gather the per-row offset vectors. Preserves RNG draw count
+        # (one np.random.rand() per sample, in order).
+        draws = np.random.rand(n_samples)
+        idxs = np.searchsorted(cumprobs, draws)
+        idxs = np.clip(idxs, 0, self._n_actions - 1)
+        offsets = np.stack([self._action_vectors[i] for i in idxs], axis=0)
+        return state + offsets
 
-    def sample_observation(self, next_state: np.ndarray, action: Any) -> Any:
+    def sample_observation(self, next_state: np.ndarray, action: Any, n_samples: int = 1) -> Any:
         # Only the NORMAL observation model is inlined — it is the only
         # path with no early-exit "None" branch and matches the wrapper's
         # RNG sequence exactly. Other model types fall back to the base
-        # class default (observation_model(...).sample()[0]).
+        # class default (observation_model(...).sample()).
         if self.observation_model_type != ObservationModelType.NORMAL:
-            return super().sample_observation(next_state=next_state, action=action)
+            return super().sample_observation(
+                next_state=next_state, action=action, n_samples=n_samples
+            )
 
         # Wrapper-equivalent near-beacon check (BaseDiscreteLightDarkObservationModel._near_beacon):
         # distances = np.linalg.norm(beacons - next_state[:, None], axis=0)
@@ -312,16 +323,86 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
         near_beacon = float(np.min(distances)) < self.beacon_radius
 
         cumprobs = self._obs_cumprobs_near_np if near_beacon else self._obs_cumprobs_far_np
-        # Wrapper builds values = [next_state + dir for dir in dirs] + [next_state],
-        # then DiscreteDistribution.sample() draws np.random.rand() and
-        # np.searchsorted; same draw replicated here.
-        idx = int(np.searchsorted(cumprobs, np.random.rand()))
         n_obs = self._n_obs_values
-        if idx >= n_obs:
-            idx = n_obs - 1
-        if idx < self._n_actions:
-            return next_state + self._action_vectors[idx]
-        return next_state
+
+        if n_samples == 1:
+            # Wrapper builds values = [next_state + dir for dir in dirs] + [next_state],
+            # then DiscreteDistribution.sample() draws np.random.rand() and
+            # np.searchsorted; same draw replicated here.
+            idx = int(np.searchsorted(cumprobs, np.random.rand()))
+            if idx >= n_obs:
+                idx = n_obs - 1
+            if idx < self._n_actions:
+                return next_state + self._action_vectors[idx]
+            return next_state
+
+        # Vectorized path: draw N uniforms in order so RNG sequence is
+        # identical to N successive single-sample draws.
+        draws = np.random.rand(n_samples)
+        idxs = np.searchsorted(cumprobs, draws)
+        idxs = np.clip(idxs, 0, n_obs - 1)
+        observations = []
+        for idx in idxs:
+            if idx < self._n_actions:
+                observations.append(next_state + self._action_vectors[idx])
+            else:
+                observations.append(next_state)
+        return np.stack(observations, axis=0)
+
+    def transition_log_probability(
+        self, state: np.ndarray, action: Any, next_states: Any
+    ) -> np.ndarray:
+        action_index = self.actions.index(action)
+        probs = self._transition_probs[action]
+        # Wrapper-equivalent values list: state + action_to_vector[a] for
+        # each action, in self.actions order. Match by exact equality.
+        candidates = np.stack(
+            [state + self._action_vectors[i] for i in range(self._n_actions)], axis=0
+        )
+        next_states_array = np.asarray(next_states)
+        if next_states_array.ndim == 1:
+            next_states_array = next_states_array.reshape(1, -1)
+        out = np.full(len(next_states_array), -np.inf, dtype=np.float64)
+        for i, ns in enumerate(next_states_array):
+            for j, candidate in enumerate(candidates):
+                if np.array_equal(ns, candidate):
+                    p = float(probs[j])
+                    out[i] = np.log(p) if p > 0.0 else -np.inf
+                    break
+        # action_index is referenced for documentation parity with
+        # state_transition_model; the per-candidate match above already
+        # uses the action-specific probs vector.
+        del action_index
+        return out
+
+    def observation_log_probability(
+        self, next_state: np.ndarray, action: Any, observations: Any
+    ) -> np.ndarray:
+        if self.observation_model_type != ObservationModelType.NORMAL:
+            return super().observation_log_probability(
+                next_state=next_state, action=action, observations=observations
+            )
+
+        distances = np.linalg.norm(self.beacons - next_state[:, np.newaxis], axis=0)
+        near_beacon = float(np.min(distances)) < self.beacon_radius
+        probs_vec = self._obs_probs_near if near_beacon else self._obs_probs_far
+
+        # Wrapper builds values = [ns + dir for dir in dirs] + [ns]
+        candidates = [next_state + self._action_vectors[i] for i in range(self._n_actions)]
+        candidates.append(next_state)
+        candidates_array = np.stack(candidates, axis=0)
+
+        observations_array = np.asarray(observations)
+        if observations_array.ndim == 1:
+            observations_array = observations_array.reshape(1, -1)
+        out = np.full(len(observations_array), -np.inf, dtype=np.float64)
+        for i, obs in enumerate(observations_array):
+            for j, candidate in enumerate(candidates_array):
+                if np.array_equal(obs, candidate):
+                    p = float(probs_vec[j])
+                    out[i] = np.log(p) if p > 0.0 else -np.inf
+                    break
+        return out
 
     def state_transition_model(self, state: np.ndarray, action: Any) -> StateTransitionModel:
         action_index = self.actions.index(action)

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
@@ -321,7 +321,12 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
     # ``sample()`` produces a byte-identical RNG draw to the legacy
     # path.
 
-    def sample_next_state(self, state: Tuple[float, float], action: int) -> NDArray[np.float64]:
+    def sample_next_state(
+        self,
+        state: Union[Tuple[float, float], NDArray[np.float64]],
+        action: int,
+        n_samples: int = 1,
+    ) -> NDArray[np.float64]:
         kernel = _native.MountainCarTransitionCpp(
             state=state,
             action=action,
@@ -332,17 +337,59 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
             max_position=self.max_position,
             covariance=self._state_transition_dist.covariance,
         )
-        return kernel.sample()[0]
+        samples = kernel.sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return np.asarray(samples)
 
     def sample_observation(
-        self, next_state: Tuple[float, float], action: int
+        self,
+        next_state: Union[Tuple[float, float], NDArray[np.float64]],
+        action: int,
+        n_samples: int = 1,
     ) -> NDArray[np.float64]:
         kernel = _native.MountainCarObservationCpp(
             next_state=next_state,
             action=action,
             covariance=self._obs_dist.covariance,
         )
-        return kernel.sample()[0]
+        samples = kernel.sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return np.asarray(samples)
+
+    def transition_log_probability(
+        self,
+        state: Union[Tuple[float, float], NDArray[np.float64]],
+        action: int,
+        next_states: Union[Sequence[Any], NDArray[np.float64]],
+    ) -> np.ndarray:
+        kernel = _native.MountainCarTransitionCpp(
+            state=state,
+            action=action,
+            power=self.power,
+            gravity=self.gravity,
+            max_speed=self.max_speed,
+            min_position=self.min_position,
+            max_position=self.max_position,
+            covariance=self._state_transition_dist.covariance,
+        )
+        probs = np.asarray(kernel.probability(next_states))
+        return np.log(probs + 1e-300)
+
+    def observation_log_probability(
+        self,
+        next_state: Union[Tuple[float, float], NDArray[np.float64]],
+        action: int,
+        observations: Union[Sequence[Any], NDArray[np.float64]],
+    ) -> np.ndarray:
+        kernel = _native.MountainCarObservationCpp(
+            next_state=next_state,
+            action=action,
+            covariance=self._obs_dist.covariance,
+        )
+        probs = np.asarray(kernel.probability(observations))
+        return np.log(probs + 1e-300)
 
     def reward(self, state: Tuple[float, float], action: int) -> float:
         position, _ = state

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -626,24 +626,75 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
     # and skip the wrapper allocation, while preserving the identical
     # kernel-construction sequence and arguments.
 
-    def sample_next_state(self, state: np.ndarray, action: int) -> np.ndarray:
+    def sample_next_state(self, state: np.ndarray, action: int, n_samples: int = 1) -> Any:
         kernel = _native.PacManTransitionCpp(
             state=self._require_state_array(state),
             action=int(action),
             **self.get_transition_cpp_ctor_kwargs(),
             patrol_dir_state=self.ghost_patrol_directions,
         )
-        return kernel.sample()[0]
+        samples = kernel.sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return samples
 
-    def sample_observation(
-        self, next_state: np.ndarray, action: int
-    ) -> Tuple[Tuple[int, int], ...]:
+    def sample_observation(self, next_state: np.ndarray, action: int, n_samples: int = 1) -> Any:
         kernel = _native.PacManObservationCpp(
             next_state=self._require_state_array(next_state),
             action=int(action),
             **self.get_observation_cpp_ctor_kwargs(),
         )
-        return self.array_to_observation(kernel.sample()[0])
+        arrays = kernel.sample(n_samples)
+        if n_samples == 1:
+            return self.array_to_observation(arrays[0])
+        return [self.array_to_observation(arr) for arr in arrays]
+
+    def transition_log_probability(
+        self, state: np.ndarray, action: int, next_states: Any
+    ) -> np.ndarray:
+        kernel = _native.PacManTransitionCpp(
+            state=self._require_state_array(state),
+            action=int(action),
+            **self.get_transition_cpp_ctor_kwargs(),
+            patrol_dir_state=self.ghost_patrol_directions,
+        )
+        # Accept either a sequence of 1-D state arrays or a 2-D ndarray.
+        if isinstance(next_states, np.ndarray) and next_states.ndim == 2:
+            stacked = next_states
+        else:
+            stacked = np.stack([np.asarray(s, dtype=np.float64) for s in next_states])
+        probs = np.asarray(kernel.probability(stacked))
+        return np.log(probs + 1e-300)
+
+    def observation_log_probability(
+        self, next_state: np.ndarray, action: int, observations: Any
+    ) -> np.ndarray:
+        kernel = _native.PacManObservationCpp(
+            next_state=self._require_state_array(next_state),
+            action=int(action),
+            **self.get_observation_cpp_ctor_kwargs(),
+        )
+        # Accept either a 2-D ndarray of shape (N, 2*num_ghosts) or a sequence
+        # of public tuple-of-(row, col) observations.
+        if isinstance(observations, np.ndarray) and observations.ndim == 2:
+            stacked = observations
+            probs = np.asarray(kernel.probability(stacked))
+            return np.log(probs + 1e-300)
+        n = len(observations)
+        probs = np.zeros(n, dtype=np.float64)
+        usable_rows: List[np.ndarray] = []
+        usable_indices: List[int] = []
+        for i, obs in enumerate(observations):
+            if len(obs) != self.num_ghosts:
+                continue  # wrong ghost count -> probability 0 -> -inf
+            usable_rows.append(self.observation_to_array(obs))
+            usable_indices.append(i)
+        if usable_rows:
+            stacked = np.stack(usable_rows)
+            sub_probs = np.asarray(kernel.probability(stacked))
+            for idx, p in zip(usable_indices, sub_probs):
+                probs[idx] = p
+        return np.log(probs + 1e-300)
 
     def reward(self, state: np.ndarray, action: int) -> float:
         """Calculate immediate reward."""

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -370,7 +370,7 @@ class ContinuousPushPOMDP(Environment):
     # These overrides skip the Python subclass, construct the native
     # kernel directly, and produce byte-identical RNG draws.
 
-    def sample_next_state(self, state: np.ndarray, action: np.ndarray) -> np.ndarray:
+    def sample_next_state(self, state: np.ndarray, action: np.ndarray, n_samples: int = 1) -> Any:
         kernel = _native.ContinuousPushTransitionCpp(
             state=state,
             action=action,
@@ -382,16 +382,65 @@ class ContinuousPushPOMDP(Environment):
             obstacles=self.obstacles,
             covariance=self._state_transition_dist.covariance,
         )
-        return kernel.sample()[0]
+        samples = kernel.sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return samples
 
-    def sample_observation(self, next_state: np.ndarray, action: np.ndarray) -> Any:
+    def sample_observation(
+        self, next_state: np.ndarray, action: np.ndarray, n_samples: int = 1
+    ) -> Any:
         kernel = _native.ContinuousPushObservationCpp(
             next_state=next_state,
             action=action,
             observation_noise=float(self.observation_noise),
             grid_size=float(self.grid_size),
         )
-        return kernel.sample()[0]
+        samples = kernel.sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return samples
+
+    def transition_log_probability(
+        self, state: np.ndarray, action: np.ndarray, next_states: Any
+    ) -> np.ndarray:
+        kernel = _native.ContinuousPushTransitionCpp(
+            state=state,
+            action=action,
+            grid_size=float(self.grid_size),
+            push_threshold=float(self.push_threshold),
+            friction_coefficient=float(self.friction_coefficient),
+            max_push=float(self.max_push),
+            robot_radius=float(self.robot_radius),
+            obstacles=self.obstacles,
+            covariance=self._state_transition_dist.covariance,
+        )
+        probs = np.asarray(kernel.probability(next_states))
+        with np.errstate(divide="ignore"):
+            return np.log(probs)
+
+    def observation_log_probability(
+        self, next_state: np.ndarray, action: np.ndarray, observations: Any
+    ) -> np.ndarray:
+        kernel = _native.ContinuousPushObservationCpp(
+            next_state=next_state,
+            action=action,
+            observation_noise=float(self.observation_noise),
+            grid_size=float(self.grid_size),
+        )
+        # batch_log_likelihood is symmetric in the object-position slice:
+        # passing the candidate observations as ``next_particles`` and the
+        # fixed next_state as ``observation`` yields the per-row log-pdf of
+        # each observation given next_state.
+        obs_arr = np.asarray(observations, dtype=float)
+        if obs_arr.ndim == 1:
+            obs_arr = obs_arr.reshape(1, -1)
+        return np.asarray(
+            kernel.batch_log_likelihood(
+                next_particles=np.ascontiguousarray(obs_arr, dtype=np.float64),
+                observation=np.ascontiguousarray(np.asarray(next_state, dtype=np.float64)),
+            )
+        )
 
     def reward(self, state: np.ndarray, action: np.ndarray) -> float:
         action = np.asarray(action, dtype=float)
@@ -688,8 +737,22 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
             action = self.action_to_vector[action]
         return super().reward_batch(np.asarray(states), action)
 
-    def sample_next_state(self, state: np.ndarray, action: Any) -> np.ndarray:
-        return super().sample_next_state(state, self.action_to_vector[action])
+    def sample_next_state(self, state: np.ndarray, action: Any, n_samples: int = 1) -> Any:
+        return super().sample_next_state(state, self.action_to_vector[action], n_samples=n_samples)
 
-    def sample_observation(self, next_state: np.ndarray, action: Any) -> Any:
-        return super().sample_observation(next_state, self.action_to_vector[action])
+    def sample_observation(self, next_state: np.ndarray, action: Any, n_samples: int = 1) -> Any:
+        return super().sample_observation(
+            next_state, self.action_to_vector[action], n_samples=n_samples
+        )
+
+    def transition_log_probability(
+        self, state: np.ndarray, action: Any, next_states: Any
+    ) -> np.ndarray:
+        return super().transition_log_probability(state, self.action_to_vector[action], next_states)
+
+    def observation_log_probability(
+        self, next_state: np.ndarray, action: Any, observations: Any
+    ) -> np.ndarray:
+        return super().observation_log_probability(
+            next_state, self.action_to_vector[action], observations
+        )

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -629,7 +629,15 @@ class PushPOMDP(DiscreteActionsEnvironment):
     # the wrapper allocation is skipped while the np.random.* call sequence
     # remains byte-identical with the wrapper path.
 
-    def sample_next_state(self, state: np.ndarray, action: str) -> np.ndarray:
+    def sample_next_state(self, state: np.ndarray, action: str, n_samples: int = 1) -> Any:
+        if n_samples == 1:
+            return self._sample_one_next_state(state, action)
+        samples: List[np.ndarray] = []
+        for _ in range(n_samples):
+            samples.append(self._sample_one_next_state(state, action))
+        return samples
+
+    def _sample_one_next_state(self, state: np.ndarray, action: str) -> np.ndarray:
         # Inline of PushStateTransition._get_actual_action() then
         # _compute_next_state_for_action(). RNG order: one np.random.random()
         # call, optionally one np.random.choice() call on error_actions.
@@ -698,7 +706,15 @@ class PushPOMDP(DiscreteActionsEnvironment):
                 return True
         return False
 
-    def sample_observation(self, next_state: np.ndarray, action: str) -> np.ndarray:
+    def sample_observation(self, next_state: np.ndarray, action: str, n_samples: int = 1) -> Any:
+        if n_samples == 1:
+            return self._sample_one_observation(next_state)
+        samples: List[np.ndarray] = []
+        for _ in range(n_samples):
+            samples.append(self._sample_one_observation(next_state))
+        return samples
+
+    def _sample_one_observation(self, next_state: np.ndarray) -> np.ndarray:
         # Inline of PushObservation.sample(1): two np.random.normal(0, sigma)
         # draws, clamped to [0, grid_size - 1]. RNG order matches the wrapper.
         gmax = self.grid_size - 1
@@ -718,6 +734,31 @@ class PushPOMDP(DiscreteActionsEnvironment):
         observation[4] = tx
         observation[5] = ty
         return observation
+
+    def transition_log_probability(
+        self, state: np.ndarray, action: str, next_states: Any
+    ) -> np.ndarray:
+        probs = np.asarray(
+            self.state_transition_model(state=state, action=action).probability(next_states)
+        )
+        with np.errstate(divide="ignore"):
+            return np.log(probs)
+
+    def observation_log_probability(
+        self, next_state: np.ndarray, action: str, observations: Any
+    ) -> np.ndarray:
+        # Closed-form 2-D Gaussian log-pdf on the object-position slice
+        # (cols 2:4) against next_state[2:4]. Robot/target dims are observed
+        # exactly so they don't affect the likelihood (the wrapper's
+        # probability() ignores them too).
+        variance = self.observation_noise * self.observation_noise
+        log_norm = -float(np.log(2.0 * np.pi * variance))
+        obs_arr = np.asarray(observations, dtype=float)
+        if obs_arr.ndim == 1:
+            obs_arr = obs_arr.reshape(1, -1)
+        diffs = obs_arr[:, 2:4] - np.asarray(next_state, dtype=float)[2:4]
+        sq = np.sum(diffs * diffs, axis=1)
+        return log_norm - 0.5 * sq / variance
 
     def reward(self, state: np.ndarray, action: str) -> float:
         # Compute next state to evaluate reward based on action result

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -411,7 +411,7 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):
     # allocation while preserving the identical kernel-construction
     # sequence and arguments.
 
-    def sample_next_state(self, state: RockSampleState, action: int) -> RockSampleState:
+    def sample_next_state(self, state: RockSampleState, action: int, n_samples: int = 1) -> Any:
         kernel = _native.RockSampleTransitionCpp(
             state=np.asarray(state, dtype=float),
             action=int(action),
@@ -421,9 +421,14 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):
             rock_positions=self._rock_positions_int32,
             sensor_efficiency=self.sensor_efficiency,
         )
-        return kernel.sample()[0]
+        samples = kernel.sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return samples
 
-    def sample_observation(self, next_state: RockSampleState, action: int) -> str:
+    def sample_observation(
+        self, next_state: RockSampleState, action: int, n_samples: int = 1
+    ) -> Any:
         kernel = _native.RockSampleObservationCpp(
             next_state=np.asarray(next_state, dtype=float),
             action=int(action),
@@ -433,7 +438,41 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):
             rock_positions=self._rock_positions_int32,
             sensor_efficiency=self.sensor_efficiency,
         )
-        return _OBS_CODE_TO_STR[kernel.sample()[0]]
+        codes = kernel.sample(n_samples)
+        if n_samples == 1:
+            return _OBS_CODE_TO_STR[codes[0]]
+        return [_OBS_CODE_TO_STR[c] for c in codes]
+
+    def transition_log_probability(
+        self, state: RockSampleState, action: int, next_states: Any
+    ) -> np.ndarray:
+        kernel = _native.RockSampleTransitionCpp(
+            state=np.asarray(state, dtype=float),
+            action=int(action),
+            map_rows=self.map_size[0],
+            map_cols=self.map_size[1],
+            num_rocks=len(self.rock_positions),
+            rock_positions=self._rock_positions_int32,
+            sensor_efficiency=self.sensor_efficiency,
+        )
+        probs = np.asarray(kernel.probability(next_states))
+        return np.log(probs + 1e-300)
+
+    def observation_log_probability(
+        self, next_state: RockSampleState, action: int, observations: Any
+    ) -> np.ndarray:
+        kernel = _native.RockSampleObservationCpp(
+            next_state=np.asarray(next_state, dtype=float),
+            action=int(action),
+            map_rows=self.map_size[0],
+            map_cols=self.map_size[1],
+            num_rocks=len(self.rock_positions),
+            rock_positions=self._rock_positions_int32,
+            sensor_efficiency=self.sensor_efficiency,
+        )
+        codes = np.array([_OBS_STR_TO_CODE.get(v, -1) for v in observations], dtype=np.int32)
+        probs = np.asarray(kernel.probability(codes))
+        return np.log(probs + 1e-300)
 
     def sample_next_step(
         self, state: RockSampleState, action: int

--- a/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
+++ b/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
@@ -538,7 +538,7 @@ class SafeAntVelocityPOMDP(DiscreteActionsEnvironment):
     # and skip the wrapper allocation, while preserving the identical
     # kernel-construction sequence and arguments.
 
-    def sample_next_state(self, state: np.ndarray, action: int) -> np.ndarray:
+    def sample_next_state(self, state: np.ndarray, action: int, n_samples: int = 1) -> Any:
         kernel = _native.SafeAntVelocityTransitionCpp(
             state=state,
             action=action,
@@ -548,15 +548,51 @@ class SafeAntVelocityPOMDP(DiscreteActionsEnvironment):
             max_force=self.max_force,
             force_scales=DEFAULT_FORCE_SCALES,
         )
-        return kernel.sample()[0]
+        samples = kernel.sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return samples
 
-    def sample_observation(self, next_state: np.ndarray, action: int) -> np.ndarray:
+    def sample_observation(self, next_state: np.ndarray, action: int, n_samples: int = 1) -> Any:
         kernel = _native.SafeAntVelocityObservationCpp(
             next_state=next_state,
             action=action,
             covariance=self._observation_covariance,
         )
-        return kernel.sample()[0]
+        samples = kernel.sample(n_samples)
+        if n_samples == 1:
+            return samples[0]
+        return samples
+
+    def transition_log_probability(
+        self, state: np.ndarray, action: int, next_states: Any
+    ) -> np.ndarray:
+        # Re-use the Python ``probability()`` defined on the wrapper subclass:
+        # the force-direction distribution is uniform on a ring (no closed-form
+        # density), so the wrapper's tolerance-based consistency check is the
+        # canonical implementation. Wrapper construction is a thin shim over
+        # ``SafeAntVelocityTransitionCpp`` and matches the env's settings.
+        wrapper = SafeAntVelocityStateTransition(
+            state=state,
+            action=action,
+            dt=self.dt,
+            mass=self.mass,
+            damping=self.damping,
+            max_force=self.max_force,
+        )
+        probs = np.asarray(wrapper.probability(list(next_states)))
+        return np.log(probs + 1e-300)
+
+    def observation_log_probability(
+        self, next_state: np.ndarray, action: int, observations: Any
+    ) -> np.ndarray:
+        kernel = _native.SafeAntVelocityObservationCpp(
+            next_state=next_state,
+            action=action,
+            covariance=self._observation_covariance,
+        )
+        probs = np.asarray(kernel.probability(observations))
+        return np.log(probs + 1e-300)
 
     def sample_next_step(
         self, state: np.ndarray, action: int

--- a/POMDPPlanners/environments/sanity_pomdp.py
+++ b/POMDPPlanners/environments/sanity_pomdp.py
@@ -26,7 +26,7 @@ Classes:
 """
 
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Sequence, Union
 
 import numpy as np
 
@@ -338,11 +338,41 @@ class SanityPOMDP(DiscreteActionsEnvironment):
     # observations are deterministic, so no RNG draws occur and the
     # behavior is byte-identical to the wrapper-based path.
 
-    def sample_next_state(self, state: int, action: int) -> int:
-        return 0 if action == 0 else 1
+    def sample_next_state(
+        self, state: int, action: int, n_samples: int = 1
+    ) -> Union[int, np.ndarray]:
+        next_state = 0 if action == 0 else 1
+        if n_samples == 1:
+            return next_state
+        return np.full(n_samples, next_state, dtype=np.int64)
 
-    def sample_observation(self, next_state: int, action: int) -> int:
-        return next_state
+    def sample_observation(
+        self, next_state: int, action: int, n_samples: int = 1
+    ) -> Union[int, np.ndarray]:
+        if n_samples == 1:
+            return next_state
+        return np.full(n_samples, next_state, dtype=np.int64)
+
+    def transition_log_probability(
+        self,
+        state: int,
+        action: int,
+        next_states: Union[Sequence[int], np.ndarray],
+    ) -> np.ndarray:
+        next_states_arr = np.asarray(next_states)
+        expected = 0 if action == 0 else 1
+        probs = np.where(next_states_arr == expected, 1.0, 0.0)
+        return np.log(probs + 1e-300)
+
+    def observation_log_probability(
+        self,
+        next_state: int,
+        action: int,
+        observations: Union[Sequence[int], np.ndarray],
+    ) -> np.ndarray:
+        observations_arr = np.asarray(observations)
+        probs = np.where(observations_arr == next_state, 1.0, 0.0)
+        return np.log(probs + 1e-300)
 
     def reward(self, state: int, action: int) -> float:
         # Higher reward for being in good state (0)

--- a/POMDPPlanners/environments/tiger_pomdp.py
+++ b/POMDPPlanners/environments/tiger_pomdp.py
@@ -277,17 +277,53 @@ class TigerPOMDP(DiscreteActionsEnvironment):
     # Inline the wrapper's sample() body to skip per-call wrapper
     # allocation. The RNG draw sequence is preserved bit-for-bit.
 
-    def sample_next_state(self, state: str, action: str) -> str:
+    def sample_next_state(self, state: str, action: str, n_samples: int = 1):
         if action in ("open_left", "open_right"):
-            return str(np.random.choice(STATES))
-        return state
+            samples = [str(np.random.choice(STATES)) for _ in range(n_samples)]
+        else:
+            samples = [state] * n_samples
+        if n_samples == 1:
+            return samples[0]
+        return samples
 
-    def sample_observation(self, next_state: str, action: str) -> str:
+    def sample_observation(self, next_state: str, action: str, n_samples: int = 1):
+        samples: List[str] = []
         if action == "listen":
             if next_state == "tiger_left":
-                return "hear_left" if np.random.random() < 0.85 else "hear_right"
-            return "hear_right" if np.random.random() < 0.85 else "hear_left"
-        return "hear_nothing"
+                for _ in range(n_samples):
+                    samples.append("hear_left" if np.random.random() < 0.85 else "hear_right")
+            else:
+                for _ in range(n_samples):
+                    samples.append("hear_right" if np.random.random() < 0.85 else "hear_left")
+        else:
+            samples = ["hear_nothing"] * n_samples
+        if n_samples == 1:
+            return samples[0]
+        return samples
+
+    def transition_log_probability(self, state: str, action: str, next_states) -> np.ndarray:
+        result = np.zeros(len(next_states))
+        if action in ("open_left", "open_right"):
+            for i, ns in enumerate(next_states):
+                result[i] = np.log(0.5) if ns in STATES else -np.inf
+        else:
+            for i, ns in enumerate(next_states):
+                result[i] = 0.0 if ns == state else -np.inf
+        return result
+
+    def observation_log_probability(self, next_state: str, action: str, observations) -> np.ndarray:
+        result = np.zeros(len(observations))
+        if action == "listen":
+            for i, obs in enumerate(observations):
+                if obs not in OBSERVATIONS:
+                    result[i] = -np.inf
+                    continue
+                correct = "hear_left" if next_state == "tiger_left" else "hear_right"
+                result[i] = np.log(0.85) if obs == correct else np.log(0.15)
+        else:
+            for i, obs in enumerate(observations):
+                result[i] = 0.0 if obs == "hear_nothing" else -np.inf
+        return result
 
     def reward(self, state: str, action: str) -> float:
         if action == "listen":

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
@@ -934,3 +934,195 @@ def test_sample_observation_rng_pinned_equivalence(base_cartpole_environment):
             direct_obs,
             err_msg=f"sample_observation mismatch for ({next_state.tolist()}, {action})",
         )
+
+
+def test_sample_next_state_n_samples_equivalence(base_cartpole_environment):
+    """Test sample_next_state with n>1 matches state_transition_model().sample(n) under fixed RNG.
+
+    Purpose: Validates that the n_samples-aware sample_next_state override produces
+        byte-identical batched results to the wrapper-based path when both use the same
+        native RNG seed.
+
+    Given: A CartPolePOMDP environment and (state, action) pairs covering both actions
+        and a range of state vectors near and away from equilibrium, with the native
+        module RNG seeded identically before each pair of draws, for n in {1, 5, 100}
+    When: A batch is drawn through state_transition_model(s, a).sample(n) and again
+        through env.sample_next_state(s, a, n_samples=n) after re-seeding
+    Then: The two batches are equal element-wise across all combinations and all n
+
+    Test type: unit
+    """
+    from POMDPPlanners.environments.cartpole_pomdp import (  # pylint: disable=import-outside-toplevel
+        _native,
+    )
+
+    env = base_cartpole_environment
+    cases = [
+        (np.array([0.0, 0.0, 0.0, 0.0]), 0),
+        (np.array([0.0, 0.0, 0.0, 0.0]), 1),
+        (np.array([0.1, 0.05, 0.02, -0.1]), 1),
+        (np.array([-0.1, -0.05, -0.02, 0.1]), 0),
+    ]
+    for n in (1, 5, 100):
+        for state, action in cases:
+            _native.set_seed(2024)
+            np.random.seed(2024)
+            random.seed(2024)
+            wrapper_samples = env.state_transition_model(state=state, action=action).sample(n)
+            _native.set_seed(2024)
+            np.random.seed(2024)
+            random.seed(2024)
+            direct_samples = env.sample_next_state(state=state, action=action, n_samples=n)
+            wrapper_arr = np.asarray(wrapper_samples).reshape(n, -1)
+            direct_arr = np.asarray(direct_samples).reshape(n, -1)
+            np.testing.assert_array_equal(
+                wrapper_arr,
+                direct_arr,
+                err_msg=f"sample_next_state n={n} mismatch for ({state.tolist()}, {action})",
+            )
+
+
+def test_sample_observation_n_samples_equivalence(base_cartpole_environment):
+    """Test sample_observation with n>1 matches observation_model().sample(n) under fixed RNG.
+
+    Purpose: Validates that the n_samples-aware sample_observation override produces
+        byte-identical batched results to the wrapper-based path when both use the same
+        native RNG seed.
+
+    Given: A CartPolePOMDP environment and (next_state, action) pairs covering both
+        actions across a range of state vectors, with the native module RNG seeded
+        identically, for n in {1, 5, 100}
+    When: A batch is drawn through observation_model(ns, a).sample(n) and again through
+        env.sample_observation(ns, a, n_samples=n) after re-seeding
+    Then: The two batches are equal element-wise across all combinations and all n
+
+    Test type: unit
+    """
+    from POMDPPlanners.environments.cartpole_pomdp import (  # pylint: disable=import-outside-toplevel
+        _native,
+    )
+
+    env = base_cartpole_environment
+    cases = [
+        (np.array([0.0, 0.0, 0.0, 0.0]), 0),
+        (np.array([0.0, 0.0, 0.0, 0.0]), 1),
+        (np.array([0.1, 0.05, 0.02, -0.1]), 1),
+        (np.array([-0.1, -0.05, -0.02, 0.1]), 0),
+    ]
+    for n in (1, 5, 100):
+        for next_state, action in cases:
+            _native.set_seed(99)
+            np.random.seed(99)
+            random.seed(99)
+            wrapper_samples = env.observation_model(next_state=next_state, action=action).sample(n)
+            _native.set_seed(99)
+            np.random.seed(99)
+            random.seed(99)
+            direct_samples = env.sample_observation(
+                next_state=next_state, action=action, n_samples=n
+            )
+            wrapper_arr = np.asarray(wrapper_samples).reshape(n, -1)
+            direct_arr = np.asarray(direct_samples).reshape(n, -1)
+            np.testing.assert_array_equal(
+                wrapper_arr,
+                direct_arr,
+                err_msg=(
+                    f"sample_observation n={n} mismatch for " f"({next_state.tolist()}, {action})"
+                ),
+            )
+
+
+def test_transition_log_probability_equivalence(base_cartpole_environment):
+    """Test transition_log_probability matches np.log(probability) from the wrapper.
+
+    Purpose: Validates that transition_log_probability returns log-PDFs equivalent
+        (within fp tolerance) to applying np.log to the wrapper-based probability path.
+
+    Given: A CartPolePOMDP environment and (state, action) pairs covering both actions,
+        plus a batch of candidate next-state arrays
+    When: Log-probabilities are computed via env.transition_log_probability(s, a, vals)
+        and via np.log(env.state_transition_model(s, a).probability(vals) + 1e-300)
+    Then: The two ndarrays are equal element-wise within fp tolerance
+
+    Test type: unit
+    """
+    env = base_cartpole_environment
+    candidate_states = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.001, 0.002, 0.05, 0.0],
+            [0.05, 0.0, 0.02, 0.01],
+            [-0.02, 0.01, -0.005, 0.0],
+            [1.0, 0.5, 0.1, 0.2],
+        ]
+    )
+    cases = [
+        (np.array([0.0, 0.0, 0.0, 0.0]), 0),
+        (np.array([0.0, 0.0, 0.0, 0.0]), 1),
+        (np.array([0.1, 0.05, 0.02, -0.1]), 1),
+        (np.array([-0.1, -0.05, -0.02, 0.1]), 0),
+    ]
+    for state, action in cases:
+        direct = env.transition_log_probability(
+            state=state, action=action, next_states=candidate_states
+        )
+        wrapper_probs = np.asarray(
+            env.state_transition_model(state=state, action=action).probability(candidate_states)
+        )
+        ref = np.log(wrapper_probs + 1e-300)
+        np.testing.assert_allclose(
+            direct,
+            ref,
+            rtol=1e-12,
+            atol=1e-12,
+            err_msg=f"transition_log_probability mismatch for ({state.tolist()}, {action})",
+        )
+
+
+def test_observation_log_probability_equivalence(base_cartpole_environment):
+    """Test observation_log_probability matches np.log(probability) from the wrapper.
+
+    Purpose: Validates that observation_log_probability returns log-PDFs equivalent
+        (within fp tolerance) to applying np.log to the wrapper-based probability path.
+
+    Given: A CartPolePOMDP environment and (next_state, action) pairs covering both
+        actions, plus a batch of candidate observation arrays
+    When: Log-probabilities are computed via env.observation_log_probability(ns, a, obs)
+        and via np.log(env.observation_model(ns, a).probability(obs) + 1e-300)
+    Then: The two ndarrays are equal element-wise within fp tolerance
+
+    Test type: unit
+    """
+    env = base_cartpole_environment
+    candidate_obs = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.05, 0.02, 0.01, 0.0],
+            [-0.05, -0.02, -0.01, 0.0],
+            [0.5, 0.5, 0.5, 0.5],
+            [1.0, 0.0, 0.1, -0.1],
+        ]
+    )
+    cases = [
+        (np.array([0.0, 0.0, 0.0, 0.0]), 0),
+        (np.array([0.0, 0.0, 0.0, 0.0]), 1),
+        (np.array([0.1, 0.05, 0.02, -0.1]), 1),
+        (np.array([-0.1, -0.05, -0.02, 0.1]), 0),
+    ]
+    for next_state, action in cases:
+        direct = env.observation_log_probability(
+            next_state=next_state, action=action, observations=candidate_obs
+        )
+        wrapper_probs = np.asarray(
+            env.observation_model(next_state=next_state, action=action).probability(candidate_obs)
+        )
+        ref = np.log(wrapper_probs + 1e-300)
+        np.testing.assert_allclose(
+            direct,
+            ref,
+            rtol=1e-12,
+            atol=1e-12,
+            err_msg=(
+                f"observation_log_probability mismatch for " f"({next_state.tolist()}, {action})"
+            ),
+        )

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
@@ -1106,3 +1106,234 @@ class TestContinuousLaserTagDirectSampleApiEquivalence:
         o_direct = env.sample_observation(ns_wrap, "up")
 
         assert np.array_equal(o_wrap, o_direct)
+
+
+class TestContinuousLaserTagBatchSampleAndLogProb:
+    """Tests for n_samples batching and log-probability methods on Continuous LaserTag."""
+
+    @pytest.mark.parametrize("n", [1, 5, 100])
+    def test_sample_next_state_n_samples_equivalence(self, n: int) -> None:
+        """sample_next_state(n_samples=n) matches wrapper.sample(n) under pinned native RNG.
+
+        Purpose: Validates that the batched sample_next_state path issues the same
+            sequence of native RNG draws as the wrapper for n in {1, 5, 100}.
+
+        Given: A ContinuousLaserTagPOMDP with no walls, a fixed (state, action)
+            and the module-level _native RNG pinned identically before each call.
+        When: Drawing via env.state_transition_model(s, a).sample(n) and via
+            env.sample_next_state(s, a, n_samples=n).
+        Then: For n==1 the single ndarray equals the wrapper's first sample; for n>1
+            each row is byte-equal to the wrapper's row at the same index.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([1.0, 0.0, 0.0])
+
+        _native.set_seed(2024)
+        np.random.seed(2024)
+        wrap_samples = env.state_transition_model(state, action).sample(n_samples=n)
+
+        _native.set_seed(2024)
+        np.random.seed(2024)
+        direct = env.sample_next_state(state, action, n_samples=n)
+
+        if n == 1:
+            assert isinstance(direct, np.ndarray)
+            assert np.array_equal(direct, wrap_samples[0])
+        else:
+            assert len(direct) == n
+            for i in range(n):
+                assert np.array_equal(direct[i], wrap_samples[i])
+
+    @pytest.mark.parametrize("n", [1, 5, 100])
+    def test_sample_observation_n_samples_equivalence(self, n: int) -> None:
+        """sample_observation(n_samples=n) matches wrapper.sample(n) under pinned native RNG.
+
+        Purpose: Validates that the batched sample_observation path issues the same
+            sequence of native RNG draws as the wrapper for n in {1, 5, 100}.
+
+        Given: A ContinuousLaserTagPOMDP and a fixed (next_state, action) with
+            the native RNG pinned identically before each call.
+        When: Drawing via env.observation_model(...).sample(n) and via
+            env.sample_observation(..., n_samples=n).
+        Then: All N observations are byte-equal between wrapper and override.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        next_state = np.array([4.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([1.0, 0.0, 0.0])
+
+        _native.set_seed(99)
+        np.random.seed(99)
+        wrap_obs = env.observation_model(next_state, action).sample(n_samples=n)
+
+        _native.set_seed(99)
+        np.random.seed(99)
+        direct = env.sample_observation(next_state, action, n_samples=n)
+
+        if n == 1:
+            assert isinstance(direct, np.ndarray)
+            assert np.array_equal(direct, wrap_obs[0])
+        else:
+            assert len(direct) == n
+            for i in range(n):
+                assert np.array_equal(direct[i], wrap_obs[i])
+
+    def test_transition_log_probability_equivalence(self) -> None:
+        """transition_log_probability matches log of the wrapper's probability.
+
+        Purpose: Validates env.transition_log_probability matches the wrapper-model
+            log-probability output (the native kernel returns 0 for the continuous
+            transition density, so log -> -inf for all candidate next states).
+
+        Given: A ContinuousLaserTagPOMDP and a fixed (state, action) with a batch
+            of candidate next states sampled from the wrapper.
+        When: Computing log via wrapper.probability + np.log and via
+            env.transition_log_probability.
+        Then: The two ndarrays agree within fp tolerance (both are -inf since the
+            native probability returns 0 for the continuous density).
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([1.0, 0.0, 0.0])
+
+        _native.set_seed(2024)
+        wrap_model = env.state_transition_model(state, action)
+        next_states = wrap_model.sample(n_samples=8)
+
+        with np.errstate(divide="ignore"):
+            expected = np.log(np.asarray(wrap_model.probability(next_states)))
+        actual = env.transition_log_probability(state, action, next_states)
+
+        assert actual.shape == (len(next_states),)
+        np.testing.assert_allclose(actual, expected, atol=1e-10, equal_nan=True)
+
+    def test_observation_log_probability_equivalence(self) -> None:
+        """observation_log_probability matches log of the wrapper's PDF.
+
+        Purpose: Validates env.observation_log_probability returns log of the
+            wrapper's Gaussian-product PDF within fp tolerance.
+
+        Given: A ContinuousLaserTagPOMDP and a fixed (next_state, action) with a
+            batch of observations sampled from the wrapper.
+        When: Computing log via wrapper.probability + np.log and via
+            env.observation_log_probability.
+        Then: The two ndarrays agree within 1e-10 absolute tolerance.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        next_state = np.array([4.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([1.0, 0.0, 0.0])
+
+        _native.set_seed(99)
+        wrap_model = env.observation_model(next_state, action)
+        observations = wrap_model.sample(n_samples=8)
+
+        with np.errstate(divide="ignore"):
+            expected = np.log(np.asarray(wrap_model.probability(observations)))
+        actual = env.observation_log_probability(next_state, action, observations)
+
+        assert actual.shape == (len(observations),)
+        np.testing.assert_allclose(actual, expected, atol=1e-10, equal_nan=True)
+
+    def test_observation_log_probability_terminal_state(self) -> None:
+        """observation_log_probability handles terminal next_state (-inf for non-terminal obs).
+
+        Purpose: Validates the terminal-sentinel branch of observation_log_probability
+            returns log(1)=0 for the terminal observation and -inf otherwise.
+
+        Given: A ContinuousLaserTagPOMDP and a terminal next_state.
+        When: Querying log-prob for the terminal sentinel and an arbitrary non-terminal obs.
+        Then: First entry is 0.0, second is -inf.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        terminal_state = np.array([3.0, 3.0, 8.0, 5.0, 1.0])
+        action = np.array([0.0, 0.0, 1.0])
+        terminal_obs = np.full(8, -1.0)
+        non_terminal_obs = np.array([3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
+
+        actual = env.observation_log_probability(
+            terminal_state, action, [terminal_obs, non_terminal_obs]
+        )
+
+        assert actual.shape == (2,)
+        assert actual[0] == 0.0
+        assert np.isneginf(actual[1])
+
+
+class TestContinuousLaserTagDiscreteActionsBatchSampleAndLogProb:
+    """Tests for n_samples batching and log-probability on the DiscreteActions wrapper."""
+
+    @pytest.mark.parametrize("n", [1, 5, 100])
+    def test_sample_next_state_n_samples_equivalence_discrete_actions(self, n: int) -> None:
+        """Discrete-actions sample_next_state(n_samples=n) matches wrapper under pinned RNG.
+
+        Purpose: Validates that the discrete-actions subclass routes string actions
+            through action_to_vector before delegating to the parent batched override,
+            preserving byte-identical results across all N samples.
+
+        Given: A ContinuousLaserTagPOMDPDiscreteActions and ("up" action) with the
+            native RNG pinned identically before each call.
+        When: Drawing via env.state_transition_model(state, "up").sample(n) and via
+            env.sample_next_state(state, "up", n_samples=n).
+        Then: All N samples are byte-equal between wrapper and override.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDPDiscreteActions(
+            discount_factor=0.95, walls=[], dangerous_areas=[]
+        )
+        state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
+
+        _native.set_seed(11)
+        np.random.seed(11)
+        wrap_samples = env.state_transition_model(state, "up").sample(n_samples=n)
+
+        _native.set_seed(11)
+        np.random.seed(11)
+        direct = env.sample_next_state(state, "up", n_samples=n)
+
+        if n == 1:
+            assert isinstance(direct, np.ndarray)
+            assert np.array_equal(direct, wrap_samples[0])
+        else:
+            assert len(direct) == n
+            for i in range(n):
+                assert np.array_equal(direct[i], wrap_samples[i])
+
+    def test_observation_log_probability_discrete_actions(self) -> None:
+        """observation_log_probability on the discrete-actions subclass matches wrapper.
+
+        Purpose: Validates the discrete-actions log-prob path translates string actions
+            and produces the same output as the wrapper.
+
+        Given: A ContinuousLaserTagPOMDPDiscreteActions, fixed next_state and "up" action.
+        When: Computing log via wrapper.probability + np.log and via
+            env.observation_log_probability(next_state, "up", observations).
+        Then: The two arrays agree within 1e-10 absolute tolerance.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDPDiscreteActions(
+            discount_factor=0.95, walls=[], dangerous_areas=[]
+        )
+        next_state = np.array([4.0, 3.0, 8.0, 5.0, 0.0])
+
+        _native.set_seed(57)
+        wrap_model = env.observation_model(next_state, "up")
+        observations = wrap_model.sample(n_samples=8)
+
+        with np.errstate(divide="ignore"):
+            expected = np.log(np.asarray(wrap_model.probability(observations)))
+        actual = env.observation_log_probability(next_state, "up", observations)
+
+        assert actual.shape == (len(observations),)
+        np.testing.assert_allclose(actual, expected, atol=1e-10, equal_nan=True)

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -2160,6 +2160,166 @@ class TestLaserTagDirectSampleApiEquivalence:
         assert tuple(o_wrap) == tuple(o_direct)
 
 
+class TestLaserTagBatchSampleAndLogProb:
+    """Tests for n_samples batching and log-probability methods on LaserTagPOMDP."""
+
+    @pytest.mark.parametrize("n", [1, 5, 100])
+    @pytest.mark.parametrize("action", [0, 1, 2, 3, 4])
+    def test_sample_next_state_n_samples_equivalence(self, n: int, action: int) -> None:
+        """sample_next_state(n_samples=n) matches wrapper.sample(n) under pinned RNG.
+
+        Purpose: Validates batched sample_next_state preserves byte-identical RNG
+            draw sequence vs the wrapper for n in {1, 5, 100}.
+
+        Given: A LaserTagPOMDP with transition_error_prob>0 to exercise the actual-action
+            error branch, and a fixed (state, action). RNG seeded identically before each draw.
+        When: Drawing via env.state_transition_model(s, a).sample(n) and via
+            env.sample_next_state(s, a, n_samples=n).
+        Then: For n==1 the single result equals the wrapper's first sample; for n>1
+            each row equals the wrapper's row at the same index.
+
+        Test type: unit
+        """
+        env = LaserTagPOMDP(discount_factor=0.95, transition_error_prob=0.2)
+        state = np.array([3.0, 4.0, 5.0, 2.0, 0.0])
+
+        np.random.seed(123)
+        random.seed(123)
+        wrap_samples = env.state_transition_model(state, action).sample(n_samples=n)
+
+        np.random.seed(123)
+        random.seed(123)
+        direct = env.sample_next_state(state, action, n_samples=n)
+
+        if n == 1:
+            assert isinstance(direct, np.ndarray)
+            assert np.array_equal(direct, wrap_samples[0])
+        else:
+            assert len(direct) == n  # type: ignore[arg-type]
+            for i in range(n):
+                assert np.array_equal(direct[i], wrap_samples[i])
+
+    def test_sample_next_state_terminal_tag_n_samples_equivalence(self) -> None:
+        """Terminal-tag branch returns N copies and matches the wrapper for n>1.
+
+        Purpose: Validates that the terminal-tag fast path replicates the wrapper
+            output across all n samples without consuming extra RNG draws.
+
+        Given: A LaserTagPOMDP and a state where robot==opponent with action=4.
+        When: Drawing wrapper.sample(n_samples=5) and env.sample_next_state(..., n_samples=5).
+        Then: All five samples in each match elementwise.
+
+        Test type: unit
+        """
+        env = LaserTagPOMDP(discount_factor=0.95)
+        state = np.array([3.0, 3.0, 3.0, 3.0, 0.0])
+
+        np.random.seed(0)
+        random.seed(0)
+        wrap_samples = env.state_transition_model(state, 4).sample(n_samples=5)
+
+        np.random.seed(0)
+        random.seed(0)
+        direct = env.sample_next_state(state, 4, n_samples=5)
+
+        assert len(direct) == 5  # type: ignore[arg-type]
+        for i in range(5):
+            assert np.array_equal(direct[i], wrap_samples[i])
+
+    @pytest.mark.parametrize("n", [1, 5, 100])
+    @pytest.mark.parametrize("action", [0, 4])
+    def test_sample_observation_n_samples_equivalence(self, n: int, action: int) -> None:
+        """sample_observation(n_samples=n) matches wrapper.sample(n) under pinned RNG.
+
+        Purpose: Validates batched sample_observation produces byte-identical 8-direction
+            laser noise sequences as the wrapper for n in {1, 5, 100}.
+
+        Given: A LaserTagPOMDP and a fixed (next_state, action) with RNG seeded identically.
+        When: Drawing via env.observation_model(...).sample(n) and via
+            env.sample_observation(..., n_samples=n).
+        Then: All N observations agree elementwise.
+
+        Test type: unit
+        """
+        env = LaserTagPOMDP(discount_factor=0.95)
+        next_state = np.array([3.0, 4.0, 5.0, 2.0, 0.0])
+
+        np.random.seed(7)
+        random.seed(7)
+        wrap_obs = env.observation_model(next_state, action).sample(n_samples=n)
+
+        np.random.seed(7)
+        random.seed(7)
+        direct = env.sample_observation(next_state, action, n_samples=n)
+
+        if n == 1:
+            assert tuple(direct) == tuple(wrap_obs[0])  # type: ignore[arg-type]
+        else:
+            assert len(direct) == n  # type: ignore[arg-type]
+            for i in range(n):
+                assert tuple(direct[i]) == tuple(wrap_obs[i])
+
+    @pytest.mark.parametrize("action", [0, 1, 2, 3, 4])
+    def test_transition_log_probability_equivalence(self, action: int) -> None:
+        """transition_log_probability matches log of the wrapper's probability.
+
+        Purpose: Validates env.transition_log_probability returns log of the
+            wrapper-model probability within fp tolerance for representative
+            candidate next states drawn from the model.
+
+        Given: A LaserTagPOMDP with transition_error_prob>0 and a fixed (state, action).
+        When: A batch of 16 candidate next states is drawn from the wrapper, and we
+            compute log via wrapper.probability + np.log and via env.transition_log_probability.
+        Then: The two log-probability arrays agree within 1e-10 absolute tolerance.
+
+        Test type: unit
+        """
+        env = LaserTagPOMDP(discount_factor=0.95, transition_error_prob=0.2)
+        state = np.array([3.0, 4.0, 5.0, 2.0, 0.0])
+
+        np.random.seed(2024)
+        wrap_model = env.state_transition_model(state, action)
+        next_states = wrap_model.sample(n_samples=16)
+        # Add an unreachable state to exercise log(0) -> -inf
+        unreachable = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
+        next_states.append(unreachable)
+
+        with np.errstate(divide="ignore"):
+            expected = np.log(np.asarray(wrap_model.probability(next_states)))
+        actual = env.transition_log_probability(state, action, next_states)
+
+        assert actual.shape == (len(next_states),)
+        np.testing.assert_allclose(actual, expected, atol=1e-10, equal_nan=True)
+
+    @pytest.mark.parametrize("action", [0, 4])
+    def test_observation_log_probability_equivalence(self, action: int) -> None:
+        """observation_log_probability matches log of the wrapper's probability.
+
+        Purpose: Validates env.observation_log_probability returns log of the
+            wrapper-model PDF within fp tolerance for sampled observations.
+
+        Given: A LaserTagPOMDP and a fixed (next_state, action).
+        When: A batch of 8 observations is drawn from the wrapper, and we compute log
+            via wrapper.probability + np.log and via env.observation_log_probability.
+        Then: The two log-probability arrays agree within 1e-10 absolute tolerance.
+
+        Test type: unit
+        """
+        env = LaserTagPOMDP(discount_factor=0.95)
+        next_state = np.array([3.0, 4.0, 5.0, 2.0, 0.0])
+
+        np.random.seed(31)
+        wrap_model = env.observation_model(next_state, action)
+        observations = wrap_model.sample(n_samples=8)
+
+        with np.errstate(divide="ignore"):
+            expected = np.log(np.asarray(wrap_model.probability(observations)))
+        actual = env.observation_log_probability(next_state, action, observations)
+
+        assert actual.shape == (len(observations),)
+        np.testing.assert_allclose(actual, expected, atol=1e-10, equal_nan=True)
+
+
 if __name__ == "__main__":
     # Run tests if script is executed directly
     pytest.main([__file__, "-v"])

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
@@ -22,6 +22,9 @@ from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.core.distributions import DiscreteDistribution
 from POMDPPlanners.core.policy import PolicyRunData
 from POMDPPlanners.core.simulation import History, StepData
+from POMDPPlanners.environments.light_dark_pomdp import (
+    _native,  # pylint: disable=no-name-in-module
+)
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDP,
     ContinuousLightDarkPOMDPDiscreteActions,
@@ -2229,3 +2232,248 @@ def test_reward_batch_discrete_actions_matches_scalar(base_light_dark_environmen
     np.random.seed(99)
     expected = np.array([env.reward(states[i], action) for i in range(100)])
     np.testing.assert_allclose(batch_rewards, expected)
+
+
+# ---------------------------------------------------------------------------
+# Batch sampling and log-probability API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_samples", [1, 5, 100])
+def test_continuous_sample_next_state_n_samples_equivalence(n_samples):
+    """sample_next_state(n_samples=N) matches the wrapper sample(N) under fixed C++ seed.
+
+    Purpose: Validates that the n_samples parameter on sample_next_state
+        produces byte-identical RNG draws to state_transition_model().sample(N).
+
+    Given: A ContinuousLightDarkPOMDP environment and a (state, action) pair,
+        with the native C++ RNG seeded identically before each call.
+    When: env.sample_next_state(state, action, n_samples=N) is invoked and
+        compared against env.state_transition_model(state, action).sample(N).
+    Then: For n_samples=1 a single (2,) ndarray is returned; for n_samples>1
+        a (N, 2) ndarray equal to the wrapper result is returned.
+
+    Test type: unit
+    """
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    state = np.array([3.0, 4.0])
+    action = np.array([1.0, 0.5])
+
+    _native.set_seed(123)
+    direct = env.sample_next_state(state, action, n_samples=n_samples)
+    _native.set_seed(123)
+    wrapper = env.state_transition_model(state, action).sample(n_samples=n_samples)
+
+    if n_samples == 1:
+        assert isinstance(direct, np.ndarray)
+        assert direct.shape == (2,)
+        assert np.array_equal(direct, wrapper[0])
+    else:
+        assert isinstance(direct, np.ndarray)
+        assert direct.shape == (n_samples, 2)
+        wrapper_arr = np.stack(wrapper, axis=0)
+        np.testing.assert_array_equal(direct, wrapper_arr)
+
+
+@pytest.mark.parametrize("n_samples", [1, 5, 100])
+def test_continuous_sample_observation_n_samples_equivalence(n_samples):
+    """sample_observation(n_samples=N) matches the wrapper sample(N) under fixed seed.
+
+    Purpose: Validates that the n_samples parameter on sample_observation
+        produces byte-identical RNG draws to observation_model().sample(N).
+
+    Given: A ContinuousLightDarkPOMDP environment and a (next_state, action)
+        pair near a beacon, with the native C++ RNG seeded identically before
+        each call.
+    When: env.sample_observation(ns, a, n_samples=N) is invoked and compared
+        against env.observation_model(ns, a).sample(N).
+    Then: For n_samples=1 a (2,) ndarray; for n_samples>1 a (N, 2) ndarray
+        equal to the wrapper.
+
+    Test type: unit
+    """
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    next_state = np.array([5.0, 5.0])  # near beacon
+    action = np.array([0.0, 0.0])
+
+    _native.set_seed(456)
+    direct = env.sample_observation(next_state, action, n_samples=n_samples)
+    _native.set_seed(456)
+    wrapper = env.observation_model(next_state, action).sample(n_samples=n_samples)
+
+    if n_samples == 1:
+        assert isinstance(direct, np.ndarray)
+        assert direct.shape == (2,)
+        assert np.array_equal(direct, wrapper[0])
+    else:
+        assert isinstance(direct, np.ndarray)
+        assert direct.shape == (n_samples, 2)
+        wrapper_arr = np.stack(wrapper, axis=0)
+        np.testing.assert_array_equal(direct, wrapper_arr)
+
+
+def test_continuous_transition_log_probability_equivalence():
+    """transition_log_probability matches np.log(state_transition_model().probability()).
+
+    Purpose: Validates that the native log-probability path returns the same
+        numbers as the wrapper-based np.log(probability(...)) path.
+
+    Given: A ContinuousLightDarkPOMDP env, a (state, action) pair, and a
+        batch of candidate next-states.
+    When: env.transition_log_probability(state, action, candidates) is invoked
+        and compared against np.log(state_transition_model.probability).
+    Then: The resulting (N,) ndarrays are allclose within 1e-12 tolerance.
+
+    Test type: unit
+    """
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    state = np.array([3.0, 4.0])
+    action = np.array([1.0, 0.5])
+    candidates = np.array([[4.0, 4.5], [3.5, 4.0], [3.9, 4.6], [10.0, 0.0]])
+
+    direct = env.transition_log_probability(state, action, candidates)
+    wrapper_probs = np.asarray(
+        env.state_transition_model(state, action).probability(list(candidates))
+    )
+    expected = np.log(wrapper_probs + 1e-300)
+
+    assert direct.shape == (4,)
+    np.testing.assert_allclose(direct, expected, atol=1e-12, rtol=0.0)
+
+
+def test_continuous_observation_log_probability_equivalence():
+    """observation_log_probability matches np.log(observation_model().probability()).
+
+    Purpose: Validates the native observation log-prob path against the
+        wrapper-based reference.
+
+    Given: A ContinuousLightDarkPOMDP env (NORMAL_NOISE), a near-beacon
+        next_state, and a batch of candidate observations.
+    When: env.observation_log_probability(ns, a, candidates) is invoked and
+        compared against np.log(observation_model.probability).
+    Then: The resulting (N,) ndarrays are allclose within 1e-12 tolerance.
+
+    Test type: unit
+    """
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    next_state = np.array([5.0, 5.0])
+    action = np.array([0.0, 0.0])
+    candidates = np.array([[5.0, 5.0], [5.5, 5.5], [4.5, 4.5], [10.0, 0.0]])
+
+    direct = env.observation_log_probability(next_state, action, candidates)
+    wrapper_probs = np.asarray(
+        env.observation_model(next_state, action).probability(list(candidates))
+    )
+    expected = np.log(wrapper_probs + 1e-300)
+
+    assert direct.shape == (4,)
+    np.testing.assert_allclose(direct, expected, atol=1e-12, rtol=0.0)
+
+
+@pytest.mark.parametrize("n_samples", [1, 5, 100])
+def test_continuous_discrete_actions_sample_next_state_n_samples_equivalence(n_samples):
+    """Discrete-action variant forwards n_samples to the continuous super.
+
+    Purpose: Validates that ContinuousLightDarkPOMDPDiscreteActions delegates
+        n_samples through to the continuous-action path after looking up the
+        cached action vector.
+
+    Given: A ContinuousLightDarkPOMDPDiscreteActions env, a state, and a
+        string action.
+    When: env.sample_next_state(state, action, n_samples=N) is invoked and
+        compared against env.state_transition_model(state, action).sample(N).
+    Then: For n_samples=1 a (2,) ndarray; for n_samples>1 a (N, 2) ndarray
+        equal to the wrapper-stacked result.
+
+    Test type: unit
+    """
+    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    state = np.array([2.0, 3.0])
+    action = "up"
+
+    _native.set_seed(11)
+    direct = env.sample_next_state(state, action, n_samples=n_samples)
+    _native.set_seed(11)
+    wrapper = env.state_transition_model(state, action).sample(n_samples=n_samples)
+
+    if n_samples == 1:
+        assert isinstance(direct, np.ndarray)
+        assert direct.shape == (2,)
+        assert np.array_equal(direct, wrapper[0])
+    else:
+        assert direct.shape == (n_samples, 2)
+        np.testing.assert_array_equal(direct, np.stack(wrapper, axis=0))
+
+
+def test_continuous_discrete_actions_log_probability_equivalence():
+    """Discrete-action variant forwards log-prob queries to continuous super.
+
+    Purpose: Validates that the discrete-action wrapper resolves the action
+        string to its vector and produces equivalent transition and observation
+        log-probabilities.
+
+    Given: A ContinuousLightDarkPOMDPDiscreteActions env, a state, an action,
+        and batches of candidate next-states / observations.
+    When: env.transition_log_probability and env.observation_log_probability
+        are called with the string action.
+    Then: Their outputs match the per-sample wrapper-based np.log(probability)
+        within 1e-12 tolerance.
+
+    Test type: unit
+    """
+    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    state = np.array([2.0, 3.0])
+    action = "up"
+    candidates = np.array([[2.0, 4.0], [3.0, 3.0], [1.0, 3.0]])
+
+    direct = env.transition_log_probability(state, action, candidates)
+    wrapper = np.asarray(env.state_transition_model(state, action).probability(list(candidates)))
+    np.testing.assert_allclose(direct, np.log(wrapper + 1e-300), atol=1e-12, rtol=0.0)
+
+    next_state = np.array([5.0, 5.0])
+    obs_candidates = np.array([[5.0, 5.0], [5.5, 5.5]])
+    direct_obs = env.observation_log_probability(next_state, action, obs_candidates)
+    wrapper_obs = np.asarray(
+        env.observation_model(next_state, action).probability(list(obs_candidates))
+    )
+    np.testing.assert_allclose(direct_obs, np.log(wrapper_obs + 1e-300), atol=1e-12, rtol=0.0)
+
+
+def test_continuous_sample_observation_falls_back_for_non_normal_noise():
+    """Non-NORMAL_NOISE observation models still honour n_samples via base path.
+
+    Purpose: Validates that NORMAL_NOISE_NO_OBS_IN_DARK and DISTANCE_BASED
+        observation models receive n_samples=N propagated to the wrapper's
+        sample(N) call (executed through the Python base-class fallback).
+
+    Given: ContinuousLightDarkPOMDP envs configured with the two non-native
+        observation model variants and a fixed numpy RNG seed.
+    When: env.sample_observation(next_state, action, n_samples=N) is called
+        and compared with env.observation_model(...).sample(N).
+    Then: Both paths return lists of length N with matching observations.
+
+    Test type: unit
+    """
+    for obs_type in (
+        ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK,
+        ObservationModelType.DISTANCE_BASED,
+    ):
+        env = ContinuousLightDarkPOMDP(
+            discount_factor=0.95,
+            observation_model_type=obs_type,
+        )
+        next_state = np.array([5.0, 5.0])
+        action = np.array([0.0, 0.0])
+
+        np.random.seed(31)
+        direct = env.sample_observation(next_state, action, n_samples=4)
+        np.random.seed(31)
+        wrapper = env.observation_model(next_state, action).sample(n_samples=4)
+
+        assert len(direct) == 4
+        assert len(wrapper) == 4
+        for i in range(4):
+            if isinstance(direct[i], np.ndarray):
+                assert np.array_equal(direct[i], wrapper[i])
+            else:
+                assert direct[i] == wrapper[i]

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_pomdp.py
@@ -1716,3 +1716,229 @@ def test_sample_observation_falls_back_for_non_normal_model_types():
                 assert np.array_equal(wrapper_obs, direct_obs)
             else:
                 assert wrapper_obs == direct_obs
+
+
+# ---------------------------------------------------------------------------
+# Batch sampling and log-probability API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_samples", [1, 5, 100])
+def test_discrete_sample_next_state_n_samples_equivalence(n_samples):
+    """sample_next_state(n_samples=N) matches the wrapper sample(N) under fixed seed.
+
+    Purpose: Validates that the n_samples parameter on sample_next_state
+        produces byte-identical RNG draws to state_transition_model().sample(N)
+        for the discrete environment, which uses np.random.rand() and
+        np.searchsorted on pre-computed cumprob tables.
+
+    Given: A DiscreteLightDarkPOMDP environment, a (state, action) pair, and
+        identical numpy RNG seeds before each call.
+    When: env.sample_next_state(state, action, n_samples=N) is invoked and
+        compared against env.state_transition_model(state, action).sample(N).
+    Then: For n_samples=1 a single (2,) ndarray; for n_samples>1 a (N, 2)
+        ndarray equal to the wrapper-stacked result.
+
+    Test type: unit
+    """
+    env = DiscreteLightDarkPOMDP(
+        discount_factor=0.95,
+        transition_error_prob=0.05,
+        observation_error_prob=0.05,
+        beacons=[(0, 0), (5, 5)],
+        beacon_radius=1.5,
+        grid_size=11,
+    )
+    state = np.array([2, 3])
+    action = "up"
+
+    np.random.seed(123)
+    direct = env.sample_next_state(state, action, n_samples=n_samples)
+    np.random.seed(123)
+    wrapper = env.state_transition_model(state, action).sample(n_samples=n_samples)
+
+    if n_samples == 1:
+        assert isinstance(direct, np.ndarray)
+        assert direct.shape == (2,)
+        assert np.array_equal(direct, wrapper[0])
+    else:
+        assert isinstance(direct, np.ndarray)
+        assert direct.shape == (n_samples, 2)
+        wrapper_arr = np.stack(wrapper, axis=0)
+        np.testing.assert_array_equal(direct, wrapper_arr)
+
+
+@pytest.mark.parametrize("n_samples", [1, 5, 100])
+def test_discrete_sample_observation_n_samples_equivalence(n_samples):
+    """sample_observation(n_samples=N) matches wrapper sample(N) for NORMAL model.
+
+    Purpose: Validates that the n_samples parameter on sample_observation
+        for the NORMAL discrete observation model produces byte-identical
+        RNG draws to observation_model().sample(N).
+
+    Given: A DiscreteLightDarkPOMDP env (NORMAL observation model), a
+        (next_state, action) pair, and identical numpy RNG seeds.
+    When: env.sample_observation(ns, a, n_samples=N) is invoked and compared
+        against env.observation_model(ns, a).sample(N).
+    Then: For n_samples=1 a (2,) ndarray; for n_samples>1 a (N, 2) ndarray
+        equal to the wrapper.
+
+    Test type: unit
+    """
+    env = DiscreteLightDarkPOMDP(
+        discount_factor=0.95,
+        transition_error_prob=0.05,
+        observation_error_prob=0.05,
+        beacons=[(0, 0), (5, 5)],
+        beacon_radius=1.5,
+        grid_size=11,
+        observation_model_type=ObservationModelType.NORMAL,
+    )
+    next_state = np.array([5, 5])  # near beacon
+    action = "up"
+
+    np.random.seed(456)
+    direct = env.sample_observation(next_state, action, n_samples=n_samples)
+    np.random.seed(456)
+    wrapper = env.observation_model(next_state, action).sample(n_samples=n_samples)
+
+    if n_samples == 1:
+        assert isinstance(direct, np.ndarray)
+        assert direct.shape == (2,)
+        assert np.array_equal(direct, wrapper[0])
+    else:
+        assert isinstance(direct, np.ndarray)
+        assert direct.shape == (n_samples, 2)
+        wrapper_arr = np.stack(wrapper, axis=0)
+        np.testing.assert_array_equal(direct, wrapper_arr)
+
+
+def test_discrete_transition_log_probability_equivalence():
+    """transition_log_probability matches np.log(state_transition_model().probability()).
+
+    Purpose: Validates that the discrete log-probability path returns the
+        same numbers as the wrapper-based np.log(probability) path.
+
+    Given: A DiscreteLightDarkPOMDP env, a (state, action) pair, and a list
+        of candidate next-states (each obtainable via one of the four moves
+        plus an off-distribution candidate).
+    When: env.transition_log_probability is invoked and compared against
+        np.log(state_transition_model().probability(...)).
+    Then: The (N,) ndarrays are allclose within 1e-12 tolerance, including
+        the -inf entry for an unreachable candidate.
+
+    Test type: unit
+    """
+    env = DiscreteLightDarkPOMDP(
+        discount_factor=0.95,
+        transition_error_prob=0.05,
+        beacons=[(0, 0), (5, 5)],
+        grid_size=11,
+    )
+    state = np.array([2, 3])
+    action = "up"
+
+    candidates = [
+        state + np.array([0, 1]),  # up   - high prob
+        state + np.array([0, -1]),  # down - low prob
+        state + np.array([1, 0]),  # right - low prob
+        state + np.array([-1, 0]),  # left - low prob
+        np.array([99, 99]),  # off-distribution
+    ]
+    candidates_arr = np.stack(candidates, axis=0)
+
+    direct = env.transition_log_probability(state, action, candidates_arr)
+    wrapper_probs = np.asarray(env.state_transition_model(state, action).probability(candidates))
+    expected = np.log(wrapper_probs + 1e-300)
+
+    assert direct.shape == (5,)
+    np.testing.assert_allclose(direct[:4], expected[:4], atol=1e-12, rtol=0.0)
+    assert direct[4] == -np.inf
+
+
+def test_discrete_observation_log_probability_equivalence():
+    """observation_log_probability matches np.log(observation_model().probability()).
+
+    Purpose: Validates the discrete observation log-prob path against the
+        wrapper-based reference for the NORMAL observation model.
+
+    Given: A DiscreteLightDarkPOMDP env (NORMAL), a near-beacon next_state,
+        and a list of candidate observations.
+    When: env.observation_log_probability is called and compared against
+        np.log(observation_model().probability).
+    Then: The (N,) ndarrays match within 1e-12 tolerance.
+
+    Test type: unit
+    """
+    env = DiscreteLightDarkPOMDP(
+        discount_factor=0.95,
+        observation_error_prob=0.1,
+        beacons=[(0, 0), (5, 5)],
+        beacon_radius=1.5,
+        grid_size=11,
+        observation_model_type=ObservationModelType.NORMAL,
+    )
+    next_state = np.array([5, 5])  # near beacon
+    action = "up"
+
+    candidates = [
+        next_state + np.array([0, 1]),
+        next_state + np.array([0, -1]),
+        next_state + np.array([1, 0]),
+        next_state + np.array([-1, 0]),
+        next_state,  # the "no-noise" observation
+        np.array([99, 99]),  # off-distribution
+    ]
+    candidates_arr = np.stack(candidates, axis=0)
+
+    direct = env.observation_log_probability(next_state, action, candidates_arr)
+    wrapper_probs = np.asarray(env.observation_model(next_state, action).probability(candidates))
+    expected = np.log(wrapper_probs + 1e-300)
+
+    assert direct.shape == (6,)
+    np.testing.assert_allclose(direct[:5], expected[:5], atol=1e-12, rtol=0.0)
+    assert direct[5] == -np.inf
+
+
+def test_discrete_sample_observation_falls_back_for_non_normal_with_n_samples():
+    """Non-NORMAL observation model variants honour n_samples via base path.
+
+    Purpose: Validates that NO_OBS_IN_DARK and DISTANCE_BASED observation
+        models receive n_samples=N propagated to the wrapper sample(N) call.
+
+    Given: DiscreteLightDarkPOMDP envs configured with the two non-NORMAL
+        observation model variants and identical numpy / random seeds.
+    When: env.sample_observation(next_state, action, n_samples=N) is called
+        and compared with env.observation_model(...).sample(N).
+    Then: Both paths return lists of length N with matching observations.
+
+    Test type: unit
+    """
+    for obs_type in (
+        ObservationModelType.NO_OBS_IN_DARK,
+        ObservationModelType.DISTANCE_BASED,
+    ):
+        env = DiscreteLightDarkPOMDP(
+            discount_factor=0.95,
+            beacons=[(0, 0), (5, 5)],
+            beacon_radius=1.5,
+            grid_size=11,
+            observation_model_type=obs_type,
+        )
+        next_state = np.array([5, 5])
+        action = "up"
+
+        np.random.seed(31)
+        random.seed(31)
+        direct = env.sample_observation(next_state, action, n_samples=4)
+        np.random.seed(31)
+        random.seed(31)
+        wrapper = env.observation_model(next_state, action).sample(n_samples=4)
+
+        assert len(direct) == 4
+        assert len(wrapper) == 4
+        for i in range(4):
+            if isinstance(direct[i], np.ndarray):
+                assert np.array_equal(direct[i], wrapper[i])
+            else:
+                assert direct[i] == wrapper[i]

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
@@ -1222,3 +1222,192 @@ def test_sample_observation_rng_pinned_equivalence(base_mountain_car_environment
             direct_obs,
             err_msg=f"sample_observation mismatch for ({next_state}, {action})",
         )
+
+
+def test_sample_next_state_n_samples_equivalence(base_mountain_car_environment):
+    """Test sample_next_state with n>1 matches state_transition_model().sample(n) under fixed RNG.
+
+    Purpose: Validates that the n_samples-aware sample_next_state override produces
+        byte-identical batched results to the wrapper-based path when both use the same
+        native RNG seed.
+
+    Given: A MountainCarPOMDP environment and (state, action) pairs covering the three
+        actions and a few representative positions, with the native module RNG seeded
+        identically before each pair of draws, for n in {1, 5, 100}
+    When: A batch is drawn through state_transition_model(s, a).sample(n) and again
+        through env.sample_next_state(s, a, n_samples=n) after re-seeding
+    Then: The two batches are equal element-wise across all combinations and all n
+
+    Test type: unit
+    """
+    from POMDPPlanners.environments.mountain_car_pomdp import (  # pylint: disable=import-outside-toplevel
+        _native,
+    )
+
+    env = base_mountain_car_environment
+    cases = [
+        ((-0.5, 0.0), -1),
+        ((-0.5, 0.0), 0),
+        ((-0.5, 0.0), 1),
+        ((0.0, 0.05), 1),
+    ]
+    for n in (1, 5, 100):
+        for state, action in cases:
+            _native.set_seed(2024)
+            np.random.seed(2024)
+            random.seed(2024)
+            wrapper_samples = env.state_transition_model(state=state, action=action).sample(n)
+            _native.set_seed(2024)
+            np.random.seed(2024)
+            random.seed(2024)
+            direct_samples = env.sample_next_state(state=state, action=action, n_samples=n)
+            wrapper_arr = np.asarray(wrapper_samples).reshape(n, -1)
+            direct_arr = np.asarray(direct_samples).reshape(n, -1)
+            np.testing.assert_array_equal(
+                wrapper_arr,
+                direct_arr,
+                err_msg=f"sample_next_state n={n} mismatch for ({state}, {action})",
+            )
+
+
+def test_sample_observation_n_samples_equivalence(base_mountain_car_environment):
+    """Test sample_observation with n>1 matches observation_model().sample(n) under fixed RNG.
+
+    Purpose: Validates that the n_samples-aware sample_observation override produces
+        byte-identical batched results to the wrapper-based path when both use the same
+        native RNG seed.
+
+    Given: A MountainCarPOMDP environment and (next_state, action) pairs covering the
+        three actions, with the native module RNG seeded identically, for n in {1, 5, 100}
+    When: A batch is drawn through observation_model(ns, a).sample(n) and again through
+        env.sample_observation(ns, a, n_samples=n) after re-seeding
+    Then: The two batches are equal element-wise across all combinations and all n
+
+    Test type: unit
+    """
+    from POMDPPlanners.environments.mountain_car_pomdp import (  # pylint: disable=import-outside-toplevel
+        _native,
+    )
+
+    env = base_mountain_car_environment
+    cases = [
+        ((-0.5, 0.0), -1),
+        ((-0.5, 0.0), 0),
+        ((-0.5, 0.0), 1),
+        ((0.0, 0.05), 1),
+    ]
+    for n in (1, 5, 100):
+        for next_state, action in cases:
+            _native.set_seed(99)
+            np.random.seed(99)
+            random.seed(99)
+            wrapper_samples = env.observation_model(next_state=next_state, action=action).sample(n)
+            _native.set_seed(99)
+            np.random.seed(99)
+            random.seed(99)
+            direct_samples = env.sample_observation(
+                next_state=next_state, action=action, n_samples=n
+            )
+            wrapper_arr = np.asarray(wrapper_samples).reshape(n, -1)
+            direct_arr = np.asarray(direct_samples).reshape(n, -1)
+            np.testing.assert_array_equal(
+                wrapper_arr,
+                direct_arr,
+                err_msg=f"sample_observation n={n} mismatch for ({next_state}, {action})",
+            )
+
+
+def test_transition_log_probability_equivalence(base_mountain_car_environment):
+    """Test transition_log_probability matches np.log(probability) from the wrapper.
+
+    Purpose: Validates that transition_log_probability returns log-PDFs equivalent
+        (within fp tolerance) to applying np.log to the wrapper-based probability path.
+
+    Given: A MountainCarPOMDP environment and (state, action) pairs covering the three
+        actions, plus a batch of candidate next-state arrays
+    When: Log-probabilities are computed via env.transition_log_probability(s, a, vals)
+        and via np.log(env.state_transition_model(s, a).probability(vals) + 1e-300)
+    Then: The two ndarrays are equal element-wise within fp tolerance
+
+    Test type: unit
+    """
+    env = base_mountain_car_environment
+    candidate_states = np.array(
+        [
+            [-0.4956519, 0.00211698],
+            [-0.6, 0.01],
+            [-0.4, 0.0],
+            [0.5, 0.07],
+            [-1.2, -0.07],
+        ]
+    )
+    cases = [
+        ((-0.5, 0.0), -1),
+        ((-0.5, 0.0), 0),
+        ((-0.5, 0.0), 1),
+        ((0.0, 0.05), 1),
+        ((-1.0, -0.03), 0),
+    ]
+    for state, action in cases:
+        direct = env.transition_log_probability(
+            state=state, action=action, next_states=candidate_states
+        )
+        wrapper_probs = np.asarray(
+            env.state_transition_model(state=state, action=action).probability(candidate_states)
+        )
+        ref = np.log(wrapper_probs + 1e-300)
+        np.testing.assert_allclose(
+            direct,
+            ref,
+            rtol=1e-12,
+            atol=1e-12,
+            err_msg=f"transition_log_probability mismatch for ({state}, {action})",
+        )
+
+
+def test_observation_log_probability_equivalence(base_mountain_car_environment):
+    """Test observation_log_probability matches np.log(probability) from the wrapper.
+
+    Purpose: Validates that observation_log_probability returns log-PDFs equivalent
+        (within fp tolerance) to applying np.log to the wrapper-based probability path.
+
+    Given: A MountainCarPOMDP environment and (next_state, action) pairs covering the
+        three actions, plus a batch of candidate observation arrays
+    When: Log-probabilities are computed via env.observation_log_probability(ns, a, obs)
+        and via np.log(env.observation_model(ns, a).probability(obs) + 1e-300)
+    Then: The two ndarrays are equal element-wise within fp tolerance
+
+    Test type: unit
+    """
+    env = base_mountain_car_environment
+    candidate_obs = np.array(
+        [
+            [-0.5, 0.0],
+            [-0.4, 0.01],
+            [-0.6, 0.02],
+            [0.0, -0.05],
+            [0.4, 0.05],
+        ]
+    )
+    cases = [
+        ((-0.5, 0.0), -1),
+        ((-0.5, 0.0), 0),
+        ((-0.5, 0.0), 1),
+        ((0.0, 0.05), 1),
+        ((-1.0, -0.03), 0),
+    ]
+    for next_state, action in cases:
+        direct = env.observation_log_probability(
+            next_state=next_state, action=action, observations=candidate_obs
+        )
+        wrapper_probs = np.asarray(
+            env.observation_model(next_state=next_state, action=action).probability(candidate_obs)
+        )
+        ref = np.log(wrapper_probs + 1e-300)
+        np.testing.assert_allclose(
+            direct,
+            ref,
+            rtol=1e-12,
+            atol=1e-12,
+            err_msg=f"observation_log_probability mismatch for ({next_state}, {action})",
+        )

--- a/POMDPPlanners/tests/test_environments/test_pacman_native/test_pacman_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_native/test_pacman_native_equivalence.py
@@ -362,3 +362,209 @@ class TestSampleNextStateOverrideEquivalence:
                 via_override = env.sample_observation(next_state=next_state, action=action)
 
                 assert via_wrapper == via_override
+
+
+class TestNSamplesAndLogProbabilityEquivalence:
+    """env-level n_samples + log-probability methods match wrapper path."""
+
+    @staticmethod
+    def _seeded_loop_states(env: PacManPOMDP, state: np.ndarray, action: int, n: int):
+        env.ghost_patrol_directions[:] = 0
+        _native.set_seed(2024)
+        return [env.state_transition_model(state, action).sample()[0] for _ in range(n)]
+
+    @staticmethod
+    def _seeded_batch_states(env: PacManPOMDP, state: np.ndarray, action: int, n: int):
+        env.ghost_patrol_directions[:] = 0
+        _native.set_seed(2024)
+        if n == 1:
+            return [env.sample_next_state(state=state, action=action)]
+        return list(env.sample_next_state(state=state, action=action, n_samples=n))
+
+    @staticmethod
+    def _seeded_loop_obs(env: PacManPOMDP, next_state: np.ndarray, action: int, n: int):
+        _native.set_seed(99)
+        return [env.observation_model(next_state, action).sample()[0] for _ in range(n)]
+
+    @staticmethod
+    def _seeded_batch_obs(env: PacManPOMDP, next_state: np.ndarray, action: int, n: int):
+        _native.set_seed(99)
+        if n == 1:
+            return [env.sample_observation(next_state=next_state, action=action)]
+        return list(env.sample_observation(next_state=next_state, action=action, n_samples=n))
+
+    def test_sample_next_state_n_samples_equivalence_n_1(self) -> None:
+        """env.sample_next_state(n=1) matches one wrapper sample(1) call.
+
+        Purpose: Validates that the n_samples=1 fast path equals the
+        legacy wrapper path bit-exactly under shared seed and identical
+        ``ghost_patrol_directions`` buffer state.
+
+        Given: An env, an initial state, and action=1 (East).
+        When: Both paths run with ``_native.set_seed(2024)`` and patrol
+            buffer reset to zeros.
+        Then: ``np.array_equal`` on the returned arrays.
+
+        Test type: integration
+        """
+        env = _build_env()
+        state = env.initial_state_dist().sample()[0]
+        loop = self._seeded_loop_states(env, state, action=1, n=1)
+        batch = self._seeded_batch_states(env, state, action=1, n=1)
+        np.testing.assert_array_equal(batch[0], loop[0])
+
+    def test_sample_next_state_n_samples_equivalence_n_5(self) -> None:
+        """env.sample_next_state(n=5) matches 5 wrapper sample(1) calls.
+
+        Purpose: Validates that the batched n_samples path advances the
+        native RNG in the same order as repeated single-sample wrapper
+        calls under shared seed and matching patrol-direction buffers.
+
+        Given: An env and a non-terminal state.
+        When: Both paths run with the same seed.
+        Then: All 5 returned states are np.array_equal.
+
+        Test type: integration
+        """
+        env = _build_env()
+        state = env.initial_state_dist().sample()[0]
+        loop = self._seeded_loop_states(env, state, action=1, n=5)
+        batch = self._seeded_batch_states(env, state, action=1, n=5)
+        assert len(batch) == 5
+        for a, b in zip(loop, batch):
+            np.testing.assert_array_equal(a, b)
+
+    def test_sample_next_state_n_samples_equivalence_n_100(self) -> None:
+        """env.sample_next_state(n=100) matches 100 wrapper sample(1) calls.
+
+        Purpose: Larger-N variant of the equivalence check, sufficient
+        to cover patrol-direction mutation patterns and multi-ghost RNG
+        consumption order.
+
+        Given: An env and an initial state.
+        When: Both paths run with the same seed.
+        Then: All 100 returned states are np.array_equal.
+
+        Test type: integration
+        """
+        env = _build_env()
+        state = env.initial_state_dist().sample()[0]
+        loop = self._seeded_loop_states(env, state, action=1, n=100)
+        batch = self._seeded_batch_states(env, state, action=1, n=100)
+        assert len(batch) == 100
+        for a, b in zip(loop, batch):
+            np.testing.assert_array_equal(a, b)
+
+    def test_sample_observation_n_samples_equivalence_n_1(self) -> None:
+        """env.sample_observation(n=1) matches one wrapper sample(1) call.
+
+        Purpose: Validates the n_samples=1 observation fast path matches
+        the legacy wrapper path bit-exactly under shared seed.
+
+        Given: A non-terminal next_state and action=0.
+        When: Both paths run with ``_native.set_seed(99)``.
+        Then: The two observations are equal (tuple-of-tuples form).
+
+        Test type: integration
+        """
+        env = _build_env()
+        next_state = env.initial_state_dist().sample()[0]
+        loop = self._seeded_loop_obs(env, next_state, action=0, n=1)
+        batch = self._seeded_batch_obs(env, next_state, action=0, n=1)
+        assert batch[0] == loop[0]
+
+    def test_sample_observation_n_samples_equivalence_n_5(self) -> None:
+        """env.sample_observation(n=5) matches 5 wrapper sample(1) calls.
+
+        Purpose: Validates the batched observation sampler consumes the
+        native RNG in the same order as repeated wrapper calls.
+
+        Given: A non-terminal next_state and action=0.
+        When: Both paths run with the same seed.
+        Then: All 5 observations match in tuple-of-tuples form.
+
+        Test type: integration
+        """
+        env = _build_env()
+        next_state = env.initial_state_dist().sample()[0]
+        loop = self._seeded_loop_obs(env, next_state, action=0, n=5)
+        batch = self._seeded_batch_obs(env, next_state, action=0, n=5)
+        assert batch == loop
+
+    def test_sample_observation_n_samples_equivalence_n_100(self) -> None:
+        """env.sample_observation(n=100) matches 100 wrapper sample(1) calls.
+
+        Purpose: Larger-N variant for thorough RNG-order coverage.
+
+        Given: A non-terminal next_state.
+        When: Both paths run with the same seed.
+        Then: All 100 observations match in tuple-of-tuples form.
+
+        Test type: integration
+        """
+        env = _build_env()
+        next_state = env.initial_state_dist().sample()[0]
+        loop = self._seeded_loop_obs(env, next_state, action=0, n=100)
+        batch = self._seeded_batch_obs(env, next_state, action=0, n=100)
+        assert batch == loop
+
+    def test_transition_log_probability_equivalence(self) -> None:
+        """transition_log_probability matches log(state_transition_model.probability).
+
+        Purpose: Validates that the env-level vectorized log-probability
+        equals ``log(prob + 1e-300)`` of the per-call wrapper path.
+
+        Given: An initial state, action, and a candidate set including
+            the actual sampled next state plus a perturbed copy.
+        When: env.transition_log_probability is compared to
+            ``np.log(wrapper.probability(...) + 1e-300)``.
+        Then: Arrays agree elementwise within 1e-10.
+
+        Test type: integration
+        """
+        env = _build_env()
+        state = env.initial_state_dist().sample()[0]
+        env.ghost_patrol_directions[:] = 0
+        _native.set_seed(0)
+        next_state = env.state_transition_model(state, 1).sample()[0]
+        perturbed = next_state.copy()
+        perturbed[env._idx_pac_row] += 1  # pylint: disable=protected-access
+        candidates = [next_state, perturbed]
+
+        env.ghost_patrol_directions[:] = 0
+        log_p = env.transition_log_probability(state, 1, candidates)
+
+        env.ghost_patrol_directions[:] = 0
+        expected = np.log(
+            np.asarray(env.state_transition_model(state, 1).probability(candidates)) + 1e-300
+        )
+
+        assert log_p.shape == (len(candidates),)
+        np.testing.assert_allclose(log_p, expected, atol=1e-10)
+
+    def test_observation_log_probability_equivalence(self) -> None:
+        """observation_log_probability matches log(observation_model.probability).
+
+        Purpose: Validates that the env-level vectorized log-density
+        equals the per-call wrapper path on a small candidate
+        observation list (tuple-of-(row, col) format).
+
+        Given: A non-terminal next_state and three candidate observations.
+        When: env.observation_log_probability is compared to
+            ``log(wrapper.probability(...) + 1e-300)``.
+        Then: Arrays agree elementwise within 1e-10.
+
+        Test type: integration
+        """
+        env = _build_env()
+        next_state = env.initial_state_dist().sample()[0]
+        _native.set_seed(13)
+        obs_list = [env.observation_model(next_state, 0).sample()[0] for _ in range(3)]
+
+        log_p = env.observation_log_probability(next_state, 0, obs_list)
+        expected = np.log(
+            np.asarray(env.observation_model(next_state, 0).probability(obs_list)) + 1e-300
+        )
+
+        assert log_p.shape == (len(obs_list),)
+        np.testing.assert_allclose(log_p, expected, atol=1e-10)

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
@@ -9,6 +9,7 @@ environment, and discrete actions wrapper for the Continuous Push POMDP.
 from typing import Any
 
 import numpy as np
+import pytest
 
 from POMDPPlanners.core.environment import SpaceType
 from POMDPPlanners.environments.push_pomdp.continuous_push_pomdp import (
@@ -842,3 +843,219 @@ class TestSampleHotPathOverridesEquivalence:
             assert vec.dtype == np.float64, action_name
             assert vec.shape == (2,), action_name
             assert vec.flags["C_CONTIGUOUS"], action_name
+
+
+# ------------------------------------------------------------------
+# Batch sampling and log-probability equivalence
+# ------------------------------------------------------------------
+
+
+class TestSampleBatchAndLogProbabilityEquivalence:
+    """Pinned-seed equivalence for the new n_samples and log-probability paths."""
+
+    @pytest.mark.parametrize("n_samples", [1, 5, 100])
+    def test_sample_next_state_n_samples_equivalence(self, n_samples):
+        """Pinned-seed equivalence: sample_next_state(..., n) vs wrapper.sample(n).
+
+        Purpose: Validates that the new ``n_samples`` parameter on
+            ``sample_next_state`` preserves the kernel's RNG-draw order.
+            Both paths construct the same ``_native.ContinuousPushTransitionCpp``
+            and call ``kernel.sample(n)`` under the same module-level RNG seed,
+            so the per-sample outputs must be byte-identical.
+
+        Given: A ContinuousPushPOMDP env with non-trivial covariance and a
+            (state, action) pair, with ``_native.set_seed`` pinned before
+            each path.
+        When: state_transition_model(s, a).sample(n) and
+            sample_next_state(s, a, n_samples=n) are each called under the
+            same seed.
+        Then: For n==1 the override returns a single ndarray equal to
+            wrapper[0]; for n>1 it returns a length-n list of ndarrays
+            element-by-element equal to the wrapper output.
+
+        Test type: unit
+        """
+        from POMDPPlanners.environments.push_pomdp import (  # pylint: disable=import-outside-toplevel
+            _native,
+        )
+
+        env = ContinuousPushPOMDP(
+            discount_factor=0.99,
+            state_transition_cov_matrix=np.eye(2) * 0.01,
+            robot_radius=0.3,
+        )
+        state = np.array([2.5, 3.1, 3.0, 3.0, 8.0, 8.0])
+        action = np.array([1.0, 0.0])
+        seed = 4242
+        _native.set_seed(seed)
+        wrapper_samples = env.state_transition_model(state, action).sample(n_samples)
+        _native.set_seed(seed)
+        direct = env.sample_next_state(state, action, n_samples=n_samples)
+        if n_samples == 1:
+            assert isinstance(direct, np.ndarray)
+            np.testing.assert_array_equal(direct, wrapper_samples[0])
+        else:
+            assert len(direct) == n_samples
+            for i in range(n_samples):
+                np.testing.assert_array_equal(direct[i], wrapper_samples[i])
+
+    @pytest.mark.parametrize("n_samples", [1, 5, 100])
+    def test_sample_observation_n_samples_equivalence(self, n_samples):
+        """Pinned-seed equivalence: sample_observation(..., n) vs wrapper.sample(n).
+
+        Purpose: Validates that the new ``n_samples`` parameter on
+            ``sample_observation`` preserves the kernel's RNG-draw order.
+
+        Given: A ContinuousPushPOMDP env, a (next_state, action) pair, and
+            ``_native.set_seed`` pinned before each path.
+        When: observation_model(ns, a).sample(n) and
+            sample_observation(ns, a, n_samples=n) are each called under
+            the same seed.
+        Then: For n==1 the override returns a single ndarray; for n>1 it
+            returns a length-n list. Both match the wrapper output
+            element-by-element.
+
+        Test type: unit
+        """
+        from POMDPPlanners.environments.push_pomdp import (  # pylint: disable=import-outside-toplevel
+            _native,
+        )
+
+        env = ContinuousPushPOMDP(
+            discount_factor=0.99,
+            observation_noise=0.3,
+            robot_radius=0.3,
+        )
+        next_state = np.array([5.0, 5.0, 4.5, 5.5, 8.0, 8.0])
+        action = np.array([0.5, 0.5])
+        seed = 909090
+        _native.set_seed(seed)
+        wrapper_samples = env.observation_model(next_state, action).sample(n_samples)
+        _native.set_seed(seed)
+        direct = env.sample_observation(next_state, action, n_samples=n_samples)
+        if n_samples == 1:
+            assert isinstance(direct, np.ndarray)
+            np.testing.assert_array_equal(direct, wrapper_samples[0])
+        else:
+            assert len(direct) == n_samples
+            for i in range(n_samples):
+                np.testing.assert_array_equal(direct[i], wrapper_samples[i])
+
+    def test_transition_log_probability_equivalence(self):
+        """transition_log_probability == log(state_transition_model.probability).
+
+        Purpose: Validates that the new vectorized log-probability path
+            yields ``np.log(probability(...))`` from the wrapper for several
+            candidate next-states.
+
+        Given: A ContinuousPushPOMDP env, a (state, action) pair, and a list
+            of candidate next-states drawn from the same kernel under
+            distinct seeds (so they have non-trivial probability mass).
+        When: env.transition_log_probability(s, a, next_states) is called.
+        Then: The result equals ``np.log(probability(next_states))`` from
+            the wrapper to numerical tolerance.
+
+        Test type: unit
+        """
+        from POMDPPlanners.environments.push_pomdp import (  # pylint: disable=import-outside-toplevel
+            _native,
+        )
+
+        env = ContinuousPushPOMDP(
+            discount_factor=0.99,
+            state_transition_cov_matrix=np.eye(2) * 0.01,
+            robot_radius=0.3,
+        )
+        state = np.array([5.0, 5.0, 5.5, 5.0, 8.0, 8.0])
+        action = np.array([0.5, 0.5])
+        wrapper = env.state_transition_model(state, action)
+        candidates = []
+        for seed in (1, 2, 3, 4, 5):
+            _native.set_seed(seed)
+            candidates.append(wrapper.sample()[0])
+        wrapper_probs = np.asarray(wrapper.probability(candidates))
+        with np.errstate(divide="ignore"):
+            expected_log = np.log(wrapper_probs)
+        log_probs = env.transition_log_probability(state, action, candidates)
+        assert log_probs.shape == (len(candidates),)
+        np.testing.assert_allclose(log_probs, expected_log, rtol=1e-12, atol=1e-12)
+
+    def test_observation_log_probability_equivalence(self):
+        """observation_log_probability == log(observation_model.probability).
+
+        Purpose: Validates that the new vectorized log-probability path
+            yields ``np.log(probability(...))`` from the wrapper for several
+            candidate observations.
+
+        Given: A ContinuousPushPOMDP env, a (next_state, action) pair, and
+            a list of candidate observations spanning equal-to-truth and
+            offset positions.
+        When: env.observation_log_probability(ns, a, observations) is called.
+        Then: The result equals ``np.log(probability(observations))`` from
+            the wrapper to numerical tolerance.
+
+        Test type: unit
+        """
+        env = ContinuousPushPOMDP(
+            discount_factor=0.99,
+            observation_noise=0.3,
+            robot_radius=0.3,
+        )
+        next_state = np.array([3.0, 3.0, 5.0, 5.0, 8.0, 8.0])
+        action = np.array([1.0, 0.0])
+        wrapper = env.observation_model(next_state, action)
+        observations = [
+            next_state.copy(),  # zero-diff
+            np.array([3.0, 3.0, 5.1, 5.0, 8.0, 8.0]),
+            np.array([3.0, 3.0, 5.5, 4.6, 8.0, 8.0]),
+            np.array([3.0, 3.0, 6.0, 5.0, 8.0, 8.0]),
+        ]
+        wrapper_probs = np.asarray(wrapper.probability(observations))
+        expected_log = np.log(wrapper_probs)
+        log_probs = env.observation_log_probability(next_state, action, observations)
+        assert log_probs.shape == (len(observations),)
+        np.testing.assert_allclose(log_probs, expected_log, rtol=1e-12, atol=1e-12)
+
+    def test_discrete_actions_log_probability_resolves_action(self):
+        """Discrete-actions wrapper resolves str action via action_to_vector.
+
+        Purpose: Validates that
+            ``ContinuousPushPOMDPDiscreteActions.transition_log_probability``
+            and ``observation_log_probability`` look up the cached action
+            vector and produce the same result as calling the parent override
+            with that vector directly.
+
+        Given: A ContinuousPushPOMDPDiscreteActions env, a (state, action,
+            next_state) triple.
+        When: For each str action, env.{transition,observation}_log_probability
+            is compared against the parent override called with
+            ``action_to_vector[a]``.
+        Then: Both paths produce np.allclose results.
+
+        Test type: unit
+        """
+        env = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99,
+            state_transition_cov_matrix=np.eye(2) * 0.01,
+            observation_noise=0.3,
+        )
+        state = np.array([5.0, 5.0, 5.5, 5.0, 9.0, 9.0])
+        next_states = [
+            np.array([5.5, 5.0, 5.5, 5.0, 9.0, 9.0]),
+            np.array([5.0, 5.5, 5.5, 5.0, 9.0, 9.0]),
+        ]
+        observations = [
+            np.array([5.0, 5.0, 5.5, 5.0, 9.0, 9.0]),
+            np.array([5.0, 5.0, 5.6, 5.1, 9.0, 9.0]),
+        ]
+        for str_action in env.get_actions():
+            vec = env.action_to_vector[str_action]
+            via_str = env.transition_log_probability(state, str_action, next_states)
+            via_vec = ContinuousPushPOMDP.transition_log_probability(env, state, vec, next_states)
+            np.testing.assert_allclose(via_str, via_vec, rtol=1e-12, atol=1e-12)
+
+            via_str_obs = env.observation_log_probability(state, str_action, observations)
+            via_vec_obs = ContinuousPushPOMDP.observation_log_probability(
+                env, state, vec, observations
+            )
+            np.testing.assert_allclose(via_str_obs, via_vec_obs, rtol=1e-12, atol=1e-12)

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
@@ -1399,3 +1399,157 @@ class TestSampleHotPathOverridesEquivalence:
                     f"Mismatch for next_state={next_state}, action={action}, seed={seed}: "
                     f"wrapper={wrapper_obs}, direct={direct_obs}"
                 )
+
+    @pytest.mark.parametrize("n_samples", [1, 5, 100])
+    def test_sample_next_state_n_samples_equivalence(self, n_samples):
+        """Pinned-seed equivalence: sample_next_state(..., n) vs wrapper.sample(n).
+
+        Purpose: Validates that the new ``n_samples`` parameter on
+            ``sample_next_state`` preserves the exact RNG-draw order of the
+            wrapper path. Each of the n inner draws is bit-identical to the
+            corresponding draw produced by ``state_transition_model(...).sample(n)``.
+
+        Given: A PushPOMDP with non-zero transition_error_prob (so the
+            np.random.choice branch fires for some draws), a fixed (state,
+            action) pair, and identical np / random seeds before each path.
+        When: state_transition_model(s, a).sample(n_samples) and
+            sample_next_state(s, a, n_samples=n_samples) are each called
+            under the same seed.
+        Then: The two outputs are equal element-by-element. For n==1 the
+            override returns a single ndarray (back-compat); for n>1 it
+            returns a length-n list of ndarrays.
+
+        Test type: unit
+        """
+        env = PushPOMDP(
+            discount_factor=0.95,
+            grid_size=10,
+            push_threshold=1.0,
+            friction_coefficient=0.3,
+            obstacles=[(3.0, 3.0), (7.0, 7.0)],
+            obstacle_radius=0.5,
+            transition_error_prob=0.3,
+        )
+        state = np.array([2.5, 3.1, 3.0, 3.0, 9.0, 9.0])
+        action = "right"
+        seed = 1234
+        np.random.seed(seed)
+        random.seed(seed)
+        wrapper_samples = env.state_transition_model(state, action).sample(n_samples)
+        np.random.seed(seed)
+        random.seed(seed)
+        direct = env.sample_next_state(state, action, n_samples=n_samples)
+        if n_samples == 1:
+            assert isinstance(direct, np.ndarray)
+            assert np.array_equal(direct, wrapper_samples[0])
+        else:
+            assert len(direct) == n_samples
+            for i in range(n_samples):
+                assert np.array_equal(
+                    direct[i], wrapper_samples[i]
+                ), f"Mismatch at i={i}: direct={direct[i]} vs wrapper={wrapper_samples[i]}"
+
+    @pytest.mark.parametrize("n_samples", [1, 5, 100])
+    def test_sample_observation_n_samples_equivalence(self, n_samples):
+        """Pinned-seed equivalence: sample_observation(..., n) vs wrapper.sample(n).
+
+        Purpose: Validates that the new ``n_samples`` parameter on
+            ``sample_observation`` preserves the wrapper's RNG-draw order
+            (two np.random.normal draws per sample, in row order).
+
+        Given: A PushPOMDP env, a fixed (next_state, action) pair, and
+            identical np / random seeds before each path.
+        When: observation_model(ns, a).sample(n_samples) and
+            sample_observation(ns, a, n_samples=n_samples) are each called
+            under the same seed.
+        Then: The two outputs are equal element-by-element.
+
+        Test type: unit
+        """
+        env = PushPOMDP(discount_factor=0.95, grid_size=10, observation_noise=0.4)
+        next_state = np.array([5.0, 5.0, 4.5, 5.5, 9.0, 9.0])
+        action = "up"
+        seed = 7777
+        np.random.seed(seed)
+        random.seed(seed)
+        wrapper_samples = env.observation_model(next_state, action).sample(n_samples)
+        np.random.seed(seed)
+        random.seed(seed)
+        direct = env.sample_observation(next_state, action, n_samples=n_samples)
+        if n_samples == 1:
+            assert isinstance(direct, np.ndarray)
+            assert np.array_equal(direct, wrapper_samples[0])
+        else:
+            assert len(direct) == n_samples
+            for i in range(n_samples):
+                assert np.array_equal(direct[i], wrapper_samples[i])
+
+    def test_transition_log_probability_equivalence(self):
+        """transition_log_probability == log(state_transition_model(..).probability(..)).
+
+        Purpose: Validates the new vectorized log-probability path matches
+            ``np.log(probability(...))`` from the wrapper.
+
+        Given: A PushPOMDP with transition_error_prob > 0 (so non-degenerate
+            probability mass over multiple candidate next-states), a fixed
+            (state, action) pair, and a list of candidate next_states drawn
+            from both the intended-action result and one error-action result.
+        When: env.transition_log_probability(s, a, next_states) is called.
+        Then: The result equals ``np.log(probability(next_states))`` from
+            the wrapper, with -inf for impossible next-states.
+
+        Test type: unit
+        """
+        env = PushPOMDP(
+            discount_factor=0.95,
+            grid_size=10,
+            transition_error_prob=0.25,
+        )
+        state = np.array([2.0, 3.0, 5.0, 5.0, 9.0, 9.0])
+        action = "right"
+        wrapper = env.state_transition_model(state, action)
+        # Candidate next-states: intended ("right" -> robot+x), one error
+        # action result, and an impossible state.
+        candidates = [
+            wrapper.sample()[0],  # intended
+            np.array([2.0, 3.0, 5.0, 5.0, 9.0, 9.0]),  # impossible / no-move
+            np.array([1.0, 3.0, 5.0, 5.0, 9.0, 9.0]),  # left-error result
+            np.array([2.0, 4.0, 5.0, 5.0, 9.0, 9.0]),  # up-error result
+        ]
+        wrapper_probs = wrapper.probability(candidates)
+        with np.errstate(divide="ignore"):
+            expected_log = np.log(wrapper_probs)
+        log_probs = env.transition_log_probability(state, action, candidates)
+        assert log_probs.shape == (len(candidates),)
+        np.testing.assert_array_equal(log_probs, expected_log)
+
+    def test_observation_log_probability_equivalence(self):
+        """observation_log_probability == log(observation_model(..).probability(..)).
+
+        Purpose: Validates the new vectorized log-probability path matches
+            ``np.log(probability(...))`` from the wrapper.
+
+        Given: A PushPOMDP env, a fixed (next_state, action) pair, and a
+            list of candidate observations spanning equal-to-truth and
+            offset positions.
+        When: env.observation_log_probability(ns, a, observations) is called.
+        Then: The result equals ``np.log(probability(observations))`` from
+            the wrapper to numerical tolerance.
+
+        Test type: unit
+        """
+        env = PushPOMDP(discount_factor=0.95, grid_size=10, observation_noise=0.5)
+        next_state = np.array([3.0, 3.0, 5.0, 5.0, 9.0, 9.0])
+        action = "up"
+        wrapper = env.observation_model(next_state, action)
+        observations = [
+            next_state.copy(),  # zero-diff -> max log-pdf
+            np.array([3.0, 3.0, 5.1, 5.0, 9.0, 9.0]),
+            np.array([3.0, 3.0, 5.5, 4.6, 9.0, 9.0]),
+            np.array([3.0, 3.0, 6.0, 5.0, 9.0, 9.0]),
+        ]
+        wrapper_probs = wrapper.probability(observations)
+        expected_log = np.log(wrapper_probs)
+        log_probs = env.observation_log_probability(next_state, action, observations)
+        assert log_probs.shape == (len(observations),)
+        np.testing.assert_allclose(log_probs, expected_log, rtol=1e-12, atol=1e-12)

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_native_equivalence.py
@@ -748,3 +748,135 @@ def test_sample_observation_override_matches_wrapper(
     via_override = env.sample_observation(next_state=next_state, action=action)
 
     assert via_wrapper == via_override
+
+
+# ---------------------------------------------------------------------------
+# 21. n_samples / log-probability equivalence (PR-A)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n", [1, 5, 100])
+def test_sample_next_state_n_samples_equivalence(env: RockSamplePOMDP, n: int) -> None:
+    """env.sample_next_state(n) matches n calls of state_transition_model.sample(1).
+
+    Purpose: Validates that the env-level batched sampler advances the
+    native RNG in the same order as repeated wrapper calls of size 1, so
+    the n_samples >= 2 path is bit-equivalent to the per-call wrapper
+    path under the same seed.
+
+    Given: A live (non-terminal) state and a check action (the only
+        non-deterministic action class for transitions; in this env the
+        kernel does not consume RNG for transitions, so this also covers
+        movement actions trivially).
+    When: Both paths are seeded identically and asked for n samples.
+    Then: All returned states are np.array_equal element-wise.
+
+    Test type: integration
+    """
+    state = _state(2, 2, (True, True, False, True))
+    action = 2  # east move
+
+    _native.set_seed(2024)
+    loop = [env.state_transition_model(state, action).sample()[0] for _ in range(n)]
+
+    _native.set_seed(2024)
+    if n == 1:
+        batch = [env.sample_next_state(state=state, action=action)]
+    else:
+        batch = list(env.sample_next_state(state=state, action=action, n_samples=n))
+
+    assert len(batch) == n
+    for a, b in zip(loop, batch):
+        np.testing.assert_array_equal(a, b)
+
+
+@pytest.mark.parametrize("n", [1, 5, 100])
+def test_sample_observation_n_samples_equivalence(env: RockSamplePOMDP, n: int) -> None:
+    """env.sample_observation(n) matches n calls of observation_model.sample(1).
+
+    Purpose: Validates that the env-level batched observation sampler
+    consumes the native RNG in the same order as repeated single-sample
+    wrapper calls under the same seed.
+
+    Given: A check action against rock 0 from a far cell so the Bernoulli
+        flip actually consumes RNG (yielding non-trivial variation).
+    When: Both paths are seeded identically and asked for n samples.
+    Then: The string-coded observation sequences match exactly.
+
+    Test type: integration
+    """
+    next_state = _state(5, 5, (True, False, True, False))
+    action = 5  # check rock 0
+
+    _native.set_seed(99)
+    loop = [env.observation_model(next_state, action).sample()[0] for _ in range(n)]
+
+    _native.set_seed(99)
+    if n == 1:
+        batch = [env.sample_observation(next_state=next_state, action=action)]
+    else:
+        batch = list(env.sample_observation(next_state=next_state, action=action, n_samples=n))
+
+    assert len(batch) == n
+    assert loop == batch
+
+
+def test_transition_log_probability_equivalence(env: RockSamplePOMDP) -> None:
+    """transition_log_probability returns log of state_transition_model.probability.
+
+    Purpose: Validates the env-level vectorized log-probability matches
+    the wrapper path elementwise (after taking ``log`` with a tiny
+    floor). RockSample transitions are deterministic, so the result is
+    a vector of 0.0 for the actual deterministic next state and -inf
+    (effectively log(0+eps)) for perturbed candidates.
+
+    Given: A state and action plus a list of [actual_next, perturbed].
+    When: env.transition_log_probability is compared to log of the
+        wrapper-based probability().
+    Then: Arrays agree elementwise within 1e-10.
+
+    Test type: integration
+    """
+    state = _state(2, 2, (True, True, False, True))
+    action = 2  # east move
+
+    next_state = env.state_transition_model(state, action).sample()[0]
+    perturbed = next_state.copy()
+    perturbed[0] = perturbed[0] + 1
+    candidates = [next_state, perturbed]
+
+    log_p = env.transition_log_probability(state, action, candidates)
+    expected = np.log(
+        np.asarray(env.state_transition_model(state, action).probability(candidates)) + 1e-300
+    )
+
+    assert log_p.shape == (len(candidates),)
+    np.testing.assert_allclose(log_p, expected, atol=1e-10)
+
+
+def test_observation_log_probability_equivalence(env: RockSamplePOMDP) -> None:
+    """observation_log_probability returns log of observation_model.probability.
+
+    Purpose: Validates the env-level vectorized log-probability matches
+    the wrapper path on the canonical observation alphabet, including
+    the unknown-label case which must collapse to -inf.
+
+    Given: A check action at a far rock with known efficiency.
+    When: log-probabilities for ['good','bad','none'] are compared
+        between the env-level method and ``log(wrapper.probability(...))``.
+    Then: Arrays agree elementwise within 1e-10.
+
+    Test type: integration
+    """
+    rocks = (True, False, True, False)
+    next_state = _state(5, 5, rocks)
+    action = 5  # check rock 0
+
+    obs_list = ["good", "bad", "none"]
+    log_p = env.observation_log_probability(next_state, action, obs_list)
+
+    expected = np.log(
+        np.asarray(env.observation_model(next_state, action).probability(obs_list)) + 1e-300
+    )
+    assert log_p.shape == (len(obs_list),)
+    np.testing.assert_allclose(log_p, expected, atol=1e-10)

--- a/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_native_equivalence.py
@@ -537,3 +537,132 @@ def test_sample_observation_override_matches_wrapper(env, next_state, action):
     via_override = env.sample_observation(next_state=next_state, action=action)
 
     np.testing.assert_array_equal(via_wrapper, via_override)
+
+
+# ---------------------------------------------------------------------------
+# n_samples / log-probability equivalence (PR-A)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n", [1, 5, 100])
+def test_sample_next_state_n_samples_equivalence(env, n):
+    """env.sample_next_state(n) matches n calls of state_transition_model.sample(1).
+
+    Purpose: Validates that the env-level batched transition sampler
+    advances the native RNG in the same order as repeated wrapper
+    sample(1) calls under the same seed.
+
+    Given: A non-zero force action so the uniform-angle RNG is consumed.
+    When: Both paths are seeded identically and asked for n samples.
+    Then: Returned states are np.array_equal element-wise.
+
+    Test type: integration
+    """
+    state = np.array([0.5, -0.2, 1.0, 0.5])
+    action = 2
+
+    _native.set_seed(2024)
+    loop = [env.state_transition_model(state, action).sample()[0] for _ in range(n)]
+
+    _native.set_seed(2024)
+    if n == 1:
+        batch = [env.sample_next_state(state=state, action=action)]
+    else:
+        batch = list(env.sample_next_state(state=state, action=action, n_samples=n))
+
+    assert len(batch) == n
+    for a, b in zip(loop, batch):
+        np.testing.assert_array_equal(a, b)
+
+
+@pytest.mark.parametrize("n", [1, 5, 100])
+def test_sample_observation_n_samples_equivalence(env, n):
+    """env.sample_observation(n) matches n calls of observation_model.sample(1).
+
+    Purpose: Validates that the env-level batched observation sampler
+    advances the native RNG in the same order as repeated wrapper
+    sample(1) calls under the same seed.
+
+    Given: A representative non-zero next_state.
+    When: Both paths are seeded identically.
+    Then: All sampled observations are np.array_equal element-wise.
+
+    Test type: integration
+    """
+    next_state = np.array([0.5, -0.2, 1.0, 0.5])
+    action = 2
+
+    _native.set_seed(99)
+    loop = [env.observation_model(next_state, action).sample()[0] for _ in range(n)]
+
+    _native.set_seed(99)
+    if n == 1:
+        batch = [env.sample_observation(next_state=next_state, action=action)]
+    else:
+        batch = list(env.sample_observation(next_state=next_state, action=action, n_samples=n))
+
+    assert len(batch) == n
+    for a, b in zip(loop, batch):
+        np.testing.assert_array_equal(a, b)
+
+
+def test_transition_log_probability_equivalence(env):
+    """transition_log_probability matches log of state_transition_model.probability.
+
+    Purpose: Validates the env-level vectorized log-probability matches
+    the wrapper-based path. The transition's probability() is the
+    tolerance-based ring-consistency check (no closed-form density).
+
+    Given: A state, action with non-zero force, and a few candidate
+        next states sampled from the same kernel plus a perturbed one.
+    When: env.transition_log_probability is compared to log of wrapper
+        probability().
+    Then: Arrays agree elementwise within 1e-10.
+
+    Test type: integration
+    """
+    state = np.array([0.0, 0.0, 0.5, -0.3])
+    action = 2
+
+    _native.set_seed(11)
+    samples = list(env.state_transition_model(state, action).sample(3))
+    perturbed = samples[0].copy()
+    perturbed[0] += 5.0  # break the ring-consistency check
+    candidates = list(samples) + [perturbed]
+
+    log_p = env.transition_log_probability(state, action, candidates)
+    expected = np.log(
+        np.asarray(env.state_transition_model(state, action).probability(candidates)) + 1e-300
+    )
+
+    assert log_p.shape == (len(candidates),)
+    np.testing.assert_allclose(log_p, expected, atol=1e-10)
+
+
+def test_observation_log_probability_equivalence(env):
+    """observation_log_probability matches log of observation_model.probability.
+
+    Purpose: Validates the env-level vectorized log-density matches the
+    wrapper path on a list of candidate observations (Gaussian density).
+
+    Given: A representative next_state and a small set of candidate
+        observations near its identity-mean.
+    When: env.observation_log_probability is compared to log of wrapper
+        probability().
+    Then: Arrays agree elementwise within 1e-10.
+
+    Test type: integration
+    """
+    next_state = np.array([0.6, -0.1, 1.2, 0.8])
+    action = 2
+
+    _native.set_seed(13)
+    candidates = list(env.observation_model(next_state, action).sample(4))
+
+    log_p = env.observation_log_probability(next_state, action, candidates)
+    expected = np.log(
+        np.asarray(env.observation_model(next_state, action).probability(candidates)) + 1e-300
+    )
+
+    assert log_p.shape == (len(candidates),)
+    np.testing.assert_allclose(log_p, expected, atol=1e-10)

--- a/POMDPPlanners/tests/test_environments/test_sanity_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_sanity_pomdp.py
@@ -909,3 +909,141 @@ def test_sample_observation_rng_pinned_equivalence(sanity_pomdp):
             f"sample_observation mismatch for ({next_state}, {action}): "
             f"{wrapper_obs} vs {direct_obs}"
         )
+
+
+def test_sample_next_state_n_samples_equivalence(sanity_pomdp):
+    """Test that sample_next_state with n>1 matches state_transition_model().sample(n) under fixed RNG.
+
+    Purpose: Validates that the n_samples-aware sample_next_state override produces
+        results equivalent (value-wise) to repeatedly drawing from the wrapper-based path.
+
+    Given: A SanityPOMDP environment and the four (state, action) combinations covering
+        the full discrete state-action space, with both np.random and random pinned, and
+        n in {1, 5, 100}
+    When: A batch of samples is drawn through state_transition_model(s, a).sample(n) and
+        through env.sample_next_state(s, a, n_samples=n) after re-seeding
+    Then: The two batches contain the same values across all (state, action) combinations
+        and all n values
+
+    Test type: unit
+    """
+    cases = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    for n in (1, 5, 100):
+        for state, action in cases:
+            np.random.seed(123)
+            random.seed(123)
+            wrapper_samples = sanity_pomdp.state_transition_model(
+                state=state, action=action
+            ).sample(n)
+            np.random.seed(123)
+            random.seed(123)
+            direct_samples = sanity_pomdp.sample_next_state(state=state, action=action, n_samples=n)
+            wrapper_arr = np.asarray(wrapper_samples)
+            direct_arr = np.asarray(direct_samples).reshape(-1)
+            np.testing.assert_array_equal(
+                wrapper_arr,
+                direct_arr,
+                err_msg=f"sample_next_state n={n} mismatch for ({state}, {action})",
+            )
+
+
+def test_sample_observation_n_samples_equivalence(sanity_pomdp):
+    """Test that sample_observation with n>1 matches observation_model().sample(n) under fixed RNG.
+
+    Purpose: Validates that the n_samples-aware sample_observation override produces
+        results equivalent (value-wise) to drawing from the wrapper-based path.
+
+    Given: A SanityPOMDP environment and the four (next_state, action) combinations,
+        with both np.random and random pinned, and n in {1, 5, 100}
+    When: A batch of samples is drawn through observation_model(ns, a).sample(n) and
+        through env.sample_observation(ns, a, n_samples=n) after re-seeding
+    Then: The two batches contain the same values across all combinations and all n
+
+    Test type: unit
+    """
+    cases = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    for n in (1, 5, 100):
+        for next_state, action in cases:
+            np.random.seed(7)
+            random.seed(7)
+            wrapper_samples = sanity_pomdp.observation_model(
+                next_state=next_state, action=action
+            ).sample(n)
+            np.random.seed(7)
+            random.seed(7)
+            direct_samples = sanity_pomdp.sample_observation(
+                next_state=next_state, action=action, n_samples=n
+            )
+            wrapper_arr = np.asarray(wrapper_samples)
+            direct_arr = np.asarray(direct_samples).reshape(-1)
+            np.testing.assert_array_equal(
+                wrapper_arr,
+                direct_arr,
+                err_msg=f"sample_observation n={n} mismatch for ({next_state}, {action})",
+            )
+
+
+def test_transition_log_probability_equivalence(sanity_pomdp):
+    """Test that transition_log_probability matches np.log(probability) from wrapper.
+
+    Purpose: Validates that the new transition_log_probability hot-path produces
+        log-probabilities equal (within fp tolerance) to the wrapper-based computation.
+
+    Given: A SanityPOMDP environment and (state, action) pairs covering all four
+        discrete combinations, plus a candidate next-state list including both valid
+        and invalid values
+    When: log-probabilities are computed via env.transition_log_probability(s, a, vals)
+        and via np.log(env.state_transition_model(s, a).probability(vals) + 1e-300)
+    Then: Both ndarrays are equal within fp tolerance for every combination
+
+    Test type: unit
+    """
+    cases = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    candidates = [0, 1, 0, 1]
+    for state, action in cases:
+        direct = sanity_pomdp.transition_log_probability(
+            state=state, action=action, next_states=candidates
+        )
+        wrapper_probs = np.asarray(
+            sanity_pomdp.state_transition_model(state=state, action=action).probability(candidates)
+        )
+        ref = np.log(wrapper_probs + 1e-300)
+        np.testing.assert_allclose(
+            direct,
+            ref,
+            err_msg=f"transition_log_probability mismatch for ({state}, {action})",
+        )
+
+
+def test_observation_log_probability_equivalence(sanity_pomdp):
+    """Test that observation_log_probability matches np.log(probability) from wrapper.
+
+    Purpose: Validates that the new observation_log_probability hot-path produces
+        log-probabilities equal (within fp tolerance) to the wrapper-based computation.
+
+    Given: A SanityPOMDP environment and (next_state, action) pairs covering all four
+        discrete combinations, plus a candidate observation list with both valid and
+        invalid values
+    When: log-probabilities are computed via env.observation_log_probability(ns, a, obs)
+        and via np.log(env.observation_model(ns, a).probability(obs) + 1e-300)
+    Then: Both ndarrays are equal within fp tolerance for every combination
+
+    Test type: unit
+    """
+    cases = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    candidates = [0, 1, 0, 1]
+    for next_state, action in cases:
+        direct = sanity_pomdp.observation_log_probability(
+            next_state=next_state, action=action, observations=candidates
+        )
+        wrapper_probs = np.asarray(
+            sanity_pomdp.observation_model(next_state=next_state, action=action).probability(
+                candidates
+            )
+        )
+        ref = np.log(wrapper_probs + 1e-300)
+        np.testing.assert_allclose(
+            direct,
+            ref,
+            err_msg=f"observation_log_probability mismatch for ({next_state}, {action})",
+        )


### PR DESCRIPTION
## Summary

Part 1 of 4 in the env-API redesign laid out in `~/.claude/plans/crispy-booping-scott.md`. Sits on top of merged PR #98 (env-sample-direct-api).

Adds four hot-path methods on `Environment` with default impls that delegate to the existing factory + `.sample()` / `.probability()` so envs that don't override see no behavior change:

```python
def sample_next_state(self, state, action, n_samples: int = 1) -> Any
def sample_observation(self, next_state, action, n_samples: int = 1) -> Any
def transition_log_probability(self, state, action, next_states) -> np.ndarray
def observation_log_probability(self, next_state, action, observations) -> np.ndarray
```

The first two **extend** the `n_samples=1` methods added in PR #98. The latter two are **new**. When `n_samples=1` the sampling methods return a single state/observation (back-compat); when `n_samples>1` they return a list/ndarray of length n. Log-probability methods always return ndarray of shape (N,).

All 14 environments are overridden:

- **Pure-Python wrappers** (Tiger, Sanity, MountainCar, CartPole, DiscreteLightDark, LaserTag, Push, Pacman): inline the wrapper's body with vectorized loops preserving exact RNG draw order.
- **pybind11/native-backed** (ContinuousLightDark, ContinuousPush, ContinuousLaserTag, RockSample, SafetyAnt): construct `_native.<Env>{Transition,Observation}Cpp` directly with batch-sized args.
- **Discrete-actions wrappers**: delegate `n_samples` + log-prob calls through cached `action_to_vector`.

**This PR is purely additive** — wrappers and factory methods untouched. Production callers are migrated in PR-B; tests in PR-C; wrappers + factories deleted in PR-D.

## Behavior preservation

~370 new pinned-seed (or statistical, for envs whose native C++ kernel uses a non-numpy RNG) equivalence tests in 14 env test files compare the new direct-API outputs to wrapper-path outputs for `n_samples` in {1, 5, 100}.

## Test results

- **1406 env tests pass** (was 1036 baseline before this PR)
- **76 planner tests pass** (POMCPOW, PFT_DPW, POMCP, SparsePFT — all on the arena backend)
- pylint 9.97/10 (only pre-existing warnings)
- pyright 0 errors (2 pre-existing warnings on Pacman wrapper return types — untouched factory methods)

## Next PRs in the sequence

- **PR-B**: migrate `particle_beliefs.py` / `cost.py` / `episodes.py` / 9 MCTS planners / bench script to the new API
- **PR-C**: migrate 53 test files off direct wrapper instantiation
- **PR-D**: delete the 24 wrapper classes + factory methods + StateTransitionModel/ObservationModel ABCs (~-2k LOC)

## Test plan

- [x] All env tests pass
- [x] Planner regression tests pass
- [x] Pinned-seed / statistical equivalence tests added per env
- [x] black + pylint + pyright clean