### PR TITLE
perf(icvar): vectorize compute_reward_batch + scalar obs fast-path on ContinuousLaserTag

### DIFF
--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -27,6 +27,7 @@ Classes:
 
 from __future__ import annotations
 
+import math
 from enum import Enum
 from pathlib import Path
 from collections.abc import Hashable
@@ -337,6 +338,19 @@ class ContinuousLaserTagPOMDP(Environment):
         probs = np.asarray(kernel.probability(observations))
         with np.errstate(divide="ignore"):
             return np.log(probs)
+
+    def observation_log_probability_single(
+        self, next_state: Any, action: Any, observation: Any
+    ) -> float:
+        # Scalar fast-path for POMCPOW's WeightedParticleBeliefStateUpdate.
+        # Skips the size-1 np.asarray + np.errstate + np.log wrap that the
+        # batched path would do, and the [0] re-index in the base default.
+        kernel = self._get_obs_kernel(action)
+        kernel.set_next_state(next_state)
+        prob = float(kernel.probability([observation])[0])
+        if prob <= 0.0:
+            return -math.inf
+        return math.log(prob)
 
     def sample_next_state_batch(self, states: Any, action: np.ndarray) -> np.ndarray:
         # Short-circuit when the caller already hands us a C-contiguous
@@ -835,6 +849,13 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
     ) -> np.ndarray:
         return ContinuousLaserTagPOMDP.observation_log_probability(
             self, next_state, self.action_to_vector[action], observations
+        )
+
+    def observation_log_probability_single(
+        self, next_state: Any, action: Any, observation: Any
+    ) -> float:
+        return ContinuousLaserTagPOMDP.observation_log_probability_single(
+            self, next_state, self.action_to_vector[action], observation
         )
 
     def sample_next_state_batch(self, states: Any, action: Any) -> np.ndarray:

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
@@ -47,6 +47,14 @@ class ContinuousLightDarkRewardModel(BaseLightDarkRewardModel):
         self.obstacle_reward = obstacle_reward
         self.goal_reward = goal_reward
         self.fuel_cost = fuel_cost
+        # Cached scalars/arrays for compute_reward_batch hot path:
+        # squared radii skip per-call sqrts in mask checks, and obstacle
+        # rows are pre-broadcast as (1, M) views to avoid the (N, 2, M)
+        # intermediate that np.linalg.norm forces.
+        self._goal_radius_sq = float(goal_state_radius) * float(goal_state_radius)
+        self._obstacle_radius_sq = float(obstacle_radius) * float(obstacle_radius)
+        self._obs_x_row = np.ascontiguousarray(obstacles[0]).reshape(1, -1)
+        self._obs_y_row = np.ascontiguousarray(obstacles[1]).reshape(1, -1)
 
     def _is_goal_state(self, state: np.ndarray) -> bool:
         """Check if state is within goal state radius."""
@@ -96,21 +104,29 @@ class ContinuousLightDarkRewardModel(BaseLightDarkRewardModel):
 
     def compute_reward_batch(self, states: np.ndarray, action: np.ndarray) -> np.ndarray:
         next_states = states + action
-        dists_to_goal = np.linalg.norm(next_states - self.goal_state, axis=1)
-        rewards = -self.fuel_cost - dists_to_goal
+        nx = next_states[:, 0]
+        ny = next_states[:, 1]
 
-        goal_mask = dists_to_goal <= self.goal_state_radius
+        # Goal distance from raw components — cheaper than np.linalg.norm.
+        g_dx = nx - self.goal_state[0]
+        g_dy = ny - self.goal_state[1]
+        sq_dist_to_goal = g_dx * g_dx + g_dy * g_dy
+        rewards = -self.fuel_cost - np.sqrt(sq_dist_to_goal)
+        goal_mask = sq_dist_to_goal <= self._goal_radius_sq
         rewards[goal_mask] += self.goal_reward
 
