### PR TITLE
perf(planners,sampler): scalar action sampler + env-owned hash_action (CLD: POMCPOW 1.35x, PFT-DPW 1.24x)

### DIFF
--- a/POMDPPlanners/core/environment.py
+++ b/POMDPPlanners/core/environment.py
@@ -453,6 +453,28 @@ class Environment(ABC):  # pylint: disable=too-many-public-methods
         return observation
 
     @abstractmethod
+    def hash_action(self, action: Any) -> Hashable:
+        """Return a hashable key consistent with action equality.
+
+        Used by tree-search planners to index action children of a belief
+        node in O(1). The returned key MUST satisfy::
+
+            action_a == action_b   (per env's notion of equality)
+            ==> hash_action(action_a) == hash_action(action_b)
+
+        Subclasses with non-hashable actions (e.g. ``np.ndarray``) must
+        override to return a hashable surrogate (``tobytes()`` is the
+        standard choice for ndarray actions, which mirrors the
+        ``np.array_equal`` semantics used by the linear-scan fallback).
+
+        Args:
+            action: Action to hash.
+
+        Returns:
+            A hashable key derived from ``action``.
+        """
+
+    @abstractmethod
     def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> Any:
         """Sample one or more next states for ``(state, action)``.
 

--- a/POMDPPlanners/core/tree/arena.py
+++ b/POMDPPlanners/core/tree/arena.py
@@ -208,22 +208,37 @@ class Tree:
         action: Any,
         parent_id: int,
         data: Any = None,
+        action_key: Optional[Hashable] = None,
     ) -> int:
         """Allocate an action node under ``parent_id`` and return its ID.
 
         Also: (a) extend the parent's CDF by 1.0 (action nodes default to
-        unit weight); (b) register ``(parent_id, action) → node_id`` in
-        ``action_child_lookup`` if ``action`` is hashable.
+        unit weight); (b) register ``(parent_id, key) → node_id`` in
+        ``action_child_lookup`` where ``key`` is the explicit ``action_key``
+        if provided (caller guarantees hashable), or the raw ``action``
+        (silently dropped if unhashable).
         """
         node_id = self._allocate(ACTION, parent_id)
         self.action[node_id] = action
         self.data[node_id] = data
         self._extend_cdf(parent_id, 1.0)
+        self._register_action_child(parent_id, action, action_key, node_id)
+        return node_id
+
+    def _register_action_child(
+        self,
+        parent_id: int,
+        action: Any,
+        action_key: Optional[Hashable],
+        node_id: int,
+    ) -> None:
+        if action_key is not None:
+            self.action_child_lookup[(parent_id, action_key)] = node_id
+            return
         try:
             self.action_child_lookup[(parent_id, action)] = node_id
         except TypeError:
             pass  # unhashable action; rely on linear-scan get_action_child
-        return node_id
 
     def _extend_cdf(self, parent_id: int, weight: float) -> None:
         cdf = self.children_cdf[parent_id]
@@ -324,11 +339,20 @@ class Tree:
                 return cid
         return None
 
-    def get_action_child_indexed(self, belief_id: int, action: Any) -> Optional[int]:
-        """O(1) lookup of an action child of ``belief_id`` by hashable action.
+    def get_action_child_indexed(
+        self,
+        belief_id: int,
+        action: Any = None,
+        action_key: Optional[Hashable] = None,
+    ) -> Optional[int]:
+        """O(1) lookup of an action child of ``belief_id`` by hashable key.
 
-        Returns ``None`` if no match or if ``action`` is not hashable.
+        If ``action_key`` is provided the caller guarantees it is hashable;
+        the lookup uses it directly. Otherwise, the raw ``action`` is tried
+        and ``None`` is returned for unhashable values.
         """
+        if action_key is not None:
+            return self.action_child_lookup.get((belief_id, action_key))
         try:
             return self.action_child_lookup.get((belief_id, action))
         except TypeError:

--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
@@ -18,6 +18,7 @@ Classes:
 import math
 from enum import Enum
 from pathlib import Path
+from collections.abc import Hashable
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 _INTEGRATOR_CODES: dict[str, int] = {"euler": 0, "semi-implicit euler": 1}
@@ -403,6 +404,10 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
 
     def is_equal_observation(self, observation1: np.ndarray, observation2: np.ndarray) -> bool:
         return np.array_equal(observation1, observation2)
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete int actions (0, 1); already hashable.
+        return action
 
     def get_metric_names(self) -> List[str]:
         """Get names of CartPole POMDP specific metrics.

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -536,6 +536,11 @@ class ContinuousLaserTagPOMDP(Environment):
         # match that contract by hashing the float64 byte representation.
         return np.ascontiguousarray(np.asarray(observation, dtype=float)).tobytes()
 
+    def hash_action(self, action: Any) -> Hashable:
+        # Continuous actions are ndarray of shape (3,); bytes match
+        # np.array_equal semantics for arrays of identical shape and dtype.
+        return np.ascontiguousarray(action, dtype=np.float64).tobytes()
+
     # ------------------------------------------------------------------
     # Metrics
     # ------------------------------------------------------------------
@@ -884,6 +889,10 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
             else:
                 converted.append(step)
         return super()._count_episode_metrics(converted)
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete-action variant: actions are str labels (e.g. "up").
+        return action
 
 
 class _ContinuousLaserTagInitialDist(Distribution):

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -22,6 +22,7 @@ Classes:
 
 from enum import Enum
 from pathlib import Path
+from collections.abc import Hashable
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import numpy as np
@@ -829,6 +830,10 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         Observations are 8-dimensional laser measurements or terminal observations.
         """
         return np.array_equal(observation1, observation2)
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete int actions (0..4); already hashable.
+        return action
 
     def _get_native_rollout_params(
         self,

--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
@@ -26,6 +26,7 @@ Classes:
 """
 
 import math
+from collections.abc import Hashable
 from enum import Enum
 from typing import Any, Dict, List, Sequence, Tuple, Union
 
@@ -789,6 +790,11 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
             and self.observation_model_type == other.observation_model_type
         )
 
+    def hash_action(self, action: Any) -> Hashable:
+        # Continuous actions are ndarray; bytes match np.array_equal semantics
+        # for arrays of identical shape and dtype.
+        return np.ascontiguousarray(action, dtype=np.float64).tobytes()
+
 
 class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, DiscreteActionsEnvironment):
     """Continuous Light-Dark POMDP environment with discrete actions.
@@ -1044,3 +1050,7 @@ class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, Discrete
                 for k, value in self.action_to_vector.items()
             )
         )
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete-action variant: actions are str labels (e.g. "up").
+        return action

--- a/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
@@ -1,5 +1,6 @@
 import random
 from bisect import bisect
+from collections.abc import Hashable
 from enum import Enum
 from typing import Any, List, Sequence, Tuple, Union
 
@@ -871,3 +872,7 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
                 upper_confidence_bound=dangerous_states_counter_ci[1],
             ),
         ]
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete-action env: actions are str labels (e.g. "up").
+        return action

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
@@ -21,6 +21,7 @@ Classes:
 
 from enum import Enum
 from pathlib import Path
