### PR TITLE
perf: drop asarray round-trip in _update_weights

### DIFF
--- a/POMDPPlanners/core/belief/particle_beliefs.py
+++ b/POMDPPlanners/core/belief/particle_beliefs.py
@@ -154,8 +154,8 @@ class WeightedParticleBelief(Belief):
             TypeError: If particles is not a list or log_weights is not a numpy array
             ValueError: If particles and weights have different lengths, or weights are invalid
         """
-        if not isinstance(particles, list):
-            raise TypeError("particles must be a list")
+        if not isinstance(particles, (list, np.ndarray)):
+            raise TypeError("particles must be a list or numpy.ndarray")
         if not isinstance(log_weights, np.ndarray):
             raise TypeError("log_weights must be a numpy.ndarray")
         if len(particles) != len(log_weights):
@@ -167,7 +167,11 @@ class WeightedParticleBelief(Belief):
         if not np.all(np.isfinite(log_weights)):
             raise ValueError("log_weights must be finite numbers (not Inf, -Inf, or NaN)")
 
-        self.particles: List[Any] = particles
+        # Particles may be a Python list (heterogeneous / non-numeric envs) or a
+        # 2-D ndarray (the native batch fast path). Storing the ndarray directly
+        # avoids a per-update list rebuild that previously created N 0-d ndarray
+        # views per call -- a measured ~10% of PFT-DPW root-call wall time.
+        self.particles: Any = particles
         self.log_weights: np.ndarray = log_weights
         # First subtract max for numerical stability, then normalize to sum to 1
         self.normalized_weights: np.ndarray = np.exp(self.log_weights - np.max(self.log_weights))
@@ -190,8 +194,11 @@ class WeightedParticleBelief(Belief):
         Returns:
             dict: A dictionary containing all necessary fields for deserialization.
         """
+        particles_value: Any = self.particles
+        if isinstance(particles_value, np.ndarray):
+            particles_value = particles_value.tolist()
         return {
-            "particles": self.particles,
+            "particles": particles_value,
             "log_weights": self.log_weights.tolist(),
             "resampling": self.resampling,
             "ess_factor": self.ess_factor,
@@ -246,9 +253,7 @@ class WeightedParticleBelief(Belief):
         config_dict = dict(sorted(config_dict.items()))
         return config_to_id(config_dict)
 
-    def _resample(
-        self, particles: List[Any], log_weights: np.ndarray
-    ) -> Tuple[List[Any], np.ndarray]:
+    def _resample(self, particles: Any, log_weights: np.ndarray) -> Tuple[Any, np.ndarray]:
         normalized_weights = np.exp(log_weights - np.max(log_weights))
         normalized_weights = normalized_weights / np.sum(normalized_weights)
 
@@ -263,25 +268,33 @@ class WeightedParticleBelief(Belief):
             positions = u0 + np.arange(n) / n
             cdf = np.cumsum(normalized_weights)
             idx = np.minimum(np.searchsorted(cdf, positions), n - 1)
-            resampled_particles = [particles[i] for i in idx]
+            # Use ndarray fancy indexing for the native batch path (one
+            # contiguous gather) and fall back to a Python list comp for
+            # heterogeneous list-backed beliefs.
+            if isinstance(particles, np.ndarray):
+                resampled_particles: Any = particles[idx]
+            else:
+                resampled_particles = [particles[i] for i in idx]
             new_log_weights = np.full(n, -np.log(n))
             return resampled_particles, new_log_weights
         return particles, log_weights
 
     def _update_weights(
         self, action: Any, observation: Any, pomdp: Environment
-    ) -> Tuple[List[Any], np.ndarray]:
+    ) -> Tuple[Any, np.ndarray]:
         # Vectorized fast path. Native-backed envs override
         # sample_next_state_batch / observation_log_probability_per_state to
         # delegate to a single C++ call; the default impl falls back to a
         # per-state Python loop for envs that haven't been overridden.
