### PR TITLE
PR-D2: Add is_state_near_beacon env helper for LightDark

### DIFF
--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/base_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/base_light_dark_pomdp.py
@@ -15,6 +15,7 @@ from POMDPPlanners.core.environment import (
     StateTransitionModel,
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.utils.numba_kernels import any_point_within_radius_kernel
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_visualizer import (
     LightDarkPOMDPVisualizer,
 )
@@ -286,6 +287,19 @@ class BaseLightDarkPOMDP(Environment, ABC):
     @abstractmethod
     def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
         pass
+
+    def is_state_near_beacon(self, state: np.ndarray) -> bool:
+        """Return True if ``state`` lies within ``beacon_radius`` of any beacon.
+
+        Used by tests and observation-model selection logic. Replaces the
+        previous wrapper-attribute access pattern (``model.near_beacon``)
+        with an env-level method that does not require the wrapper class.
+        """
+        return bool(
+            any_point_within_radius_kernel(
+                np.asarray(state, dtype=float), self.beacons, self.beacon_radius
+            )
+        )
 
     def initial_state_dist(self) -> Distribution:
         return DiscreteDistribution(values=[self.start_state], probs=np.array([1.0]))


### PR DESCRIPTION
## Summary

Part of PR-D in the env-API redesign laid out in \`~/.claude/plans/crispy-booping-scott.md\`. Adds a tiny env helper that exposes beacon-proximity check at the env level so wrapper-attribute tests can stop reaching into observation-model internals.

\`\`\`python
class BaseLightDarkPOMDP:
    def is_state_near_beacon(self, state: np.ndarray) -> bool:
        return bool(any_point_within_radius_kernel(state, self.beacons, self.beacon_radius))
\`\`\`

Internally calls the existing numba kernel that the wrapper subclasses already use — same check, same result, just exposed at the env level.

## Why this PR exists

Lots of LightDark tests assert proximity by constructing an observation-model wrapper and checking \`.near_beacon\`. That pattern blocks PR-D3 (which deletes the wrapper classes). After this PR, those tests can call \`env.is_state_near_beacon(state)\` directly.

## Test plan

- [x] LightDark env tests pass (353/353)
- [x] black + pylint + pyright clean

## Next

PR-D3 will delete the 24 wrapper classes + factory methods + ABCs and clean up the now-obsolete wrapper-attribute-asserting tests. Originally I tried to do the test cleanup in this PR but the parallel agents hit usage limits; the cleaner path is to do test deletion + wrapper deletion together in PR-D3 since they're tightly coupled.