+from collections.abc import Hashable
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import matplotlib
@@ -365,6 +366,10 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
         self, observation1: Tuple[float, float], observation2: Tuple[float, float]
     ) -> bool:
         return np.array_equal(observation1, observation2)
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete int actions (-1, 0, 1); already hashable.
+        return action
 
     def get_metric_names(self) -> List[str]:
         """Get names of Mountain Car POMDP specific metrics.

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -20,6 +20,7 @@ Classes:
 
 from enum import Enum
 from pathlib import Path
+from collections.abc import Hashable
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import numpy as np
@@ -872,6 +873,10 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
     def is_equal_observation(self, observation1: Any, observation2: Any) -> bool:
         """Check if two observations are equal."""
         return observation1 == observation2
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete int actions (movement directions); already hashable.
+        return action
 
     # ------------------------------------------------------------------
     # Pickling

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -21,6 +21,7 @@ Classes:
 
 from enum import Enum
 from pathlib import Path
+from collections.abc import Hashable
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -548,6 +549,11 @@ class ContinuousPushPOMDP(Environment):
     def is_equal_observation(self, observation1: np.ndarray, observation2: np.ndarray) -> bool:
         return bool(np.array_equal(observation1, observation2))
 
+    def hash_action(self, action: Any) -> Hashable:
+        # Continuous actions are ndarray of shape (2,); bytes match
+        # np.array_equal semantics for arrays of identical shape and dtype.
+        return np.ascontiguousarray(action, dtype=np.float64).tobytes()
+
     def cache_visualization(self, history: List[StepData], cache_path: Path) -> None:
         """Cache animated visualization of the continuous push episode.
 
@@ -809,3 +815,7 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
         return super().observation_log_probability_per_state(
             next_states, self.action_to_vector[action], observation
         )
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete-action variant: actions are str labels (e.g. "up").
+        return action

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -111,7 +111,7 @@ class RandomInitialStateDistribution(Distribution):
         return np.random.uniform(0, self.grid_size - 1, size=2)
 
 
-class PushPOMDP(DiscreteActionsEnvironment):
+class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-methods
     """Robotic push task formulated as a POMDP.
 
     This environment simulates a robot that must push an object to a target location
@@ -550,6 +550,10 @@ class PushPOMDP(DiscreteActionsEnvironment):
         # ndarray observations are unhashable; ``tobytes()`` is consistent with
         # ``np.array_equal`` for fixed-shape/dtype observations of this env.
         return np.ascontiguousarray(observation).tobytes()
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete-action env: actions are str labels (e.g. "up").
+        return action
 
     def __getstate__(self) -> Dict[str, Any]:
         # Per-action C++ kernel cache holds pybind11 objects that are not

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -15,6 +15,7 @@ Classes:
 import math
 from enum import Enum
 from pathlib import Path
+from collections.abc import Hashable
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -637,6 +638,10 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
     def is_equal_observation(self, observation1: Any, observation2: Any) -> bool:
         """Check if two observations are equal."""
         return observation1 == observation2
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete int actions; already hashable.
+        return action
 
     def get_metric_names(self) -> List[str]:
         """Get names of RockSample POMDP specific metrics.

--- a/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
+++ b/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
@@ -25,6 +25,7 @@ Classes:
 from enum import Enum
 from math import hypot
 from pathlib import Path
+from collections.abc import Hashable
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -267,6 +268,10 @@ class SafeAntVelocityPOMDP(DiscreteActionsEnvironment):
 
     def is_equal_observation(self, observation1: np.ndarray, observation2: np.ndarray) -> bool:
         return np.array_equal(observation1, observation2)
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete int actions (force levels); already hashable.
+        return action
 
     def cache_visualization(self, history: List[StepData], cache_path: Path) -> None:
         """Cache animated visualization of the safety ant velocity episode.

--- a/POMDPPlanners/environments/sanity_pomdp.py
+++ b/POMDPPlanners/environments/sanity_pomdp.py
@@ -24,7 +24,8 @@ Classes:
 """
 
 from pathlib import Path
-from typing import List, Optional, Sequence, Union
+from collections.abc import Hashable
+from typing import Any, List, Optional, Sequence, Union
 
 import numpy as np
 
@@ -266,3 +267,7 @@ class SanityPOMDP(DiscreteActionsEnvironment):
 
     def is_equal_observation(self, observation1: int, observation2: int) -> bool:
         return observation1 == observation2
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete int actions (0, 1); already hashable.
+        return action

--- a/POMDPPlanners/environments/tiger_pomdp.py
+++ b/POMDPPlanners/environments/tiger_pomdp.py
@@ -20,6 +20,7 @@ Classes:
 
 from enum import Enum
 from pathlib import Path
+from collections.abc import Hashable
 from typing import Any, List, Optional, Sequence, Union
 
 import numpy as np
@@ -249,6 +250,10 @@ class TigerPOMDP(DiscreteActionsEnvironment):
 
     def is_equal_observation(self, observation1: Any, observation2: Any) -> bool:
         return observation1 == observation2
+
+    def hash_action(self, action: Any) -> Hashable:
+        # Discrete-action env: actions are str labels (LISTEN/OPEN_LEFT/...).
+        return action
 
     def get_metric_names(self) -> List[str]:
         """Get names of Tiger POMDP specific metrics.

--- a/POMDPPlanners/planners/mcts_planners/icvar_pft_dpw.py
+++ b/POMDPPlanners/planners/mcts_planners/icvar_pft_dpw.py
@@ -129,6 +129,7 @@ class ICVaR_PFT_DPW(ArenaPathSimulationPolicyCostSetting):
             delta=self.delta,
             discrete_actions=self.discrete_actions,
             visit_count_penalty=self.visit_count_penalty,
+            environment=self.environment,
         )
 
         action_children_count = len(tree.children_ids[action_id])

--- a/POMDPPlanners/planners/mcts_planners/icvar_pomcpow.py
+++ b/POMDPPlanners/planners/mcts_planners/icvar_pomcpow.py
@@ -171,6 +171,7 @@ class ICVaR_POMCPOW(ArenaPathSimulationPolicyCostSetting):
             delta=self.delta,
             discrete_actions=self.discrete_actions,
             visit_count_penalty=self.visit_count_penalty,
+            environment=self.environment,
         )
 
     def _select_or_create_observation_node(

--- a/POMDPPlanners/planners/mcts_planners/pft_dpw.py
+++ b/POMDPPlanners/planners/mcts_planners/pft_dpw.py
@@ -161,6 +161,7 @@ class PFT_DPW(ArenaDoubleProgressiveWideningMCTSPolicy):
             exploration_constant=self.exploration_constant,
             k_a=self.k_a,
             min_visit_count_per_action=self.min_visit_count_per_action,
+            environment=self.environment,
         )
 
         return_sample = self._simulate_return(

--- a/POMDPPlanners/planners/mcts_planners/pomcp_dpw.py
+++ b/POMDPPlanners/planners/mcts_planners/pomcp_dpw.py
@@ -147,6 +147,7 @@ class POMCP_DPW(ArenaDoubleProgressiveWideningMCTSPolicy):
             exploration_constant=self.exploration_constant,
             k_a=self.k_a,
             min_visit_count_per_action=self.min_visit_count_per_action,
+            environment=self.environment,
         )
         action = tree.action[action_id]
 

--- a/POMDPPlanners/planners/mcts_planners/pomcpow.py
+++ b/POMDPPlanners/planners/mcts_planners/pomcpow.py
@@ -154,6 +154,7 @@ class POMCPOW(
             exploration_constant=self.exploration_constant,
             k_a=self.k_a,
             min_visit_count_per_action=self.min_visit_count_per_action,
+            environment=self.environment,
         )
         action = tree.action[action_id]
 

--- a/POMDPPlanners/planners/planners_utils/cvar_progressive_widening.py
+++ b/POMDPPlanners/planners/planners_utils/cvar_progressive_widening.py
@@ -1,9 +1,16 @@
-from POMDPPlanners.planners.planners_utils.dpw import ActionSampler, ActionNode
+from typing import Optional
+
+from POMDPPlanners.core.environment import Environment
 from POMDPPlanners.core.tree import BeliefNode
 from POMDPPlanners.core.tree.arena import Tree
 from POMDPPlanners.planners.planners_utils.cvar_exploration import (
     get_explored_action_node,
     get_explored_action_node_arena,
+)
+from POMDPPlanners.planners.planners_utils.dpw import (
+    ActionNode,
+    ActionSampler,
+    _get_or_add_action_child,
 )
 
 
@@ -68,11 +75,16 @@ def cvar_action_progressive_widening_arena(  # pylint: disable=too-many-argument
     delta: float,
     discrete_actions: bool = False,  # pylint: disable=unused-argument
     visit_count_penalty: float = 0.0,
+    environment: Optional[Environment] = None,
 ) -> int:
     """Arena variant of :func:`cvar_action_progressive_widening`.
 
     Returns the action-node ID selected by CVaR-aware progressive widening
     from belief node ``belief_id`` in ``tree``.
