### PR TITLE
perf: env-owned hash_observation to skip linear obs lookup in POMCPOW

### DIFF
--- a/POMDPPlanners/core/environment.py
+++ b/POMDPPlanners/core/environment.py
@@ -21,6 +21,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from collections.abc import Hashable
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -129,7 +130,7 @@ register_serializer(SpaceInfo, _serialize_space_info)
 register_deserializer(SpaceInfo, _deserialize_space_info)
 
 
-class Environment(ABC):
+class Environment(ABC):  # pylint: disable=too-many-public-methods
     """Abstract base class for POMDP environments.
 
     This is the core abstract class that all POMDP environments must inherit from.
@@ -421,6 +422,35 @@ class Environment(ABC):
             Subclasses must implement this method to define observation equality.
             This is particularly important for discrete observation spaces.
         """
+
+    def hash_observation(self, observation: Any) -> Hashable:
+        """Return a hashable key consistent with :meth:`is_equal_observation`.
+
+        Used by tree-search planners to index belief children by observation
+        in O(1). The returned key MUST satisfy the contract::
+
+            is_equal_observation(a, b) implies hash_observation(a) == hash_observation(b)
+
+        Args:
+            observation: Observation to hash.
+
+        Returns:
+            A hashable key derived from ``observation`` (default: the
+            observation itself when it is already hashable).
+
+        Raises:
+            NotImplementedError: If the observation is not hashable and the
+                subclass has not provided an override. Subclasses with
+                non-hashable observations (e.g. ``np.ndarray``) MUST override.
+        """
+        try:
+            hash(observation)
+        except TypeError as exc:
+            raise NotImplementedError(
+                f"{type(self).__name__} must override hash_observation "
+                "for non-hashable observations"
+            ) from exc
+        return observation
 
     @abstractmethod
     def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> Any:

--- a/POMDPPlanners/core/tree/arena.py
+++ b/POMDPPlanners/core/tree/arena.py
@@ -45,6 +45,7 @@ observations/actions (e.g. ``np.ndarray``); use the linear-scan
 """
 
 import bisect
+from collections.abc import Hashable
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -161,12 +162,15 @@ class Tree:
         weight: float = 1.0,
         parent_id: Optional[int] = None,
         data: Any = None,
+        obs_key: Optional[Hashable] = None,
     ) -> int:
         """Allocate a belief node and return its ID.
 
         If ``parent_id`` is provided, also: (a) extend the parent's CDF by
-        ``weight``; (b) register ``(parent_id, observation) → node_id`` in
-        ``obs_child_lookup`` if ``observation`` is hashable.
+        ``weight``; (b) register ``(parent_id, key) → node_id`` in
+        ``obs_child_lookup`` where ``key`` is the explicit ``obs_key`` if
+        provided (caller guarantees hashable), or the raw ``observation``
+        (silently dropped if unhashable).
         """
         if not isinstance(belief, Belief):
             # Runtime guard for callers that bypass static typing.
@@ -181,11 +185,23 @@ class Tree:
         self.data[node_id] = data
         if parent_id is not None:
             self._extend_cdf(parent_id, weight_f)
-            try:
-                self.obs_child_lookup[(parent_id, observation)] = node_id
-            except TypeError:
-                pass  # unhashable observation; rely on linear-scan get_belief_child
+            self._register_obs_child(parent_id, observation, obs_key, node_id)
         return node_id
+
+    def _register_obs_child(
+        self,
+        parent_id: int,
+        observation: Any,
+        obs_key: Optional[Hashable],
+        node_id: int,
+    ) -> None:
+        if obs_key is not None:
+            self.obs_child_lookup[(parent_id, obs_key)] = node_id
+            return
+        try:
+            self.obs_child_lookup[(parent_id, observation)] = node_id
+        except TypeError:
+            pass  # unhashable observation; rely on linear-scan get_belief_child
 
     def add_action_node(
         self,
@@ -273,11 +289,20 @@ class Tree:
                 return cid
         return None
 
-    def get_belief_child_indexed(self, action_id: int, observation: Any) -> Optional[int]:
-        """O(1) lookup of a belief child of ``action_id`` by hashable observation.
+    def get_belief_child_indexed(
+        self,
+        action_id: int,
+        observation: Any = None,
+        obs_key: Optional[Hashable] = None,
+    ) -> Optional[int]:
+        """O(1) lookup of a belief child of ``action_id`` by hashable key.
 
-        Returns ``None`` if no match or if ``observation`` is not hashable.
+        If ``obs_key`` is provided the caller guarantees it is hashable; the
+        lookup uses it directly. Otherwise, the raw ``observation`` is tried
+        and ``None`` is returned for unhashable values.
         """
