### PR TITLE
perf(envs): Tiger-pattern RNG/numpy fixes across 6 envs

### DIFF
--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -260,6 +260,13 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             dtype=np.int64,
         )
         self._reward_n_walls: int = len(walls_list)
+        # Precomputed error-action lookup for the action-error coin in
+        # _resolve_actual_action / _python_sample_next_state. Avoids a
+        # per-call list comprehension + np.random.choice over a Python
+        # list (~5 µs → ~1.5 µs).
+        self._error_actions_for: Dict[int, List[int]] = {
+            a: [b for b in (0, 1, 2, 3) if b != a] for a in (0, 1, 2, 3)
+        }
 
     def _is_valid_position_inline(self, pos: Tuple[int, int]) -> bool:
         row, col = pos
@@ -344,8 +351,8 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         if action == 4:
             return 4
         if np.random.random() < self.transition_error_prob:
-            available_actions = [a for a in (0, 1, 2, 3) if a != action]
-            return int(np.random.choice(available_actions))
+            available = self._error_actions_for[action]
+            return available[np.random.randint(3)]
         return action
 
     def _python_sample_next_state(self, state: np.ndarray, action: int, n_samples: int) -> Any:
@@ -354,8 +361,8 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             actual_action = action
         else:
             if np.random.random() < self.transition_error_prob:
-                available_actions = [a for a in [0, 1, 2, 3] if a != action]
-                actual_action = int(np.random.choice(available_actions))
+                available = self._error_actions_for[action]
+                actual_action = available[np.random.randint(3)]
             else:
                 actual_action = action
 
@@ -520,22 +527,21 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             self._laser_distance_inline(robot_pos, direction, opp_pos)
             for direction in _LASER_DIRECTIONS
         ]
-        # Add Gaussian noise to each measurement (8 np.random.normal draws per
-        # sample, in dir order — matches wrapper's RNG draw sequence).
+        # Add Gaussian noise to each measurement. Single batched np.random.normal
+        # call (size=8 for n=1, size=n*8 for n>1) replaces a per-direction
+        # scalar dispatch — same RNG draw count, lower per-call overhead.
+        sigma = self.measurement_noise
         if n_samples == 1:
-            noisy: List[float] = []
-            for true_measure in true_measurements:
-                noise_value = np.random.normal(0, self.measurement_noise)
-                noisy.append(max(0.0, true_measure + noise_value))
-            return tuple(noisy)
+            noise = np.random.normal(0.0, sigma, size=8)
+            return tuple(max(0.0, t + float(noise[i])) for i, t in enumerate(true_measurements))
 
+        noise_batch = np.random.normal(0.0, sigma, size=(n_samples, 8))
         samples: List[Tuple[float, ...]] = []
-        for _ in range(n_samples):
-            noisy_inner: List[float] = []
-            for true_measure in true_measurements:
-                noise_value = np.random.normal(0, self.measurement_noise)
-                noisy_inner.append(max(0.0, true_measure + noise_value))
-            samples.append(tuple(noisy_inner))
+        for j in range(n_samples):
+            row = noise_batch[j]
+            samples.append(
+                tuple(max(0.0, t + float(row[i])) for i, t in enumerate(true_measurements))
+            )
         return samples
 
     def transition_log_probability(
@@ -724,11 +730,12 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             return False
 
         pos_row, pos_col = position
-
+        # Square-distance comparison avoids np.sqrt per area (~400 ns each).
+        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
         for danger_row, danger_col in self.dangerous_areas:
-            # Calculate Euclidean distance
-            distance = np.sqrt((pos_row - danger_row) ** 2 + (pos_col - danger_col) ** 2)
-            if distance <= self.dangerous_area_radius:
+            dr = pos_row - danger_row
+            dc = pos_col - danger_col
+            if dr * dr + dc * dc <= radius_sq:
                 return True
 
         return False

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
@@ -339,12 +339,10 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
     def initial_state_dist(self) -> Distribution:
         class InitialState(Distribution):
             def sample(self, n_samples: int = 1) -> List[np.ndarray]:
-                samples = []
-                for _ in range(n_samples):
-                    position = np.random.uniform(-0.6, -0.4)
-                    velocity = 0.0
-                    samples.append(np.array([position, velocity]))
-                return samples
+                # Vectorized batch RNG draw + per-row np.array — avoids the
+                # per-iteration np.random.uniform dispatch for n_samples > 1.
+                positions = np.random.uniform(-0.6, -0.4, size=n_samples)
+                return [np.array([float(p), 0.0]) for p in positions]
 
         return InitialState()
 

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -236,6 +236,13 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             for label, (dx, dy) in self._ACTION_TO_DXY.items()
         }
 