+
+    When ``environment`` is supplied, ``environment.hash_action`` is used to
+    index action children in O(1). When omitted, falls back to the legacy
+    linear-scan path for backwards compatibility.
     """
     children = tree.children_ids[belief_id]
     belief_visits = tree.visit_count[belief_id]
@@ -80,13 +92,7 @@ def cvar_action_progressive_widening_arena(  # pylint: disable=too-many-argument
 
     if is_leaf or belief_visits == 0 or len(children) <= k_a * belief_visits**alpha_a:
         action = action_sampler.sample()
-        existing_id = tree.get_action_child_indexed(belief_id, action)
-        if existing_id is not None:
-            return existing_id
-        existing_id = tree.get_action_child(belief_id, action)
-        if existing_id is not None:
-            return existing_id
-        return tree.add_action_node(action=action, parent_id=belief_id)
+        return _get_or_add_action_child(tree, belief_id, action, environment)
 
     return get_explored_action_node_arena(
         tree=tree,

--- a/POMDPPlanners/planners/planners_utils/dpw.py
+++ b/POMDPPlanners/planners/planners_utils/dpw.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 
+from POMDPPlanners.core.environment import Environment
 from POMDPPlanners.core.tree import ActionNode, BeliefNode
 from POMDPPlanners.core.tree.arena import Tree
 
@@ -554,7 +555,7 @@ def ucb1_exploration(belief_node: BeliefNode, exploration_constant: float) -> Ac
     return belief_node.children[np.argmax(ucb)]
 
 
-def action_progressive_widening_arena(
+def action_progressive_widening_arena(  # pylint: disable=too-many-arguments
     tree: Tree,
     belief_id: int,
     alpha_a: float,
@@ -562,12 +563,17 @@ def action_progressive_widening_arena(
     exploration_constant: float,
     k_a: float,
     min_visit_count_per_action: int = 1,
+    environment: Optional[Environment] = None,
 ) -> int:
     """Arena variant of :func:`action_progressive_widening`.
 
     Returns the action-node ID (an int) selected by progressive widening +
     UCB1 from belief node ``belief_id`` in ``tree``. Mirrors the
     semantics of the legacy helper but operates on the column-store tree.