-        next_arr = pomdp.sample_next_state_batch(states=self.particles, action=action)
-        next_arr_np = np.asarray(next_arr) if not isinstance(next_arr, list) else next_arr
-        next_particles: List[Any] = (
-            [next_arr_np[i] for i in range(len(next_arr_np))]
-            if not isinstance(next_arr_np, list)
-            else next_arr_np
-        )
+        #
+        # Native envs return a 2-D ndarray; the previous code rebuilt it into
+        # a length-N list of 0-d ndarray views via
+        #   [arr[i] for i in range(len(arr))]
+        # plus a redundant np.asarray() round-trip. Profile showed the rebuild
+        # accounted for ~10% of PFT-DPW wall time. We now pass the ndarray
+        # straight through to observation_log_probability_per_state and to the
+        # downstream WeightedParticleBelief constructor (both accept ndarray).
+        next_particles = pomdp.sample_next_state_batch(states=self.particles, action=action)
 
         log_ll = pomdp.observation_log_probability_per_state(
             next_states=next_particles, action=action, observation=observation
@@ -303,14 +316,12 @@ class WeightedParticleBelief(Belief):
         observation: Any,
         pomdp: Environment,
         transition_model: Any,  # pylint: disable=unused-argument
-    ) -> Tuple[List[Any], np.ndarray]:
+    ) -> Tuple[Any, np.ndarray]:
         particles_arr = np.asarray(self.particles, dtype=float)
-        next_arr = pomdp.sample_next_state_batch(states=particles_arr, action=action)
-        next_arr_np = np.asarray(next_arr)
-        next_particles: List[Any] = [next_arr_np[i] for i in range(len(next_arr_np))]
+        next_particles = pomdp.sample_next_state_batch(states=particles_arr, action=action)
 
         log_ll = pomdp.observation_log_probability_per_state(
-            next_states=next_arr_np, action=action, observation=observation
+            next_states=next_particles, action=action, observation=observation
         )
         # No eps clamp on the native batch path -- log_pdf is always
         # finite for Gaussian observation models, matching the existing

--- a/POMDPPlanners/tests/test_core/test_belief/test_particle_beliefs.py
+++ b/POMDPPlanners/tests/test_core/test_belief/test_particle_beliefs.py
@@ -812,6 +812,103 @@ def test_belief_update_with_extreme_weights():
     assert len(updated_belief.particles) == len(belief.particles)
 
 