+        if obs_key is not None:
+            return self.obs_child_lookup.get((action_id, obs_key))
         try:
             return self.obs_child_lookup.get((action_id, observation))
         except TypeError:

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from enum import Enum
 from pathlib import Path
+from collections.abc import Hashable
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -513,6 +514,11 @@ class ContinuousLaserTagPOMDP(Environment):
             np.asarray(observation1, dtype=float),
             np.asarray(observation2, dtype=float),
         )
+
+    def hash_observation(self, observation: Any) -> Hashable:
+        # is_equal_observation casts to float arrays before comparing;
+        # match that contract by hashing the float64 byte representation.
+        return np.ascontiguousarray(np.asarray(observation, dtype=float)).tobytes()
 
     # ------------------------------------------------------------------
     # Metrics

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/base_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/base_light_dark_pomdp.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
+from collections.abc import Hashable
 from typing import Any, List, Optional, Tuple
 
 import logging
@@ -336,6 +337,12 @@ class BaseLightDarkPOMDP(Environment, ABC):
 
     def is_equal_observation(self, observation1: Any, observation2: Any) -> bool:
         return np.array_equal(observation1, observation2)
+
+    def hash_observation(self, observation: Any) -> Hashable:
+        # ndarray observations are not hashable; ``tobytes()`` matches
+        # ``np.array_equal`` byte-for-byte for arrays of the same shape/dtype,
+        # which is invariant for this environment's observations.
+        return np.ascontiguousarray(observation).tobytes()
 
     @property
     def config_id(self) -> str:

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -26,6 +26,7 @@ Classes:
 import math
 from enum import Enum
 from pathlib import Path
+from collections.abc import Hashable
 from typing import Any, List, Optional, Tuple
 
 import numpy as np
@@ -472,6 +473,11 @@ class PushPOMDP(DiscreteActionsEnvironment):
 
     def is_equal_observation(self, observation1: np.ndarray, observation2: np.ndarray) -> bool:
         return np.array_equal(observation1, observation2)
+
+    def hash_observation(self, observation: Any) -> Hashable:
+        # ndarray observations are unhashable; ``tobytes()`` is consistent with
+        # ``np.array_equal`` for fixed-shape/dtype observations of this env.
+        return np.ascontiguousarray(observation).tobytes()
 
     def _get_native_rollout_obstacles(self) -> np.ndarray:
         # Returns (M, 2) float64 array of obstacle centres; cached on first call.