+
+    When ``environment`` is supplied, ``environment.hash_action`` is used to
+    index action children in O(1). When omitted, falls back to the legacy
+    linear-scan path for backwards compatibility.
     """
     # Root-only: ensure every existing action has been visited at least
     # min_visit_count_per_action times before considering widening.
@@ -582,17 +588,33 @@ def action_progressive_widening_arena(
 
     if is_leaf or belief_visits == 0 or len(children) <= k_a * belief_visits**alpha_a:
         action = action_sampler.sample()
-        existing_id = tree.get_action_child_indexed(belief_id, action)
-        if existing_id is not None:
-            return existing_id
-        existing_id = tree.get_action_child(belief_id, action)
-        if existing_id is not None:
-            return existing_id
-        return tree.add_action_node(action=action, parent_id=belief_id)
+        return _get_or_add_action_child(tree, belief_id, action, environment)
 
     return ucb1_exploration_arena(
         tree=tree, belief_id=belief_id, exploration_constant=exploration_constant
     )
+
+
+def _get_or_add_action_child(
+    tree: Tree,
+    belief_id: int,
+    action: Any,
+    environment: Optional[Environment],
+) -> int:
+    if environment is not None:
+        action_key = environment.hash_action(action)
+        existing_id = tree.get_action_child_indexed(belief_id, action_key=action_key)
+        if existing_id is not None:
+            return existing_id
+        return tree.add_action_node(action=action, parent_id=belief_id, action_key=action_key)
+    # Legacy fallback for callers that did not pass an environment.
+    existing_id = tree.get_action_child_indexed(belief_id, action)
+    if existing_id is not None:
+        return existing_id
+    existing_id = tree.get_action_child(belief_id, action)
+    if existing_id is not None:
+        return existing_id
+    return tree.add_action_node(action=action, parent_id=belief_id)
 
 
 def ucb1_exploration_arena(tree: Tree, belief_id: int, exploration_constant: float) -> int:

--- a/POMDPPlanners/tests/test_core/test_arena_tree.py
+++ b/POMDPPlanners/tests/test_core/test_arena_tree.py
@@ -52,6 +52,9 @@ class _MockEnvironment(Environment):
     def is_equal_observation(self, observation1, observation2):
         return observation1 == observation2
 
+    def hash_action(self, action):
+        return action
+
     def is_terminal(self, state):
         del state
         return False

--- a/POMDPPlanners/tests/test_core/test_environment.py
+++ b/POMDPPlanners/tests/test_core/test_environment.py
@@ -87,6 +87,9 @@ class MockEnvironment(Environment):
     def is_equal_observation(self, observation1: np.ndarray, observation2: np.ndarray) -> bool:
         return np.array_equal(observation1, observation2)
 
+    def hash_action(self, action):
+        return action
+
 
 class DifferentEnvironment(Environment):
     def __init__(
@@ -136,6 +139,9 @@ class DifferentEnvironment(Environment):
 
     def is_equal_observation(self, observation1: np.ndarray, observation2: np.ndarray) -> bool:
         return np.array_equal(observation1, observation2)
+
+    def hash_action(self, action):
+        return action
 
 
 @pytest.fixture

--- a/POMDPPlanners/tests/test_core/test_hash_action_contract.py
+++ b/POMDPPlanners/tests/test_core/test_hash_action_contract.py
@@ -1,0 +1,481 @@
+"""Contract and integration tests for ``Environment.hash_action``.
+
+Validates the per-env hash/equality contract for actions across every
+concrete environment in the project, plus integration tests that exercise
+POMCPOW and PFT-DPW to confirm ``tree.action_child_lookup`` is populated
+when each env's ``hash_action`` is plumbed through the planner-utils.
+"""
+
+# pylint: disable=protected-access  # tests inspect internal lookup dict
+
+import random
+from typing import Any, Callable, List
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief import get_initial_belief
+from POMDPPlanners.core.environment import Environment
+from POMDPPlanners.core.tree.arena import Tree
+from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp import CartPolePOMDP
+from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_pomdp import (
+    ContinuousLaserTagPOMDP,
+    ContinuousLaserTagPOMDPDiscreteActions,
+)
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import LaserTagPOMDP
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ContinuousLightDarkPOMDP,
+    ContinuousLightDarkPOMDPDiscreteActions,
+)
+from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
+    DiscreteLightDarkPOMDP,
+)
+from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp import MountainCarPOMDP
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import PacManPOMDP
+from POMDPPlanners.environments.push_pomdp.continuous_push_pomdp import ContinuousPushPOMDP
+from POMDPPlanners.environments.push_pomdp.push_pomdp import PushPOMDP
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import RockSamplePOMDP
+from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_pomdp import (
+    SafeAntVelocityPOMDP,
+)
+from POMDPPlanners.environments.sanity_pomdp import SanityPOMDP
+from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.planners.mcts_planners.pft_dpw import PFT_DPW
+from POMDPPlanners.planners.mcts_planners.pomcpow import POMCPOW
+from POMDPPlanners.planners.planners_utils.dpw import ActionSampler
+
+
+np.random.seed(42)
+random.seed(42)
+
+
+# ---------------------------------------------------------------------------
+# Per-env action factories: each returns ``(env, list_of_distinct_actions)``.
+# Continuous-action envs supply two distinct ndarrays plus a duplicate that is
+# element-wise equal to the first so the hash-equals-on-equality contract is
+# exercised end-to-end.
+# ---------------------------------------------------------------------------
+
+
+def _continuous_light_dark_factory():
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    actions = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
+    return env, actions
+
+
+def _continuous_light_dark_discrete_factory():
+    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    return env, env.get_actions()
+
+
+def _discrete_light_dark_factory():
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+    return env, env.get_actions()
+
+
+def _continuous_laser_tag_factory():
+    env = ContinuousLaserTagPOMDP(discount_factor=0.95)
+    actions = [np.array([1.0, 0.0, 0.0]), np.array([0.0, 1.0, 0.0])]
+    return env, actions
+
+
+def _continuous_laser_tag_discrete_factory():
+    env = ContinuousLaserTagPOMDPDiscreteActions(discount_factor=0.95)
+    return env, env.get_actions()
+
+
+def _laser_tag_factory():
+    env = LaserTagPOMDP(discount_factor=0.95)
+    return env, env.get_actions()
+
+
+def _continuous_push_factory():
+    env = ContinuousPushPOMDP(discount_factor=0.95)
+    actions = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
+    return env, actions
+
+
+def _push_factory():
+    env = PushPOMDP(discount_factor=0.95)
+    return env, env.get_actions()
+
+
+def _cartpole_factory():
+    env = CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    return env, env.get_actions()
+
+
+def _mountain_car_factory():
+    env = MountainCarPOMDP(discount_factor=0.99)
+    return env, env.get_actions()
+
+
+def _pacman_factory():
+    env = PacManPOMDP(maze_size=(5, 5), walls=set(), initial_pellets=[(2, 2)])
+    return env, env.get_actions()
+
+
+def _rock_sample_factory():
+    env = RockSamplePOMDP(map_size=(5, 5), rock_positions=[(0, 0), (2, 2)])
+    return env, env.get_actions()
+
+
+def _safety_ant_factory():
+    env = SafeAntVelocityPOMDP(discount_factor=0.95)
+    return env, env.get_actions()
+
+
+def _tiger_factory():
+    env = TigerPOMDP(discount_factor=0.95)
+    return env, env.get_actions()
+
+
+def _sanity_factory():
+    env = SanityPOMDP(discount_factor=0.95)
+    return env, env.get_actions()
+
+
+_ALL_ENV_FACTORIES: List[Callable[[], Any]] = [
+    _continuous_light_dark_factory,
+    _continuous_light_dark_discrete_factory,
+    _discrete_light_dark_factory,
+    _continuous_laser_tag_factory,
+    _continuous_laser_tag_discrete_factory,
+    _laser_tag_factory,
+    _continuous_push_factory,
+    _push_factory,
+    _cartpole_factory,
+    _mountain_car_factory,
+    _pacman_factory,
+    _rock_sample_factory,
+    _safety_ant_factory,
+    _tiger_factory,
+    _sanity_factory,
+]
+
+
+# ---------------------------------------------------------------------------
+# Universal contract: the hash result is hashable and idempotent for every
+# concrete env.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", _ALL_ENV_FACTORIES)
+def test_hash_action_is_hashable_and_idempotent(factory):
+    """Every concrete env returns a hashable, idempotent key from hash_action.
+
+    Purpose: Validates the universal contract that every concrete env honours
+
+    Given: Each concrete Environment subclass and a representative action
+    When: hash_action is invoked on the same action twice
+    Then: The result is itself hashable and the two calls return equal keys
+
+    Test type: unit
+    """
+    env, actions = factory()
+    assert isinstance(env, Environment)
+    for action in actions:
+        key = env.hash_action(action)
+        # Result must be hashable (hash() must not raise).
+        hash(key)
+        # Idempotent under repeated calls.
+        if isinstance(action, np.ndarray):
+            key_again = env.hash_action(action.copy())
+        else:
+            key_again = env.hash_action(action)
+        assert key == key_again
+
+
+# ---------------------------------------------------------------------------
+# Discrete-action envs: each label is a unique stable hash.
+# ---------------------------------------------------------------------------
+
+
+_DISCRETE_FACTORIES: List[Callable[[], Any]] = [
+    _continuous_light_dark_discrete_factory,
+    _discrete_light_dark_factory,
+    _continuous_laser_tag_discrete_factory,
+    _laser_tag_factory,
+    _push_factory,
+    _cartpole_factory,
+    _mountain_car_factory,
+    _pacman_factory,
+    _rock_sample_factory,
+    _safety_ant_factory,
+    _tiger_factory,
+    _sanity_factory,
+]
+
+
+@pytest.mark.parametrize("factory", _DISCRETE_FACTORIES)
+def test_hash_action_distinct_keys_for_discrete(factory):
+    """Distinct discrete actions hash to distinct keys.
+
+    Purpose: Validates the dup-prevention contract for discrete action spaces
+
+    Given: A discrete-action env and the full list of available actions
+    When: hash_action is computed for every action
+    Then: All keys are pairwise distinct, ensuring no two action children
+        can collide in tree.action_child_lookup
+
+    Test type: unit
+    """
+    env, actions = factory()
+    keys = [env.hash_action(a) for a in actions]
+    assert len(set(keys)) == len(keys)
+
+
+# ---------------------------------------------------------------------------
+# ndarray-action envs: equal arrays hash equal, different arrays hash apart.
+# ---------------------------------------------------------------------------
+
+
+_NDARRAY_ACTION_FACTORIES: List[Callable[[], Any]] = [
+    _continuous_light_dark_factory,
+    _continuous_laser_tag_factory,
+    _continuous_push_factory,
+]
+
+
+@pytest.mark.parametrize("factory", _NDARRAY_ACTION_FACTORIES)
+def test_hash_action_ndarray_equal_pair(factory):
+    """Two ndarrays with the same content hash to the same key.
+
+    Purpose: Validates the forward direction of the contract for ndarray actions
+
+    Given: A continuous-action env and two distinct ndarray objects with
+        identical content
+    When: hash_action is computed for each
+    Then: The two keys are equal so the indexed lookup will resolve them
+        to the same action child
+
+    Test type: unit
+    """
+    env, actions = factory()
+    action = actions[0]
+    twin = action.copy()
+    assert action is not twin
+    assert env.hash_action(action) == env.hash_action(twin)
+
+
+@pytest.mark.parametrize("factory", _NDARRAY_ACTION_FACTORIES)
+def test_hash_action_ndarray_unequal_pair(factory):
+    """Two ndarrays with different content hash to different keys.
+
+    Purpose: Validates the dup-prevention invariant for ndarray actions
+
+    Given: A continuous-action env and two ndarray actions with different content
+    When: hash_action is computed for each
+    Then: The two keys differ so the indexed lookup creates distinct action
+        children rather than collapsing them
+
+    Test type: unit
+    """
+    env, actions = factory()
+    assert env.hash_action(actions[0]) != env.hash_action(actions[1])
+
+
+# ---------------------------------------------------------------------------
+# Planner-side smoke: tree.action_child_lookup is populated after a small
+# search and identical action samples reuse the same node.
+# ---------------------------------------------------------------------------
+
+
+class _FixedNDArrayActionSampler(ActionSampler):
+    """Cycles through a small fixed pool of ndarray actions.
+
+    Used to drive the planner-side smoke test deterministically: the same
+    action vectors are sampled repeatedly so that the indexed lookup must
+    resolve to the existing action child rather than inserting a duplicate.
+    """
+
+    def __init__(self, actions: List[np.ndarray]):
+        self._actions = [np.asarray(a, dtype=np.float64) for a in actions]
+        self._idx = 0
+
+    def sample(self, belief_node=None):  # pylint: disable=unused-argument
+        a = self._actions[self._idx % len(self._actions)]
+        self._idx += 1
+        return a.copy()
+
+
+def _run_pomcpow_continuous_light_dark():
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    sampler = _FixedNDArrayActionSampler(
+        [np.array([1.0, 0.0]), np.array([0.0, 1.0]), np.array([-1.0, 0.0])]
+    )
+    planner = POMCPOW(
+        environment=env,
+        discount_factor=0.95,
+        depth=5,
+        exploration_constant=1.0,
+        k_o=3.0,
+        k_a=3.0,
+        alpha_o=0.5,
+        alpha_a=0.5,
+        n_simulations=50,
+        action_sampler=sampler,
+        name="POMCPOWHashActionSmoke",
+    )
+    belief = get_initial_belief(pomdp=env, n_particles=20, resampling=True)
+    planner.action(belief)
+    return planner
+
+
+def _run_pft_dpw_continuous_light_dark():
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    sampler = _FixedNDArrayActionSampler(
+        [np.array([1.0, 0.0]), np.array([0.0, 1.0]), np.array([-1.0, 0.0])]
+    )
+    planner = PFT_DPW(
+        environment=env,
+        discount_factor=0.95,
+        depth=5,
+        exploration_constant=1.0,
+        k_o=3.0,
+        k_a=3.0,
+        alpha_o=0.5,
+        alpha_a=0.5,
+        n_simulations=50,
+        action_sampler=sampler,
+        name="PFTDPWHashActionSmoke",
+    )
+    belief = get_initial_belief(pomdp=env, n_particles=20, resampling=True)
+    planner.action(belief)
+    return planner
+
+
+def test_pomcpow_action_child_lookup_populated_for_ndarray_actions(monkeypatch):
+    """POMCPOW populates action_child_lookup via env.hash_action for ndarrays.
+
+    Purpose: Confirms hash_action is plumbed through action_progressive_widening
+        into tree.action_child_lookup for envs with ndarray actions, eliminating
+        the linear np.array_equal scan that previously dominated profiling.
+
+    Given: POMCPOW running on ContinuousLightDarkPOMDP (ndarray actions) with a
+        fixed-pool action sampler that emits the same vectors repeatedly.
+    When: A small search is executed via planner.action(belief).
+    Then: tree.action_child_lookup is non-empty (was permanently empty before
+        this PR) and the linear-scan get_action_child is never called once
+        the indexed lookup is in play.
+
+    Test type: integration
+    """
+    np.random.seed(0)
+    random.seed(0)
+    captured_trees: List[Tree] = []
+    original_action_pw = (
+        # pylint: disable=import-outside-toplevel
+        __import__(
+            "POMDPPlanners.planners.planners_utils.dpw",
+            fromlist=["action_progressive_widening_arena"],
+        ).action_progressive_widening_arena
+    )
+
+    def _wrapped(*args, **kwargs):
+        tree = kwargs.get("tree", args[0] if args else None)
+        if tree is not None and tree not in captured_trees:
+            captured_trees.append(tree)
+        return original_action_pw(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "POMDPPlanners.planners.mcts_planners.pomcpow.action_progressive_widening_arena",
+        _wrapped,
+    )
+
+    _run_pomcpow_continuous_light_dark()
+
+    assert captured_trees, "POMCPOW did not invoke action_progressive_widening_arena"
+    tree = captured_trees[0]
+    assert tree.action_child_lookup, (
+        "POMCPOW must populate tree.action_child_lookup via env.hash_action; "
+        "an empty lookup means the linear-scan path is still in play"
+    )
+
+
+def test_pft_dpw_action_child_lookup_populated_for_ndarray_actions(monkeypatch):
+    """PFT-DPW populates action_child_lookup via env.hash_action for ndarrays.
+
+    Purpose: Mirrors the POMCPOW smoke test for the PFT-DPW planner so the
+        new hash_action path is verified for both DPW-style planners.
+
+    Given: PFT-DPW running on ContinuousLightDarkPOMDP (ndarray actions).
+    When: A small search is executed via planner.action(belief).
+    Then: tree.action_child_lookup is non-empty after the run.
+
+    Test type: integration
+    """
+    np.random.seed(0)
+    random.seed(0)
+    captured_trees: List[Tree] = []
+    original_action_pw = (
+        # pylint: disable=import-outside-toplevel
+        __import__(
+            "POMDPPlanners.planners.planners_utils.dpw",
+            fromlist=["action_progressive_widening_arena"],
+        ).action_progressive_widening_arena
+    )
+
+    def _wrapped(*args, **kwargs):
+        tree = kwargs.get("tree", args[0] if args else None)
+        if tree is not None and tree not in captured_trees:
+            captured_trees.append(tree)
+        return original_action_pw(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "POMDPPlanners.planners.mcts_planners.pft_dpw.action_progressive_widening_arena",
+        _wrapped,
+    )
+
+    _run_pft_dpw_continuous_light_dark()
+
+    assert captured_trees, "PFT-DPW did not invoke action_progressive_widening_arena"
+    tree = captured_trees[0]
+    assert (
+        tree.action_child_lookup
+    ), "PFT-DPW must populate tree.action_child_lookup via env.hash_action"
+
+
+def test_action_child_lookup_distinguishes_distinct_ndarray_actions():
+    """Distinct ndarray actions get distinct nodes in action_child_lookup.
+
+    Purpose: Verifies the dup-prevention invariant that the linear scan
+        previously enforced: distinct actions produce distinct keys, identical
+        actions reuse the same node.
+
+    Given: A Tree, an env with ndarray actions, and three distinct action
+        vectors plus one duplicate of the first.
+    When: add_action_node is invoked with the env-derived action_key for each.
+    Then: The three distinct actions allocate three distinct child IDs;
+        the duplicate of the first reuses the original child via the indexed
+        lookup; and no two ndarray-equal actions ever share a parent.
+
+    Test type: integration
+    """
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    belief = get_initial_belief(pomdp=env, n_particles=4, resampling=True)
+    tree = Tree()
+    root_id = tree.add_belief_node(belief=belief)
+
+    action_a = np.array([1.0, 0.0])
+    action_b = np.array([0.0, 1.0])
+    action_c = np.array([-1.0, 0.0])
+    action_a_dup = np.array([1.0, 0.0])
+
+    ids = []
+    for action in (action_a, action_b, action_c, action_a_dup):
+        key = env.hash_action(action)
+        existing = tree.get_action_child_indexed(root_id, action_key=key)
+        if existing is not None:
+            ids.append(existing)
+            continue
+        ids.append(tree.add_action_node(action=action, parent_id=root_id, action_key=key))
+
+    assert len(set(ids[:3])) == 3, "distinct ndarray actions must allocate distinct child IDs"
+    assert ids[3] == ids[0], "duplicate ndarray action must reuse the existing child"
+
+    # No two children of root_id share an ndarray-equal action.
+    children = tree.children_ids[root_id]
+    for i, cid_i in enumerate(children):
+        for cid_j in children[i + 1 :]:
+            assert not np.array_equal(tree.action[cid_i], tree.action[cid_j])

--- a/POMDPPlanners/tests/test_core/test_hyper_parameter_tuning.py
+++ b/POMDPPlanners/tests/test_core/test_hyper_parameter_tuning.py
@@ -351,6 +351,9 @@ class TestHyperParameterRunParamsIdUniqueness:
             def is_equal_observation(self, observation1, observation2):
                 return observation1 == observation2
 
+            def hash_action(self, action):
+                return action
+
         class MockBelief(Belief):
             @property
             def config_id(self):
@@ -447,6 +450,9 @@ class TestHyperParameterRunParamsIdUniqueness:
 
             def is_equal_observation(self, observation1, observation2):
                 return observation1 == observation2
+
+            def hash_action(self, action):
+                return action
 
         class MockBelief(Belief):
             @property
@@ -548,6 +554,9 @@ class TestHyperParameterRunParamsIdUniqueness:
 
             def is_equal_observation(self, observation1, observation2):
                 return observation1 == observation2
+
+            def hash_action(self, action):
+                return action
 
         class MockBelief(Belief):
             @property
@@ -651,6 +660,9 @@ class TestHyperParameterRunParamsIdUniqueness:
 
             def is_equal_observation(self, observation1, observation2):
                 return observation1 == observation2
+
+            def hash_action(self, action):
+                return action
 
         class MockBelief(Belief):
             @property
@@ -1117,6 +1129,9 @@ class TestOptimizedPolicyResultValidation:
 
             def is_equal_observation(self, observation1, observation2):
                 return observation1 == observation2
+
+            def hash_action(self, action):
+                return action
 
         return MockEnv()
 

--- a/POMDPPlanners/tests/test_core/test_policy.py
+++ b/POMDPPlanners/tests/test_core/test_policy.py
@@ -78,6 +78,9 @@ class MockEnvironment(Environment):
     def is_equal_observation(self, observation1, observation2):
         return True
 
+    def hash_action(self, action):
+        return action
+
 
 class MockBelief(Belief):
     def __init__(self, environment: Environment):

--- a/POMDPPlanners/tests/test_core/test_tree.py
+++ b/POMDPPlanners/tests/test_core/test_tree.py
@@ -60,6 +60,9 @@ class MockEnvironment(Environment):
         """Check if two observations are equal."""
         return observation1 == observation2
 
+    def hash_action(self, action):
+        return action
+
     def is_terminal(self, state):
         """Check if state is terminal."""
         return False

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_path_simulation_policy.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_path_simulation_policy.py
@@ -77,6 +77,9 @@ class MockEnvironment(Environment):
     def is_equal_observation(self, observation1, observation2):
         return observation1 == observation2
 
+    def hash_action(self, action):
+        return action
+
     def is_equal_state(self, state1, state2):
         return state1 == state2
 

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py
@@ -766,6 +766,9 @@ class _StepCountingEnv(Environment):
     def is_equal_observation(self, observation1: Any, observation2: Any) -> bool:
         return observation1 == observation2
 
+    def hash_action(self, action: Any) -> Any:
+        return action
+
     def get_actions(self) -> List[Any]:
         return [0, 1, 2]
 

--- a/POMDPPlanners/tests/test_utils/test_action_samplers.py
+++ b/POMDPPlanners/tests/test_utils/test_action_samplers.py
@@ -4,6 +4,9 @@ This module tests the action sampler implementations used for continuous action
 space sampling in POMDP planners, particularly for PFT-DPW integration.
 """
 
