### PR TITLE
perf(icvar bundle 2): indexed obs lookup + Numba batch reward + arena pre-size + laser-tag wrappers

### DIFF
--- a/POMDPPlanners/core/tree/arena.py
+++ b/POMDPPlanners/core/tree/arena.py
@@ -90,25 +90,41 @@ class Tree:
         # Hash-indexed children lookups; populated when the key is hashable.
         self.obs_child_lookup: Dict[Tuple[int, Any], int] = {}
         self.action_child_lookup: Dict[Tuple[int, Any], int] = {}
+        # Logical node count. May be less than ``len(self.kind)`` after a
+        # call to :meth:`reserve` pre-fills the columns with sentinels.
+        self._size: int = 0
 
     def __len__(self) -> int:
-        return len(self.kind)
+        return self._size
 
     def reserve(self, capacity: int) -> None:
-        """Pre-allocate the underlying buffer of every column for ``capacity`` nodes.
+        """Pre-allocate ``capacity`` slots in every per-node column.
 
         Mirrors Julia's ``sizehint!`` / ``Vector{T}(undef, n)``. After this
-        call every column still has length 0, but ``capacity`` slots are
-        reserved so subsequent ``append`` calls (up to ``capacity``) don't
-        trigger reallocation. Useful when the maximum tree size is known
-        in advance (e.g., ``2 * tree_queries`` in POMCPOW.jl).
+        call ``len(tree)`` is unchanged, but ``capacity`` slots are
+        physically resident in each column so the first ``capacity``
+        subsequent allocations write at a cursor instead of triggering
+        ``list.append`` (and the periodic O(N) realloc bursts that come
+        with it). Useful when the maximum tree size is known in advance
+        (e.g., ``2 * n_simulations * depth`` for POMCPOW-style planners).
+
+        Allocations beyond ``capacity`` fall back to ``append`` and grow
+        the columns normally. Calling :meth:`reserve` more than once is
+        idempotent in the sense that columns are re-padded up to
+        ``capacity`` if more headroom is needed; existing entries are
+        preserved.
         """
-        # The buffer's element type doesn't matter — clear() immediately
-        # drops the elements but preserves the underlying list capacity.
-        # Annotate as Any so pyright doesn't object to extend()ing an
-        # int/float/object-typed column with a list of Nones.
-        buffer: Any = [None] * capacity
-        for column in (
+        # Pad every column up to ``capacity`` slots, leaving any existing
+        # nodes (positions ``[0, _size)``) untouched. The sentinel value
+        # is a placeholder; ``_allocate`` overwrites it when the cursor
+        # advances over the slot, so the concrete value never matters at
+        # runtime — but we annotate columns as ``Any`` here to avoid
+        # variance complaints when extending an int/float-typed list with
+        # ``None`` (and vice versa).
+        target_len = max(self._size, capacity)
+        # Each column's element type is enforced by ``_allocate``'s writes;
+        # the sentinel exists only to grow the underlying buffer.
+        columns: List[Any] = [
             self.kind,
             self.parent_id,
             self.children_ids,
@@ -126,29 +142,55 @@ class Tree:
             self.data,
             self.sample,
             self.children_cdf,
-        ):
-            column.extend(buffer)
-            column.clear()
+        ]
+        for column in columns:
+            current_len = len(column)
+            if target_len > current_len:
+                column.extend([None] * (target_len - current_len))
 
     def _allocate(self, kind: int, parent_id: Optional[int]) -> int:
-        node_id = len(self.kind)
-        self.kind.append(kind)
-        self.parent_id.append(parent_id)
-        self.children_ids.append([])
-        self.visit_count.append(0)
-        self.q_value.append(0.0)
-        self.v_value.append(0.0)
-        self.lower_confidence_bound.append(0.0)
-        self.upper_confidence_bound.append(0.0)
-        self.immediate_cost.append(None)
-        self.immediate_reward.append(None)
-        self.weight.append(1.0)
-        self.action.append(None)
-        self.observation.append(None)
-        self.belief.append(None)
-        self.data.append(None)
-        self.sample.append([])
-        self.children_cdf.append([])
+        node_id = self._size
+        if node_id < len(self.kind):
+            # Reserved slot exists — overwrite in place. This path avoids
+            # ``list.append``'s amortised growth and the periodic O(N)
+            # realloc bursts on every column.
+            self.kind[node_id] = kind
+            self.parent_id[node_id] = parent_id
+            self.children_ids[node_id] = []
+            self.visit_count[node_id] = 0
+            self.q_value[node_id] = 0.0
+            self.v_value[node_id] = 0.0
+            self.lower_confidence_bound[node_id] = 0.0
+            self.upper_confidence_bound[node_id] = 0.0
+            self.immediate_cost[node_id] = None
+            self.immediate_reward[node_id] = None
+            self.weight[node_id] = 1.0
+            self.action[node_id] = None
+            self.observation[node_id] = None
+            self.belief[node_id] = None
+            self.data[node_id] = None
+            self.sample[node_id] = []
+            self.children_cdf[node_id] = []
+        else:
+            # Past the reserved zone — fall back to append.
+            self.kind.append(kind)
+            self.parent_id.append(parent_id)
+            self.children_ids.append([])
+            self.visit_count.append(0)
+            self.q_value.append(0.0)
+            self.v_value.append(0.0)
+            self.lower_confidence_bound.append(0.0)
+            self.upper_confidence_bound.append(0.0)
+            self.immediate_cost.append(None)
+            self.immediate_reward.append(None)
+            self.weight.append(1.0)
+            self.action.append(None)
+            self.observation.append(None)
+            self.belief.append(None)
+            self.data.append(None)
+            self.sample.append([])
+            self.children_cdf.append([])
+        self._size += 1
         if parent_id is not None:
             self.children_ids[parent_id].append(node_id)
         return node_id

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -326,7 +326,9 @@ class ContinuousLaserTagPOMDP(Environment):
     ) -> np.ndarray:
         kernel = self._get_trans_kernel(action)
         kernel.set_state(state)
-        probs = np.asarray(kernel.probability(next_states))
+        # kernel.probability returns a C-contiguous float64 ndarray; skip
+        # the redundant np.asarray wrap.
+        probs = kernel.probability(next_states)
         with np.errstate(divide="ignore"):
             return np.log(probs)
 
@@ -335,7 +337,9 @@ class ContinuousLaserTagPOMDP(Environment):
     ) -> np.ndarray:
         kernel = self._get_obs_kernel(action)
         kernel.set_next_state(next_state)
-        probs = np.asarray(kernel.probability(observations))
+        # kernel.probability returns a C-contiguous float64 ndarray; skip
+        # the redundant np.asarray wrap.
+        probs = kernel.probability(observations)
         with np.errstate(divide="ignore"):
             return np.log(probs)
 
@@ -369,7 +373,9 @@ class ContinuousLaserTagPOMDP(Environment):
         kernel = self._get_trans_kernel(action)
         # batch_sample reads the per-row state from the input, not the
         # kernel's stored state, so no set_state is needed here.
-        return np.asarray(kernel.batch_sample(states_array), dtype=np.float64)
+        # The native kernel returns a C-contiguous float64 ndarray
+        # (py::array_t<double>) so the np.asarray re-wrap is a no-op — drop it.
+        return kernel.batch_sample(states_array)
 
     def observation_log_probability_per_state(
         self, next_states: Any, action: np.ndarray, observation: Any
@@ -396,15 +402,13 @@ class ContinuousLaserTagPOMDP(Environment):
             observation_array = np.ascontiguousarray(np.asarray(observation, dtype=np.float64))
         kernel = self._get_obs_kernel(action)
         # batch_log_likelihood reads next_state per row from the input;
-        # no set_next_state needed.
-        log_probs = np.asarray(
-            kernel.batch_log_likelihood(
-                next_particles=next_states_array,
-                observation=observation_array,
-            ),
-            dtype=np.float64,
+        # no set_next_state needed. Native kernel returns a C-contiguous
+        # float64 ndarray (py::array_t<double>) so the np.asarray re-wrap is
+        # a no-op — drop it.
+        return kernel.batch_log_likelihood(
+            next_particles=next_states_array,
+            observation=observation_array,
         )
-        return log_probs
 
     def simulate_random_rollout(
         self,

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.numba_kernels import (
+    compute_reward_base_batch_kernel,
     compute_reward_base_kernel,
     compute_reward_decaying_hit_prob_kernel,
 )
@@ -47,14 +48,6 @@ class ContinuousLightDarkRewardModel(BaseLightDarkRewardModel):
         self.obstacle_reward = obstacle_reward
         self.goal_reward = goal_reward
         self.fuel_cost = fuel_cost
-        # Cached scalars/arrays for compute_reward_batch hot path:
-        # squared radii skip per-call sqrts in mask checks, and obstacle
-        # rows are pre-broadcast as (1, M) views to avoid the (N, 2, M)
-        # intermediate that np.linalg.norm forces.
-        self._goal_radius_sq = float(goal_state_radius) * float(goal_state_radius)
-        self._obstacle_radius_sq = float(obstacle_radius) * float(obstacle_radius)
-        self._obs_x_row = np.ascontiguousarray(obstacles[0]).reshape(1, -1)
-        self._obs_y_row = np.ascontiguousarray(obstacles[1]).reshape(1, -1)
 
     def _is_goal_state(self, state: np.ndarray) -> bool:
         """Check if state is within goal state radius."""
@@ -103,31 +96,25 @@ class ContinuousLightDarkRewardModel(BaseLightDarkRewardModel):
         return self.obstacle_reward if np.random.rand() < self.obstacle_hit_probability else 0.0
 
     def compute_reward_batch(self, states: np.ndarray, action: np.ndarray) -> np.ndarray:
-        next_states = states + action
-        nx = next_states[:, 0]
-        ny = next_states[:, 1]
-
-        # Goal distance from raw components — cheaper than np.linalg.norm.
-        g_dx = nx - self.goal_state[0]
-        g_dy = ny - self.goal_state[1]
-        sq_dist_to_goal = g_dx * g_dx + g_dy * g_dy
-        rewards = -self.fuel_cost - np.sqrt(sq_dist_to_goal)
-        goal_mask = sq_dist_to_goal <= self._goal_radius_sq
-        rewards[goal_mask] += self.goal_reward
-
-        # Obstacle membership — squared distances on (N, M), no (N, 2, M)
-        # intermediate. self._obs_{x,y}_row are cached (1, M) views.
-        o_dx = nx[:, None] - self._obs_x_row
-        o_dy = ny[:, None] - self._obs_y_row
-        sq_obs_dists = o_dx * o_dx + o_dy * o_dy
-        in_range = np.any(sq_obs_dists <= self._obstacle_radius_sq, axis=1)
-        obstacle_mask = in_range & ~goal_mask
+        # Deterministic part runs in a Numba kernel. The mask flags the rows
+        # where the next state landed in an obstacle region but was not at
+        # goal / out-of-grid; those rows still need the stochastic obstacle
+        # contribution applied in Python so seeded RNG stays reproducible.
+        rewards, obstacle_mask = compute_reward_base_batch_kernel(
+            states,
+            action,
+            self.goal_state,
+            self.obstacles,
+            self.goal_state_radius,
+            self.obstacle_radius,
+            float(self.grid_size),
+            self.fuel_cost,
+            self.goal_reward,
+            self.obstacle_reward,
+        )
         n_obs = int(np.count_nonzero(obstacle_mask))
         if n_obs > 0:
             rewards[obstacle_mask] += self._obstacle_reward_batch(n_obs)
-
-        oob = (nx < 0.0) | (ny < 0.0) | (nx > self.grid_size) | (ny > self.grid_size)
-        rewards[oob & ~goal_mask & ~in_range] += self.obstacle_reward
         return rewards
 
     def _obstacle_reward_batch(self, n: int) -> np.ndarray:

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py
@@ -16,6 +16,10 @@ Public kernels
 - :func:`compute_reward_base_kernel` — deterministic part of the Standard /
   DangerousStates reward model plus an ``is_obstacle_hit_region`` flag so the
   Python caller can decide whether to draw a uniform.
+- :func:`compute_reward_base_batch_kernel` — batched version of
+  :func:`compute_reward_base_kernel`. Returns ``(rewards, obstacle_mask)`` so
+  the Python caller can apply the stochastic obstacle-hit contribution where
+  the mask is ``True``, preserving the seeded RNG call pattern.
 - :func:`compute_reward_decaying_hit_prob_kernel` — full reward for the
   Decaying-Hit-Probability model (uniform drawn in Python and passed in).
 """