+        # Precomputed error-action list per action label. Avoids per-call
+        # list comprehension + np.random.choice over a Python list (~5 µs)
+        # in _sample_one_next_state's error branch.
+        self._error_actions_for: Dict[str, List[str]] = {
+            a: [b for b in self.actions if b != a] for a in self.actions
+        }
+
         # Flat (M*2,) float64 buffer of obstacle centres; shared across all
         # cached kernels (they each copy it at construction).
         if self.obstacles:
@@ -303,10 +310,11 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
 
     def _sample_one_next_state(self, state: np.ndarray, action: str) -> np.ndarray:
         # RNG order: one np.random.random() call, optionally one
-        # np.random.choice() call over the error-action list.
+        # np.random.randint() call indexing into the precomputed error list.
+        # randint+index is ~3.5x faster than np.random.choice over a Python list.
         if self.transition_error_prob > 0.0 and np.random.random() < self.transition_error_prob:
-            error_actions = [a for a in self.actions if a != action]
-            actual_action = np.random.choice(error_actions)
+            error_actions = self._error_actions_for[action]
+            actual_action = error_actions[np.random.randint(len(error_actions))]
         else:
             actual_action = action
         return self._compute_next_state_for_action(state, actual_action)
@@ -409,16 +417,17 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         return samples
 
     def _sample_one_observation(self, next_state: np.ndarray) -> np.ndarray:
-        # Two np.random.normal(0, sigma) draws (object-x, object-y), clamped
-        # to [0, grid_size - 1]. Robot and target slices are observed exactly.
+        # Two Gaussian draws (object-x, object-y), clamped to [0, grid_size - 1].
+        # Robot and target slices are observed exactly. Single size=2 draw beats
+        # two scalar np.random.normal calls by avoiding dispatch overhead.
         gmax = self.grid_size - 1
         rx, ry = float(next_state[0]), float(next_state[1])
         ox, oy = float(next_state[2]), float(next_state[3])
         tx, ty = float(next_state[4]), float(next_state[5])
-        noise_std = self.observation_noise
 
-        nox = max(0.0, min(ox + np.random.normal(0, noise_std), gmax))
-        noy = max(0.0, min(oy + np.random.normal(0, noise_std), gmax))
+        noise = np.random.normal(0.0, self.observation_noise, size=2)
+        nox = max(0.0, min(ox + float(noise[0]), gmax))
+        noy = max(0.0, min(oy + float(noise[1]), gmax))
 
         observation = np.empty(6)
         observation[0] = rx

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -490,7 +490,15 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
     ) -> np.ndarray:
         kernel = self._get_obs_kernel(int(action))
         kernel.set_next_state(np.asarray(next_state, dtype=float))
-        codes = np.array([_OBS_STR_TO_CODE.get(v, -1) for v in observations], dtype=np.int32)
+        # Length-1 fast path: skip the list comprehension + np.array allocation.
+        if hasattr(observations, "__len__") and len(observations) == 1:
+            codes = np.array([_OBS_STR_TO_CODE.get(observations[0], -1)], dtype=np.int32)
+        else:
+            codes = np.fromiter(
+                (_OBS_STR_TO_CODE.get(v, -1) for v in observations),
+                dtype=np.int32,
+                count=len(observations) if hasattr(observations, "__len__") else -1,
+            )
         probs = np.asarray(kernel.probability(codes))
         return np.log(probs + 1e-300)
 

--- a/POMDPPlanners/environments/sanity_pomdp.py
+++ b/POMDPPlanners/environments/sanity_pomdp.py
@@ -249,9 +249,10 @@ class SanityPOMDP(DiscreteActionsEnvironment):
         return np.log(probs + 1e-300)
 
     def reward(self, state: int, action: int) -> float:
-        # Higher reward for being in good state (0)
-        next_state = self.sample_next_state(state, action)
-        return 1.0 if next_state == 0 else 0.0
+        # Transition is deterministic: action 0 -> next_state 0 (reward 1.0),
+        # action != 0 -> next_state != 0 (reward 0.0). Inline to avoid the
+        # sample_next_state call overhead on the hot path.
+        return 1.0 if action == 0 else 0.0
 
     def is_terminal(self, state: int) -> bool:
         return False  # No terminal states