+# pylint: disable=too-many-lines
+
+import math
 import pickle
 import random
 import tempfile
@@ -239,29 +242,26 @@ class TestUnitCircleActionSampler:
             assert np.linalg.norm(action) == 0.0
 
     def test_unit_circle_action_sampler_repeatability(self):
-        """Test action sampling reproducibility with fixed seed.
+        """Test action sampling reproducibility with the seed kwarg.
 
-        Purpose: Validates that sampling is reproducible when random seed is fixed
+        Purpose: Validates that sampling is reproducible when the per-instance
+        seed is fixed via the ``seed`` constructor argument.
 
-        Given: Fixed numpy random seed and UnitCircleActionSampler
-        When: Actions are sampled multiple times with same seed
+        Given: Two UnitCircleActionSampler instances constructed with the same seed
+        When: Actions are sampled from each
         Then: Identical sequences of actions are produced
 
         Test type: unit
         """
-        sampler = UnitCircleActionSampler(max_action_magnitude=1.0)
+        sampler1 = UnitCircleActionSampler(max_action_magnitude=1.0, seed=42)
+        sampler2 = UnitCircleActionSampler(max_action_magnitude=1.0, seed=42)
 
-        # First sequence
-        np.random.seed(42)
-        actions1 = [sampler.sample() for _ in range(10)]
+        actions1 = [sampler1.sample() for _ in range(10)]
+        actions2 = [sampler2.sample() for _ in range(10)]
 
-        # Second sequence with same seed
-        np.random.seed(42)
-        actions2 = [sampler.sample() for _ in range(10)]
-
-        # Should be identical
+        # Should be byte-identical
         for a1, a2 in zip(actions1, actions2):
-            assert np.allclose(a1, a2)
+            assert np.array_equal(a1, a2)
 
     def test_unit_circle_action_sampler_serialization_pickle(self):
         """Test serialization and deserialization using pickle.