--- a/POMDPPlanners/planners/mcts_planners/pomcpow.py
+++ b/POMDPPlanners/planners/mcts_planners/pomcpow.py
@@ -198,8 +198,17 @@ class POMCPOW(
         children_count = len(tree.children_ids[action_id])
         action_visits = tree.visit_count[action_id]
         if children_count <= self.k_o * action_visits**self.alpha_o:
-            existing_id = tree.get_belief_child_indexed(action_id, observation)
-            if existing_id is None:
+            try:
+                obs_key = self.environment.hash_observation(observation)
+                # Indexed lookup is authoritative when obs_key is available.
+                # The contract on ``hash_observation`` guarantees:
+                #   is_equal_observation(a, b) ==> hash_observation(a) ==
+                #   hash_observation(b)
+                # so a None result means no equal observation has been added.
+                existing_id = tree.get_belief_child_indexed(action_id, obs_key=obs_key)
+            except NotImplementedError:
+                # Env not migrated; fall back to linear-scan path.
+                obs_key = None
                 existing_id = tree.get_belief_child(action_id, observation, self.environment)
             if existing_id is None:
                 next_belief_id = tree.add_belief_node(
@@ -207,6 +216,7 @@ class POMCPOW(
                     observation=observation,
                     parent_id=action_id,
                     weight=1.0,
+                    obs_key=obs_key,
                 )
             else:
                 tree.increment_weight(existing_id, delta=1.0)

--- a/POMDPPlanners/tests/test_core/test_environment.py
+++ b/POMDPPlanners/tests/test_core/test_environment.py
@@ -478,3 +478,53 @@ class TestEnvironmentLogger:
         env.logger.info("Test message to trigger directory creation")
         # Note: In queue-based logging, the logs directory is created by the writer thread
         # when the first message is processed, so we can't immediately assert its existence
+
+
+class TestHashObservationDefault:
+    """Default ``Environment.hash_observation`` behaviour."""
+
+    def test_returns_observation_when_already_hashable(self, base_environment: MockEnvironment):
+        """Default hash_observation returns the observation if already hashable.
+
+        Purpose: Validates the default identity-based key for hashable observations
+
+        Given: MockEnvironment instance and a hashable observation (string)
+        When: hash_observation is called with the hashable observation
+        Then: The returned key equals the observation itself
+
+        Test type: unit
+        """
+        assert base_environment.hash_observation("o1") == "o1"
+        assert base_environment.hash_observation((1, 2, 3)) == (1, 2, 3)
+        assert base_environment.hash_observation(7) == 7
+
+    def test_raises_not_implemented_for_unhashable(self, base_environment: MockEnvironment):
+        """Default hash_observation raises NotImplementedError for unhashable inputs.
+
+        Purpose: Validates that unmigrated envs surface a clear error for ndarray observations
+
+        Given: MockEnvironment instance and a non-hashable np.ndarray observation
+        When: hash_observation is called with the ndarray
+        Then: NotImplementedError is raised mentioning the env class name
+
+        Test type: unit
+        """
+        observation = np.array([1.0, 2.0, 3.0])
+        with pytest.raises(NotImplementedError, match="MockEnvironment"):
+            base_environment.hash_observation(observation)
+
+    def test_returned_key_is_consistent_with_is_equal_observation(
+        self, base_environment: MockEnvironment
+    ):
+        """Default hash_observation respects the equality contract for hashables.
+
+        Purpose: Validates is_equal_observation(a, b) implies equal hashes for default impl
+
+        Given: MockEnvironment and two equal hashable observations plus an unequal pair
+        When: hash_observation is computed for each pair
+        Then: Equal observations share a key; unequal observations differ in key
+
+        Test type: unit
+        """
+        assert base_environment.hash_observation("a") == base_environment.hash_observation("a")
+        assert base_environment.hash_observation("a") != base_environment.hash_observation("b")

--- a/POMDPPlanners/tests/test_core/test_hash_observation_contract.py
+++ b/POMDPPlanners/tests/test_core/test_hash_observation_contract.py
@@ -1,0 +1,263 @@
+"""Contract and integration tests for ``Environment.hash_observation``.
+
+Validates the contract pair with ``is_equal_observation`` for the three envs
+that drive POMCPOW's observation widening hot path
+(ContinuousLightDark, LaserTag, Push), and that POMCPOW's observation
+indexing actually populates the tree's ``obs_child_lookup`` for those envs.
+"""
+
+# pylint: disable=protected-access  # tests inspect internal lookup dict
+
+import random
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief import get_initial_belief
+from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_pomdp import (
+    ContinuousLaserTagPOMDPDiscreteActions,
+)
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import LaserTagPOMDP
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ContinuousLightDarkPOMDPDiscreteActions,
+)
+from POMDPPlanners.environments.push_pomdp.push_pomdp import PushPOMDP
+from POMDPPlanners.planners.mcts_planners.pomcpow import POMCPOW
+from POMDPPlanners.planners.planners_utils.dpw import ActionSampler
+
+
+np.random.seed(42)
+random.seed(42)
+
+
+class _DiscreteActionSampler(ActionSampler):
+    """Trivial action sampler over a fixed list of discrete actions."""
+
+    def __init__(self, actions):
+        self._actions = list(actions)
+
+    def sample(self, belief_node=None):
+        return self._actions[int(np.random.randint(0, len(self._actions)))]
+
+    def get_space(self):
+        return self._actions
+
+
+def _make_continuous_light_dark():
+    return ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+
+
+def _make_continuous_laser_tag():
+    return ContinuousLaserTagPOMDPDiscreteActions(discount_factor=0.95)
+
+
+def _make_laser_tag():
+    return LaserTagPOMDP(discount_factor=0.95)
+
+
+def _make_push():
+    return PushPOMDP(discount_factor=0.95)
+
+
+# ---------------------------------------------------------------------------
+# Contract tests: is_equal_observation(a, b) implies hash_observation(a) ==
+# hash_observation(b) for envs whose observations are non-hashable (ndarray).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "env_factory,observation",
+    [
+        (_make_continuous_light_dark, np.array([1.5, -2.0])),
+        (_make_continuous_laser_tag, np.array([0.4, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7])),
+        (_make_push, np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])),
+    ],
+)
+def test_hash_observation_self_equal(env_factory, observation):
+    """hash_observation is reflexive: an observation hashes equal to itself.
+
+    Purpose: Validates the trivial reflexive contract for ndarray observations
+
+    Given: An environment with non-hashable ndarray observations and a sample observation
+    When: hash_observation is called twice on the same observation
+    Then: The two returned keys are equal and is_equal_observation also returns True
+
+    Test type: unit
+    """
+    env = env_factory()
+    key_a = env.hash_observation(observation)
+    key_b = env.hash_observation(observation.copy())
+    assert key_a == key_b
+    assert env.is_equal_observation(observation, observation.copy())
+
+
+@pytest.mark.parametrize(
+    "env_factory,obs_a,obs_b",
+    [
+        (_make_continuous_light_dark, np.array([1.5, -2.0]), np.array([1.5, -2.0])),
+        (
+            _make_continuous_laser_tag,
+            np.array([0.4, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7]),
+            np.array([0.4, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7]),
+        ),
+        (
+            _make_push,
+            np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
+            np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
+        ),
+    ],
+)
+def test_hash_observation_equal_pair(env_factory, obs_a, obs_b):
+    """Equal observations under is_equal_observation share a hash key.
+
+    Purpose: Validates the forward direction of the hash/equality contract
+
+    Given: An environment and two element-wise equal but distinct ndarray observations
+    When: hash_observation is computed for each and is_equal_observation is invoked
+    Then: hash_observation returns identical keys and is_equal_observation returns True
+
+    Test type: unit
+    """
+    env = env_factory()
+    assert env.is_equal_observation(obs_a, obs_b)
+    assert env.hash_observation(obs_a) == env.hash_observation(obs_b)
+
+
+@pytest.mark.parametrize(
+    "env_factory,obs_a,obs_b",
+    [
+        (_make_continuous_light_dark, np.array([1.5, -2.0]), np.array([1.5, 2.0])),
+        (
+            _make_continuous_laser_tag,
+            np.array([0.4, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7]),
+            np.array([0.5, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7]),
+        ),
+        (
+            _make_push,
+            np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
+            np.array([0.0, 1.0, 2.0, 3.0, 4.0, 6.0]),
+        ),
+    ],
+)
+def test_hash_observation_unequal_pair(env_factory, obs_a, obs_b):
+    """Unequal observations produce distinct hash keys.
+
+    Purpose: Validates that the indexed lookup distinguishes different observations
+
+    Given: An environment and two distinct ndarray observations
+    When: hash_observation is computed for each
+    Then: The keys differ and is_equal_observation also returns False
+
+    Test type: unit
+    """
+    env = env_factory()
+    assert not env.is_equal_observation(obs_a, obs_b)
+    assert env.hash_observation(obs_a) != env.hash_observation(obs_b)
+
+
+def test_laser_tag_default_hash_uses_tuple_observations():
+    """LaserTagPOMDP keeps the default hash because its observations are tuples.
+
+    Purpose: Validates that hashable-observation envs work with the default override
+
+    Given: LaserTagPOMDP whose sample_observation returns tuples (already hashable)
+    When: hash_observation is called on a representative tuple observation
+    Then: The returned key equals the tuple and the env did NOT override the default
+
+    Test type: unit
+    """
+    env = _make_laser_tag()
+    sample_tuple = (1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0)
+    assert env.hash_observation(sample_tuple) == sample_tuple
+    # Confirm the LaserTagPOMDP class itself does not define hash_observation;
+    # i.e. it inherits the default from Environment.
+    assert "hash_observation" not in LaserTagPOMDP.__dict__
+
+
+# ---------------------------------------------------------------------------
+# POMCPOW integration: indexed lookup populates obs_child_lookup so the
+# linear scan is short-circuited for the three benchmarked envs.
+# ---------------------------------------------------------------------------
+
+
+def _planner_for(env, action_sampler):
+    return POMCPOW(
+        environment=env,
+        discount_factor=env.discount_factor,
+        depth=10,
+        exploration_constant=1.0,
+        k_o=3.0,
+        k_a=3.0,
+        alpha_o=0.5,
+        alpha_a=0.5,
+        n_simulations=20,
+        action_sampler=action_sampler,
+        name="TestPOMCPOWHashObs",
+    )
+
+
+@pytest.mark.parametrize(
+    "env_factory",
+    [_make_continuous_light_dark, _make_push],
+)
+def test_pomcpow_observation_widening_populates_obs_child_lookup(env_factory, monkeypatch):
+    """POMCPOW's _observation_widening routes through the indexed lookup.
+
+    Purpose: Confirms hash_observation flows through POMCPOW into
+        tree.obs_child_lookup, so the linear-scan fallback is short-circuited
+        for envs with ndarray observations.
+
+    Given: An env with ndarray observations (LightDark or Push) that overrides
+        hash_observation, and a POMCPOW planner running ``_observation_widening``
+        on a small hand-built tree.
+    When: ``_observation_widening`` is invoked twice with the same observation.
+    Then: After the first call ``obs_child_lookup`` has been populated; the
+        second call hits the indexed-lookup fast path (no linear scan via
+        ``get_belief_child``) and bumps the existing child's weight rather
+        than allocating a new one.
+
+    Test type: integration
+    """
+    np.random.seed(0)
+    random.seed(0)
+    env = env_factory()
+    actions = env.get_actions()
+    sampler = _DiscreteActionSampler(actions)
+    planner = _planner_for(env, sampler)
+
+    from POMDPPlanners.core.tree.arena import Tree  # pylint: disable=import-outside-toplevel
+
+    # Hand-build a minimal tree: root belief -> one action node.
+    belief = get_initial_belief(pomdp=env, n_particles=8, resampling=True)
+    tree = Tree()
+    root_id = tree.add_belief_node(belief=belief)
+    tree.visit_count[root_id] += 1
+    action_id = tree.add_action_node(action=actions[0], parent_id=root_id)
+    tree.visit_count[action_id] += 1
+
+    state = belief.sample()
+    next_state = env.sample_next_state(state=state, action=actions[0])
+    observation = env.sample_observation(next_state=next_state, action=actions[0])
+
+    # First call: should add a new belief child and register it in the lookup.
+    first_id = planner._observation_widening(  # pyright: ignore[reportPrivateUsage]
+        tree=tree, action_id=action_id, observation=observation
+    )
+    assert tree.obs_child_lookup, (
+        "_observation_widening must register the new ndarray-keyed child via "
+        "hash_observation in obs_child_lookup"
+    )
+    weight_after_first = tree.weight[first_id]
+
+    # Patch get_belief_child to fail loudly; the second call MUST hit the
+    # indexed fast path and never fall through to the linear scan.
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("get_belief_child should not be called when indexed lookup hits")
+
+    monkeypatch.setattr(tree, "get_belief_child", _boom)
+
+    second_id = planner._observation_widening(  # pyright: ignore[reportPrivateUsage]
+        tree=tree, action_id=action_id, observation=observation
+    )
+    assert second_id == first_id, "indexed lookup should resolve to the existing child"
+    assert tree.weight[second_id] == pytest.approx(weight_after_first + 1.0)


