### PR TITLE
PR-D1: Per-state batch env API + migrate WeightedParticleBelief

### DIFF
--- a/POMDPPlanners/core/belief/particle_beliefs.py
+++ b/POMDPPlanners/core/belief/particle_beliefs.py
@@ -267,39 +267,28 @@ class WeightedParticleBelief(Belief):
     def _update_weights(
         self, action: Any, observation: Any, pomdp: Environment
     ) -> Tuple[List[Any], np.ndarray]:
-        # Fast path: if the env's transition model exposes a native batch
-        # entry point, process all particles in a single C++ call. When the
-        # observation model also exposes batch_log_likelihood, the
-        # per-particle Python loop is eliminated entirely and the belief
-        # update becomes O(1) Python round trips instead of O(N).
-        transition_model = pomdp.state_transition_model(state=self.particles[0], action=action)
-        if hasattr(transition_model, "batch_sample"):
-            return self._update_weights_batch(
-                action=action,
-                observation=observation,
-                pomdp=pomdp,
-                transition_model=transition_model,
-            )
-
-        # Fallback: per-particle Python loop. Byte-identical to pre-Layer-2
-        # behaviour for envs without native batch support.
-        next_particles = [
-            pomdp.sample_next_state(state=particle, action=action) for particle in self.particles
-        ]
-        # Use the env's vectorized log-probability API; one call per particle
-        # (env returns a length-1 ndarray for the single-observation query).
-        log_probs = np.array(
-            [
-                pomdp.observation_log_probability(
-                    next_state=next_particle, action=action, observations=[observation]
-                )[0]
-                for next_particle in next_particles
-            ]
+        # Vectorized fast path. Native-backed envs override
+        # sample_next_state_batch / observation_log_probability_per_state to
+        # delegate to a single C++ call; the default impl falls back to a
+        # per-state Python loop for envs that haven't been overridden.
+        next_arr = pomdp.sample_next_state_batch(states=self.particles, action=action)
+        next_arr_np = np.asarray(next_arr) if not isinstance(next_arr, list) else next_arr
+        next_particles: List[Any] = (
+            [next_arr_np[i] for i in range(len(next_arr_np))]
+            if not isinstance(next_arr_np, list)
+            else next_arr_np
         )
 
-        # log(eps + p) for parity with the pre-migration behavior, but the
-        # env returns log p directly so we exp + clamp here.
-        probs = np.exp(log_probs)
+        log_ll = pomdp.observation_log_probability_per_state(
+            next_states=next_particles, action=action, observation=observation
+        )
+
+        # Apply the eps floor for the non-native fallback path. Native envs
+        # using log_pdf (Gaussian) never produce -inf; this is a no-op there.
+        # For discrete-prob envs that may return -inf for impossible
+        # observations, the eps preserves the pre-migration weight contract
+        # (log(eps + p) instead of log(p) -> -inf).
+        probs = np.exp(log_ll)
         next_log_weights = self.log_weights + np.log(self.eps + probs)
 
         return next_particles, next_log_weights
@@ -309,36 +298,20 @@ class WeightedParticleBelief(Belief):
         action: Any,
         observation: Any,
         pomdp: Environment,
-        transition_model: Any,
+        transition_model: Any,  # pylint: disable=unused-argument
     ) -> Tuple[List[Any], np.ndarray]:
         particles_arr = np.asarray(self.particles, dtype=float)
-        next_arr = transition_model.batch_sample(particles_arr)
-        next_particles: List[Any] = [next_arr[i] for i in range(len(next_arr))]
+        next_arr = pomdp.sample_next_state_batch(states=particles_arr, action=action)
+        next_arr_np = np.asarray(next_arr)
+        next_particles: List[Any] = [next_arr_np[i] for i in range(len(next_arr_np))]
 