@@ -274,8 +274,8 @@ class TestUnitCircleActionSampler:
 
         Test type: unit
         """
-        # Create original sampler
-        original_sampler = UnitCircleActionSampler(max_action_magnitude=2.5)
+        # Create original sampler with explicit seed for deterministic comparison
+        original_sampler = UnitCircleActionSampler(max_action_magnitude=2.5, seed=123)
 
         # Serialize with pickle
         pickled_data = pickle.dumps(original_sampler)
@@ -287,15 +287,12 @@ class TestUnitCircleActionSampler:
         assert deserialized_sampler.max_action_magnitude == original_sampler.max_action_magnitude
         assert type(deserialized_sampler) == type(original_sampler)
 
-        # Check that both samplers produce valid actions
-        np.random.seed(123)
+        # Both samplers carry equivalent private RNG state from the same seed,
+        # so the next draw from each must match byte-for-byte.
         original_action = original_sampler.sample()
-
-        np.random.seed(123)
         deserialized_action = deserialized_sampler.sample()
 
-        # With same seed, should produce identical results
-        assert np.allclose(original_action, deserialized_action)
+        assert np.array_equal(original_action, deserialized_action)
 
         # Both actions should respect magnitude constraint
         assert np.linalg.norm(original_action) <= 2.5 + 1e-10
@@ -484,6 +481,93 @@ class TestUnitCircleActionSampler:
             assert action.shape == (2,)
             assert np.linalg.norm(action) <= 1.0 + 1e-10
 
+    def test_unit_circle_action_sampler_distribution_equivalence(self):
+        """Test that the scalar-Python rewrite preserves the target distribution.
+
+        Purpose: Validates that switching from numpy 0-D dispatches to
+        ``random``+``math`` scalar primitives still produces a uniform-in-area
+        distribution within a circle of the requested radius.
+
+        Given: A UnitCircleActionSampler with max_action_magnitude=1.0
+        When: 10000 samples are drawn
+        Then:
+            - All sample radii are within max_action_magnitude (with float epsilon)
+            - Mean radius is within 3 sigma of the analytical 2/3
+            - Angular distribution is uniform across 12 bins (chi-square p > 0.001)
+
+        Test type: unit
+        """
+        max_magnitude = 1.0
+        num_samples = 10_000
+        sampler = UnitCircleActionSampler(max_action_magnitude=max_magnitude, seed=2026)
+
+        samples = np.array([sampler.sample() for _ in range(num_samples)])
+
+        radii = np.linalg.norm(samples, axis=1)
+        assert radii.max() <= max_magnitude + 1e-12
+
+        # Analytical mean radius for uniform-in-area: 2/3 * R.
+        # Variance of radius is R^2 * (2/3 - 4/9) = R^2 * 2/9.
+        expected_mean_radius = (2.0 / 3.0) * max_magnitude
+        std_mean = math.sqrt((max_magnitude**2) * (2.0 / 9.0) / num_samples)
+        assert abs(radii.mean() - expected_mean_radius) < 3.0 * std_mean
+
+        # Chi-square test on 12 angular bins. Critical value for chi^2(df=11)
+        # at p=0.001 is approximately 31.264.
+        angles = np.arctan2(samples[:, 1], samples[:, 0]) % (2.0 * math.pi)
+        num_bins = 12
+        bin_edges = np.linspace(0.0, 2.0 * math.pi, num_bins + 1)
+        observed, _ = np.histogram(angles, bins=bin_edges)
+        expected_per_bin = num_samples / num_bins
+        chi_square = float(np.sum((observed - expected_per_bin) ** 2 / expected_per_bin))
+        assert chi_square < 31.264
+
+    def test_unit_circle_action_sampler_seeded_determinism(self):
+        """Test that two instances seeded identically produce identical sequences.
+
+        Purpose: Validates that the new ``seed`` kwarg yields byte-identical
+        sample sequences across independently constructed samplers.
+
+        Given: Two UnitCircleActionSampler instances each constructed with seed=42
+        When: 1000 samples are drawn from each in sequence
+        Then: The two sample arrays are byte-identical
+
+        Test type: unit
+        """
+        sampler_a = UnitCircleActionSampler(max_action_magnitude=1.5, seed=42)
+        sampler_b = UnitCircleActionSampler(max_action_magnitude=1.5, seed=42)
+
+        samples_a = np.array([sampler_a.sample() for _ in range(1000)])
+        samples_b = np.array([sampler_b.sample() for _ in range(1000)])
+
+        assert np.array_equal(samples_a, samples_b)
+
+    def test_unit_circle_action_sampler_seeded_independent_of_module_random(self):
+        """Test that a seeded sampler is unaffected by global ``random.seed``.
+
+        Purpose: Validates that a sampler with its own ``seed`` keeps a private
+        ``random.Random`` instance and ignores changes to the module-level RNG.
+
+        Given: A UnitCircleActionSampler constructed with seed=7
+        When: The module-level ``random.seed`` is reset between two draws
+        Then: The two draws still match the expected seeded sequence
+
+        Test type: unit
+        """
+        seeded = UnitCircleActionSampler(max_action_magnitude=1.0, seed=7)
+        reference = UnitCircleActionSampler(max_action_magnitude=1.0, seed=7)
+
+        random.seed(0)
+        first = seeded.sample()
+        random.seed(99999)
+        second = seeded.sample()
+
+        ref_first = reference.sample()
+        ref_second = reference.sample()
+
+        assert np.array_equal(first, ref_first)
+        assert np.array_equal(second, ref_second)
+
 
 class TestUsageExamples:
     """Test cases for usage examples from docstrings."""
@@ -511,7 +595,7 @@ class TestUsageExamples:
 
         # Test action sampling
         actions = [action_sampler.sample() for _ in range(5)]
-        for i, action in enumerate(actions):
+        for action in actions:
             magnitude = np.linalg.norm(action)
             assert isinstance(action, np.ndarray)
             assert action.shape == (2,)
@@ -530,7 +614,7 @@ class TestUsageExamples:
         )
 
         initial_belief = get_initial_belief(nav_env, n_particles=50)  # Reduced from 200
-        action, run_data = planner.action(initial_belief)
+        action, _ = planner.action(initial_belief)
 
         # Verify the selected action
         assert isinstance(action, list)
@@ -997,7 +1081,7 @@ class TestDiscreteActionSampler:
         assert isinstance(reduce_result, tuple)
         assert len(reduce_result) == 3
         assert reduce_result[0] == DiscreteActionSampler
-        assert reduce_result[1] == ()  # Empty constructor args
+        assert not reduce_result[1]  # Empty constructor args
         assert reduce_result[2] == {"actions": actions}  # State dict
 
         # Test reconstruction

--- a/POMDPPlanners/utils/action_samplers.py
+++ b/POMDPPlanners/utils/action_samplers.py
@@ -1,3 +1,4 @@
+import math
 import random
 from typing import Any, List, Optional
 
@@ -20,25 +21,39 @@ class UnitCircleActionSampler(ActionSampler):
     with naive rectangular sampling.
 
     Mathematical Foundation:
-        - Angle θ ~ Uniform(0, 2π)
-        - Radius r ~ √Uniform(0, 1) × max_magnitude
-        - Action = [r·cos(θ), r·sin(θ)]
+        - Angle theta ~ Uniform(0, 2*pi)
+        - Radius r ~ sqrt(Uniform(0, 1)) * max_magnitude
+        - Action = [r*cos(theta), r*sin(theta)]
 
     The square root transformation for radius ensures uniform area distribution
     within the circle rather than biasing toward the center.
 
     Args:
         max_action_magnitude: Maximum magnitude of action vectors (circle radius)
+        seed: Optional integer seed. When provided, draws come from a private
+            ``random.Random`` instance keyed on the seed for deterministic
+            reproduction. When ``None`` (default), draws come from the
+            module-level ``random`` generator, which the caller may seed via
+            ``random.seed``.
     """
 
