### PR TITLE
PR-C: Migrate test suite off env factory + .sample()/.probability() pattern

### DIFF
--- a/POMDPPlanners/tests/benchmarks/test_benchmark_environments.py
+++ b/POMDPPlanners/tests/benchmarks/test_benchmark_environments.py
@@ -39,7 +39,7 @@ def test_bench_tiger_state_transition(benchmark, tiger_state_action):
     Purpose: Measure state transition sampling in isolation.
 
     Given: A TigerPOMDP environment with a valid state and action.
-    When: state_transition_model is called and sampled repeatedly.
+    When: sample_next_state is called repeatedly.
     Then: Execution time is recorded for regression tracking.
 
     Test type: performance
@@ -48,7 +48,7 @@ def test_bench_tiger_state_transition(benchmark, tiger_state_action):
     np.random.seed(42)
 
     def run():
-        return env.state_transition_model(state=state, action=action).sample()[0]
+        return env.sample_next_state(state=state, action=action)
 
     benchmark(run)
 
@@ -60,17 +60,17 @@ def test_bench_tiger_observation_model(benchmark, tiger_state_action):
     Purpose: Measure observation sampling in isolation.
 
     Given: A TigerPOMDP environment with a sampled next state and action.
-    When: observation_model is called and sampled repeatedly.
+    When: sample_observation is called repeatedly.
     Then: Execution time is recorded for regression tracking.
 
     Test type: performance
     """
     env, state, action = tiger_state_action
     np.random.seed(42)
-    next_state = env.state_transition_model(state=state, action=action).sample()[0]
+    next_state = env.sample_next_state(state=state, action=action)
 
     def run():
-        return env.observation_model(next_state=next_state, action=action).sample()[0]
+        return env.sample_observation(next_state=next_state, action=action)
 
     benchmark(run)
 
@@ -136,7 +136,7 @@ def test_bench_discrete_ld_state_transition(benchmark, discrete_ld_state_action)
     Purpose: Measure state transition sampling in isolation.
 
     Given: A DiscreteLightDarkPOMDP with a valid state and action.
-    When: state_transition_model is called and sampled repeatedly.
+    When: sample_next_state is called repeatedly.
     Then: Execution time is recorded for regression tracking.
 
     Test type: performance
@@ -145,7 +145,7 @@ def test_bench_discrete_ld_state_transition(benchmark, discrete_ld_state_action)
     np.random.seed(42)
 
     def run():
-        return env.state_transition_model(state=state, action=action).sample()[0]
+        return env.sample_next_state(state=state, action=action)
 
     benchmark(run)
 
@@ -157,17 +157,17 @@ def test_bench_discrete_ld_observation_model(benchmark, discrete_ld_state_action
     Purpose: Measure observation sampling in isolation.
 
     Given: A DiscreteLightDarkPOMDP with a sampled next state and action.
-    When: observation_model is called and sampled repeatedly.
+    When: sample_observation is called repeatedly.
     Then: Execution time is recorded for regression tracking.
 
     Test type: performance
     """
     env, state, action = discrete_ld_state_action
     np.random.seed(42)
-    next_state = env.state_transition_model(state=state, action=action).sample()[0]
+    next_state = env.sample_next_state(state=state, action=action)
 
     def run():
-        return env.observation_model(next_state=next_state, action=action).sample()[0]
+        return env.sample_observation(next_state=next_state, action=action)
 
     benchmark(run)
 