### PR DESCRIPTION
## Summary

Today POMCPOW's `_observation_widening` falls through to a linear scan of `tree.children_ids[action_id]` and `np.array_equal` for every observation, because the tree's `obs_child_lookup` insert silently fails on unhashable keys (ndarray observations from ContinuousLightDark, ContinuousLaserTag, Push). On the bench that scan averaged ~51 children per call and accounted for 20%+ of POMCPOW runtime. This PR adds an env-level `hash_observation(obs) -> Hashable` (contract pair with `is_equal_observation`), overrides it for the three benchmarked envs, and routes the precomputed key from POMCPOW into the tree's indexed lookup so the linear-scan path is bypassed entirely.

## Layering rationale

The environment owns observation type AND equality (`is_equal_observation`), so it should own hashing too. The Tree stays env-agnostic — `add_belief_node` and `get_belief_child_indexed` gain an optional `obs_key` kwarg, and the planner is responsible for computing it. POMCPOW does so via `try: env.hash_observation(...) except NotImplementedError: ...` so unmigrated envs cleanly fall back to today's linear scan — no breaking changes. The default `Environment.hash_observation` returns the observation when hashable and raises `NotImplementedError` otherwise, so envs whose obs are already hashable (Tiger strings, RockSample strings, LaserTag tuples, Sanity ints, etc.) require no change. The three migrated envs (`BaseLightDarkPOMDP`, `ContinuousLaserTagPOMDP`, `PushPOMDP`) override with `tobytes()`-based keys consistent with their existing `np.array_equal`-based equality.