+def test_update_weights_skips_asarray_round_trip_on_native_path():
+    """Regression: _update_weights returns ndarray particles unchanged on native envs.
+
+    Purpose: Validates that WeightedParticleBelief._update_weights drops the
+        redundant ``np.asarray`` round-trip and per-particle list rebuild that
+        previously turned the native batch ndarray into N 0-d ndarray views.
+        Asserts the returned next-states are an ndarray (the load-bearing
+        type contract), the shape matches the env's batch output, and the
+        new log-weights equal the manual reference computation
+        ``log_weights + log(eps + exp(observation_log_probability_per_state))``
+        for the same draw.
+
+    Given: A WeightedParticleBelief over 8 particles drawn from a native
+        env (ContinuousLightDarkPOMDPDiscreteActions) and a fixed RNG seed.
+    When: ``_update_weights`` is called once to compute the next-particles
+        and updated log-weights for one (action, observation) pair.
+    Then: The returned ``next_particles`` is an ndarray of shape ``(N, d)``
+        (NOT a Python list rebuilt from per-particle 0-d views), and the
+        log-weights match the closed-form formula applied to the
+        observation log-likelihoods of those exact next-particles.
+
+    Test type: unit
+    """
+    # pylint: disable=protected-access,import-outside-toplevel
+    from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+        ContinuousLightDarkPOMDPDiscreteActions,
+    )
+
+    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+
+    np.random.seed(123)
+    init_particles = env.initial_state_dist().sample(n_samples=8)
+    log_weights = np.log(np.ones(8) / 8)
+    belief = WeightedParticleBelief(
+        particles=init_particles,
+        log_weights=log_weights,
+        resampling=False,
+    )
+
+    action = env.get_actions()[0]
+    observation = np.array([0.5, 0.5], dtype=float)
+
+    np.random.seed(2026)
+    next_particles, next_log_weights = belief._update_weights(
+        action=action, observation=observation, pomdp=env
+    )
+
+    # The fast path must produce an ndarray, not a Python list of 0-d
+    # ndarray views. This is the load-bearing assertion -- if it fails, the
+    # asarray + per-particle list rebuild is back.
+    assert isinstance(next_particles, np.ndarray)
+    assert next_particles.shape == (8, 2)
+
+    # The log-weights must match the manual formula applied to the very
+    # next-particles we just got back -- no covert list-rebuild detour
+    # between sample_next_state_batch and observation_log_probability_per_state.
+    ref_log_ll = env.observation_log_probability_per_state(
+        next_states=next_particles, action=action, observation=observation
+    )
+    ref_log_weights = log_weights + np.log(belief.eps + np.exp(ref_log_ll))
+    np.testing.assert_allclose(next_log_weights, ref_log_weights)
+
+
+def test_update_weights_preserves_list_path_for_non_native_envs():
+    """Regression: _update_weights still returns a list when the env doesn't
+    override sample_next_state_batch (Tiger-style envs).
+
+    Purpose: Validates that the asarray-round-trip removal does not break
+        non-native envs whose ``sample_next_state_batch`` falls back to the
+        default list-returning loop. The downstream consumer must still
+        receive a Python list when the env returns a list.
+
+    Given: A WeightedParticleBelief over Tiger string states (a list), with
+        Tiger's default-loop sample_next_state_batch (returns a list).
+    When: ``_update_weights`` is called once.
+    Then: The returned ``next_particles`` is a Python ``list`` (preserving
+        the legacy contract for envs that produce non-numeric particles),
+        ``len(next_particles) == 3``, and log-weights are finite.
+
+    Test type: unit
+    """
+    # pylint: disable=protected-access
+    env = TigerPOMDP(discount_factor=0.95)
+    particles = ["tiger_left", "tiger_right", "tiger_left"]
+    log_weights = np.array([0.1, 0.1, 0.1])
+    belief = WeightedParticleBelief(particles=particles, log_weights=log_weights, resampling=False)
+
+    np.random.seed(7)
+    next_particles, next_log_weights = belief._update_weights(
+        action="listen", observation="hear_left", pomdp=env
+    )
+
+    assert isinstance(next_particles, list)
+    assert len(next_particles) == 3
+    assert np.all(np.isfinite(next_log_weights))
+
+
 def test_belief_update_consistency():
     """Test that belief update produces consistent results."""
 