@@ -233,7 +233,7 @@ def test_bench_continuous_ld_state_transition(benchmark, continuous_ld_state_act
     Purpose: Measure state transition sampling in isolation.
 
     Given: A ContinuousLightDarkPOMDPDiscreteActions with a valid state and action.
-    When: state_transition_model is called and sampled repeatedly.
+    When: sample_next_state is called repeatedly.
     Then: Execution time is recorded for regression tracking.
 
     Test type: performance
@@ -242,7 +242,7 @@ def test_bench_continuous_ld_state_transition(benchmark, continuous_ld_state_act
     np.random.seed(42)
 
     def run():
-        return env.state_transition_model(state=state, action=action).sample()[0]
+        return env.sample_next_state(state=state, action=action)
 
     benchmark(run)
 
@@ -254,17 +254,17 @@ def test_bench_continuous_ld_observation_model(benchmark, continuous_ld_state_ac
     Purpose: Measure observation sampling in isolation.
 
     Given: A ContinuousLightDarkPOMDPDiscreteActions with a sampled next state and action.
-    When: observation_model is called and sampled repeatedly.
+    When: sample_observation is called repeatedly.
     Then: Execution time is recorded for regression tracking.
 
     Test type: performance
     """
     env, state, action = continuous_ld_state_action
     np.random.seed(42)
-    next_state = env.state_transition_model(state=state, action=action).sample()[0]
+    next_state = env.sample_next_state(state=state, action=action)
 
     def run():
-        return env.observation_model(next_state=next_state, action=action).sample()[0]
+        return env.sample_observation(next_state=next_state, action=action)
 
     benchmark(run)
 
@@ -330,7 +330,7 @@ def test_bench_rock_sample_state_transition(benchmark, rock_sample_state_action)
     Purpose: Measure state transition sampling in isolation.
 
     Given: A RockSamplePOMDP with a valid state and action.
-    When: state_transition_model is called and sampled repeatedly.
+    When: sample_next_state is called repeatedly.
     Then: Execution time is recorded for regression tracking.
 
     Test type: performance
@@ -339,7 +339,7 @@ def test_bench_rock_sample_state_transition(benchmark, rock_sample_state_action)
     np.random.seed(42)
 
     def run():
-        return env.state_transition_model(state=state, action=action).sample()[0]
+        return env.sample_next_state(state=state, action=action)
 
     benchmark(run)
 
@@ -351,17 +351,17 @@ def test_bench_rock_sample_observation_model(benchmark, rock_sample_state_action
     Purpose: Measure observation sampling in isolation.
 
     Given: A RockSamplePOMDP with a sampled next state and action.
-    When: observation_model is called and sampled repeatedly.
+    When: sample_observation is called repeatedly.
     Then: Execution time is recorded for regression tracking.
 
     Test type: performance
     """
     env, state, action = rock_sample_state_action
     np.random.seed(42)
-    next_state = env.state_transition_model(state=state, action=action).sample()[0]
+    next_state = env.sample_next_state(state=state, action=action)
 
     def run():
-        return env.observation_model(next_state=next_state, action=action).sample()[0]
+        return env.sample_observation(next_state=next_state, action=action)
 
     benchmark(run)
 
@@ -427,7 +427,7 @@ def test_bench_laser_tag_state_transition(benchmark, laser_tag_state_action):
     Purpose: Measure state transition sampling in isolation.
 
     Given: A LaserTagPOMDP with a valid state and action.
-    When: state_transition_model is called and sampled repeatedly.
+    When: sample_next_state is called repeatedly.
     Then: Execution time is recorded for regression tracking.
 
     Test type: performance
@@ -436,7 +436,7 @@ def test_bench_laser_tag_state_transition(benchmark, laser_tag_state_action):
     np.random.seed(42)
 
     def run():
-        return env.state_transition_model(state=state, action=action).sample()[0]
+        return env.sample_next_state(state=state, action=action)
 
     benchmark(run)
 
@@ -448,17 +448,17 @@ def test_bench_laser_tag_observation_model(benchmark, laser_tag_state_action):
     Purpose: Measure observation sampling in isolation.
 
     Given: A LaserTagPOMDP with a sampled next state and action.
-    When: observation_model is called and sampled repeatedly.
+    When: sample_observation is called repeatedly.
     Then: Execution time is recorded for regression tracking.
 
     Test type: performance
     """
     env, state, action = laser_tag_state_action
     np.random.seed(42)
-    next_state = env.state_transition_model(state=state, action=action).sample()[0]
+    next_state = env.sample_next_state(state=state, action=action)
 
     def run():
-        return env.observation_model(next_state=next_state, action=action).sample()[0]
+        return env.sample_observation(next_state=next_state, action=action)
 
     benchmark(run)
 

--- a/POMDPPlanners/tests/test_core/test_belief/test_belief_environment_integration.py
+++ b/POMDPPlanners/tests/test_core/test_belief/test_belief_environment_integration.py
@@ -117,9 +117,9 @@ def _simulate_one_step(env):
     particles = env.initial_state_dist().sample(n_samples=NUM_PARTICLES)
     action = env.get_actions()[0]
     state = particles[0]
-    next_state = env.state_transition_model(state, action).sample()[0]
-    observation = env.observation_model(next_state, action).sample()[0]
-    next_states = [env.state_transition_model(p, action).sample()[0] for p in particles]
+    next_state = env.sample_next_state(state, action)
+    observation = env.sample_observation(next_state, action)
+    next_states = [env.sample_next_state(p, action) for p in particles]
     return particles, action, observation, next_states
 
 
@@ -292,8 +292,8 @@ def _simulate_trajectory(env, n_steps):
     actions = []
     observations = []
     for _ in range(n_steps):
-        next_state = env.state_transition_model(state, action).sample()[0]
-        observation = env.observation_model(next_state, action).sample()[0]
+        next_state = env.sample_next_state(state, action)
+        observation = env.sample_observation(next_state, action)
         actions.append(action)
         observations.append(observation)
         state = next_state

--- a/POMDPPlanners/tests/test_core/test_belief/test_particle_beliefs.py
+++ b/POMDPPlanners/tests/test_core/test_belief/test_particle_beliefs.py
@@ -2329,7 +2329,7 @@ def test_weighted_particle_belief_immutable_updates_usage_example():
     child_beliefs = []
     for obs in observations:
         # Generate potential next state (from docstring)
-        next_state = env.state_transition_model(initial_state, action).sample()[0]
+        next_state = env.sample_next_state(initial_state, action)
 
         # Create new belief (immutable update) (from docstring)
         child_belief = belief.update(action, obs, env, next_state)
@@ -2411,7 +2411,7 @@ def test_weighted_particle_belief_mcts_integration_usage_example():
         # Add particles based on transition model (from docstring)
         for _ in range(5):  # Multiple particles per observation
             parent_state = root_belief.sample()
-            next_state = env.state_transition_model(parent_state, action).sample()[0]
+            next_state = env.sample_next_state(parent_state, action)
             child_belief.inplace_update(action, observation, env, next_state)
 
         # Create belief node for tree (from docstring)
@@ -2573,7 +2573,7 @@ def test_unweighted_particle_belief_state_update_mcts_with_uniform_beliefs_usage
         # Add particles uniformly based on environment dynamics
         for _ in range(5):  # Multiple simulations
             parent_state = root_belief.sample()
-            next_state = env.state_transition_model(parent_state, action).sample()[0]
+            next_state = env.sample_next_state(parent_state, action)
             child_belief.inplace_update(action, observation, env, next_state)
 
         # Create belief node
@@ -2677,7 +2677,7 @@ def test_unweighted_particle_belief_state_update_immutable_belief_trees_usage_ex
         # Generate next states uniformly
         for _ in range(3):  # Reduced for test speed
             current_state = root_belief.sample()
-            next_state = env.state_transition_model(current_state, action).sample()[0]
+            next_state = env.sample_next_state(current_state, action)
             # For simplicity, assume observation equals next state (fully observable case)
             child_belief = child_belief.update(action, next_state, env, next_state)
 

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
@@ -19,7 +19,6 @@ from POMDPPlanners.environments.cartpole_pomdp import (
     CartPolePOMDP,
     CartPoleStateTransition,
 )
-from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -280,7 +279,7 @@ def test_state_transition_model(base_cartpole_environment):
     Purpose: Validates that CartPolePOMDP state transition model works correctly
 
     Given: A CartPolePOMDP environment and initial state [0.0, 0.0, 0.0, 0.0] with action 0
-    When: State transition model is created and next state is sampled
+    When: env.sample_next_state is called
     Then: Returns a 4D numpy array representing the next state after applying the action
 
     Test type: unit
@@ -288,8 +287,7 @@ def test_state_transition_model(base_cartpole_environment):
     # Test state transition
     state = np.array([0.0, 0.0, 0.0, 0.0])
     action = 0
-    transition = base_cartpole_environment.state_transition_model(state, action)
-    next_state = transition.sample()[0]
+    next_state = base_cartpole_environment.sample_next_state(state=state, action=action)
     assert isinstance(next_state, np.ndarray)
     assert next_state.shape == (4,)
 
@@ -301,15 +299,14 @@ def test_state_transition_produces_varying_samples(base_cartpole_environment):
     different samples due to Gaussian process noise
 
     Given: A CartPolePOMDP environment and initial state [0.0, 0.0, 0.1, 0.0] with action 1
-    When: Multiple samples are drawn from the state transition model
+    When: Multiple samples are drawn via env.sample_next_state
     Then: Not all samples are identical, confirming stochastic behavior
 
     Test type: unit
     """
     state = np.array([0.0, 0.0, 0.1, 0.0])
     action = 1
-    transition = base_cartpole_environment.state_transition_model(state, action)
-    samples = transition.sample(n_samples=50)
+    samples = base_cartpole_environment.sample_next_state(state=state, action=action, n_samples=50)
 
     assert len(samples) == 50
     assert all(s.shape == (4,) for s in samples)
@@ -392,10 +389,10 @@ def test_state_transition_custom_covariance():
 def test_observation_model(base_cartpole_environment):
     """Test observation model.
 
-    Purpose: Validates that CartPolePOMDP observation model works correctly
+    Purpose: Validates that CartPolePOMDP observation sampling works correctly
 
-    Given: A CartPolePOMDP environment and state [0.0, 0.0, 0.0, 0.0] with action 0
-    When: Observation model is created and observation is sampled
+    Given: A CartPolePOMDP environment and next_state [0.0, 0.0, 0.0, 0.0] with action 0
+    When: env.sample_observation is called
     Then: Returns a 4D numpy array representing the noisy observation of the state
 
     Test type: unit
@@ -403,8 +400,7 @@ def test_observation_model(base_cartpole_environment):
     # Test observation model
     state = np.array([0.0, 0.0, 0.0, 0.0])
     action = 0
-    observation = base_cartpole_environment.observation_model(state, action)
-    obs = observation.sample()[0]
+    obs = base_cartpole_environment.sample_observation(next_state=state, action=action)
     assert isinstance(obs, np.ndarray)
     assert obs.shape == (4,)
 
@@ -538,58 +534,61 @@ def test_cartpole_pomdp_models():
 
 
 def test_cartpole_observation_model_probability_shape_single_observation():
-    """Test that observation model probability returns correct shape for single observation.
+    """Test that observation_log_probability returns correct shape for single observation.
 
-    Purpose: Validates that CartPoleObservation.probability() returns a 1D array of scalars,
+    Purpose: Validates that env.observation_log_probability() returns a 1D array of scalars,
     not a 2D array, when given a single observation
 
-    Given: A CartPoleObservation model with state [0.1, 0.05, 0.02, -0.1] and a single observation
-    When: probability() method is called with a list containing one observation
-    Then: Returns 1D numpy array with shape (1,) containing a scalar probability value
+    Given: A CartPolePOMDP env with diag(0.1) noise_cov, next_state [0.1, 0.05, 0.02, -0.1]
+        and a single observation
+    When: env.observation_log_probability is called with a list containing one observation
+    Then: Returns 1D numpy array with shape (1,) containing a scalar log-probability value
 
     Test type: unit
     """
-    # ARRANGE: Create observation model
+    # ARRANGE: Create env with desired noise cov
     true_state = np.array([0.1, 0.05, 0.02, -0.1])
     action = 1
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    obs_dist = CovarianceParameterizedMultivariateNormal(noise_cov)
-    obs_model = CartPoleObservation(next_state=true_state, action=action, obs_dist=obs_dist)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
 
     # Create single observation
     observation = np.array([0.12, 0.06, 0.025, -0.09])
 
-    # ACT: Get probability
-    probs = obs_model.probability([observation])
+    # ACT: Get probability via env-level API
+    log_probs = env.observation_log_probability(
+        next_state=true_state, action=action, observations=[observation]
+    )
+    probs = np.exp(log_probs)
 
     # ASSERT: Check shape and type
-    assert isinstance(probs, np.ndarray), "probability() should return numpy array"
+    assert isinstance(probs, np.ndarray), "probability should return numpy array"
     assert (
         probs.ndim == 1
-    ), f"probability() should return 1D array, got {probs.ndim}D array with shape {probs.shape}"
-    assert probs.shape == (1,), f"probability([obs]) should have shape (1,), got {probs.shape}"
+    ), f"probability should return 1D array, got {probs.ndim}D array with shape {probs.shape}"
+    assert probs.shape == (1,), f"shape (1,) expected, got {probs.shape}"
     assert np.isscalar(probs[0]), f"Individual probability should be scalar, got {type(probs[0])}"
     assert probs[0] > 0.0, f"Probability density should be positive, got {probs[0]}"
 
 
 def test_cartpole_observation_model_probability_shape_multiple_observations():
-    """Test that observation model probability returns correct shape for multiple observations.
+    """Test that observation_log_probability returns correct shape for multiple observations.
 
-    Purpose: Validates that CartPoleObservation.probability() returns a 1D array of scalars
+    Purpose: Validates that env.observation_log_probability() returns a 1D array of scalars
     when given multiple observations, with length matching number of observations
 
-    Given: A CartPoleObservation model with state [0.1, 0.05, 0.02, -0.1] and three observations
-    When: probability() method is called with a list containing three observations
-    Then: Returns 1D numpy array with shape (3,) containing scalar probability values
+    Given: A CartPolePOMDP env with diag(0.1) noise_cov, next_state [0.1, 0.05, 0.02, -0.1]
+        and three observations
+    When: env.observation_log_probability is called with a list containing three observations
+    Then: Returns 1D numpy array with shape (3,) containing scalar log-probability values
 
     Test type: unit
     """
-    # ARRANGE: Create observation model
+    # ARRANGE: Create env with desired noise cov
     true_state = np.array([0.1, 0.05, 0.02, -0.1])
     action = 1
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    obs_dist = CovarianceParameterizedMultivariateNormal(noise_cov)
-    obs_model = CartPoleObservation(next_state=true_state, action=action, obs_dist=obs_dist)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
 
     # Create multiple observations
     observations = [
@@ -598,15 +597,19 @@ def test_cartpole_observation_model_probability_shape_multiple_observations():
         np.array([0.11, 0.055, 0.022, -0.095]),
     ]
 
-    # ACT: Get probabilities
-    probs = obs_model.probability(observations)
+    # ACT: Get probabilities via env-level API
+    probs = np.exp(
+        env.observation_log_probability(
+            next_state=true_state, action=action, observations=observations
+        )
+    )
 
     # ASSERT: Check shape and type
-    assert isinstance(probs, np.ndarray), "probability() should return numpy array"
+    assert isinstance(probs, np.ndarray), "probability should return numpy array"
     assert (
         probs.ndim == 1
-    ), f"probability() should return 1D array, got {probs.ndim}D array with shape {probs.shape}"
-    assert probs.shape == (3,), f"probability(3 obs) should have shape (3,), got {probs.shape}"
+    ), f"probability should return 1D array, got {probs.ndim}D array with shape {probs.shape}"
+    assert probs.shape == (3,), f"shape (3,) expected, got {probs.shape}"
 
     # Check each probability density is a scalar and positive
     for i, prob in enumerate(probs):
@@ -618,62 +621,65 @@ def test_cartpole_observation_model_probability_shape_multiple_observations():
 
 
 def test_cartpole_observation_model_probability_empty_list():
-    """Test that observation model probability handles empty observation list correctly.
+    """Test that observation_log_probability handles empty observation list correctly.
 
-    Purpose: Validates that CartPoleObservation.probability() returns empty 1D array for empty input
+    Purpose: Validates that env.observation_log_probability() returns empty 1D array for empty input
 
-    Given: A CartPoleObservation model and an empty list of observations
-    When: probability() method is called with empty list
+    Given: A CartPolePOMDP env with diag(0.1) noise_cov and an empty list of observations
+    When: env.observation_log_probability is called with empty list
     Then: Returns empty 1D numpy array with shape (0,)
 
     Test type: unit
     """
-    # ARRANGE: Create observation model
+    # ARRANGE: Create env with desired noise cov
     true_state = np.array([0.1, 0.05, 0.02, -0.1])
     action = 1
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    obs_dist = CovarianceParameterizedMultivariateNormal(noise_cov)
-    obs_model = CartPoleObservation(next_state=true_state, action=action, obs_dist=obs_dist)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
 
-    # ACT: Get probability for empty list
-    probs = obs_model.probability([])
+    # ACT: Get probability for empty list via env-level API
+    probs = np.exp(
+        env.observation_log_probability(next_state=true_state, action=action, observations=[])
+    )
 
     # ASSERT: Check shape
-    assert isinstance(probs, np.ndarray), "probability() should return numpy array"
-    assert probs.ndim == 1, f"probability() should return 1D array, got {probs.ndim}D array"
-    assert probs.shape == (0,), f"probability([]) should have shape (0,), got {probs.shape}"
+    assert isinstance(probs, np.ndarray), "probability should return numpy array"
+    assert probs.ndim == 1, f"probability should return 1D array, got {probs.ndim}D array"
+    assert probs.shape == (0,), f"shape (0,) expected, got {probs.shape}"
 
 
 def test_cartpole_observation_model_probability_values_reasonable():
-    """Test that observation model probability values are reasonable for noisy observations.
+    """Test that observation_log_probability values are reasonable for noisy observations.
 
-    Purpose: Validates that CartPoleObservation.probability() computes reasonable probability values
+    Purpose: Validates that env.observation_log_probability computes reasonable probability values
     based on Gaussian noise model, with closer observations having higher probability
 
-    Given: A CartPoleObservation model and observations at different distances from true state
-    When: probability() method is called with observations close to and far from true state
+    Given: A CartPolePOMDP env with diag(0.1) noise_cov and observations at different
+        distances from true state
+    When: env.observation_log_probability is called with close and far observations
     Then: Closer observations have higher probability than distant observations
 
     Test type: unit
     """
-    # ARRANGE: Create observation model
+    # ARRANGE: Create env with desired noise cov
     true_state = np.array([0.1, 0.05, 0.02, -0.1])
     action = 1
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    obs_dist = CovarianceParameterizedMultivariateNormal(noise_cov)
-    obs_model = CartPoleObservation(next_state=true_state, action=action, obs_dist=obs_dist)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
 
     # Create observations: one close to true state, one far
     close_obs = true_state + np.array([0.01, 0.01, 0.01, 0.01])  # Small deviation
     far_obs = true_state + np.array([1.0, 1.0, 1.0, 1.0])  # Large deviation
 
-    # ACT: Get probabilities
-    probs = obs_model.probability([close_obs, far_obs])
+    # ACT: Get probabilities via env-level API
+    probs = np.exp(
+        env.observation_log_probability(
+            next_state=true_state, action=action, observations=[close_obs, far_obs]
+        )
+    )
 
     # ASSERT: Close observation should have higher probability
-    assert (
-        probs[0] > probs[1]
-    ), f"Close observation prob ({probs[0]}) should be higher than far observation prob ({probs[1]})"
+    assert probs[0] > probs[1], f"Close prob ({probs[0]}) should exceed far prob ({probs[1]})"
 
     # Both should be positive (Gaussian has non-zero probability everywhere)
     assert probs[0] > 0.0, "Close observation should have positive probability"

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py
@@ -298,15 +298,15 @@ class TestConfigId:
 
 class TestEquivalenceWithPerParticleLoop:
     def test_batch_transition_matches_per_particle_loop(self, env, updater):
-        """Test vectorized batch_transition matches per-particle state_transition_model.sample.
+        """Test vectorized batch_transition matches per-particle env.sample_next_state.
 
         Purpose: Verifies that batch_transition produces the same stochastic
-                 next states as the environment's state_transition_model.sample
+                 next states as the environment's sample_next_state
                  when the global RNG is seeded identically on both paths.
 
         Given: A set of particles, an action, and a fixed random seed.
         When: batch_transition is called, and the same transitions are computed
-              per-particle using the environment's state_transition_model.sample.
+              per-particle using env.sample_next_state.
         Then: Results match within floating-point tolerance.
 
         Test type: integration
@@ -315,7 +315,7 @@ class TestEquivalenceWithPerParticleLoop:
         particles = np.random.uniform(-0.05, 0.05, (50, 4))
 
         def per_particle_fn(particle, action):
-            return env.state_transition_model(state=particle, action=action).sample()[0]
+            return env.sample_next_state(state=particle, action=action)
 
         assert_batch_transition_matches_loop(
             updater=updater,
@@ -327,14 +327,14 @@ class TestEquivalenceWithPerParticleLoop:
         )
 
     def test_batch_observation_log_likelihood_matches_per_particle_loop(self, env, updater):
-        """Test vectorized log-likelihood matches per-particle observation_model.probability.
+        """Test vectorized log-likelihood matches per-particle env.observation_log_probability.
 
         Purpose: Verifies that batch_observation_log_likelihood matches the
-                 per-particle observation probability from the environment.
+                 per-particle observation log-probability from the environment.
 
         Given: A set of next-state particles and an observation.
         When: batch_observation_log_likelihood is called, and per-particle
-              log(observation_model.probability) is computed.
+              env.observation_log_probability is computed.
         Then: Results match within floating-point tolerance.
 
         Test type: integration
@@ -344,8 +344,9 @@ class TestEquivalenceWithPerParticleLoop:
         observation = np.array([0.01, 0.0, 0.02, 0.0])
 
         def per_particle_ll_fn(particle, action, obs):
-            obs_model = env.observation_model(next_state=particle, action=action)
-            return np.log(obs_model.probability([obs])[0])
+            return env.observation_log_probability(
+                next_state=particle, action=action, observations=[obs]
+            )[0]
 
         assert_batch_obs_log_likelihood_matches_loop(
             updater=updater,

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_gaussian_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_gaussian_beliefs.py
@@ -407,7 +407,7 @@ class TestEndToEndUpdate:
             initial_covariance=initial_cov,
         )
         action = np.array([1.0])
-        next_state = env.state_transition_model(belief.mean, 1).sample()[0]
+        next_state = env.sample_next_state(state=belief.mean, action=1)
         observation = next_state + np.random.randn(4) * 0.01
 
         new_belief = belief.update(action=action, observation=observation, pomdp=None)
@@ -443,7 +443,7 @@ class TestEndToEndUpdate:
             initial_covariance=large_cov,
         )
         action = np.array([1.0])
-        next_state = env.state_transition_model(belief.mean, 1).sample()[0]
+        next_state = env.sample_next_state(state=belief.mean, action=1)
         observation = next_state
 
         new_belief = belief.update(action=action, observation=observation, pomdp=None)
@@ -474,7 +474,7 @@ class TestEndToEndUpdate:
         )
 
         action = np.array([1.0])
-        next_state = env.state_transition_model(np.zeros(4), 1).sample()[0]
+        next_state = env.sample_next_state(state=np.zeros(4), action=1)
         observation = next_state
 
         new_ekf = belief_ekf.update(action=action, observation=observation, pomdp=None)

--- a/POMDPPlanners/tests/test_environments/test_environment_serialization.py
+++ b/POMDPPlanners/tests/test_environments/test_environment_serialization.py
@@ -414,7 +414,8 @@ class TestEnvironmentObservationModelSerialization:
         action = actions[0]
 
         # Sample next state
-        next_state = env.state_transition_model(state, action).sample()[0]
+        next_state = env.sample_next_state(state=state, action=action)
+        assert isinstance(next_state, str)
 
         # Create observation model
         obs_model = env.observation_model(next_state, action)
@@ -449,7 +450,7 @@ class TestEnvironmentObservationModelSerialization:
         action = actions[0]
 
         # Sample next state
-        next_state = env.state_transition_model(state, action).sample()[0]
+        next_state = env.sample_next_state(state=state, action=action)
 
         # Create observation model
         obs_model = env.observation_model(next_state, action)

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -1009,9 +1009,8 @@ class TestLaserTagPOMDPTransitionError:
         env = LaserTagPOMDP(discount_factor=0.95, transition_error_prob=0.7)
         state = np.array([3.0, 5.0, 1.0, 1.0, 0.0])
 
-        # Sample many transitions with North action (0)
-        transition = env.state_transition_model(state, 0)
-        next_states = transition.sample(n_samples=1000)
+        # Sample many transitions with North action (0) via the env-level API.
+        next_states = env.sample_next_state(state, 0, n_samples=1000)
         robot_positions = [(int(ns[0]), int(ns[1])) for ns in next_states]
 
         position_counts = Counter(robot_positions)

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_continuous_laser_tag_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_continuous_laser_tag_vectorized_updater.py
@@ -347,9 +347,7 @@ class TestEquivalenceWithPerParticleLoop:
         _native.set_seed(2024)
         scalar_rows = []
         for i in range(n):
-            scalar_rows.append(
-                env.state_transition_model(state=particles[i], action=action).sample()[0]
-            )
+            scalar_rows.append(env.sample_next_state(particles[i], action))
         scalar_result = np.stack(scalar_rows, axis=0)
 
         np.testing.assert_allclose(vec_result, scalar_result, atol=1e-12)
@@ -383,11 +381,7 @@ class TestEquivalenceWithPerParticleLoop:
         action = np.array([1.0, 0.0, 0.0])
 
         def per_particle_ll_fn(particle, act, observation):
-            obs_model = env.observation_model(next_state=particle, action=act)
-            prob = obs_model.probability([observation])[0]
-            if prob > 0:
-                return np.log(prob)
-            return -np.inf
+            return env.observation_log_probability(particle, act, [observation])[0]
 
         assert_batch_obs_log_likelihood_matches_loop(
             updater=updater,

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
@@ -318,21 +318,19 @@ def test_beacons_and_obstacles_array_structure():
 
 
 def test_state_transition_model(pomdp):
-    # Test state transition
+    # Test state transition via the env-level sample API.
     state = np.array([0.0, 0.0])
     action = np.array([0.0, 0.0])
-    transition = pomdp.state_transition_model(state, action)
-    next_state = transition.sample()[0]
+    next_state = pomdp.sample_next_state(state, action)
     assert isinstance(next_state, np.ndarray)
     assert next_state.shape == (2,)
 
 
 def test_observation_model(pomdp):
-    # Test observation model
+    # Test observation model via the env-level sample API.
     state = np.array([0.0, 0.0])
     action = np.array([0.0, 0.0])
-    observation = pomdp.observation_model(state, action)
-    obs = observation.sample()[0]
+    obs = pomdp.sample_observation(state, action)
     assert isinstance(obs, np.ndarray)
     assert obs.shape == (2,)
 
@@ -578,10 +576,12 @@ def test_continuous_light_dark_pomdp_state_transition_model(
     env = base_continuous_light_dark_pomdp
     state = np.array([5, 5])
     action = np.array([0, 1])
-    dist = env.state_transition_model(state, action)
 
+    # The wrapper inheritance contract still exists.
+    dist = env.state_transition_model(state, action)
     assert isinstance(dist, StateTransitionModel)
-    next_state = dist.sample()
+
+    next_state = env.sample_next_state(state, action)
     expected_next_state = state + action
     # Allow for noise in state transition (3 standard deviations)
     assert np.allclose(next_state, expected_next_state, atol=3.0)

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/benchmark_light_dark_vectorized_belief.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/benchmark_light_dark_vectorized_belief.py
@@ -76,7 +76,7 @@ def _benchmark_continuous_transition(env: ContinuousLightDarkPOMDP, updater) -> 
         states = [particles[i].copy() for i in range(n)]
 
         mean_loop, _ = _time_fn(
-            lambda: [env.state_transition_model(s, action).sample()[0] for s in states],
+            lambda: [env.sample_next_state(s, action) for s in states],
             n_runs=N_RUNS_FAST,
         )
         mean_vec, _ = _time_fn(
@@ -99,16 +99,7 @@ def _benchmark_continuous_log_lik(env: ContinuousLightDarkPOMDP, updater, observ
             mean_loop, _ = _time_fn(
                 lambda: np.array(
                     [
-                        (
-                            np.log(p)
-                            if (
-                                p := env.observation_model(particles[i], action).probability(
-                                    [observation]
-                                )[0]
-                            )
-                            > 0
-                            else -np.inf
-                        )
+                        env.observation_log_probability(particles[i], action, [observation])[0]
                         for i in range(n)
                     ]
                 ),
@@ -200,7 +191,7 @@ def _benchmark_discrete_transition(env: DiscreteLightDarkPOMDP, updater) -> None
         states = [particles[i].copy() for i in range(n)]
 
         mean_loop, _ = _time_fn(
-            lambda: [env.state_transition_model(s, action).sample()[0] for s in states],
+            lambda: [env.sample_next_state(s, action) for s in states],
             n_runs=N_RUNS_FAST,
         )
         mean_vec, _ = _time_fn(
@@ -222,16 +213,7 @@ def _benchmark_discrete_log_lik(env: DiscreteLightDarkPOMDP, updater, observatio
         mean_loop, _ = _time_fn(
             lambda: np.array(
                 [
-                    (
-                        np.log(p)
-                        if (
-                            p := env.observation_model(particles[i], action).probability(
-                                [observation]
-                            )[0]
-                        )
-                        > 0
-                        else -np.inf
-                    )
+                    env.observation_log_probability(particles[i], action, [observation])[0]
                     for i in range(n)
                 ]
             ),

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_discrete_light_dark_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_discrete_light_dark_vectorized_updater.py
@@ -218,9 +218,7 @@ class TestBatchObservationLogLikelihood:
             vectorized_ll = updater.batch_observation_log_likelihood(particles, action, obs)
             per_particle_ll = np.empty(n)
             for j in range(n):
-                obs_model = env.observation_model(next_state=particles[j], action=action)
-                prob = obs_model.probability([obs])[0]
-                per_particle_ll[j] = np.log(prob) if prob > 0 else -np.inf
+                per_particle_ll[j] = env.observation_log_probability(particles[j], action, [obs])[0]
 
             np.testing.assert_allclose(vectorized_ll, per_particle_ll, atol=1e-10)
 
@@ -353,7 +351,10 @@ class TestNoObsInDarkLogLikelihood:
         action = "right"
         particles = np.random.randint(0, 10, size=(n, 2)).astype(float)
 
-        # Test "None" observation
+        # Test "None" observation. The vectorized updater uses a strict -inf
+        # floor for impossible observations, while observation_log_probability
+        # uses log(prob + 1e-300); we therefore go via the wrapper here so we
+        # can apply the matching np.log(prob) if prob > 0 else -inf rule.
         vectorized_ll = no_obs_updater.batch_observation_log_likelihood(particles, action, "None")
         per_particle_ll = np.empty(n)
         for i in range(n):
@@ -493,7 +494,10 @@ class TestDistanceBasedLogLikelihood:
         action = "right"
         particles = np.random.randint(0, 10, size=(n, 2)).astype(float)
 
-        # Test "None" observation
+        # Test "None" observation. The vectorized updater uses a strict -inf
+        # floor for impossible observations, while observation_log_probability
+        # uses log(prob + 1e-300); we therefore go via the wrapper here so we
+        # can apply the matching np.log(prob) if prob > 0 else -inf rule.
         vectorized_ll = dist_updater.batch_observation_log_likelihood(particles, action, "None")
         per_particle_ll = np.empty(n)
         for i in range(n):

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
@@ -51,7 +51,7 @@ def test_state_transition_model(base_mountain_car_environment):
     Purpose: Validates that state transition model correctly updates car position and velocity for different actions
 
     Given: MountainCarPOMDP environment and test state [0.0, 0.0] with actions -1, 0, and 1
-    When: State transition model is called and next states are sampled
+    When: env.sample_next_state is called for each action
     Then: All next states have correct 2D shape representing [position, velocity] and change based on applied action
 
     Test type: unit
@@ -59,22 +59,19 @@ def test_state_transition_model(base_mountain_car_environment):
     # Test state transition
     state = np.array([0.0, 0.0])
     action = 0
-    transition = base_mountain_car_environment.state_transition_model(state, action)
-    new_state = transition.sample()[0]
+    new_state = base_mountain_car_environment.sample_next_state(state=state, action=action)
     assert isinstance(new_state, np.ndarray)
     assert new_state.shape == (2,)
 
     # Test with different action
     action = 1
-    transition = base_mountain_car_environment.state_transition_model(state, action)
-    new_state = transition.sample()[0]
+    new_state = base_mountain_car_environment.sample_next_state(state=state, action=action)
     assert isinstance(new_state, np.ndarray)
     assert new_state.shape == (2,)
 
     # Test with negative action
     action = -1
-    transition = base_mountain_car_environment.state_transition_model(state, action)
-    new_state = transition.sample()[0]
+    new_state = base_mountain_car_environment.sample_next_state(state=state, action=action)
     assert isinstance(new_state, np.ndarray)
     assert new_state.shape == (2,)
 
@@ -86,15 +83,16 @@ def test_state_transition_produces_varying_samples(base_mountain_car_environment
     different samples due to Gaussian process noise
 
     Given: A MountainCarPOMDP environment and initial state [-0.5, 0.0] with action 1
-    When: Multiple samples are drawn from the state transition model
+    When: Multiple samples are drawn via env.sample_next_state
     Then: Not all samples are identical, confirming stochastic behavior
 
     Test type: unit
     """
     state = np.array([-0.5, 0.0])
     action = 1
-    transition = base_mountain_car_environment.state_transition_model(state, action)
-    samples = transition.sample(n_samples=50)
+    samples = base_mountain_car_environment.sample_next_state(
+        state=state, action=action, n_samples=50
+    )
 
     assert len(samples) == 50
     assert all(s.shape == (2,) for s in samples)
@@ -176,7 +174,7 @@ def test_observation_model(base_mountain_car_environment):
     Purpose: Validates that observation model correctly adds noise to position and velocity measurements
 
     Given: MountainCarPOMDP environment and test state [0.0, 0.0] with action 0
-    When: Observation model is called and observations are sampled
+    When: env.sample_observation is called
     Then: All observations have correct 2D shape and contain noise in both position and velocity components
 
     Test type: unit
@@ -184,40 +182,41 @@ def test_observation_model(base_mountain_car_environment):
     # Test observation model
     state = np.array([0.0, 0.0])
     action = 0
-    observation = base_mountain_car_environment.observation_model(state, action)
-    obs = observation.sample()[0]
+    obs = base_mountain_car_environment.sample_observation(next_state=state, action=action)
     assert isinstance(obs, np.ndarray)
     assert obs.shape == (2,)
 
     # Test multiple observations
-    observations = base_mountain_car_environment.observation_model(state, action).sample(
-        n_samples=100
+    observations = base_mountain_car_environment.sample_observation(
+        next_state=state, action=action, n_samples=100
     )
     assert len(observations) == 100
     assert all(isinstance(obs, np.ndarray) and obs.shape == (2,) for obs in observations)
 
 
 def test_observation_model_probability_single_observation(base_mountain_car_environment):
-    """Test observation model probability function with single observation.
+    """Test observation log-probability with single observation.
 
-    Purpose: Validates that observation model probability function correctly handles single observation input
+    Purpose: Validates that observation_log_probability correctly handles single observation input
 
-    Given: MountainCarPOMDP environment and observation model with specific state and covariance
-    When: probability() method is called with single observation
-    Then: Returns numpy array with shape (1,) containing probability density value
+    Given: MountainCarPOMDP environment with specific next_state and action
+    When: env.observation_log_probability is called with a single observation
+    Then: Returns numpy array with shape (1,) and exponentiated probability is positive
 
     Test type: unit
     """
     # Test single observation probability
     state = np.array([0.0, 0.0])
     action = 0
-    obs_model = base_mountain_car_environment.observation_model(state, action)
 
     # Create a single observation close to true state
     observation = np.array([0.05, 0.01])  # Small deviation from true state [0.0, 0.0]
 
-    # Get probability
-    probabilities = obs_model.probability([observation])
+    # Get probability via env-level API
+    log_probabilities = base_mountain_car_environment.observation_log_probability(
+        next_state=state, action=action, observations=[observation]
+    )
+    probabilities = np.exp(log_probabilities)
 
     # Verify output type and shape
     assert isinstance(probabilities, np.ndarray), "Probability should return numpy array"
@@ -229,20 +228,19 @@ def test_observation_model_probability_single_observation(base_mountain_car_envi
 
 
 def test_observation_model_probability_multiple_observations(base_mountain_car_environment):
-    """Test observation model probability function with multiple observations.
+    """Test observation log-probability with multiple observations.
 
-    Purpose: Validates that observation model probability function correctly handles multiple observations input
+    Purpose: Validates that observation_log_probability correctly handles multiple observations
 
-    Given: MountainCarPOMDP environment and observation model with specific state and covariance
-    When: probability() method is called with multiple observations
-    Then: Returns numpy array with shape (n,) containing probability densities for each observation
+    Given: MountainCarPOMDP environment with specific next_state and action
+    When: env.observation_log_probability is called with multiple observations
+    Then: Returns numpy array with shape (n,) of decreasing probabilities with distance
 
     Test type: unit
     """
     # Test multiple observations probability
     state = np.array([0.0, 0.0])
     action = 0
-    obs_model = base_mountain_car_environment.observation_model(state, action)
 
     # Create multiple observations at different distances from true state
     observations = [
@@ -252,8 +250,11 @@ def test_observation_model_probability_multiple_observations(base_mountain_car_e
         np.array([0.5, 0.1]),  # Far from true state (lowest probability)
     ]
 
-    # Get probabilities
-    probabilities = obs_model.probability(observations)
+    # Get probabilities via env-level API
+    log_probabilities = base_mountain_car_environment.observation_log_probability(
+        next_state=state, action=action, observations=observations
+    )
+    probabilities = np.exp(log_probabilities)
 
     # Verify output type and shape
     assert isinstance(probabilities, np.ndarray), "Probability should return numpy array"
@@ -322,22 +323,24 @@ def test_observation_model_probability_mathematical_correctness(base_mountain_ca
 
 
 def test_observation_model_probability_edge_cases(base_mountain_car_environment):
-    """Test observation model probability function edge cases.
+    """Test observation log-probability edge cases.
 
-    Purpose: Validates that observation model probability function handles edge cases correctly
+    Purpose: Validates that observation_log_probability handles edge cases correctly
 
-    Given: MountainCarPOMDP environment and observation model
-    When: probability() method is called with edge cases (empty list, extreme values)
+    Given: MountainCarPOMDP environment with specific next_state and action
+    When: env.observation_log_probability is called with edge cases (empty list, extreme values)
     Then: Function handles edge cases gracefully and returns appropriate results
 
     Test type: unit
     """
     state = np.array([0.0, 0.0])
     action = 0
-    obs_model = base_mountain_car_environment.observation_model(state, action)
 
     # Test empty list (should return empty array)
-    empty_probs = obs_model.probability([])
+    empty_log_probs = base_mountain_car_environment.observation_log_probability(
+        next_state=state, action=action, observations=[]
+    )
+    empty_probs = np.exp(empty_log_probs)
     assert isinstance(empty_probs, np.ndarray), "Empty list should return numpy array"
     assert empty_probs.shape == (
         0,
@@ -350,7 +353,10 @@ def test_observation_model_probability_edge_cases(base_mountain_car_environment)
         np.array([0.0, 0.0]),  # At true state
     ]
 
-    extreme_probs = obs_model.probability(extreme_observations)
+    extreme_log_probs = base_mountain_car_environment.observation_log_probability(
+        next_state=state, action=action, observations=extreme_observations
+    )
+    extreme_probs = np.exp(extreme_log_probs)
     assert isinstance(extreme_probs, np.ndarray), "Extreme values should return numpy array"
     assert extreme_probs.shape == (
         3,
@@ -371,20 +377,19 @@ def test_observation_model_probability_edge_cases(base_mountain_car_environment)
 
 
 def test_observation_model_probability_batch_consistency(base_mountain_car_environment):
-    """Test observation model probability function batch consistency.
+    """Test observation log-probability batch consistency.
 
-    Purpose: Validates that observation model probability function produces consistent results
+    Purpose: Validates that observation_log_probability produces consistent results
     when called multiple times with same inputs
 
-    Given: MountainCarPOMDP environment and observation model
-    When: probability() method is called multiple times with identical observations
+    Given: MountainCarPOMDP environment with specific next_state and action
+    When: env.observation_log_probability is called multiple times with identical observations
     Then: All calls return identical probability values, demonstrating deterministic behavior
 
     Test type: unit
     """
     state = np.array([0.0, 0.0])
     action = 0
-    obs_model = base_mountain_car_environment.observation_model(state, action)
 
     # Create test observations
     observations = [
@@ -393,10 +398,22 @@ def test_observation_model_probability_batch_consistency(base_mountain_car_envir
         np.array([-0.05, -0.005]),
     ]
 
-    # Call probability function multiple times
-    probs1 = obs_model.probability(observations)
-    probs2 = obs_model.probability(observations)
-    probs3 = obs_model.probability(observations)
+    # Call probability function multiple times via env-level API
+    probs1 = np.exp(
+        base_mountain_car_environment.observation_log_probability(
+            next_state=state, action=action, observations=observations
+        )
+    )
+    probs2 = np.exp(
+        base_mountain_car_environment.observation_log_probability(
+            next_state=state, action=action, observations=observations
+        )
+    )
+    probs3 = np.exp(
+        base_mountain_car_environment.observation_log_probability(
+            next_state=state, action=action, observations=observations
+        )
+    )
 
     # All results should be identical
     assert np.array_equal(probs1, probs2), "Multiple calls should return identical results"
@@ -405,13 +422,13 @@ def test_observation_model_probability_batch_consistency(base_mountain_car_envir
 
 
 def test_observation_model_probability_different_states(base_mountain_car_environment):
-    """Test observation model probability function with different true states.
+    """Test observation log-probability with different true states.
 
-    Purpose: Validates that observation model probability function works correctly
+    Purpose: Validates that observation_log_probability works correctly
     with different true states and maintains proper probability relationships
 
-    Given: MountainCarPOMDP environment and observation models with different true states
-    When: probability() method is called with observations relative to each true state
+    Given: MountainCarPOMDP environment with different true next_states
+    When: env.observation_log_probability is called with observations relative to each true state
     Then: Probabilities are highest for observations closest to their respective true states
 
     Test type: unit
@@ -425,7 +442,6 @@ def test_observation_model_probability_different_states(base_mountain_car_enviro
 
     for state in states:
         action = 0
-        obs_model = base_mountain_car_environment.observation_model(state, action)
 
         # Create observations at different distances from this true state
         observations = [
@@ -434,7 +450,11 @@ def test_observation_model_probability_different_states(base_mountain_car_enviro
             state + np.array([0.2, 0.02]),  # Far from true state
         ]
 
-        probabilities = obs_model.probability(observations)
+        probabilities = np.exp(
+            base_mountain_car_environment.observation_log_probability(
+                next_state=state, action=action, observations=observations
+            )
+        )
 
         # Verify shape and type
         assert isinstance(probabilities, np.ndarray), "Should return numpy array"
@@ -651,20 +671,20 @@ def test_mountain_car_state_bounds():
 
     # Test position bounds
     state = (pomdp.min_position - 0.1, 0.0)
-    transition = pomdp.state_transition_model(state, 0).sample()[0]
+    transition = pomdp.sample_next_state(state=state, action=0)
     assert transition[0] >= pomdp.min_position
 
     state = (pomdp.max_position + 0.1, 0.0)
-    transition = pomdp.state_transition_model(state, 0).sample()[0]
+    transition = pomdp.sample_next_state(state=state, action=0)
     assert transition[0] <= pomdp.max_position
 
     # Test velocity bounds
     state = (0.0, pomdp.max_speed + 0.1)
-    transition = pomdp.state_transition_model(state, 0).sample()[0]
+    transition = pomdp.sample_next_state(state=state, action=0)
     assert abs(transition[1]) <= pomdp.max_speed
 
     state = (0.0, -pomdp.max_speed - 0.1)
-    transition = pomdp.state_transition_model(state, 0).sample()[0]
+    transition = pomdp.sample_next_state(state=state, action=0)
     assert abs(transition[1]) <= pomdp.max_speed
 
 

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
@@ -414,15 +414,15 @@ class TestBeliefEquivalenceWithBaseline:
 
 class TestEquivalenceWithPerParticleLoop:
     def test_batch_transition_matches_per_particle_loop(self, env, updater):
-        """Test vectorized batch_transition matches per-particle state_transition_model.sample.
+        """Test vectorized batch_transition matches per-particle env.sample_next_state.
 
         Purpose: Verifies that batch_transition produces the same stochastic
-                 next states as the environment's state_transition_model.sample
+                 next states as the environment's sample_next_state
                  when the shared C++ RNG is seeded identically on both paths.
 
         Given: A set of particles, an action, and a fixed random seed.
         When: batch_transition is called, and the same transitions are computed
-              per-particle using the environment's state_transition_model.sample.
+              per-particle using env.sample_next_state.
         Then: Results match within floating-point tolerance.
 
         Test type: integration
@@ -436,7 +436,7 @@ class TestEquivalenceWithPerParticleLoop:
         )
 
         def per_particle_fn(particle, action):
-            return env.state_transition_model(state=tuple(particle), action=action).sample()[0]
+            return env.sample_next_state(state=tuple(particle), action=action)
 
         assert_batch_transition_matches_loop(
             updater=updater,
@@ -448,14 +448,14 @@ class TestEquivalenceWithPerParticleLoop:
         )
 
     def test_batch_observation_log_likelihood_matches_per_particle_loop(self, env, updater):
-        """Test vectorized log-likelihood matches per-particle observation_model.probability.
+        """Test vectorized log-likelihood matches per-particle env.observation_log_probability.
 
         Purpose: Verifies that batch_observation_log_likelihood matches the
-                 per-particle observation probability from the environment.
+                 per-particle observation log-probability from the environment.
 
         Given: A set of next-state particles and an observation.
         When: batch_observation_log_likelihood is called, and per-particle
-              log(observation_model.probability) is computed.
+              env.observation_log_probability is computed.
         Then: Results match within floating-point tolerance.
 
         Test type: integration
@@ -470,8 +470,9 @@ class TestEquivalenceWithPerParticleLoop:
         observation = np.array([-0.5, 0.0])
 
         def per_particle_ll_fn(particle, action, obs):
-            obs_model = env.observation_model(next_state=tuple(particle), action=action)
-            return np.log(obs_model.probability([obs])[0])
+            return env.observation_log_probability(
+                next_state=tuple(particle), action=action, observations=[obs]
+            )[0]
 
         assert_batch_obs_log_likelihood_matches_loop(
             updater=updater,

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_gaussian_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_gaussian_beliefs.py
@@ -408,7 +408,7 @@ class TestEndToEndUpdate:
             initial_covariance=initial_cov,
         )
         action = np.array([1.0])
-        next_state = env.state_transition_model(tuple(belief.mean), 1).sample()[0]
+        next_state = env.sample_next_state(state=tuple(belief.mean), action=1)
         observation = next_state + np.random.randn(2) * 0.01
 
         new_belief = belief.update(action=action, observation=observation, pomdp=None)
@@ -444,7 +444,7 @@ class TestEndToEndUpdate:
             initial_covariance=large_cov,
         )
         action = np.array([1.0])
-        next_state = env.state_transition_model(tuple(belief.mean), 1).sample()[0]
+        next_state = env.sample_next_state(state=tuple(belief.mean), action=1)
         observation = next_state
 
         new_belief = belief.update(action=action, observation=observation, pomdp=None)
@@ -475,7 +475,7 @@ class TestEndToEndUpdate:
         )
 
         action = np.array([1.0])
-        next_state = env.state_transition_model((-0.5, 0.0), 1).sample()[0]
+        next_state = env.sample_next_state(state=(-0.5, 0.0), action=1)
         observation = next_state
 
         new_ekf = belief_ekf.update(action=action, observation=observation, pomdp=None)

--- a/POMDPPlanners/tests/test_environments/test_pacman_native/test_pacman_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_native/test_pacman_native_equivalence.py
@@ -122,8 +122,7 @@ class TestTerminalAbsorbing:
             terminal=True,
         )
         _native.set_seed(0)
-        model = env.state_transition_model(terminal_state, 0)
-        next_state = model.sample()[0]
+        next_state = env.sample_next_state(state=terminal_state, action=0)
         np.testing.assert_array_equal(next_state, terminal_state)
 
 
@@ -151,8 +150,7 @@ class TestPelletCollection:
             terminal=False,
         )
         _native.set_seed(0)
-        model = env.state_transition_model(state, 1)  # East
-        next_state = model.sample()[0]
+        next_state = env.sample_next_state(state=state, action=1)  # East
         assert env.get_pacman_pos(next_state) == (1, 1)
         pellets_after = set(env.get_pellets(next_state))
         assert (1, 1) not in pellets_after
@@ -189,8 +187,7 @@ class TestCollisionTerminal:
         collision_found = False
         for seed in range(50):
             _native.set_seed(seed)
-            model = env.state_transition_model(state, 1)  # East
-            next_state = model.sample()[0]
+            next_state = env.sample_next_state(state=state, action=1)  # East
             if env.get_terminal(next_state) and env.get_pacman_pos(
                 next_state
             ) in env.get_ghost_positions(next_state):
@@ -220,8 +217,7 @@ class TestWinCondition:
             terminal=False,
         )
         _native.set_seed(0)
-        model = env.state_transition_model(state, 1)  # East
-        next_state = model.sample()[0]
+        next_state = env.sample_next_state(state=state, action=1)  # East
         assert env.get_pacman_pos(next_state) == (1, 1)
         assert env.get_pellets(next_state) == ()
         assert env.get_terminal(next_state)

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/benchmark_rocksample_vectorized_belief.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/benchmark_rocksample_vectorized_belief.py
@@ -46,29 +46,27 @@ def _benchmark_single_ops(env: RockSamplePOMDP) -> None:
     state = env.initial_state_dist().sample()[0]
     action = 2  # East
 
-    mean_t, std_t = _time_fn(
-        lambda: env.state_transition_model(state, action).sample()[0], n_runs=500
-    )
-    print(f"  state_transition_model.sample()      : {mean_t:.4f} +/- {std_t:.4f} ms")
+    mean_t, std_t = _time_fn(lambda: env.sample_next_state(state=state, action=action), n_runs=500)
+    print(f"  env.sample_next_state()              : {mean_t:.4f} +/- {std_t:.4f} ms")
 
-    next_state = env.state_transition_model(state, action).sample()[0]
-    obs = env.observation_model(next_state, action).sample()[0]
+    next_state = env.sample_next_state(state=state, action=action)
+    obs = env.sample_observation(next_state=next_state, action=action)
 
     mean_t, std_t = _time_fn(
-        lambda: env.observation_model(next_state, action).probability([obs]),
+        lambda: env.observation_log_probability(next_state, action, [obs]),
         n_runs=500,
     )
-    print(f"  observation_model.probability()      : {mean_t:.4f} +/- {std_t:.4f} ms")
+    print(f"  env.observation_log_probability()    : {mean_t:.4f} +/- {std_t:.4f} ms")
 
     check_action = 5
-    next_state_check = env.state_transition_model(state, check_action).sample()[0]
-    obs_check = env.observation_model(next_state_check, check_action).sample()[0]
+    next_state_check = env.sample_next_state(state=state, action=check_action)
+    obs_check = env.sample_observation(next_state=next_state_check, action=check_action)
 
     mean_t, std_t = _time_fn(
-        lambda: env.observation_model(next_state_check, check_action).probability([obs_check]),
+        lambda: env.observation_log_probability(next_state_check, check_action, [obs_check]),
         n_runs=500,
     )
-    print(f"  observation_model.probability(check)  : {mean_t:.4f} +/- {std_t:.4f} ms")
+    print(f"  env.observation_log_probability(chk) : {mean_t:.4f} +/- {std_t:.4f} ms")
 
 
 def _benchmark_sample(env: RockSamplePOMDP, particle_counts: List[int]) -> None:
@@ -92,7 +90,7 @@ def _benchmark_sample(env: RockSamplePOMDP, particle_counts: List[int]) -> None:
 
 
 def _benchmark_batch_transition(env: RockSamplePOMDP, particle_counts: List[int]) -> None:
-    print("\n--- batch_transition vs loop of state_transition_model.sample() ---")
+    print("\n--- batch_transition vs loop of env.sample_next_state() ---")
     print(f"{'N':>6} | {'Loop (ms)':>14} | {'Vectorized (ms)':>16} | {'Speedup':>8}")
     print("-" * 55)
 
@@ -105,7 +103,7 @@ def _benchmark_batch_transition(env: RockSamplePOMDP, particle_counts: List[int]
         particles = np.stack(states)
 
         mean_loop, _ = _time_fn(
-            lambda s=states: [env.state_transition_model(x, action).sample()[0] for x in s],
+            lambda s=states: [env.sample_next_state(state=x, action=action) for x in s],
             n_runs=100,
         )
 
@@ -119,7 +117,7 @@ def _benchmark_batch_transition(env: RockSamplePOMDP, particle_counts: List[int]
 
 
 def _benchmark_batch_log_likelihood(env: RockSamplePOMDP, particle_counts: List[int]) -> None:
-    print("\n--- batch_observation_log_likelihood vs loop of observation_model.probability() ---")
+    print("\n--- batch_observation_log_likelihood vs loop of env.observation_log_probability() ---")
     print(f"{'N':>6} | {'Loop (ms)':>14} | {'Vectorized (ms)':>16} | {'Speedup':>8}")
     print("-" * 55)
 
@@ -133,9 +131,7 @@ def _benchmark_batch_log_likelihood(env: RockSamplePOMDP, particle_counts: List[
         particles = np.stack(states)
 
         mean_loop, _ = _time_fn(
-            lambda s=states: [
-                env.observation_model(x, action).probability([obs_str])[0] for x in s
-            ],
+            lambda s=states: [env.observation_log_probability(x, action, [obs_str])[0] for x in s],
             n_runs=100,
         )
 
@@ -157,8 +153,8 @@ def _benchmark_belief_update(env: RockSamplePOMDP, particle_counts: List[int]) -
 
     action = 5
     state = env.initial_state_dist().sample()[0]
-    next_state = env.state_transition_model(state, action).sample()[0]
-    obs = env.observation_model(next_state, action).sample()[0]
+    next_state = env.sample_next_state(state=state, action=action)
+    obs = env.sample_observation(next_state=next_state, action=action)
 
     for n in particle_counts:
         np.random.seed(42)

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_native_equivalence.py
@@ -414,7 +414,7 @@ def test_transition_batch_sample_matches_per_particle_sample(
     updater = RockSampleVectorizedUpdater.from_environment(env)
     batch_out = updater.batch_transition(particles, np.array(action))
 
-    loop_out = np.stack([env.state_transition_model(row, action).sample()[0] for row in particles])
+    loop_out = np.stack([env.sample_next_state(state=row, action=action) for row in particles])
     np.testing.assert_array_equal(batch_out, loop_out.astype(float))
 
 
@@ -467,8 +467,7 @@ def test_observation_batch_log_likelihood_matches_per_particle(
 
     expected = np.zeros(32)
     for i, row in enumerate(particles):
-        prob = env.observation_model(row, action).probability([obs_str])[0]
-        expected[i] = np.log(max(prob, 1e-300))
+        expected[i] = env.observation_log_probability(row, action, [obs_str])[0]
 
     np.testing.assert_allclose(batch_ll, expected, atol=1e-10)
 
@@ -498,12 +497,7 @@ def test_observation_batch_log_likelihood_matches_per_particle_movement(
     updater = RockSampleVectorizedUpdater.from_environment(env)
     batch_ll = updater.batch_observation_log_likelihood(particles, np.array(2), np.array(OBS_NONE))
 
-    expected = np.array(
-        [
-            np.log(max(env.observation_model(row, 2).probability(["none"])[0], 1e-300))
-            for row in particles
-        ]
-    )
+    expected = np.array([env.observation_log_probability(row, 2, ["none"])[0] for row in particles])
     np.testing.assert_array_equal(batch_ll, np.zeros(32))
     np.testing.assert_array_equal(expected, np.zeros(32))
 
@@ -646,7 +640,7 @@ def test_batch_transition_full_parity_against_updater(env: RockSamplePOMDP, acti
     updater = RockSampleVectorizedUpdater.from_environment(env)
 
     def per_particle(particle: np.ndarray, act: int) -> np.ndarray:
-        return env.state_transition_model(particle, act).sample()[0]
+        return env.sample_next_state(state=particle, action=act)
 
     assert_batch_transition_matches_loop(
         updater=updater,

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_vectorized_updater.py
@@ -429,7 +429,7 @@ class TestEquivalenceWithPerParticleLoop:
         particles = np.stack(states)
 
         def per_particle_fn(particle, action):
-            return simple_env.state_transition_model(state=particle, action=action).sample()[0]
+            return simple_env.sample_next_state(state=particle, action=action)
 
         for action in [0, 1, 2, 3, 4, 5, 6]:  # Sample, N, E, S, W, Check0, Check1
             assert_batch_transition_matches_loop(
@@ -458,12 +458,9 @@ class TestEquivalenceWithPerParticleLoop:
         particles = np.stack(states)
 
         def per_particle_ll_fn(particle, action, obs):
-            obs_model = simple_env.observation_model(next_state=particle, action=action)
             obs_str = {OBS_NONE: "none", OBS_GOOD: "good", OBS_BAD: "bad"}[int(obs)]
-            prob = obs_model.probability([obs_str])[0]
-            if prob > 0:
-                return np.log(prob)
-            return -np.inf
+            log_prob = simple_env.observation_log_probability(particle, action, [obs_str])[0]
+            return log_prob
 
         # Check rock 0 with "good" observation
         assert_batch_obs_log_likelihood_matches_loop(

--- a/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp.py
@@ -861,12 +861,12 @@ def test_sample_next_step_observation_never_empty():
                 assert np.all(np.isfinite(observation)), "All observation values should be finite"
 
                 # Verify observation can be used in probability calculation
-                obs_model = env.observation_model(next_state, action)
                 try:
-                    probs = obs_model.probability([observation])  # Now expects list
-                    assert len(probs) == 1, "Should return one probability"
-                    prob = probs[0]
-                    assert np.isfinite(prob), "Probability should be finite"
+                    log_probs = env.observation_log_probability(next_state, action, [observation])
+                    assert len(log_probs) == 1, "Should return one log-probability"
+                    log_prob = log_probs[0]
+                    assert np.isfinite(log_prob), "Log-probability should be finite"
+                    prob = float(np.exp(log_prob))
                     assert prob >= 0.0, "Probability should be non-negative"
                 except Exception as e:  # pylint: disable=broad-exception-caught
                     pytest.fail(

--- a/POMDPPlanners/tests/test_environments/test_sanity_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_sanity_pomdp.py
@@ -312,94 +312,90 @@ class TestSanityStateTransitionModel:
         assert model.state == 0
         assert model.action == 1
 
-    def test_sample_action_0(self):
+    def test_sample_action_0(self, sanity_pomdp):
         """Test sampling with action 0 (should always lead to state 0).
 
         Purpose: Validates state transition sampling with action 0 produces deterministic state 0 transitions
 
-        Given: SanityStateTransitionModel configured with initial state=0 and action=0
-        When: Sample method is called for 10 samples
+        Given: A SanityPOMDP environment, initial state=0 and action=0
+        When: env.sample_next_state is called 10 times
         Then: All samples return state 0 (deterministic transition for action 0)
 
         Test type: unit
         """
-        model = SanityStateTransitionModel(state=0, action=0)
-        samples = model.sample(n_samples=10)
+        samples = [sanity_pomdp.sample_next_state(state=0, action=0) for _ in range(10)]
         assert all(s == 0 for s in samples)
         assert len(samples) == 10
 
-    def test_sample_action_1(self):
+    def test_sample_action_1(self, sanity_pomdp):
         """Test sampling with action 1 (should always lead to state 1).
 
         Purpose: Validates state transition sampling with action 1 produces deterministic state 1 transitions
 
-        Given: SanityStateTransitionModel configured with initial state=0 and action=1
-        When: Sample method is called for 10 samples
+        Given: A SanityPOMDP environment, initial state=0 and action=1
+        When: env.sample_next_state is called 10 times
         Then: All samples return state 1 (deterministic transition for action 1)
 
         Test type: unit
         """
-        model = SanityStateTransitionModel(state=0, action=1)
-        samples = model.sample(n_samples=10)
+        samples = [sanity_pomdp.sample_next_state(state=0, action=1) for _ in range(10)]
         assert all(s == 1 for s in samples)
         assert len(samples) == 10
 
-    def test_sample_different_states(self):
+    def test_sample_different_states(self, sanity_pomdp):
         """Test that state doesn't affect transition (only action matters).
 
-        Purpose: Validates sampling behavior for  different states
+        Purpose: Validates sampling behavior for different states
 
-        Given: Configured object with sampling capabilities
-        When: Sample method is called
-        Then: Valid samples are returned according to distribution
+        Given: A SanityPOMDP environment
+        When: env.sample_next_state is called for both states with each action
+        Then: Action 0 always leads to state 0, action 1 always leads to state 1
 
         Test type: unit
         """
         # Action 0 should always lead to state 0 regardless of current state
         for state in [0, 1]:
-            model = SanityStateTransitionModel(state=state, action=0)
-            samples = model.sample(n_samples=5)
+            samples = [sanity_pomdp.sample_next_state(state=state, action=0) for _ in range(5)]
             assert all(s == 0 for s in samples)
 
         # Action 1 should always lead to state 1 regardless of current state
         for state in [0, 1]:
-            model = SanityStateTransitionModel(state=state, action=1)
-            samples = model.sample(n_samples=5)
+            samples = [sanity_pomdp.sample_next_state(state=state, action=1) for _ in range(5)]
             assert all(s == 1 for s in samples)
 
-    def test_probability_action_0(self):
+    def test_probability_action_0(self, sanity_pomdp):
         """Test probability calculation for action 0.
 
         Purpose: Validates state transition probabilities for action 0 (deterministically leads to state 0)
 
-        Given: SanityStateTransitionModel with action=0 and test values [0,1,0,1]
-        When: Probability method is called with the test values
-        Then: Returns [1.0,0.0,1.0,0.0] probabilities (1.0 for state 0, 0.0 for state 1)
+        Given: A SanityPOMDP environment with state=0, action=0 and candidate next states [0,1,0,1]
+        When: env.transition_log_probability is called with the candidate next states
+        Then: Exponentiated log-probs equal [1.0, 0.0, 1.0, 0.0]
 
         Test type: unit
         """
-        model = SanityStateTransitionModel(state=0, action=0)
         values = [0, 1, 0, 1]
-        probs = model.probability(values)
+        log_probs = sanity_pomdp.transition_log_probability(state=0, action=0, next_states=values)
+        probs = np.exp(log_probs)
         expected = np.array([1.0, 0.0, 1.0, 0.0])
-        np.testing.assert_array_equal(probs, expected)
+        np.testing.assert_allclose(probs, expected, atol=1e-200)
 
-    def test_probability_action_1(self):
+    def test_probability_action_1(self, sanity_pomdp):
         """Test probability calculation for action 1.
 
         Purpose: Validates state transition probabilities for action 1 (deterministically leads to state 1)
 
-        Given: SanityStateTransitionModel with action=1 and test values [0,1,0,1]
-        When: Probability method is called with the test values
-        Then: Returns [0.0,1.0,0.0,1.0] probabilities (0.0 for state 0, 1.0 for state 1)
+        Given: A SanityPOMDP environment with state=0, action=1 and candidate next states [0,1,0,1]
+        When: env.transition_log_probability is called with the candidate next states
+        Then: Exponentiated log-probs equal [0.0, 1.0, 0.0, 1.0]
 
         Test type: unit
         """
-        model = SanityStateTransitionModel(state=0, action=1)
         values = [0, 1, 0, 1]
-        probs = model.probability(values)
+        log_probs = sanity_pomdp.transition_log_probability(state=0, action=1, next_states=values)
+        probs = np.exp(log_probs)
         expected = np.array([0.0, 1.0, 0.0, 1.0])
-        np.testing.assert_array_equal(probs, expected)
+        np.testing.assert_allclose(probs, expected, atol=1e-200)
 
 
 class TestSanityObservationModel:
@@ -420,94 +416,98 @@ class TestSanityObservationModel:
         assert model.next_state == 1
         assert model.action == 0
 
-    def test_sample_state_0(self):
+    def test_sample_state_0(self, sanity_pomdp):
         """Test sampling with state 0 (should always observe 0).
 
         Purpose: Validates observation sampling from state 0 produces deterministic observation 0
 
-        Given: SanityObservationModel configured with next_state=0 and action=0
-        When: Sample method is called for 10 samples
+        Given: A SanityPOMDP environment, next_state=0 and action=0
+        When: env.sample_observation is called 10 times
         Then: All samples return observation 0 (deterministic observation for state 0)
 
         Test type: unit
         """
-        model = SanityObservationModel(next_state=0, action=0)
-        samples = model.sample(n_samples=10)
+        samples = [sanity_pomdp.sample_observation(next_state=0, action=0) for _ in range(10)]
         assert all(s == 0 for s in samples)
         assert len(samples) == 10
 
-    def test_sample_state_1(self):
+    def test_sample_state_1(self, sanity_pomdp):
         """Test sampling with state 1 (should always observe 1).
 
         Purpose: Validates observation sampling from state 1 produces deterministic observation 1
 
-        Given: SanityObservationModel configured with next_state=1 and action=0
-        When: Sample method is called for 10 samples
+        Given: A SanityPOMDP environment, next_state=1 and action=0
+        When: env.sample_observation is called 10 times
         Then: All samples return observation 1 (deterministic observation for state 1)
 
         Test type: unit
         """
-        model = SanityObservationModel(next_state=1, action=0)
-        samples = model.sample(n_samples=10)
+        samples = [sanity_pomdp.sample_observation(next_state=1, action=0) for _ in range(10)]
         assert all(s == 1 for s in samples)
         assert len(samples) == 10
 
-    def test_sample_different_actions(self):
+    def test_sample_different_actions(self, sanity_pomdp):
         """Test that action doesn't affect observation (only state matters).
 
-        Purpose: Validates sampling behavior for  different actions
+        Purpose: Validates sampling behavior for different actions
 
-        Given: Configured object with sampling capabilities
-        When: Sample method is called
-        Then: Valid samples are returned according to distribution
+        Given: A SanityPOMDP environment
+        When: env.sample_observation is called for both next states with each action
+        Then: Next-state 0 always observes 0; next-state 1 always observes 1
 
         Test type: unit
         """
         # State 0 should always give observation 0 regardless of action
         for action in [0, 1]:
-            model = SanityObservationModel(next_state=0, action=action)
-            samples = model.sample(n_samples=5)
+            samples = [
+                sanity_pomdp.sample_observation(next_state=0, action=action) for _ in range(5)
+            ]
             assert all(s == 0 for s in samples)
 
         # State 1 should always give observation 1 regardless of action
         for action in [0, 1]:
-            model = SanityObservationModel(next_state=1, action=action)
-            samples = model.sample(n_samples=5)
+            samples = [
+                sanity_pomdp.sample_observation(next_state=1, action=action) for _ in range(5)
+            ]
             assert all(s == 1 for s in samples)
 
-    def test_probability_state_0(self):
+    def test_probability_state_0(self, sanity_pomdp):
         """Test probability calculation for state 0.
 
         Purpose: Validates observation probabilities for state 0 (deterministically observes observation 0)
 
-        Given: SanityObservationModel with next_state=0 and test values [0,1,0,1]
-        When: Probability method is called with the test values
-        Then: Returns [1.0,0.0,1.0,0.0] probabilities (1.0 for obs 0, 0.0 for obs 1)
+        Given: A SanityPOMDP environment with next_state=0, action=0 and candidate observations [0,1,0,1]
+        When: env.observation_log_probability is called with the candidate observations
+        Then: Exponentiated log-probs equal [1.0, 0.0, 1.0, 0.0]
 
         Test type: unit
         """
-        model = SanityObservationModel(next_state=0, action=0)
         values = [0, 1, 0, 1]
-        probs = model.probability(values)
+        log_probs = sanity_pomdp.observation_log_probability(
+            next_state=0, action=0, observations=values
+        )
+        probs = np.exp(log_probs)
         expected = np.array([1.0, 0.0, 1.0, 0.0])
-        np.testing.assert_array_equal(probs, expected)
+        np.testing.assert_allclose(probs, expected, atol=1e-200)
 
-    def test_probability_state_1(self):
+    def test_probability_state_1(self, sanity_pomdp):
         """Test probability calculation for state 1.
 
         Purpose: Validates observation probabilities for state 1 (deterministically observes observation 1)
 
-        Given: SanityObservationModel with next_state=1 and test values [0,1,0,1]
-        When: Probability method is called with the test values
-        Then: Returns [0.0,1.0,0.0,1.0] probabilities (0.0 for obs 0, 1.0 for obs 1)
+        Given: A SanityPOMDP environment with next_state=1, action=0 and candidate observations [0,1,0,1]
+        When: env.observation_log_probability is called with the candidate observations
+        Then: Exponentiated log-probs equal [0.0, 1.0, 0.0, 1.0]
 
         Test type: unit
         """
-        model = SanityObservationModel(next_state=1, action=0)
         values = [0, 1, 0, 1]
-        probs = model.probability(values)
+        log_probs = sanity_pomdp.observation_log_probability(
+            next_state=1, action=0, observations=values
+        )
+        probs = np.exp(log_probs)
         expected = np.array([0.0, 1.0, 0.0, 1.0])
-        np.testing.assert_array_equal(probs, expected)
+        np.testing.assert_allclose(probs, expected, atol=1e-200)
 
 
 class TestSanityInitialStateDist:

--- a/POMDPPlanners/tests/test_environments/test_tiger_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_tiger_pomdp.py
@@ -95,15 +95,14 @@ def test_state_transition_listen(tiger_pomdp):
     Purpose: Validates that TigerPOMDP listen action doesn't change the state
 
     Given: A TigerPOMDP environment and both states (tiger_left, tiger_right)
-    When: State transition model is created for listen action and next state is sampled
+    When: env.sample_next_state is called for the listen action repeatedly
     Then: All samples return the same state as the input state, confirming that listening doesn't change the tiger's position
 
     Test type: unit
     """
     # Listening shouldn't change the state
     for state in tiger_pomdp.states:
-        dist = tiger_pomdp.state_transition_model(state, "listen")
-        samples = dist.sample(n_samples=10)
+        samples = [tiger_pomdp.sample_next_state(state=state, action="listen") for _ in range(10)]
         assert all(s == state for s in samples)
 
 
@@ -113,15 +112,16 @@ def test_state_transition_open_door(tiger_pomdp):
     Purpose: Validates that TigerPOMDP open door actions randomly place tiger behind either door
 
     Given: A TigerPOMDP environment starting from tiger_left state and both open actions (open_left, open_right)
-    When: State transition model is created for open actions and next states are sampled 100 times
+    When: env.sample_next_state is called for the open actions 100 times
     Then: All samples are valid states and both states appear, demonstrating random placement after opening doors
 
     Test type: unit
     """
     # Opening a door should randomly place tiger behind either door
     for action in ["open_left", "open_right"]:
-        dist = tiger_pomdp.state_transition_model("tiger_left", action)
-        samples = dist.sample(n_samples=100)
+        samples = [
+            tiger_pomdp.sample_next_state(state="tiger_left", action=action) for _ in range(100)
+        ]
         assert all(s in tiger_pomdp.states for s in samples)
         assert len(set(samples)) == 2  # Should get both states
 
@@ -132,15 +132,16 @@ def test_observation_model_listen(tiger_pomdp):
     Purpose: Validates that TigerPOMDP listen action provides mostly correct observations with some noise
 
     Given: A TigerPOMDP environment and both states (tiger_left, tiger_right)
-    When: Observation model is created for listen action and observations are sampled 100 times
+    When: env.sample_observation is called for the listen action 100 times
     Then: Most observations are correct (hear_left for tiger_left, hear_right for tiger_right) with approximately 85% accuracy
 
     Test type: unit
     """
     # Test listen action with both states
     for state in tiger_pomdp.states:
-        dist = tiger_pomdp.observation_model(state, "listen")
-        samples = dist.sample(n_samples=100)
+        samples = [
+            tiger_pomdp.sample_observation(next_state=state, action="listen") for _ in range(100)
+        ]
         assert all(s in tiger_pomdp.observations for s in samples)
 
         # Should mostly get correct observation
@@ -155,7 +156,7 @@ def test_observation_model_open_door(tiger_pomdp):
     Purpose: Validates that TigerPOMDP open door actions always provide "hear_nothing" observations
 
     Given: A TigerPOMDP environment and both states (tiger_left, tiger_right) with both open actions (open_left, open_right)
-    When: Observation model is created for open actions and observations are sampled 10 times
+    When: env.sample_observation is called for the open actions 10 times
     Then: All samples return "hear_nothing", confirming that opening doors provides no auditory information
 
     Test type: unit
@@ -163,8 +164,9 @@ def test_observation_model_open_door(tiger_pomdp):
     # Opening a door should always give 'hear_nothing'
     for state in tiger_pomdp.states:
         for action in ["open_left", "open_right"]:
-            dist = tiger_pomdp.observation_model(state, action)
-            samples = dist.sample(n_samples=10)
+            samples = [
+                tiger_pomdp.sample_observation(next_state=state, action=action) for _ in range(10)
+            ]
             assert all(s == "hear_nothing" for s in samples)
 
 

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp.py
@@ -224,10 +224,8 @@ def test_integration_with_tiger_pomdp(planner, belief, environment, n_particles)
 
         # Simulate environment step
         state = current_belief.sample()
-        next_state = environment.state_transition_model(state, action[0]).sample()[0]
-        observation = environment.observation_model(next_state, action[0]).sample()[
-            0
-        ]  # Extract first element from list
+        next_state = environment.sample_next_state(state=state, action=action[0])
+        observation = environment.sample_observation(next_state=next_state, action=action[0])
 
         # Update belief
         current_belief = current_belief.update(action[0], observation, environment)

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp_dpw.py
@@ -496,8 +496,8 @@ def test_integration_with_tiger_pomdp(planner, belief, environment, n_particles)
 
         # Simulate environment step
         state = current_belief.sample()
-        next_state = environment.state_transition_model(state, action[0]).sample()[0]
-        observation = environment.observation_model(next_state, action[0]).sample()[0]
+        next_state = environment.sample_next_state(state=state, action=action[0])
+        observation = environment.sample_observation(next_state=next_state, action=action[0])
 
         # Update belief
         current_belief = current_belief.update(action[0], observation, environment)

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcpow.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcpow.py
@@ -572,8 +572,8 @@ def test_integration_with_tiger_pomdp(planner, belief, environment, n_particles)
 
         # Simulate environment step
         state = current_belief.sample()
-        next_state = environment.state_transition_model(state, action[0]).sample()[0]
-        observation = environment.observation_model(next_state, action[0]).sample()[0]
+        next_state = environment.sample_next_state(state=state, action=action[0])
+        observation = environment.sample_observation(next_state=next_state, action=action[0])
 
         # Update belief
         current_belief = current_belief.update(action[0], observation, environment)

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_sparse_pft.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_sparse_pft.py
@@ -304,10 +304,8 @@ def test_integration_with_tiger_pomdp(planner, initial_belief, environment, n_pa
 
         # Simulate environment step
         state = current_belief.sample()
-        next_state = environment.state_transition_model(state=state, action=action[0]).sample()[0]
-        next_observation = environment.observation_model(
-            next_state=next_state, action=action[0]
-        ).sample()[0]
+        next_state = environment.sample_next_state(state=state, action=action[0])
+        next_observation = environment.sample_observation(next_state=next_state, action=action[0])
 
         # Update belief
         current_belief = current_belief.update(


### PR DESCRIPTION
## Summary

Stacked on top of [PR #100](https://github.com/yaacovpariente/POMDPPlanners/pull/100) (PR-B). Part 3 of 4 in the env-API redesign laid out in `~/.claude/plans/crispy-booping-scott.md`.

Mechanical migration of **28 test files** from the legacy `env.state_transition_model(...)` / `env.observation_model(...)` factory + `.sample()` / `.probability()` pattern to the new `env.sample_next_state` / `env.sample_observation` / `env.transition_log_probability` / `env.observation_log_probability` API added in PR-A.

```
env.state_transition_model(s, a).sample()[0]      ->  env.sample_next_state(s, a)
env.observation_model(ns, a).sample()[0]          ->  env.sample_observation(ns, a)
env.observation_model(ns, a).probability([o])[0]  ->  np.exp(env.observation_log_probability(ns, a, [o])[0])
```

## Files migrated (28)

- 9 base env tests (Tiger, Sanity, MountainCar×3, CartPole×3, env_serialization)
- 5 LightDark / LaserTag / Push variants
- 5 RockSample / SafetyAnt / Pacman variants
- 4 MCTS planner tests
- 5 belief / interface / benchmark tests

## Tests intentionally left untouched (handled in PR-D)

- **`test_interfaces/test_observation_models.py`** + **`test_state_transition_models.py`** — wrapper-class API contract tests; will be deleted/rewritten when wrappers are removed
- **~20 RNG-pinned wrapper-vs-direct equivalence tests** — these compare `state_transition_model().sample(n)` to `sample_next_state(...)` under pinned seeds; migrating either side would make them tautologies; deleted in PR-D after wrapper removal
- **36+ wrapper-attribute-asserting tests** (`.near_beacon`, `.state`, `.action`, `.next_state`, `._active_dist`, `.pomdp`, etc.) — PR-D adds an env helper (`BaseLightDarkPOMDP._is_state_near_beacon`) and rewrites these as behavioral tests via the env API
- **4 native-parity test files** (continuous_light_dark / continuous_push / cartpole / mountain_car native_equivalence) — every test verifies wrapper-specific C++ inheritance + batch_sample / batch_log_likelihood contracts; rewrite in PR-D
- **2 `'None'`-observation equivalence loops** in `test_discrete_light_dark_vectorized_updater.py` — kept on wrapper because the vectorized updater uses strict `-inf` floor (incompatible with `observation_log_probability`'s `log(p+1e-300)` floor)

## Test results

- **2374 tests pass**, 8 pre-existing skips, 0 failures
- pylint clean (no new warnings)
- pyright clean

## Test plan

- [x] Mechanical migrations preserve byte-identical behavior under pinned seeds
- [x] All 28 modified test files pass
- [x] Sibling test suites (env + planner + core + interfaces + benchmarks) pass
- [x] black + pylint + pyright clean