--- a/POMDPPlanners/environments/tiger_pomdp.py
+++ b/POMDPPlanners/environments/tiger_pomdp.py
@@ -129,27 +129,28 @@ class TigerPOMDP(DiscreteActionsEnvironment):
 
     def sample_next_state(self, state: str, action: str, n_samples: int = 1):
         if action in ("open_left", "open_right"):
-            samples = [str(np.random.choice(STATES)) for _ in range(n_samples)]
-        else:
-            samples = [state] * n_samples
+            # randint(0, 2) is ~3.5x faster than np.random.choice over a list
+            if n_samples == 1:
+                return STATES[np.random.randint(0, 2)]
+            idxs = np.random.randint(0, 2, size=n_samples)
+            return [STATES[i] for i in idxs]
         if n_samples == 1:
-            return samples[0]
-        return samples
+            return state
+        return [state] * n_samples
 
     def sample_observation(self, next_state: str, action: str, n_samples: int = 1):
-        samples: List[str] = []
-        if action == "listen":
-            if next_state == "tiger_left":
-                for _ in range(n_samples):
-                    samples.append("hear_left" if np.random.random() < 0.85 else "hear_right")
-            else:
-                for _ in range(n_samples):
-                    samples.append("hear_right" if np.random.random() < 0.85 else "hear_left")
-        else:
-            samples = ["hear_nothing"] * n_samples
+        if action != "listen":
+            if n_samples == 1:
+                return "hear_nothing"
+            return ["hear_nothing"] * n_samples
+        # Listen: 0.85 prob hear matching ear, 0.15 hear opposite.
+        # Single draw of np.random.random per call (n=1) or one batched draw (n>1).
+        correct = "hear_left" if next_state == "tiger_left" else "hear_right"
+        wrong = "hear_right" if next_state == "tiger_left" else "hear_left"
         if n_samples == 1:
-            return samples[0]
-        return samples
+            return correct if np.random.random() < 0.85 else wrong
+        draws = np.random.random(size=n_samples)
+        return [correct if d < 0.85 else wrong for d in draws]
 
     def transition_log_probability(self, state: str, action: str, next_states) -> np.ndarray:
         result = np.zeros(len(next_states))


### PR DESCRIPTION
## Summary

Audit-driven sweep across six POMDP envs replacing per-step sampling patterns that
incur unnecessary NumPy dispatch overhead. All changes preserve semantics and RNG
draw counts.

- **tiger_pomdp**: \`np.random.choice(STATES)\` → \`STATES[np.random.randint(0,2)]\` (~3.5× faster); vectorize observation Gaussian draws.
- **push_pomdp**: precompute \`_error_actions_for\` and use indexed access instead of \`np.random.choice\`; one size=2 \`np.random.normal\` instead of two scalar draws.
- **laser_tag_pomdp**: same error-action pattern; vectorize 8-direction Gaussian noise into one batched draw; squared-distance compare in \`_is_in_dangerous_area\`.
- **rock_sample_pomdp**: length-1 fast path in \`observation_log_probability\`.
- **mountain_car_pomdp**: vectorize \`InitialState.sample\`.
- **sanity_pomdp**: inline deterministic \`reward()\`.

## Bench results

| Env | Bench | Before | After | Δ |
|---|---|---:|---:|---:|
| Tiger | env step (open_left) | 5,248 ns | 1,541 ns | **−71%** |
| Tiger | env step (listen) | 607 ns | 461 ns | −24% |
| Tiger | POMCPOW sims/sec | 8,933 | 15,137 | **+69%** |
| Push | POMCPOW sims/sec | 19,805 | 20,375 | +2.9% |
| MountainCar | init_state n=100 ns | ~250,000 | 35,328 | ~7× |

Cross-language reference: closes Julia POMCPOW.jl gap on Tiger from **12.1× → 7.1×**.

## Test plan

- [x] \`pytest POMDPPlanners/tests/test_environments/test_tiger_pomdp.py\` — 33 pass
- [x] \`pytest POMDPPlanners/tests/test_environments/{test_push_pomdp,test_mountain_car_pomdp.py,test_laser_tag_pomdp,test_rock_sample_pomdp}\` — 581 pass total
- [x] \`pytest POMDPPlanners/tests/test_core POMDPPlanners/tests/test_planners POMDPPlanners/tests/test_utils\` — 1331 pass
- [x] Tiger POMCPOW bench (regression check): no regression, +69% gain