-        diffs = next_states[:, :, np.newaxis] - self.obstacles[np.newaxis, :, :]
-        obs_dists = np.linalg.norm(diffs, axis=1)
-        in_range = np.any(obs_dists <= self.obstacle_radius, axis=1)
+        # Obstacle membership — squared distances on (N, M), no (N, 2, M)
+        # intermediate. self._obs_{x,y}_row are cached (1, M) views.
+        o_dx = nx[:, None] - self._obs_x_row
+        o_dy = ny[:, None] - self._obs_y_row
+        sq_obs_dists = o_dx * o_dx + o_dy * o_dy
+        in_range = np.any(sq_obs_dists <= self._obstacle_radius_sq, axis=1)
         obstacle_mask = in_range & ~goal_mask
-        n_obs = int(np.sum(obstacle_mask))
+        n_obs = int(np.count_nonzero(obstacle_mask))
         if n_obs > 0:
             rewards[obstacle_mask] += self._obstacle_reward_batch(n_obs)
 
-        oob = np.any(next_states < 0, axis=1) | np.any(next_states > self.grid_size, axis=1)
+        oob = (nx < 0.0) | (ny < 0.0) | (nx > self.grid_size) | (ny > self.grid_size)
         rewards[oob & ~goal_mask & ~in_range] += self.obstacle_reward
         return rewards
 


### PR DESCRIPTION
## Summary

Two profile-driven perf changes for ICVaR_PFT_DPW and ICVaR_POMCPOW on continuous envs.

### 1. `ContinuousLightDarkRewardModel.compute_reward_batch` (PFT-DPW path)

`compute_reward_batch` is hit once per belief node by ICVaR_PFT_DPW (~22K times per 5s window). Original implementation used `np.linalg.norm` plus a `(N, 2, M)` intermediate tensor for the obstacle-distance check.

- Replace `np.linalg.norm(...)` with raw squared-distance arithmetic and a single `np.sqrt` for the goal distance.
- Cache `goal_radius²`, `obstacle_radius²`, and pre-broadcast `obstacles[0]` / `obstacles[1]` rows in `__init__`.
- Avoid the `(N, 2, M)` intermediate; obstacle membership uses `(N, M)` squared distances.

Stochastic obstacle-hit reward path is unchanged. Behavior reproduces bit-for-bit under fixed seed.

### 2. `ContinuousLaserTagPOMDP.observation_log_probability_single` (POMCPOW path)

POMCPOW's `WeightedParticleBeliefStateUpdate.inplace_update` calls the singleton scalar log-prob once per visit. Without an override, it goes through the base default which wraps the batched `observation_log_probability` (which itself does `np.errstate` + `np.log` + `asarray` on a size-1 array).

- New override calls `kernel.probability([observation])[0]` directly and returns `math.log(prob)` (or `-math.inf` on zero).
- Mirror override on `ContinuousLaserTagPOMDPDiscreteActions` for action translation.

## Bench (sims/sec, `profile_planner_envs --budget 1 --n-calls 5 --particles 200`)

| env / planner               | before | after | Δ |
|-----------------------------|------:|------:|--:|
| ContinuousLightDark POMCPOW |  1,115 | 1,115 | flat (not a target cell) |
| ContinuousLaserTag  POMCPOW |  1,097 | 1,192 | **+8.7%** |
| ContinuousLightDark PFT-DPW |    232 |   263 | **+13.4%** |
| ContinuousLaserTag  PFT-DPW |    319 |   303 | within noise |

ICVaR_PFT_DPW gains come from change (1) because that planner evaluates rewards via the batched path on every belief node. ICVaR_POMCPOW gains come from change (2) because that planner calls `inplace_update` per visit, which routes through the new scalar fast-path. The other cells sit on different hot paths.

## Notes on what was tried and dropped

A third change — replacing `with np.errstate(divide="ignore"): np.log(probs)` with `np.log(probs + 1e-300)` in `transition_log_probability` and `observation_log_probability` — was reverted. The eps shift turned `-inf` (impossible-observation log-prob) into `≈ -690.78`, which broke `test_observation_log_probability_terminal_state`. The `-inf` contract is load-bearing: downstream particle-filter weight updates use it to zero out incompatible particles. After change (2) above, the POMCPOW per-state path no longer touches that `np.errstate` site anyway, so the optimization had no remaining hot caller.

## Test plan

- [x] `pytest POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_models.py POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py` (108 passed)
- [x] `pytest POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/` (95 passed)
- [x] Pre-commit hooks (black, pylint, pyright) green
- [ ] CI signals (full suite)