## Benchmark

`bench_hash_observation.py` — 5 calls × 1.0s budget per call, 200 particles, seed=42, headline `sims/sec = total_root_visits / total_wall_time`. Captured to `bench_hash_observation_before.txt` (origin/develop) and `bench_hash_observation_after.txt` (this branch).

| planner  | env       | before sims/sec | after sims/sec | speedup |
| -------- | --------- | --------------: | -------------: | ------: |
| POMCPOW  | lightdark |           7,978 |         17,692 |   2.22x |
| POMCPOW  | lasertag  |           6,440 |         19,030 |   2.95x |
| POMCPOW  | push      |           7,525 |         15,047 |   2.00x |
| PFT_DPW  | lightdark |           3,563 |          3,551 |   1.00x |
| PFT_DPW  | lasertag  |           3,935 |          3,914 |   0.99x |
| PFT_DPW  | push      |           3,491 |          3,524 |   1.01x |

PFT-DPW does not exercise observation indexing (its `_sample_new_belief_node` doesn't reuse belief children by observation), so its numbers are within noise as expected — confirming the speedup comes specifically from the indexed-lookup path POMCPOW uses.

## Test plan

- [x] `python -m pyright` clean (0 errors, 0 warnings) on every modified source and test file
- [x] `python -m pylint` rating unchanged from `origin/develop` baseline (9.95/10 with only pre-existing warnings; new files alone score 10.00/10)
- [x] `pytest POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp.py POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcpow.py POMDPPlanners/tests/test_core/ POMDPPlanners/tests/test_environments/test_light_dark_pomdp/ POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/ POMDPPlanners/tests/test_environments/test_push_pomdp/` — 1191 passed
- [x] New `TestHashObservationDefault` tests in `tests/test_core/test_environment.py` cover the default `hash_observation` (returns hashable obs identity, raises `NotImplementedError` for unhashable obs, contract for hashables)
- [x] New `tests/test_core/test_hash_observation_contract.py` covers the `is_equal_observation ⇒ hash_observation` contract for LightDark / ContinuousLaserTag / Push, the no-override path for LaserTagPOMDP (tuple obs), and a POMCPOW integration test that monkey-patches `Tree.get_belief_child` to fail loudly and confirms the indexed-lookup fast path resolves the second call to the same observation