-    def __init__(self, max_action_magnitude: float = 1.0):
+    def __init__(
+        self,
+        max_action_magnitude: float = 1.0,
+        *,
+        seed: Optional[int] = None,
+    ):
         """
         Initialize the unit circle action sampler.
 
         Args:
             max_action_magnitude: Maximum magnitude of the action vector (default: 1.0)
+            seed: Optional integer seed for a private ``random.Random`` instance.
+                When ``None`` (default), the module-level ``random`` generator is used.
         """
         self.max_action_magnitude = max_action_magnitude
+        self._seed = seed
+        self._rng: Optional[random.Random] = random.Random(seed) if seed is not None else None
 
     def sample(self, belief_node: Optional[BeliefNode] = None) -> np.ndarray:
         """
@@ -50,17 +65,15 @@ class UnitCircleActionSampler(ActionSampler):
         Returns:
             np.ndarray: A 2D action vector within the unit circle
         """
-        # Generate random angle in [0, 2π]
-        theta = np.random.uniform(0, 2 * np.pi)
-
-        # Generate random radius in [0, 1] using square root for uniform distribution
-        r = np.sqrt(np.random.uniform(0, 1)) * self.max_action_magnitude
-
-        # Convert polar coordinates to Cartesian
-        x = r * np.cos(theta)
-        y = r * np.sin(theta)
-
-        return np.array([x, y])
+        del belief_node  # unused - kept for ActionSampler protocol parity
+        rng = self._rng
+        if rng is None:
+            theta = random.uniform(0.0, 2.0 * math.pi)
+            r = math.sqrt(random.random()) * self.max_action_magnitude
+        else:
+            theta = rng.uniform(0.0, 2.0 * math.pi)
+            r = math.sqrt(rng.random()) * self.max_action_magnitude
+        return np.array([r * math.cos(theta), r * math.sin(theta)], dtype=np.float64)
 
 
 class DiscreteActionSampler(ActionSampler):