@@ -101,6 +105,72 @@ def compute_reward_base_kernel(
     if next_x < 0.0 or next_y < 0.0 or next_x > grid_size or next_y > grid_size:
         return reward + obstacle_reward, False
     return reward, False
+
+
+@njit(cache=True)  # type: ignore[misc]
+def compute_reward_base_batch_kernel(
+    states: np.ndarray,
+    action: np.ndarray,
+    goal_state: np.ndarray,
+    obstacles: np.ndarray,
+    goal_state_radius: float,
+    obstacle_radius: float,
+    grid_size: float,
+    fuel_cost: float,
+    goal_reward: float,
+    obstacle_reward: float,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Batched form of :func:`compute_reward_base_kernel`.
+
+    Parameters mirror the scalar kernel; ``states`` is shape ``(N, 2)``.
+    Returns ``(rewards, obstacle_mask)`` both of length ``N``. ``rewards``
+    already includes fuel, goal-distance, goal bonus, and the out-of-grid
+    penalty. The Python caller must add the stochastic obstacle-hit
+    contribution at indices where ``obstacle_mask`` is ``True``, drawing
+    its own RNG so seeded tests stay bit-identical to the per-state path.
+    """
+    n_states = states.shape[0]
+    n_obs = obstacles.shape[1]
+    goal_radius_sq = goal_state_radius * goal_state_radius
+    obs_radius_sq = obstacle_radius * obstacle_radius
+    ax = action[0]
+    ay = action[1]
+    gx0 = goal_state[0]
+    gy0 = goal_state[1]
+
+    rewards = np.empty(n_states, dtype=np.float64)
+    obstacle_mask = np.zeros(n_states, dtype=np.bool_)
+
+    for s in range(n_states):
+        next_x = states[s, 0] + ax
+        next_y = states[s, 1] + ay
+        gx = next_x - gx0
+        gy = next_y - gy0
+        sq_dist_to_goal = gx * gx + gy * gy
+        reward = -fuel_cost - sq_dist_to_goal**0.5
+
+        if sq_dist_to_goal <= goal_radius_sq:
+            rewards[s] = reward + goal_reward
+            continue
+
+        in_obstacle_range = False
+        for i in range(n_obs):
+            ox = next_x - obstacles[0, i]
+            oy = next_y - obstacles[1, i]
+            if ox * ox + oy * oy <= obs_radius_sq:
+                in_obstacle_range = True
+                break
+        if in_obstacle_range:
+            rewards[s] = reward
+            obstacle_mask[s] = True
+            continue
+
+        if next_x < 0.0 or next_y < 0.0 or next_x > grid_size or next_y > grid_size:
+            rewards[s] = reward + obstacle_reward
+        else:
+            rewards[s] = reward
+
+    return rewards, obstacle_mask
 
 
 @njit(cache=True)  # type: ignore[misc]

--- a/POMDPPlanners/planners/mcts_planners/icvar_pomcpow.py
+++ b/POMDPPlanners/planners/mcts_planners/icvar_pomcpow.py
@@ -180,8 +180,17 @@ class ICVaR_POMCPOW(ArenaPathSimulationPolicyCostSetting):
         children_count = len(tree.children_ids[action_id])
         action_visits = tree.visit_count[action_id]
         if children_count <= self.k_o * action_visits**self.alpha_o:
-            existing_id = tree.get_belief_child_indexed(action_id, next_observation)
-            if existing_id is None:
+            try:
+                obs_key = self.environment.hash_observation(next_observation)
+                # Indexed lookup is authoritative when obs_key is available.
+                # The contract on ``hash_observation`` guarantees:
+                #   is_equal_observation(a, b) ==> hash_observation(a) ==
+                #   hash_observation(b)
+                # so a None result means no equal observation has been added.
+                existing_id = tree.get_belief_child_indexed(action_id, obs_key=obs_key)
+            except NotImplementedError:
+                # Env not migrated; fall back to linear-scan path.
+                obs_key = None
                 existing_id = tree.get_belief_child(action_id, next_observation, self.environment)
             if existing_id is None:
                 next_belief_id = tree.add_belief_node(
@@ -189,6 +198,7 @@ class ICVaR_POMCPOW(ArenaPathSimulationPolicyCostSetting):
                     observation=next_observation,
                     parent_id=action_id,
                     weight=1.0,
+                    obs_key=obs_key,
                 )
             else:
                 tree.increment_weight(existing_id, delta=1.0)

--- a/POMDPPlanners/planners/planners_utils/path_simulations_policy_arena.py
+++ b/POMDPPlanners/planners/planners_utils/path_simulations_policy_arena.py
@@ -72,6 +72,11 @@ class ArenaPathSimulationPolicy(Policy):
         self.action_sampler = action_sampler
         # Optional sizehint for Tree column buffers (POMCPOW.jl-style).
         self.reserve_capacity = reserve_capacity
+        # Adaptive sizehint: remember the last tree's final node count so
+        # the next ``_learn_tree`` call can reserve a buffer that already
+        # covers the typical workload. Cuts the realloc bursts that
+        # ``_allocate`` would otherwise pay on every call.
+        self._last_tree_size: int = 0
 
         if n_simulations is not None and time_out_in_seconds is not None:
             raise ValueError("Cannot specify both n_simulations and time_out_in_seconds")
@@ -112,8 +117,9 @@ class ArenaPathSimulationPolicy(Policy):
 
     def _learn_tree(self, belief: Belief) -> Tuple[Tree, int]:
         tree = Tree()
-        if self.reserve_capacity > 0:
-            tree.reserve(self.reserve_capacity)
+        capacity = self._effective_reserve_capacity()
+        if capacity > 0:
+            tree.reserve(capacity)
         root_id = tree.add_belief_node(belief)
 
         if self.n_simulations is not None:
@@ -123,7 +129,32 @@ class ArenaPathSimulationPolicy(Policy):
         else:
             raise ValueError("Either n_simulations or time_out_in_seconds must be provided")
 
+        # Remember the final size so the next call can pre-reserve a
+        # buffer that already covers the typical workload.
+        self._last_tree_size = len(tree)
         return tree, root_id
+
+    def _effective_reserve_capacity(self) -> int:
+        """Capacity passed to :meth:`Tree.reserve` for each new tree.
+
+        If the caller supplied an explicit ``reserve_capacity`` we honour it
+        verbatim. Otherwise, prefer a sizehint derived from the previous
+        call's final tree (adaptive, dialled in after one warmup) and fall
+        back to ``2 * n_simulations`` when no history is available — each
+        simulation adds at most one belief node and one action node per
+        level it descends, so this is a safe-but-not-bloated baseline that
+        covers shallow trees and lets deeper trees fall back to
+        ``list.append`` past the reserved zone.
+        """
+        if self.reserve_capacity > 0:
+            return self.reserve_capacity
+        if self._last_tree_size > 0:
+            # 1.25x headroom so a slightly larger tree still hits the
+            # reserved zone instead of falling back to append.
+            return (self._last_tree_size * 5) // 4
+        if self.n_simulations is not None:
+            return 2 * self.n_simulations
+        return 0
 
     def _construct_tree_using_n_simulations(self, tree: Tree, root_id: int) -> None:
         if self.n_simulations is None:


### PR DESCRIPTION
## Summary

Five profile-driven perf changes for ICVaR_POMCPOW + ICVaR_PFT_DPW (and indirectly plain POMCPOW/PFT-DPW). Built on top of PR #122 — once that merges, this PR's diff narrows to just the bundle.

### Fixes

1. **`perf/icvar-pomcpow-indexed-obs-lookup`** — ICVaR_POMCPOW was passing the raw ndarray observation to `tree.get_belief_child_indexed`, which always returned `None` for unhashable inputs and silently fell through to the O(N) linear scan in `get_belief_child`. Now mirrors PR #113's pattern for plain POMCPOW: compute `obs_key = env.hash_observation(obs)` once, pass it to both indexed lookup and `add_belief_node`. Falls back to linear scan only on `NotImplementedError`.

2. **`perf/lightdark-numba-batch-reward`** — `ContinuousLightDarkRewardModel.compute_reward_batch` was the #1 cost on ICVaR_PFT_DPW LightDark (~21% of wall time even after PR #122's numpy opt). New `compute_reward_base_batch_kernel` (`@njit(cache=True)`) ports the deterministic part to Numba; Python wrapper still owns the stochastic obstacle-hit draw. Bit-identical equivalence verified against the prior numpy version. Per-call time dropped 4.7× (35μs → 7.5μs).

3. **`perf/laser-tag-wrapper-streamline`** — Removes redundant `np.asarray(..., dtype=np.float64)` wraps around already-`py::array_t<double>` native kernel returns in `sample_next_state_batch`, `observation_log_probability_per_state`, `transition_log_probability`, `observation_log_probability`. ~56k fewer per-bench numpy allocs. Modest direct gain (kernel calls already dominate); cleaner code.

4. **`perf/arena-presize-buffers`** — Cursor model in `arena.Tree`: `_size` field tracks logical node count, `__len__` returns it, `reserve()` pads columns with `None` sentinels without clearing them, `_allocate` writes-at-cursor (in-place `__setitem__`) until past the reserved zone then falls back to `append`. `path_simulations_policy_arena.py` now sizes the reserve adaptively (previous tree's size × 1.25 for time-budget mode, else `2 × n_simulations`). `_allocate` self-time on ICVaR_POMCPOW × LightDark dropped 48% (0.469s → 0.245s); cumulative dropped 61%.

## Bench (sims/sec, `profile_planner_envs --budget 1 --n-calls 5 --particles 200`)

Bundle vs PR #122 tip baseline, both runs back-to-back on the same machine:

| env / planner               | baseline | bundle | Δ |
|-----------------------------|--------:|-------:|--:|
| ICVaR_POMCPOW ContinuousLightDark |  1,121 | 1,289 | **+15.0%** |
| ICVaR_POMCPOW ContinuousLaserTag  |  1,164 | 1,374 | **+18.0%** |
| ICVaR_PFT_DPW ContinuousLightDark |    269 |   345 | **+28.3%** |
| ICVaR_PFT_DPW ContinuousLaserTag  |    318 |   327 | +2.8% (noise) |
| POMCPOW       ContinuousLightDark | 10,387 |10,789 | +3.9% |
| POMCPOW       ContinuousLaserTag  |  9,896 |10,067 | +1.7% (noise) |
| PFT_DPW       ContinuousLightDark |  4,467 | 5,458 | **+22.2%** |
| PFT_DPW       ContinuousLaserTag  |  3,431 | 3,531 | +2.9% (noise) |

Plain PFT_DPW × LightDark gets a surprise **+22.2%** because the Numba reward kernel benefits any planner that goes through `belief_expectation_cost_particle_belief` → `reward_batch`, not just ICVaR.

## Per-fix attribution (each measured in its own worktree against PR #122 baseline)

| fix | LD POMCPOW | LT POMCPOW | LD PFT-DPW | LT PFT-DPW | LD ICVaR_POMCPOW | LT ICVaR_POMCPOW | LD ICVaR_PFT_DPW | LT ICVaR_PFT_DPW |
|---|---|---|---|---|---|---|---|---|
| #1 indexed obs lookup | — | — | — | — | +11.0% | +14.9% | — | — |
| #2 Numba batch reward | — | — | (+22%) | — | (-2.1% noise) | — | +29.6% | — |
| #3+#4 LaserTag wrappers | — | — | — | (~0%) | — | +1-3% | — | (~0%) |
| #5 arena pre-size | +6% | +4% | +4% | +4% | +16% | +17% | +3% | +5% |

Stack-up is sub-additive in places (e.g. ICVaR_POMCPOW LightDark: #1 +11% + #5 +16% = +28% standalone, but bundled is +15% — the two changes share the same hot path).

## Test plan

- [x] 793 tests pass on impacted suites (`test_arena_tree.py`, all of `test_planners/test_mcts_planners/`, `test_environments/test_light_dark_pomdp/`, `test_environments/test_laser_tag_pomdp/`)
- [x] All 4 sub-branches green individually (each agent verified)
- [x] Bit-identical equivalence on `compute_reward_batch` numpy → Numba (max abs diff = 0.0 across 5 random state distributions, fixed seed)
- [x] Pre-commit hooks (black, pylint, pyright) green on the bundle
- [ ] CI signals (full suite)

## Notes

- Built on top of `perf/icvar-reward-batch-and-lasertag-scalar-obs` (PR #122). Once #122 merges to develop, this PR's diff narrows to just the bundle. If you'd rather rebase to drop the dependency, say the word.
- First call after fresh checkout will pay the Numba JIT cache-miss cost (~1-2s); subsequent runs hit the on-disk `__pycache__/*.nbc` cache.