### PR TITLE
perf: route PFT-DPW random rollout through native kernel dispatcher

### DIFF
--- a/POMDPPlanners/planners/mcts_planners/pft_dpw.py
+++ b/POMDPPlanners/planners/mcts_planners/pft_dpw.py
@@ -52,6 +52,7 @@ from POMDPPlanners.planners.planners_utils.dpw import (
 from POMDPPlanners.planners.planners_utils.path_simulations_policy_arena import (
     ArenaDoubleProgressiveWideningMCTSPolicy,
 )
+from POMDPPlanners.planners.planners_utils.rollout import random_rollout_action_sampler
 
 
 class PFT_DPW(ArenaDoubleProgressiveWideningMCTSPolicy):
@@ -216,12 +217,26 @@ class PFT_DPW(ArenaDoubleProgressiveWideningMCTSPolicy):
         return next_belief_id, immediate_reward
 
     def _random_rollout(self, state: Any, depth: int) -> float:
-        if depth > self.depth or self.environment.is_terminal(state=state):
-            return 0
-        action = self.action_sampler.sample()
-        next_state, _, reward = self.environment.sample_next_step(state=state, action=action)
-        return reward + self.discount_factor * self._random_rollout(
-            state=next_state, depth=depth + 1
+        # Route through the shared dispatcher so that envs which provide a
+        # native ``simulate_random_rollout`` C++ kernel (e.g. LaserTag, Push,
+        # Pacman, RockSample, ContinuousLightDarkDiscreteActions, ...) skip
+        # the per-step Python ``sample_next_step`` round-trip.
+        #
+        # Depth semantics: the previous Python recursion returned 0 when
+        # ``depth > self.depth`` (i.e. it allowed one final action at
+        # ``depth == self.depth``). ``random_rollout_action_sampler`` /
+        # ``python_random_rollout`` return 0 when ``depth >= max_depth``.
+        # Passing ``max_depth=self.depth + 1`` preserves the boundary
+        # exactly. See the regression test
+        # ``test_random_rollout_depth_semantics_preserved`` in
+        # ``test_pft_dpw.py``.
+        return random_rollout_action_sampler(
+            state=state,
+            depth=depth,
+            action_sampler=self.action_sampler,
+            environment=self.environment,
+            discount_factor=self.discount_factor,
+            max_depth=self.depth + 1,
         )
 
     def sample_existing_belief_node(

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py
@@ -1,10 +1,14 @@
 # pylint: disable=protected-access  # Tests need to access protected members
 import random
+from typing import Any, List
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
 
 from POMDPPlanners.core.belief import get_initial_belief
+from POMDPPlanners.core.distributions import Distribution
+from POMDPPlanners.core.environment import Environment, SpaceInfo, SpaceType
 from POMDPPlanners.core.tree import BeliefNode
 from POMDPPlanners.core.tree.arena import ACTION, BELIEF, Tree
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
@@ -12,6 +16,7 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
 )
 from POMDPPlanners.planners.mcts_planners.pft_dpw import PFT_DPW
 from POMDPPlanners.planners.planners_utils.dpw import (
+    ActionSampler,
     action_progressive_widening,
 )
 from POMDPPlanners.utils.action_samplers import UnitCircleActionSampler
@@ -696,3 +701,155 @@ def test_max_depth_reached_with_timeout(environment, action_sampler):
     assert len(tree.children_ids[root_id]) > 0
     assert tree.visit_count[root_id] > 0
     assert tree.v_value[root_id] is not None
+
+
+# ---------------------------------------------------------------------------
+# Regression test for the native-rollout-dispatcher migration.
+#
+# Background: PFT-DPW used to roll out via a hand-rolled Python recursion
+# that allowed one final action at ``depth == self.depth`` (it returned 0
+# only when ``depth > self.depth``). The migration routes the rollout
+# through ``random_rollout_action_sampler`` whose Python fallback
+# returns 0 when ``depth >= max_depth``. To preserve the old boundary
+# we pass ``max_depth=self.depth + 1``.
+#
+# This test pins the step count down so a future change cannot silently
+# shift the boundary by one.
+# ---------------------------------------------------------------------------
+
+
+class _StepCountingEnv(Environment):
+    """Minimal env that counts ``sample_next_state`` calls. No native rollout kernel."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            discount_factor=0.95,
+            name="StepCountingEnv",
+            space_info=SpaceInfo(
+                action_space=SpaceType.DISCRETE,
+                observation_space=SpaceType.DISCRETE,
+            ),
+        )
+        self.sample_next_state_calls = 0
+
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> Any:
+        self.sample_next_state_calls += 1
+        return state if n_samples == 1 else [state] * n_samples
+
+    def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> Any:
+        return 0 if n_samples == 1 else [0] * n_samples
+
+    def transition_log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+        return np.zeros(len(next_states))
+
+    def observation_log_probability(
+        self, next_state: Any, action: Any, observations: Any
+    ) -> np.ndarray:
+        return np.zeros(len(observations))
+
+    def reward(self, state: Any, action: Any) -> float:
+        return 1.0
+
+    def is_terminal(self, state: Any) -> bool:
+        return False
+
+    def initial_state_dist(self) -> Distribution:
+        mock_dist = Mock(spec=Distribution)
+        mock_dist.sample = Mock(return_value=[0])
+        return mock_dist
+
+    def initial_observation_dist(self) -> Distribution:
+        mock_dist = Mock(spec=Distribution)
+        mock_dist.sample = Mock(return_value=[0])
+        return mock_dist
+
+    def is_equal_observation(self, observation1: Any, observation2: Any) -> bool:
+        return observation1 == observation2
+
+    def get_actions(self) -> List[Any]:
+        return [0, 1, 2]
+
+
+class _SingleActionSampler(ActionSampler):
+    """Always returns the same action; no randomness so step counts are deterministic."""
+
+    def sample(self, belief_node: Any = None) -> Any:
+        return 0
+
+    def get_space(self) -> List[Any]:
+        return [0]
+
+
+def _make_pft_dpw_with_step_counter(self_depth: int) -> PFT_DPW:
+    env = _StepCountingEnv()
+    return PFT_DPW(
+        environment=env,
+        discount_factor=0.95,
+        depth=self_depth,
+        name="StepCountPFT",
+        action_sampler=_SingleActionSampler(),
+        k_a=1.0,
+        alpha_a=0.5,
+        k_o=1.0,
+        alpha_o=0.5,
+        exploration_constant=1.0,
+        n_simulations=1,
+        min_visit_count_per_action=1,
+    )
+
+
+@pytest.mark.parametrize(
+    "self_depth, entry_depth, expected_steps",
+    [
+        # Old: while depth <= self_depth: action; recurse(depth+1). At entry=1,
+        # actions taken at depths 1..self_depth (= self_depth steps).
+        (5, 1, 5),
+        # Entry mid-rollout: actions at depths 3..5 (= 3 steps).
+        (5, 3, 3),
+        # Boundary case: entry == self_depth. Old code allowed exactly one
+        # final action, returning 0 on the recursive call at depth+1.
+        (5, 5, 1),
+        # Out-of-budget: entry == self_depth + 1. Old code returned 0
+        # immediately with no actions taken.
+        (5, 6, 0),
+        # depth == 0 at entry shouldn't happen in practice (rollouts enter
+        # at depth+1 from _simulate_return), but the bound still applies.
+        (3, 0, 4),
+    ],
+)
+def test_random_rollout_depth_semantics_preserved(
+    self_depth: int, entry_depth: int, expected_steps: int
+) -> None:
+    """Verify that routing through ``random_rollout_action_sampler`` preserves step count.
+
+    Purpose: Validates that the native-rollout dispatcher migration in PFT-DPW
+        preserves the original Python recursion's step count exactly. The old
+        code returned 0 when ``depth > self.depth`` (allowing one final action
+        at ``depth == self.depth``); the new code passes ``max_depth=self.depth + 1``
+        to ``random_rollout_action_sampler`` so the ``depth >= max_depth`` boundary
+        stops at the same point.
+
+    Given: A minimal counting environment with no ``simulate_random_rollout``
+        attribute (so the dispatcher falls through to ``python_random_rollout``),
+        a deterministic single-action sampler, a PFT-DPW planner constructed
+        with ``self.depth = self_depth``, and an entry depth ``entry_depth``.
+    When: ``planner._random_rollout(state=0, depth=entry_depth)`` is called once.
+    Then: The number of ``sample_next_state`` calls equals ``expected_steps``,
+        which matches what the original Python recursion would have produced.
+
+    Test type: unit
+    """
+    planner = _make_pft_dpw_with_step_counter(self_depth=self_depth)
+    env = planner.environment
+    assert isinstance(env, _StepCountingEnv)
+    # Sanity: the dispatcher should fall through to python_random_rollout
+    # (i.e. no native rollout on this minimal env).
+    assert not hasattr(env, "simulate_random_rollout")
+
+    env.sample_next_state_calls = 0
+    planner._random_rollout(state=0, depth=entry_depth)
+
+    assert env.sample_next_state_calls == expected_steps, (
+        f"Depth semantics changed: self.depth={self_depth}, entry_depth={entry_depth}, "
+        f"expected {expected_steps} steps, got {env.sample_next_state_calls}."
+    )

--- a/bench_after.txt
+++ b/bench_after.txt
@@ -1,0 +1,31 @@
+/home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:27: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
+  import pkg_resources
+2026-04-26 16:22:37,330 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/environment.py:182 - Initializing ContinuousLightDarkPOMDPDiscreteActions environment with discount factor 0.95
+2026-04-26 16:22:37,330 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/environment.py:182 - Initializing LaserTagPOMDP environment with discount factor 0.95
+2026-04-26 16:22:37,330 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/environment.py:182 - Initializing PushPOMDP environment with discount factor 0.95
+2026-04-26 16:22:37,331 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:306 - Initialized policy: pomcpow_bench (debug=False)
+2026-04-26 16:22:43,527 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:306 - Initialized policy: pomcpow_bench (debug=False)
+2026-04-26 16:22:49,648 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:306 - Initialized policy: pomcpow_bench (debug=False)
+2026-04-26 16:22:55,716 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:306 - Initialized policy: pft_dpw_bench (debug=False)
+2026-04-26 16:23:01,869 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:306 - Initialized policy: pft_dpw_bench (debug=False)
+2026-04-26 16:23:08,077 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:306 - Initialized policy: pft_dpw_bench (debug=False)
+==========================================================================================
+ PFT-DPW native-rollout bench
+ seed=42  N_calls=5  budget=1.0s/call  particles=200
+==========================================================================================
+  POMCPOW    ContinuousLightDark    visits=    61,262  wall= 5.052s  sims/sec=    12,126
+  POMCPOW    LaserTag               visits=    57,736  wall= 5.108s  sims/sec=    11,302
+  POMCPOW    Push                   visits=    54,016  wall= 5.057s  sims/sec=    10,681
+  PFT_DPW    ContinuousLightDark    visits=    17,869  wall= 5.127s  sims/sec=     3,485
+  PFT_DPW    LaserTag               visits=    19,196  wall= 5.178s  sims/sec=     3,708
+  PFT_DPW    Push                   visits=    17,978  wall= 5.123s  sims/sec=     3,509
+
+Markdown:
+| planner | env | sims/sec |
+|---|---|---|
+| POMCPOW | ContinuousLightDark | 12,126 |
+| POMCPOW | LaserTag | 11,302 |
+| POMCPOW | Push | 10,681 |
+| PFT_DPW | ContinuousLightDark | 3,485 |
+| PFT_DPW | LaserTag | 3,708 |
+| PFT_DPW | Push | 3,509 |

--- a/bench_before.txt
+++ b/bench_before.txt
@@ -1,0 +1,31 @@
+/home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:27: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
+  import pkg_resources
+2026-04-26 16:15:33,142 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/environment.py:182 - Initializing ContinuousLightDarkPOMDPDiscreteActions environment with discount factor 0.95
+2026-04-26 16:15:33,142 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/environment.py:182 - Initializing LaserTagPOMDP environment with discount factor 0.95
+2026-04-26 16:15:33,142 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/environment.py:182 - Initializing PushPOMDP environment with discount factor 0.95
+2026-04-26 16:15:33,142 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:306 - Initialized policy: pomcpow_bench (debug=False)
+2026-04-26 16:15:39,365 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:306 - Initialized policy: pomcpow_bench (debug=False)
+2026-04-26 16:15:45,435 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:306 - Initialized policy: pomcpow_bench (debug=False)
+2026-04-26 16:15:51,496 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:306 - Initialized policy: pft_dpw_bench (debug=False)
+2026-04-26 16:15:57,636 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:306 - Initialized policy: pft_dpw_bench (debug=False)
+2026-04-26 16:16:03,731 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a3e4d1cb73e24f637/POMDPPlanners/core/policy.py:306 - Initialized policy: pft_dpw_bench (debug=False)
+==========================================================================================
+ PFT-DPW native-rollout bench
+ seed=42  N_calls=5  budget=1.0s/call  particles=200
+==========================================================================================
+  POMCPOW    ContinuousLightDark    visits=    60,847  wall= 5.071s  sims/sec=    11,999
+  POMCPOW    LaserTag               visits=    56,174  wall= 5.058s  sims/sec=    11,106
+  POMCPOW    Push                   visits=    52,762  wall= 5.051s  sims/sec=    10,445
+  PFT_DPW    ContinuousLightDark    visits=    15,026  wall= 5.114s  sims/sec=     2,938
+  PFT_DPW    LaserTag               visits=    11,871  wall= 5.078s  sims/sec=     2,338
+  PFT_DPW    Push                   visits=    12,785  wall= 5.098s  sims/sec=     2,508
+
+Markdown:
+| planner | env | sims/sec |
+|---|---|---|
+| POMCPOW | ContinuousLightDark | 11,999 |
+| POMCPOW | LaserTag | 11,106 |
+| POMCPOW | Push | 10,445 |
+| PFT_DPW | ContinuousLightDark | 2,938 |
+| PFT_DPW | LaserTag | 2,338 |
+| PFT_DPW | Push | 2,508 |

--- a/bench_pft_dpw_native_rollout.py
+++ b/bench_pft_dpw_native_rollout.py
@@ -1,0 +1,186 @@
+"""Headline sims/sec bench for PFT-DPW native-rollout migration.
+
+Times how many calls to ``planner.action(belief)`` finish in a 1.0 s budget
+on each (planner, env) combination. Reports total root-visit count divided
+by total wall time, averaged across N=5 calls per cell.
+
+Cases:
+  planners: POMCPOW, PFT_DPW
+  envs:     ContinuousLightDark (DiscreteActions variant), LaserTag, Push
+  N=5 calls, 1.0 s budget per call, 200 particles, seed=42
+
+Usage:
+    python bench_pft_dpw_native_rollout.py > bench_before.txt
+    # (apply the patch)
+    python bench_pft_dpw_native_rollout.py > bench_after.txt
+
+The bench measures wall time only (no cProfile) so headline numbers are
+not distorted by tracing overhead.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Any, Callable, Dict, List, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.belief import get_initial_belief
+from POMDPPlanners.planners.mcts_planners.pft_dpw import PFT_DPW
+from POMDPPlanners.planners.mcts_planners.pomcpow import POMCPOW
+from POMDPPlanners.utils.action_samplers import DiscreteActionSampler
+
+
+SEED = 42
+N_PARTICLES = 200
+N_CALLS = 5
+TIME_BUDGET_S = 1.0
+
+PLANNER_PARAMS: Dict[str, Any] = {
+    "discount_factor": 0.95,
+    "depth": 20,
+    "exploration_constant": 1.0,
+    "k_o": 5.0,
+    "k_a": 5.0,
+    "alpha_o": 0.5,
+    "alpha_a": 0.5,
+    "min_visit_count_per_action": 1,
+}
+
+
+def _build_continuous_light_dark() -> Any:
+    # Imported lazily so that pyright treats the env as Any (its concrete
+    # subclass is structurally complete but the abstract-class checker still
+    # flags direct construction at import-time).
+    # pylint: disable=import-outside-toplevel
+    from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+        ContinuousLightDarkPOMDPDiscreteActions,
+    )
+
+    return ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+
+
+def _build_laser_tag() -> Any:
+    # pylint: disable=import-outside-toplevel
+    from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import LaserTagPOMDP
+
+    return LaserTagPOMDP(discount_factor=0.95)
+
+
+def _build_push() -> Any:
+    # pylint: disable=import-outside-toplevel
+    from POMDPPlanners.environments.push_pomdp.push_pomdp import PushPOMDP
+
+    return PushPOMDP(discount_factor=0.95)
+
+
+def _build_envs() -> List[Tuple[str, Any]]:
+    return [
+        ("ContinuousLightDark", _build_continuous_light_dark()),
+        ("LaserTag", _build_laser_tag()),
+        ("Push", _build_push()),
+    ]
+
+
+def _make_pomcpow(env: Any) -> POMCPOW:
+    return POMCPOW(
+        environment=env,
+        action_sampler=DiscreteActionSampler(env.get_actions()),
+        name="pomcpow_bench",
+        time_out_in_seconds=int(TIME_BUDGET_S),
+        n_simulations=None,
+        **PLANNER_PARAMS,
+    )
+
+
+def _make_pft_dpw(env: Any) -> PFT_DPW:
+    return PFT_DPW(
+        environment=env,
+        action_sampler=DiscreteActionSampler(env.get_actions()),
+        name="pft_dpw_bench",
+        time_out_in_seconds=int(TIME_BUDGET_S),
+        n_simulations=None,
+        **PLANNER_PARAMS,
+    )
+
+
+def _root_visit_count(run_data: Any) -> int:
+    for var in run_data.info_variables:
+        if var.name == "root_visit_count":
+            return int(var.value)
+    return 0
+
+
+def _run_calls(planner: Any, belief: Any, n_calls: int) -> Tuple[int, float]:
+    """Run ``planner.action(belief)`` ``n_calls`` times. Return (total_root_visits, total_wall_s)."""
+    total_visits = 0
+    total_wall = 0.0
+    for _ in range(n_calls):
+        t0 = time.perf_counter()
+        _, run_data = planner.action(belief)
+        elapsed = time.perf_counter() - t0
+        total_wall += elapsed
+        total_visits += _root_visit_count(run_data)
+    return total_visits, total_wall
+
+
+def _seed_all(seed: int) -> None:
+    np.random.seed(seed)
+    random.seed(seed)
+
+
+def _bench_cell(
+    planner_name: str,
+    planner_factory: Callable[[Any], Any],
+    env_name: str,
+    env: Any,
+) -> float:
+    _seed_all(SEED)
+    belief = get_initial_belief(env, n_particles=N_PARTICLES)
+    planner = planner_factory(env)
+
+    # Warmup: one call to amortise import / JIT effects.
+    planner.action(belief)
+
+    visits, wall = _run_calls(planner, belief, N_CALLS)
+    sims_per_sec = visits / wall if wall > 0 else 0.0
+    print(
+        f"  {planner_name:<10} {env_name:<22} "
+        f"visits={visits:>10,d}  wall={wall:>6.3f}s  "
+        f"sims/sec={sims_per_sec:>10,.0f}"
+    )
+    return sims_per_sec
+
+
+def main() -> None:
+    print("=" * 90)
+    print(" PFT-DPW native-rollout bench")
+    print(
+        f" seed={SEED}  N_calls={N_CALLS}  budget={TIME_BUDGET_S}s/call  "
+        f"particles={N_PARTICLES}"
+    )
+    print("=" * 90)
+
+    envs = _build_envs()
+    planners: List[Tuple[str, Callable[[Any], Any]]] = [
+        ("POMCPOW", _make_pomcpow),
+        ("PFT_DPW", _make_pft_dpw),
+    ]
+
+    results: List[Tuple[str, str, float]] = []
+    for planner_name, factory in planners:
+        for env_name, env in envs:
+            sps = _bench_cell(planner_name, factory, env_name, env)
+            results.append((planner_name, env_name, sps))
+
+    print()
+    print("Markdown:")
+    print("| planner | env | sims/sec |")
+    print("|---|---|---|")
+    for planner_name, env_name, sps in results:
+        print(f"| {planner_name} | {env_name} | {sps:,.0f} |")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

PFT-DPW's `_random_rollout` was a hand-rolled Python recursion that called `env.sample_next_step` per step, bypassing the per-environment C++ `simulate_random_rollout` kernel that POMCPOW already uses via `random_rollout_action_sampler` (`POMDPPlanners/planners/planners_utils/rollout.py`). This PR replaces the recursion with a single call to that dispatcher so PFT-DPW gets the same native-kernel acceleration POMCPOW gets, with no other behavioral change.

## Why this is a no-behavior-change perf fix

The previous recursion returned `0` only when `depth > self.depth` (i.e. it allowed one final action at `depth == self.depth`), while `random_rollout_action_sampler` / `python_random_rollout` return `0` when `depth >= max_depth`. Passing `max_depth=self.depth + 1` keeps the boundary in the exact same place.

This is pinned by a new parametrized regression test `test_random_rollout_depth_semantics_preserved` in `POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py`. It uses a minimal counting environment with no `simulate_random_rollout` (so the dispatcher falls through to `python_random_rollout`) and asserts that the number of `sample_next_state` calls equals the count the original recursion would have produced — for entries inside, on, and one past the depth boundary. All five cases pass.

## Benchmark

Methodology: `bench_pft_dpw_native_rollout.py` in repo root. 5 calls x 1.0 s budget per call per cell, 200 particles, seed=42. Metric = `total root_visit_count / total wall time`. No cProfile (clean wall-time measurement). Same machine, same Python, same seed for both runs. Raw outputs in `bench_before.txt` (run on `origin/develop`) and `bench_after.txt` (run on this branch).

| planner | env                 | before sims/sec | after sims/sec | speedup |
|---------|---------------------|----------------:|---------------:|--------:|
| POMCPOW | ContinuousLightDark |          11,999 |         12,126 |   1.01x |
| POMCPOW | LaserTag            |          11,106 |         11,302 |   1.02x |
| POMCPOW | Push                |          10,445 |         10,681 |   1.02x |
| PFT_DPW | ContinuousLightDark |           2,938 |          3,485 |   1.19x |
| PFT_DPW | LaserTag            |           2,338 |          3,708 |   1.59x |
| PFT_DPW | Push                |           2,508 |          3,509 |   1.40x |

POMCPOW is unchanged within noise (~+1-2%) as expected — none of its source paths changed. PFT-DPW improves on every env, and the gain scales with rollout cost: LaserTag's longer rollouts see the biggest speedup, ContinuousLightDark (shorter rollouts) the smallest.

(Note: `ContinuousLightDark` here is `ContinuousLightDarkPOMDPDiscreteActions`, the variant that has a native `simulate_random_rollout` kernel and discrete actions usable with `DiscreteActionSampler`.)

## Test plan

- [x] `python -m pyright POMDPPlanners/planners/mcts_planners/pft_dpw.py POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py bench_pft_dpw_native_rollout.py` -> 0 errors, 0 warnings, 0 informations
- [x] `python -m pylint POMDPPlanners/planners/mcts_planners/pft_dpw.py POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py bench_pft_dpw_native_rollout.py` -> 10.00/10
- [x] `pytest POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py -v` -> 20 passed (15 pre-existing + 5 new parametrized boundary cases on the regression test)
- [x] New regression test `test_random_rollout_depth_semantics_preserved` covers entry depths inside the rollout window, at the boundary, and one past it
- [x] Benchmarks confirm POMCPOW unchanged within noise and PFT-DPW improves on all three target envs