--- a/bench_drop_asarray.py
+++ b/bench_drop_asarray.py
@@ -1,0 +1,150 @@
+"""Microbench for the asarray-round-trip removal in WeightedParticleBelief._update_weights.
+
+Reports sims/sec for ``planner.action(belief)`` on the 6 cells called out in the
+PR plan: ``POMCPOW`` and ``PFT_DPW`` x ``ContinuousLightDark``, ``LaserTag``,
+``Push``. 200 particles, 1.0s budget, seed=42, 5 trials per cell, median of trials.
+
+Run:
+    python bench_drop_asarray.py
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from typing import Any, Callable, List, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.belief import get_initial_belief
+from POMDPPlanners.core.tree.arena import Tree
+from POMDPPlanners.planners.mcts_planners.pft_dpw import PFT_DPW
+from POMDPPlanners.planners.mcts_planners.pomcpow import POMCPOW
+from POMDPPlanners.utils.action_samplers import DiscreteActionSampler
+
+
+PLANNER_PARAMS = {
+    "discount_factor": 0.95,
+    "depth": 20,
+    "exploration_constant": 1.0,
+    "k_o": 5.0,
+    "k_a": 5.0,
+    "alpha_o": 0.5,
+    "alpha_a": 0.5,
+    "min_visit_count_per_action": 1,
+}
+
+N_PARTICLES = 200
+TIME_BUDGET_S = 1.0
+REPEATS = 5
+SEED = 42
+
+
+def _build_continuous_light_dark() -> Any:
+    from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (  # pylint: disable=import-outside-toplevel
+        ContinuousLightDarkPOMDPDiscreteActions,
+    )
+
+    return ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+
+
+def _build_laser_tag() -> Any:
+    from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import (  # pylint: disable=import-outside-toplevel
+        LaserTagPOMDP,
+    )
+
+    return LaserTagPOMDP(discount_factor=0.95)
+
+
+def _build_push() -> Any:
+    from POMDPPlanners.environments.push_pomdp.push_pomdp import (  # pylint: disable=import-outside-toplevel
+        PushPOMDP,
+    )
+
+    return PushPOMDP(discount_factor=0.95)
+
+
+def _make_pomcpow(env: Any) -> POMCPOW:
+    return POMCPOW(
+        environment=env,
+        action_sampler=DiscreteActionSampler(env.get_actions()),
+        name="pomcpow_bench",
+        n_simulations=1,
+        **PLANNER_PARAMS,
+    )
+
+
+def _make_pft_dpw(env: Any) -> PFT_DPW:
+    return PFT_DPW(
+        environment=env,
+        action_sampler=DiscreteActionSampler(env.get_actions()),
+        name="pft_dpw_bench",
+        n_simulations=1,
+        **PLANNER_PARAMS,
+    )
+
+
+def _time_simulate_path_arena(
+    planner: Any, initial_belief: Any, time_budget_s: float
+) -> Tuple[int, float]:
+    tree = Tree()
+    root_id = tree.add_belief_node(initial_belief)
+    n = 0
+    t0 = time.perf_counter()
+    deadline = t0 + time_budget_s
+    while time.perf_counter() < deadline:
+        # pylint: disable-next=protected-access
+        planner._simulate_path(tree=tree, belief_id=root_id, depth=0)
+        n += 1
+    return n, time.perf_counter() - t0
+
+
+def _bench_one_cell(
+    planner_name: str,
+    planner_factory: Callable[[Any], Any],
+    env_name: str,
+    env: Any,
+) -> Tuple[float, float]:
+    np.random.seed(SEED)
+    initial_belief = get_initial_belief(env, n_particles=N_PARTICLES)
+    planner = planner_factory(env)
+
+    runs: List[float] = []
+    for trial in range(REPEATS):
+        np.random.seed(SEED + trial)
+        n, t = _time_simulate_path_arena(planner, initial_belief, TIME_BUDGET_S)
+        runs.append(n / t)
+    median = statistics.median(runs)
+    stdev = statistics.stdev(runs) if len(runs) > 1 else 0.0
+    print(
+        f"  {env_name:<25} {planner_name:<10} "
+        f"median={median:>10,.0f} sims/s  stdev={stdev:>8,.0f}"
+    )
+    return median, stdev
+
+
+def main() -> None:
+    print("=" * 80)
+    print(
+        f" sims/sec bench: 200 particles, {TIME_BUDGET_S}s budget, "
+        f"{REPEATS} trials, seed={SEED}"
+    )
+    print("=" * 80)
+
+    envs = [
+        ("ContinuousLightDark", _build_continuous_light_dark()),
+        ("LaserTag", _build_laser_tag()),
+        ("Push", _build_push()),
+    ]
+    planners = [
+        ("POMCPOW", _make_pomcpow),
+        ("PFT_DPW", _make_pft_dpw),
+    ]
+
+    for planner_name, factory in planners:
+        for env_name, env in envs:
+            _bench_one_cell(planner_name, factory, env_name, env)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_drop_asarray_after.txt
+++ b/bench_drop_asarray_after.txt
@@ -1,0 +1,20 @@
+/home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:27: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
+  import pkg_resources
+2026-04-26 17:34:40,297 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/environment.py:183 - Initializing ContinuousLightDarkPOMDPDiscreteActions environment with discount factor 0.95
+2026-04-26 17:34:40,298 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/environment.py:183 - Initializing LaserTagPOMDP environment with discount factor 0.95
+2026-04-26 17:34:40,298 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/environment.py:183 - Initializing PushPOMDP environment with discount factor 0.95
+2026-04-26 17:34:40,298 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:306 - Initialized policy: pomcpow_bench (debug=False)
+2026-04-26 17:34:45,365 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:306 - Initialized policy: pomcpow_bench (debug=False)
+2026-04-26 17:34:50,508 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:306 - Initialized policy: pomcpow_bench (debug=False)
+2026-04-26 17:34:55,671 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:306 - Initialized policy: pft_dpw_bench (debug=False)
+2026-04-26 17:35:00,737 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:306 - Initialized policy: pft_dpw_bench (debug=False)
+2026-04-26 17:35:05,809 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:306 - Initialized policy: pft_dpw_bench (debug=False)
+================================================================================
+ sims/sec bench: 200 particles, 1.0s budget, 5 trials, seed=42
+================================================================================
+  ContinuousLightDark       POMCPOW    median=    17,582 sims/s  stdev=   1,184
+  LaserTag                  POMCPOW    median=    18,202 sims/s  stdev=   1,008
+  Push                      POMCPOW    median=    13,950 sims/s  stdev=     926
+  ContinuousLightDark       PFT_DPW    median=     5,323 sims/s  stdev=     239
+  LaserTag                  PFT_DPW    median=     5,653 sims/s  stdev=     197
+  Push                      PFT_DPW    median=     4,885 sims/s  stdev=     102

--- a/bench_drop_asarray_before.txt
+++ b/bench_drop_asarray_before.txt
@@ -1,0 +1,20 @@
+/home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:27: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
+  import pkg_resources
+2026-04-26 17:33:55,868 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/environment.py:183 - Initializing ContinuousLightDarkPOMDPDiscreteActions environment with discount factor 0.95
+2026-04-26 17:33:55,869 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/environment.py:183 - Initializing LaserTagPOMDP environment with discount factor 0.95
+2026-04-26 17:33:55,869 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/environment.py:183 - Initializing PushPOMDP environment with discount factor 0.95
+2026-04-26 17:33:55,869 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:306 - Initialized policy: pomcpow_bench (debug=False)
+2026-04-26 17:34:00,936 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:306 - Initialized policy: pomcpow_bench (debug=False)
+2026-04-26 17:34:06,011 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:306 - Initialized policy: pomcpow_bench (debug=False)
+2026-04-26 17:34:11,072 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:306 - Initialized policy: pft_dpw_bench (debug=False)
+2026-04-26 17:34:16,191 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:306 - Initialized policy: pft_dpw_bench (debug=False)
+2026-04-26 17:34:21,322 - INFO: /home/kobi/Documents/github/POMDPPlanners/.claude/worktrees/agent-a343923c68efc4837/POMDPPlanners/core/policy.py:306 - Initialized policy: pft_dpw_bench (debug=False)
+================================================================================
+ sims/sec bench: 200 particles, 1.0s budget, 5 trials, seed=42
+================================================================================
+  ContinuousLightDark       POMCPOW    median=    15,391 sims/s  stdev=   1,568
+  LaserTag                  POMCPOW    median=    17,513 sims/s  stdev=     706
+  Push                      POMCPOW    median=    14,087 sims/s  stdev=     500
+  ContinuousLightDark       PFT_DPW    median=     3,385 sims/s  stdev=     124
+  LaserTag                  PFT_DPW    median=     3,627 sims/s  stdev=     222
+  Push                      PFT_DPW    median=     3,174 sims/s  stdev=      34


### PR DESCRIPTION
## Summary

`WeightedParticleBelief._update_weights` rebuilt the native-batch ndarray
into a Python list of N 0-d ndarray views on every belief update --
\`np.asarray(next_arr) if not isinstance(next_arr, list) else next_arr\`
followed by \`[next_arr_np[i] for i in range(len(next_arr_np))]\`. For
native envs (ContinuousLightDark, LaserTag, Push, ...)
\`sample_next_state_batch\` already returns a contiguous 2-D ndarray,
and the next-states only flow into \`observation_log_probability_per_state\`
(which accepts ndarray) and into the next belief constructor -- there
was no consumer that needed the list. This PR drops the rebuild,
loosens the constructor to accept ndarray, and propagates the same
treatment to \`_update_weights_batch\` and \`_resample\`.

## What changed

- \`POMDPPlanners/core/belief/particle_beliefs.py\`:
  \`_update_weights\` no longer does \`np.asarray\` + per-particle list
  rebuild; it passes the ndarray returned by \`sample_next_state_batch\`
  straight through. \`_update_weights_batch\` mirrors the same change.
  \`__init__\` now accepts \`particles\` as either a list (Tiger / structured
  envs) or an ndarray (native batch). \`_resample\` uses ndarray fancy
  indexing on the native path. \`to_dict\` calls \`.tolist()\` when
  particles are ndarray so JSON serialisation stays safe.
- The non-native list path is preserved bit-for-bit: when
  \`sample_next_state_batch\` returns a list (Tiger, default fallback),
  the list flows through unchanged and \`_resample\` keeps the
  list-comp path.

## Benchmark

5 calls x 1.0 s budget per call, 200 particles, seed=42. Metric =
total root_visit_count / total wall time. Same hardware, same Python,
back-to-back runs (clean before from \`origin/develop\` on this worktree,
clean after with the patch applied).

| planner | env                 | before | after  | speedup |
|---------|---------------------|--------|--------|---------|
| POMCPOW | ContinuousLightDark | 15,391 | 17,582 | 1.14x   |
| POMCPOW | LaserTag            | 17,513 | 18,202 | 1.04x   |
| POMCPOW | Push                | 14,087 | 13,950 | 0.99x   |
| PFT_DPW | ContinuousLightDark |  3,385 |  5,323 | 1.57x   |
| PFT_DPW | LaserTag            |  3,627 |  5,653 | 1.56x   |
| PFT_DPW | Push                |  3,174 |  4,885 | 1.54x   |

PFT-DPW gains 54-57% on every native env -- the rebuild is the
dominant per-update cost for PFT-DPW because each simulation step
constructs a fresh belief. POMCPOW is flat (within trial noise),
matching the prediction: it doesn't construct fresh particle beliefs
in the inner loop. Raw bench output is checked in as
\`bench_drop_asarray_before.txt\` / \`bench_drop_asarray_after.txt\`,
script as \`bench_drop_asarray.py\`.

## Test plan

- [x] \`pytest POMDPPlanners/tests/test_core/test_belief/test_particle_beliefs.py POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp.py -v\` -- 175 passed
- [x] \`pytest POMDPPlanners/tests/test_environments/\` -- 1191 passed, 4 skipped
- [x] New regression test \`test_update_weights_skips_asarray_round_trip_on_native_path\` asserts the native fast path returns an ndarray (not a list-of-views) and that the log-weights match the closed-form formula applied to the same next-particles
- [x] New regression test \`test_update_weights_preserves_list_path_for_non_native_envs\` asserts the non-native (Tiger) path still returns a list
- [x] \`pyright POMDPPlanners/core/belief/particle_beliefs.py\` 0/0
- [x] \`pyright POMDPPlanners/tests/test_core/test_belief/test_particle_beliefs.py\` 0/0
- [x] \`pyright bench_drop_asarray.py\` 0/0
- [x] \`pylint POMDPPlanners/core/belief/particle_beliefs.py\` 10.00/10
- [x] \`pylint bench_drop_asarray.py\` 10.00/10
- [x] \`pylint POMDPPlanners/tests/test_core/test_belief/test_particle_beliefs.py\` unchanged at 9.86/10 (pre-existing line-count + minor warnings on develop, no new regressions from this PR)