--- a/bench_cld_action_hashing.py
+++ b/bench_cld_action_hashing.py
@@ -1,0 +1,107 @@
+"""Sims/sec bench for ContinuousLightDarkPOMDP with the action-sampler /
+action-hashing PR.
+
+Drives ``planner._simulate_path`` directly under a 1.0 s wall-clock budget per
+trial, after a 0.1 s warm-up. Reports the median across 3 trials for both
+POMCPOW and PFT-DPW.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from typing import Any, Callable, List, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.belief import get_initial_belief
+from POMDPPlanners.core.tree.arena import Tree
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ContinuousLightDarkPOMDP,
+)
+from POMDPPlanners.planners.mcts_planners.pft_dpw import PFT_DPW
+from POMDPPlanners.planners.mcts_planners.pomcpow import POMCPOW
+from POMDPPlanners.utils.action_samplers import UnitCircleActionSampler
+
+
+PLANNER_PARAMS = dict(
+    discount_factor=0.95,
+    depth=20,
+    exploration_constant=1.0,
+    k_o=5.0,
+    k_a=5.0,
+    alpha_o=0.5,
+    alpha_a=0.5,
+    min_visit_count_per_action=1,
+)
+TIME_BUDGET_S = 1.0
+WARMUP_S = 0.1
+N_PARTICLES = 100
+N_REPEATS = 3
+
+
+def make_pomcpow(env: Any) -> POMCPOW:
+    return POMCPOW(
+        environment=env,
+        action_sampler=UnitCircleActionSampler(max_action_magnitude=1.0),
+        name="pomcpow_bench",
+        n_simulations=1,
+        **PLANNER_PARAMS,
+    )
+
+
+def make_pft_dpw(env: Any) -> PFT_DPW:
+    return PFT_DPW(
+        environment=env,
+        action_sampler=UnitCircleActionSampler(max_action_magnitude=1.0),
+        name="pft_dpw_bench",
+        n_simulations=1,
+        **PLANNER_PARAMS,
+    )
+
+
+def run_for_budget(planner: Any, belief: Any, budget_s: float) -> Tuple[int, float]:
+    tree = Tree()
+    root_id = tree.add_belief_node(belief)
+    n = 0
+    t0 = time.perf_counter()
+    deadline = t0 + budget_s
+    while time.perf_counter() < deadline:
+        planner._simulate_path(
+            tree=tree, belief_id=root_id, depth=0
+        )  # pylint: disable=protected-access
+        n += 1
+    return n, time.perf_counter() - t0
+
+
+def bench_pair(name: str, factory: Callable[[Any], Any], env: Any) -> None:
+    rates: List[float] = []
+    for _ in range(N_REPEATS):
+        np.random.seed(0)
+        belief_i = get_initial_belief(env, n_particles=N_PARTICLES)
+        planner_i = factory(env)
+        run_for_budget(planner_i, belief_i, WARMUP_S)
+        n, t = run_for_budget(planner_i, belief_i, TIME_BUDGET_S)
+        rates.append(n / t)
+    median = statistics.median(rates)
+    stdev = statistics.stdev(rates) if len(rates) > 1 else 0.0
+    print(
+        f"  {name:<8} x ContinuousLightDark   median={median:>8,.0f} sims/s  "
+        f"stdev={stdev:>7,.0f}  runs={[f'{r:.0f}' for r in rates]}"
+    )
+
+
+def main() -> None:
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    print()
+    print("=" * 80)
+    print(
+        f"  CLD bench (action-hashing PR) — {TIME_BUDGET_S:.1f}s × {N_REPEATS}, {N_PARTICLES} particles"
+    )
+    print("=" * 80)
+    bench_pair("POMCPOW", make_pomcpow, env)
+    bench_pair("PFT_DPW", make_pft_dpw, env)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Two cross-cutting fixes to the planner hot path on continuous-action environments, surfaced by cProfile of POMCPOW and PFT-DPW on `ContinuousLightDarkPOMDP`:

1. **Scalar `UnitCircleActionSampler.sample`** — was 14% of total wall time, paying full numpy dispatch on five 0-D ops per call. Replaced with `random` + `math` scalar ops; ndarray alloc preserved. **6.80× faster on the method itself.**
2. **Env-owned `hash_action`** — `Tree.action_child_lookup` was permanently empty for any env using ndarray actions because the dict was keyed on the raw (unhashable) action. Mirrors commit `98e8cde` for `hash_observation`. Now O(1) hits everywhere; the linear-scan + `np.array_equal` path is dead for in-tree planners.

Both ICVaR variants (`ICVaR_PFT_DPW`, `ICVaR_POMCPOW`) get the wiring through `cvar_progressive_widening.cvar_action_progressive_widening_arena`, not just the non-CVaR planners.

## Bench (median of 3 runs, 1 s budget, 100 particles, depth 20)

| pair | baseline | after | speedup |
|---|---:|---:|---:|
| POMCPOW × ContinuousLightDark | 4,997 | **6,761** | **1.35×** |
| PFT-DPW × ContinuousLightDark | 2,838 | **3,523** | **1.24×** |

Both fixes contribute. Fix 1 alone is 6.80× on the sampler microbench; Fix 2 alone removes the 16% `get_action_child` linear scan from POMCPOW × CLD. Together they hit the cross-cutting bottlenecks of every continuous-action env.

## Commits

1. `perf(action-sampler): scalar Python in UnitCircleActionSampler.sample`
2. `perf(planners,arena): env-owned hash_action; O(1) action child lookup`
3. `bench: add bench_cld_action_hashing.py`

## Test plan

- [x] `pytest POMDPPlanners/tests/test_core/ POMDPPlanners/tests/test_environments/ POMDPPlanners/tests/test_planners/ POMDPPlanners/tests/test_utils/test_action_samplers.py` — **2,283 passing, 9 skipped, 0 failed.**
- [x] New `test_hash_action_contract.py` (36 tests): per-env idempotence, hash-implies-equality, hashability, plus a planner smoke test that asserts `tree.action_child_lookup` is non-empty after a 50-sim POMCPOW run on CLD (was permanently empty before; now ~14 entries on a 65-node tree).
- [x] New `test_unit_circle_action_sampler_distribution_equivalence` (10k samples, mean-radius 3-sigma + 12-bin chi-square at p=0.001) and seeded determinism tests.
- [x] `python -m pyright` clean (0 / 0) on every touched file.
- [x] `python -m pylint` 10.00 / 10 on `POMDPPlanners/planners/`, `arena.py`, both new test files; 9.96 / 10 on `environment.py` (pre-existing W0611/abstract-shadowing already on develop); 9.98 / 10 aggregate on `POMDPPlanners/environments/`.
- [x] `python setup.py build_ext --inplace` clean rebuild.
- [x] `python bench_cld_action_hashing.py` — speedups above.

## Per-env hash_action overrides

15 envs each declare their own `hash_action`, no implicit base-class fallback (the user explicitly required this — every env defines the contract):

| env | body |
|---|---|
| `ContinuousLightDarkPOMDP`, `ContinuousLaserTagPOMDP`, `ContinuousPushPOMDP` | `np.ascontiguousarray(action, dtype=np.float64).tobytes()` |
| All other 12 envs (discrete-action: int / str) | `return action` |

## Parallelisation

Two subagents ran concurrently in worktree-isolation, anchored to the latest `origin/develop`:
- **Fix 1** subagent — `UnitCircleActionSampler` scalar port + tests; ~8 min wall-clock.
- **Fix 2** subagent — `hash_action` plumbing across 15 envs + arena + 5 planners + 2 progressive-widening helpers + 6 mock-env tests + new contract test; ~28 min wall-clock.

Both completed cleanly; their diffs were lifted into a single integration worktree off `origin/develop`, rebuilt once, full test suite + bench captured before commits were composed.

## Notes for review

- **No behavioral change** for any planner — the action progressive-widening logic is identical, just with O(1) instead of O(n) action-child lookup.
- **RNG source change** in `UnitCircleActionSampler` (numpy → Python's `random`). The new `seed` kwarg lets callers preserve byte-identity in tests; two pre-existing seeded-equivalence tests were rewritten to use it. Distribution semantics are unchanged.
- **Backwards compat**: `Tree.add_action_node` and `get_action_child_indexed` still accept the legacy raw-action path (no `action_key`) — only in-tree planners migrated.