-        obs_model = pomdp.observation_model(next_state=next_arr[0], action=action)
-        if hasattr(obs_model, "batch_log_likelihood"):
-            observation_arr = np.asarray(observation, dtype=float).ravel()
-            # pyright cannot see through the hasattr narrowing onto a
-            # concrete native subclass (e.g. MountainCarObservationCpp);
-            # the runtime hasattr guarantees the call is safe.
-            log_ll = obs_model.batch_log_likelihood(  # type: ignore[attr-defined]
-                next_arr, observation_arr
-            )
-            # No eps clamp on the native batch path -- log_pdf is always
-            # finite for Gaussian observation models, matching the existing
-            # VectorizedWeightedParticleBelief contract.
-            next_log_weights = self.log_weights + log_ll
-            return next_particles, next_log_weights
-
-        probs = np.array(
-            [
-                pomdp.observation_model(next_state=next_particle, action=action).probability(
-                    [observation]
-                )[0]
-                for next_particle in next_particles
-            ]
+        log_ll = pomdp.observation_log_probability_per_state(
+            next_states=next_arr_np, action=action, observation=observation
         )
-        next_log_weights = self.log_weights + np.log(self.eps + probs)
+        # No eps clamp on the native batch path -- log_pdf is always
+        # finite for Gaussian observation models, matching the existing
+        # VectorizedWeightedParticleBelief contract.
+        next_log_weights = self.log_weights + log_ll
         return next_particles, next_log_weights
 
     def update(

--- a/POMDPPlanners/core/environment.py
+++ b/POMDPPlanners/core/environment.py
@@ -665,6 +665,61 @@ class Environment(ABC):
         )
         return np.log(probs + 1e-300)
 
+    def sample_next_state_batch(self, states: Any, action: Any) -> Any:
+        """Sample one next state per input state, all under the same action.
+
+        Used by particle filters: given N current particles and one action,
+        draw N next states (one per particle) in a single vectorized call.
+
+        The default implementation falls back to a per-state Python loop
+        delegating to :meth:`sample_next_state`. Native-backed envs (those
+        whose state-transition kernel exposes ``batch_sample(states_array)``)
+        should override to avoid the loop.
+
+        Args:
+            states: A sequence (length N) or ndarray of shape ``(N, *dim)``
+                of input particles.
+            action: A single action to apply to every particle.
+
+        Returns:
+            For numeric envs: ``np.ndarray`` of shape ``(N, *dim)``.
+            For structured envs (Tiger strings, Pacman tuples): a list of
+            length N.
+        """
+        return [self.sample_next_state(state=s, action=action) for s in states]
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: Any, observation: Any
+    ) -> np.ndarray:
+        """Log-probability of one observation under each candidate next-state.
+
+        Used by particle filters: given N candidate next-states and ONE
+        observation, return N log-likelihoods.
+
+        The default implementation falls back to a per-state Python loop
+        delegating to :meth:`observation_log_probability`. Native-backed envs
+        (those whose observation kernel exposes
+        ``batch_log_likelihood(next_states_array, observation_array)``) should
+        override to avoid the loop.
+
+        Args:
+            next_states: A sequence (length N) or ndarray of shape ``(N, *dim)``
+                of candidate next-states.
+            action: The action that was executed.
+            observation: A single observation.
+
+        Returns:
+            ndarray of shape ``(N,)`` with log-probabilities or log-PDFs.
+        """
+        return np.asarray(
+            [
+                self.observation_log_probability(
+                    next_state=ns, action=action, observations=[observation]
+                )[0]
+                for ns in next_states
+            ]
+        )
+
     def sample_next_step(self, state: Any, action: Any) -> Tuple[Any, Any, float]:
         """Sample a complete state transition step.
 

--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
@@ -438,6 +438,45 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
         probs = np.asarray(kernel.probability(observations))
         return np.log(probs + 1e-300)
 
+    def sample_next_state_batch(self, states: Any, action: int) -> np.ndarray:
+        states_array = np.ascontiguousarray(np.asarray(states, dtype=np.float64))
+        if states_array.ndim == 1:
+            states_array = states_array.reshape(1, -1)
+        kernel = _native.CartPoleTransitionCpp(
+            state=states_array[0],
+            action=action,
+            force_mag=self.force_mag,
+            total_mass=self.total_mass,
+            polemass_length=self.polemass_length,
+            gravity=self.gravity,
+            length=self.length,
+            kinematics_integrator=self.kinematics_integrator,
+            tau=self.tau,
+            masspole=self.masspole,
+            covariance=self._state_transition_dist.covariance,
+        )
+        return np.asarray(kernel.batch_sample(states_array), dtype=np.float64)
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: int, observation: Any
+    ) -> np.ndarray:
+        next_states_array = np.ascontiguousarray(np.asarray(next_states, dtype=np.float64))
+        if next_states_array.ndim == 1:
+            next_states_array = next_states_array.reshape(1, -1)
+        observation_array = np.ascontiguousarray(np.asarray(observation, dtype=np.float64))
+        kernel = _native.CartPoleObservationCpp(
+            next_state=next_states_array[0],
+            action=action,
+            covariance=self._obs_dist.covariance,
+        )
+        return np.asarray(
+            kernel.batch_log_likelihood(
+                next_particles=next_states_array,
+                observation=observation_array,
+            ),
+            dtype=np.float64,
+        )
+
     def reward(self, state: np.ndarray, action: int) -> float:
         terminated = self.is_terminal(state)
 

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -440,6 +440,48 @@ class ContinuousLaserTagPOMDP(Environment):
         with np.errstate(divide="ignore"):
             return np.log(probs)
 
+    def sample_next_state_batch(self, states: Any, action: np.ndarray) -> np.ndarray:
+        states_array = np.ascontiguousarray(np.asarray(states, dtype=np.float64))
+        if states_array.ndim == 1:
+            states_array = states_array.reshape(1, -1)
+        kernel = _native.ContinuousLaserTagTransitionCpp(
+            state=states_array[0],
+            action=np.asarray(action, dtype=float),
+            robot_covariance=self._robot_transition_dist.covariance,
+            opponent_covariance=self._opponent_transition_dist.covariance,
+            pursuit_speed=self.pursuit_speed,
+            walls=self._walls,
+            grid_size=self._grid_size,
+            robot_radius=self.robot_radius,
+            opponent_radius=self.opponent_radius,
+            tag_radius=self.tag_radius,
+        )
+        return np.asarray(kernel.batch_sample(states_array), dtype=np.float64)
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: np.ndarray, observation: Any
+    ) -> np.ndarray:
+        next_states_array = np.ascontiguousarray(np.asarray(next_states, dtype=np.float64))
+        if next_states_array.ndim == 1:
+            next_states_array = next_states_array.reshape(1, -1)
+        observation_array = np.ascontiguousarray(np.asarray(observation, dtype=np.float64))
+        kernel = _native.ContinuousLaserTagObservationCpp(
+            next_state=next_states_array[0],
+            action=np.asarray(action, dtype=float),
+            measurement_noise=self.measurement_noise,
+            walls=self._walls,
+            grid_size=self._grid_size,
+            opponent_radius=self.opponent_radius,
+        )
+        log_probs = np.asarray(
+            kernel.batch_log_likelihood(
+                next_particles=next_states_array,
+                observation=observation_array,
+            ),
+            dtype=np.float64,
+        )
+        return log_probs
+
     def reward(self, state: np.ndarray, action: np.ndarray) -> float:
         if bool(state[4]):
             return 0.0
@@ -776,6 +818,16 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
     ) -> np.ndarray:
         return super().observation_log_probability(
             next_state, self.action_to_vector[action], observations
+        )
+
+    def sample_next_state_batch(self, states: Any, action: Any) -> np.ndarray:
+        return super().sample_next_state_batch(states, self.action_to_vector[action])
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: Any, observation: Any
+    ) -> np.ndarray:
+        return super().observation_log_probability_per_state(
+            next_states, self.action_to_vector[action], observation
         )
 
     def reward(self, state: np.ndarray, action: Any) -> float:

--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
@@ -497,6 +497,47 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
             next_state=next_state, action=action, observations=observations
         )
 
+    def sample_next_state_batch(self, states: Any, action: np.ndarray) -> np.ndarray:
+        states_array = np.ascontiguousarray(np.asarray(states, dtype=np.float64))
+        if states_array.ndim == 1:
+            states_array = states_array.reshape(1, -1)
+        kernel = _native.ContinuousLightDarkTransitionCpp(
+            state=states_array[0],
+            action=action,
+            covariance=self._state_transition_dist.covariance,
+        )
+        return np.asarray(kernel.batch_sample(states_array), dtype=np.float64)
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: np.ndarray, observation: Any
+    ) -> np.ndarray:
+        if self.observation_model_type != ObservationModelType.NORMAL_NOISE:
+            # NoObsInDark and DistanceBased models lack a native batch kernel;
+            # fall back to the base-class per-state Python loop.
+            return super().observation_log_probability_per_state(
+                next_states=next_states, action=action, observation=observation
+            )
+        next_states_array = np.ascontiguousarray(np.asarray(next_states, dtype=np.float64))
+        if next_states_array.ndim == 1:
+            next_states_array = next_states_array.reshape(1, -1)
+        observation_array = np.ascontiguousarray(np.asarray(observation, dtype=np.float64))
+        kernel = _native.ContinuousLightDarkObservationCpp(
+            next_state=next_states_array[0],
+            action=action,
+            covariance_near=self._obs_dist_near_beacon.covariance,
+            covariance_far=self._obs_dist_far_from_beacon.covariance,
+            beacons=self.beacons,
+            beacon_radius=float(self.beacon_radius),
+            grid_size=float(self.grid_size),
+        )
+        return np.asarray(
+            kernel.batch_log_likelihood(
+                next_particles=next_states_array,
+                observation=observation_array,
+            ),
+            dtype=np.float64,
+        )
+
     def reward(self, state: np.ndarray, action: np.ndarray) -> float:
         return self.reward_model.compute_reward(state, action)
 
@@ -773,6 +814,16 @@ class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, Discrete
     ) -> np.ndarray:
         return super().observation_log_probability(
             next_state, self.action_to_vector[action], observations
+        )
+
+    def sample_next_state_batch(self, states: Any, action: Any) -> np.ndarray:
+        return super().sample_next_state_batch(states, self.action_to_vector[action])
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: Any, observation: Any
+    ) -> np.ndarray:
+        return super().observation_log_probability_per_state(
+            next_states, self.action_to_vector[action], observation
         )
 
     def __eq__(self, other):

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
@@ -391,6 +391,42 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
         probs = np.asarray(kernel.probability(observations))
         return np.log(probs + 1e-300)
 
+    def sample_next_state_batch(self, states: Any, action: int) -> np.ndarray:
+        states_array = np.ascontiguousarray(np.asarray(states, dtype=np.float64))
+        if states_array.ndim == 1:
+            states_array = states_array.reshape(1, -1)
+        kernel = _native.MountainCarTransitionCpp(
+            state=states_array[0],
+            action=action,
+            power=self.power,
+            gravity=self.gravity,
+            max_speed=self.max_speed,
+            min_position=self.min_position,
+            max_position=self.max_position,
+            covariance=self._state_transition_dist.covariance,
+        )
+        return np.asarray(kernel.batch_sample(states_array), dtype=np.float64)
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: int, observation: Any
+    ) -> np.ndarray:
+        next_states_array = np.ascontiguousarray(np.asarray(next_states, dtype=np.float64))
+        if next_states_array.ndim == 1:
+            next_states_array = next_states_array.reshape(1, -1)
+        observation_array = np.ascontiguousarray(np.asarray(observation, dtype=np.float64))
+        kernel = _native.MountainCarObservationCpp(
+            next_state=next_states_array[0],
+            action=action,
+            covariance=self._obs_dist.covariance,
+        )
+        return np.asarray(
+            kernel.batch_log_likelihood(
+                next_particles=next_states_array,
+                observation=observation_array,
+            ),
+            dtype=np.float64,
+        )
+
     def reward(self, state: Tuple[float, float], action: int) -> float:
         position, _ = state
 

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -696,6 +696,51 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
                 probs[idx] = p
         return np.log(probs + 1e-300)
 
+    def sample_next_state_batch(self, states: Any, action: int) -> np.ndarray:
+        if isinstance(states, np.ndarray) and states.ndim == 2:
+            states_array = np.ascontiguousarray(states, dtype=np.float64)
+        else:
+            states_array = np.ascontiguousarray(
+                np.stack([self._require_state_array(s) for s in states]),
+                dtype=np.float64,
+            )
+        kernel = _native.PacManTransitionCpp(
+            state=states_array[0],
+            action=int(action),
+            **self.get_transition_cpp_ctor_kwargs(),
+            patrol_dir_state=self.ghost_patrol_directions,
+        )
+        return np.asarray(kernel.batch_sample(states_array), dtype=np.float64)
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: int, observation: Any
+    ) -> np.ndarray:
+        if isinstance(next_states, np.ndarray) and next_states.ndim == 2:
+            next_states_array = np.ascontiguousarray(next_states, dtype=np.float64)
+        else:
+            next_states_array = np.ascontiguousarray(
+                np.stack([self._require_state_array(s) for s in next_states]),
+                dtype=np.float64,
+            )
+        if isinstance(observation, np.ndarray):
+            observation_array = np.ascontiguousarray(observation, dtype=np.float64).ravel()
+        else:
+            observation_array = np.ascontiguousarray(
+                self.observation_to_array(observation), dtype=np.float64
+            )
+        kernel = _native.PacManObservationCpp(
+            next_state=next_states_array[0],
+            action=int(action),
+            **self.get_observation_cpp_ctor_kwargs(),
+        )
+        return np.asarray(
+            kernel.batch_log_likelihood(
+                next_particles=next_states_array,
+                observation=observation_array,
+            ),
+            dtype=np.float64,
+        )
+
     def reward(self, state: np.ndarray, action: int) -> float:
         """Calculate immediate reward."""
         state = self._require_state_array(state)

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -442,6 +442,44 @@ class ContinuousPushPOMDP(Environment):
             )
         )
 
+    def sample_next_state_batch(self, states: Any, action: np.ndarray) -> np.ndarray:
+        states_array = np.ascontiguousarray(np.asarray(states, dtype=np.float64))
+        if states_array.ndim == 1:
+            states_array = states_array.reshape(1, -1)
+        kernel = _native.ContinuousPushTransitionCpp(
+            state=states_array[0],
+            action=action,
+            grid_size=float(self.grid_size),
+            push_threshold=float(self.push_threshold),
+            friction_coefficient=float(self.friction_coefficient),
+            max_push=float(self.max_push),
+            robot_radius=float(self.robot_radius),
+            obstacles=self.obstacles,
+            covariance=self._state_transition_dist.covariance,
+        )
+        return np.asarray(kernel.batch_sample(states_array), dtype=np.float64)
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: np.ndarray, observation: Any
+    ) -> np.ndarray:
+        next_states_array = np.ascontiguousarray(np.asarray(next_states, dtype=np.float64))
+        if next_states_array.ndim == 1:
+            next_states_array = next_states_array.reshape(1, -1)
+        observation_array = np.ascontiguousarray(np.asarray(observation, dtype=np.float64))
+        kernel = _native.ContinuousPushObservationCpp(
+            next_state=next_states_array[0],
+            action=action,
+            observation_noise=float(self.observation_noise),
+            grid_size=float(self.grid_size),
+        )
+        return np.asarray(
+            kernel.batch_log_likelihood(
+                next_particles=next_states_array,
+                observation=observation_array,
+            ),
+            dtype=np.float64,
+        )
+
     def reward(self, state: np.ndarray, action: np.ndarray) -> float:
         action = np.asarray(action, dtype=float)
         next_state = self._sample_transition(state, action)
@@ -755,4 +793,14 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
     ) -> np.ndarray:
         return super().observation_log_probability(
             next_state, self.action_to_vector[action], observations
+        )
+
+    def sample_next_state_batch(self, states: Any, action: Any) -> np.ndarray:
+        return super().sample_next_state_batch(states, self.action_to_vector[action])
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: Any, observation: Any
+    ) -> np.ndarray:
+        return super().observation_log_probability_per_state(
+            next_states, self.action_to_vector[action], observation
         )

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -474,6 +474,45 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):
         probs = np.asarray(kernel.probability(codes))
         return np.log(probs + 1e-300)
 
+    def sample_next_state_batch(self, states: Any, action: int) -> np.ndarray:
+        states_array = np.ascontiguousarray(np.asarray(states, dtype=np.float64))
+        if states_array.ndim == 1:
+            states_array = states_array.reshape(1, -1)
+        kernel = _native.RockSampleTransitionCpp(
+            state=states_array[0],
+            action=int(action),
+            map_rows=self.map_size[0],
+            map_cols=self.map_size[1],
+            num_rocks=len(self.rock_positions),
+            rock_positions=self._rock_positions_int32,
+            sensor_efficiency=self.sensor_efficiency,
+        )
+        return np.asarray(kernel.batch_sample(states_array), dtype=np.float64)
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: int, observation: Any
+    ) -> np.ndarray:
+        next_states_array = np.ascontiguousarray(np.asarray(next_states, dtype=np.float64))
+        if next_states_array.ndim == 1:
+            next_states_array = next_states_array.reshape(1, -1)
+        kernel = _native.RockSampleObservationCpp(
+            next_state=next_states_array[0],
+            action=int(action),
+            map_rows=self.map_size[0],
+            map_cols=self.map_size[1],
+            num_rocks=len(self.rock_positions),
+            rock_positions=self._rock_positions_int32,
+            sensor_efficiency=self.sensor_efficiency,
+        )
+        observation_code = _OBS_STR_TO_CODE.get(observation, -1)
+        return np.asarray(
+            kernel.batch_log_likelihood(
+                next_particles=next_states_array,
+                observation=int(observation_code),
+            ),
+            dtype=np.float64,
+        )
+
     def sample_next_step(
         self, state: RockSampleState, action: int
     ) -> Tuple[RockSampleState, str, float]:

--- a/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
+++ b/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
@@ -594,6 +594,41 @@ class SafeAntVelocityPOMDP(DiscreteActionsEnvironment):
         probs = np.asarray(kernel.probability(observations))
         return np.log(probs + 1e-300)
 
+    def sample_next_state_batch(self, states: Any, action: int) -> np.ndarray:
+        states_array = np.ascontiguousarray(np.asarray(states, dtype=np.float64))
+        if states_array.ndim == 1:
+            states_array = states_array.reshape(1, -1)
+        kernel = _native.SafeAntVelocityTransitionCpp(
+            state=states_array[0],
+            action=int(action),
+            dt=self.dt,
+            mass=self.mass,
+            damping=self.damping,
+            max_force=self.max_force,
+            force_scales=DEFAULT_FORCE_SCALES,
+        )
+        return np.asarray(kernel.batch_sample(states_array), dtype=np.float64)
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: int, observation: Any
+    ) -> np.ndarray:
+        next_states_array = np.ascontiguousarray(np.asarray(next_states, dtype=np.float64))
+        if next_states_array.ndim == 1:
+            next_states_array = next_states_array.reshape(1, -1)
+        observation_array = np.ascontiguousarray(np.asarray(observation, dtype=np.float64))
+        kernel = _native.SafeAntVelocityObservationCpp(
+            next_state=next_states_array[0],
+            action=int(action),
+            covariance=self._observation_covariance,
+        )
+        return np.asarray(
+            kernel.batch_log_likelihood(
+                next_particles=next_states_array,
+                observation=observation_array,
+            ),
+            dtype=np.float64,
+        )
+
     def sample_next_step(
         self, state: np.ndarray, action: int
     ) -> Tuple[np.ndarray, np.ndarray, float]:


### PR DESCRIPTION
## Summary

Stacked on top of [PR #101](https://github.com/yaacovpariente/POMDPPlanners/pull/101) (PR-C). Part of PR-D in the env-API redesign laid out in \`~/.claude/plans/crispy-booping-scott.md\`.

Adds the last two methods needed for full wrapper-class removal:

\`\`\`python
def sample_next_state_batch(self, states, action) -> Union[np.ndarray, List[Any]]
def observation_log_probability_per_state(self, next_states, action, observation) -> np.ndarray
\`\`\`

Default implementations are per-state Python loops; native-backed envs override to delegate to a single \`kernel.batch_sample(...)\` / \`kernel.batch_log_likelihood(...)\` C++ call.

## Migrates `WeightedParticleBelief._update_weights`

Removes the \`hasattr(transition_model, 'batch_sample')\` dispatching that constructed a wrapper just to detect batch capability. Now always:

\`\`\`python
particles = pomdp.sample_next_state_batch(states=self.particles, action=action)
log_ll    = pomdp.observation_log_probability_per_state(
                next_states=particles, action=action, observation=observation)
next_log_weights = self.log_weights + np.log(self.eps + np.exp(log_ll))
\`\`\`

This was the last remaining production-side wrapper-class dependency. Once merged, PR-D3 can delete the wrapper classes safely.

## Per-state speedups (microbench, N=256–500 particles)

| Env | sample_next_state_batch | observation_log_probability_per_state |
|---|---:|---:|
| MountainCar | 44× | 422× |
| CartPole | 33× | 117× |
| ContinuousLaserTag | 23× | 19× |
| RockSample | 157× | 146× |
| SafeAntVelocity | 46× | 85× |
| PacMan | 50× | 238× |
| ContinuousLightDark | (PFT-DPW recovered 1,038 → 3,170 sims/s) | |
| ContinuousPush | similar | |

## End-to-end bench (sims/sec, 1.0s × 2 trials, median)

| Env | POMCPOW | PFT-DPW |
|---|---:|---:|
| Tiger | 9,036 (flat) | 1,668 (flat) |
| ContinuousLightDarkDiscreteActions | 9,193 (flat) | **3,135 (matches PR-B baseline)** |
| LaserTag | 2,776 (flat) | 217 (flat) |
| Push | 7,188 (flat) | 703 (flat) |

PFT-DPW on continuous envs is now restored after the PR-D simplification of \`_update_weights\` would have regressed it.

## Test plan

- [x] All env tests pass (1406)
- [x] All planner tests pass (76)
- [x] All belief tests pass (2098 total)
- [x] Equivalence with the pre-migration batch path verified at the env level (max abs diff 0–1.1e-16)
- [x] black + pylint + pyright clean

## Next

- **PR-D2**: rewrite ~36 wrapper-attribute-asserting tests via new env helpers (e.g. \`BaseLightDarkPOMDP._is_state_near_beacon\`)
- **PR-D3**: delete the 24 wrapper classes + factory methods + StateTransitionModel/ObservationModel ABCs