### PR TITLE
perf: Numba kernels for WeightedParticleBelief._resample and ContinuousLightDark _is_near_beacon_scalar

### DIFF
--- a/POMDPPlanners/core/belief/particle_beliefs.py
+++ b/POMDPPlanners/core/belief/particle_beliefs.py
@@ -27,6 +27,7 @@ import numpy as np
 from POMDPPlanners.core.belief.base_belief import Belief
 from POMDPPlanners.core.distributions import DiscreteDistribution
 from POMDPPlanners.core.environment import Environment
+from POMDPPlanners.utils.numba_kernels import systematic_resample_kernel
 from POMDPPlanners.utils.config_to_id import config_to_id
 
 
@@ -255,30 +256,26 @@ class WeightedParticleBelief(Belief):
         return config_to_id(config_dict)
 
     def _resample(self, particles: Any, log_weights: np.ndarray) -> Tuple[Any, np.ndarray]:
-        normalized_weights = np.exp(log_weights - np.max(log_weights))
-        normalized_weights = normalized_weights / np.sum(normalized_weights)
-
-        effective_sample_size = 1 / np.sum(np.square(normalized_weights))
-        if effective_sample_size < self.ess_threshold:
-            # Systematic resampling: one stratified uniform draw, vectorised
-            # CDF lookup via np.searchsorted. Unbiased and lower-variance
-            # than i.i.d. multinomial (random.choices) -- see Doucet &
-            # Johansen 2009. Replaces the per-call CPython bisect loop.
-            n = len(particles)
-            u0 = np.random.random() / n
-            positions = u0 + np.arange(n) / n
-            cdf = np.cumsum(normalized_weights)
-            idx = np.minimum(np.searchsorted(cdf, positions), n - 1)
-            # Use ndarray fancy indexing for the native batch path (one
-            # contiguous gather) and fall back to a Python list comp for
-            # heterogeneous list-backed beliefs.
-            if isinstance(particles, np.ndarray):
-                resampled_particles: Any = particles[idx]
-            else:
-                resampled_particles = [particles[i] for i in idx]
-            new_log_weights = np.full(n, -np.log(n))
-            return resampled_particles, new_log_weights
-        return particles, log_weights
+        # Fused log-weight normalize + ESS check + systematic resample in
+        # one Numba kernel. Replaces 6+ separate vectorised numpy passes
+        # (max, exp, sum, normalise, square, cumsum, searchsorted, ...)
+        # whose temp-array allocations dominated this method on small N.
+        n = len(particles)
+        u0 = np.random.random() / n
+        idx, did_resample, new_log_weights = systematic_resample_kernel(
+            log_weights=np.ascontiguousarray(log_weights, dtype=np.float64),
+            ess_threshold=float(self.ess_threshold),
+            u0=float(u0),
+        )
+        if not did_resample:
+            return particles, log_weights
+        # ndarray fancy index for the native batch path (one contiguous
+        # gather); list comp for heterogeneous list-backed beliefs.
+        if isinstance(particles, np.ndarray):
+            resampled_particles: Any = particles[idx]
+        else:
+            resampled_particles = [particles[i] for i in idx]
+        return resampled_particles, new_log_weights
 
     def _update_weights(
         self, action: Any, observation: Any, pomdp: Environment

--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
@@ -57,6 +57,7 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_da
 )
 from POMDPPlanners.utils.numba_kernels import (
     any_point_within_radius_kernel,
+    any_point_within_radius_sq_xy_kernel,
     min_distance_to_points_kernel,
     mvn_sample_2d_kernel,
 )
@@ -255,9 +256,6 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
         self._cls_obs_log_norm_far = self._build_log_norm_2d(observation_cov_matrix)
         self._cls_obs_log_norm_near = self._build_log_norm_2d(observation_cov_matrix * 0.5)
         self._cls_beacon_radius_sq = float(beacon_radius) * float(beacon_radius)
-        # Beacons stored as (2, N) float ndarray; precompute (N, 2) for the
-        # singleton near-beacon scan.
-        self._cls_beacons_t = np.ascontiguousarray(self.beacons.T, dtype=np.float64)
         # Initialize reward model based on type
         self.reward_model: BaseLightDarkRewardModel
         if reward_model_type == RewardModelType.STANDARD:
@@ -606,19 +604,11 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
         return -math.log(2.0 * math.pi) - 0.5 * math.log(det)
 
     def _is_near_beacon_scalar(self, x: float, y: float) -> bool:
-        # Scalar near-beacon scan; mirrors the broadcasting check in
-        # BaseContinuousLightDarkObservationModel._near_beacon but without
-        # numpy allocation. Returns True if within beacon_radius of any beacon.
-        beacons = self._cls_beacons_t
-        if beacons.shape[0] == 0:
-            return False
-        radius_sq = self._cls_beacon_radius_sq
-        for i in range(beacons.shape[0]):
-            dx = x - beacons[i, 0]
-            dy = y - beacons[i, 1]
-            if dx * dx + dy * dy <= radius_sq:
-                return True
-        return False
+        # Numba kernel scan over self.beacons (2, N). Empty-beacon set is
+        # handled by the kernel returning False on the zero-iteration loop.
+        return bool(
+            any_point_within_radius_sq_xy_kernel(x, y, self.beacons, self._cls_beacon_radius_sq)
+        )
 
     def observation_log_probability_single(
         self, next_state: Any, action: Any, observation: Any

--- a/POMDPPlanners/utils/numba_kernels.py
+++ b/POMDPPlanners/utils/numba_kernels.py
@@ -26,7 +26,11 @@ Public kernels
   the query to any of ``N`` points.
 - :func:`mvn_sample_2d_kernel` — 2-D multivariate-normal sample given
   pre-drawn standard normals and a transposed Cholesky factor.
+- :func:`systematic_resample_kernel` — fused log-weight normalization,
+  ESS check, and systematic resampling index draw for particle filters.
 """
+
+from typing import Tuple
 
 import numpy as np
 from numba import njit
@@ -93,3 +97,72 @@ def mvn_sample_2d_kernel(
         out[i, 0] = m0 + z0 * lt00 + z1 * lt10
         out[i, 1] = m1 + z0 * lt01 + z1 * lt11
     return out
+
+
+@njit(cache=True)  # type: ignore[misc]
+def systematic_resample_kernel(
+    log_weights: np.ndarray,
+    ess_threshold: float,
+    u0: float,
+) -> Tuple[np.ndarray, bool, np.ndarray]:
+    """Fused log-weight normalization, ESS check, and systematic resample.
+
+    Returns ``(idx, did_resample, new_log_weights)``.
+
+    - ``idx`` is the resample index array of length ``N`` (or empty when
+      no resample was needed).
+    - ``did_resample`` is True when ESS < ``ess_threshold`` and indices
+      were drawn.
+    - ``new_log_weights`` is ``-log(N)`` repeated when resampling fired,
+      else the original ``log_weights`` (caller can ignore in the latter
+      case; we return it for a uniform return signature).
+
+    The kernel fuses what NumPy needed in 6+ separate vectorised passes
+    (max, exp, sum, normalise, square, cumsum, searchsorted, fancy index)
+    into a single C loop, avoiding the temporary array allocations that
+    dominate the cost on small N (~200).
+
+    The caller draws ``u0`` (one uniform in ``[0, 1/N)``) so the kernel
+    stays deterministic under the caller's RNG and tests stay seedable.
+    """
+    n = log_weights.shape[0]
+    # Pass 1: max log-weight (for the numerically-stable exp shift).
+    max_lw = log_weights[0]
+    for i in range(1, n):
+        if log_weights[i] > max_lw:
+            max_lw = log_weights[i]
+
+    # Pass 2: exp-shift, sum.
+    weights = np.empty(n, dtype=np.float64)
+    total = 0.0
+    for i in range(n):
+        w = np.exp(log_weights[i] - max_lw)
+        weights[i] = w
+        total += w
+    inv_total = 1.0 / total
+
+    # Pass 3: normalize, sum-of-squares, build CDF in-place.
+    sq_sum = 0.0
+    cdf_running = 0.0
+    for i in range(n):
+        w_norm = weights[i] * inv_total
+        sq_sum += w_norm * w_norm
+        cdf_running += w_norm
+        weights[i] = cdf_running  # repurpose as CDF buffer
+
+    ess = 1.0 / sq_sum
+    if ess >= ess_threshold:
+        return np.empty(0, dtype=np.int64), False, log_weights
+
+    # Pass 4: systematic resample. ``positions`` are sorted and ``cdf`` is
+    # sorted, so a single linear sweep replaces N binary searches.
+    idx = np.empty(n, dtype=np.int64)
+    inv_n = 1.0 / n
+    j = 0
+    for i in range(n):
+        u = u0 + i * inv_n
+        while j < n - 1 and weights[j] < u:
+            j += 1
+        idx[i] = j
+    new_log_weights = np.full(n, -np.log(n))
+    return idx, True, new_log_weights

--- a/POMDPPlanners/utils/numba_kernels.py
+++ b/POMDPPlanners/utils/numba_kernels.py
@@ -55,6 +55,28 @@ def any_point_within_radius_kernel(
 
 
 @njit(cache=True)  # type: ignore[misc]
+def any_point_within_radius_sq_xy_kernel(
+    x: float,
+    y: float,
+    points: np.ndarray,
+    radius_sq: float,
+) -> bool:
+    """Scalar (x, y) variant of :func:`any_point_within_radius_kernel`.
+
+    Takes pre-squared radius and scalar query coordinates so callers in
+    a hot per-visit path can avoid the per-call (2,) ndarray allocation
+    that the ndarray-query variant forces.
+    """
+    n_points = points.shape[1]
+    for i in range(n_points):
+        dx = x - points[0, i]
+        dy = y - points[1, i]
+        if dx * dx + dy * dy <= radius_sq:
+            return True
+    return False
+
+
+@njit(cache=True)  # type: ignore[misc]
 def min_distance_to_points_kernel(
     query: np.ndarray,
     points: np.ndarray,


### PR DESCRIPTION
## Summary

Two profile-driven Numba kernels that landed on the `perf/icvar-bundle-2` branch *after* PR #123 was merged. Cherry-picked here as a small follow-up.

### 1. `WeightedParticleBelief._resample` → `systematic_resample_kernel`

Fuses log-weight normalization, ESS check, CDF construction, and systematic resample index draw into one `@njit` kernel. Replaces 6+ separate vectorised numpy passes whose temp-array allocations dominated this method on N~200.

The kernel returns `(idx, did_resample, new_log_weights)`. Python wrapper still owns the RNG draw (one uniform in `[0, 1/N)`) so seeded tests stay byte-identical. Particle gather (ndarray fancy index vs list comp) stays in Python because particle storage is heterogeneous.

### 2. `ContinuousLightDarkPOMDP._is_near_beacon_scalar` → `any_point_within_radius_sq_xy_kernel`

Adds `any_point_within_radius_sq_xy_kernel`: scalar `(x, y)` variant of the existing `any_point_within_radius_kernel`. Takes pre-squared radius and scalar query coords so per-visit callers avoid the `(2,)` ndarray allocation that the ndarray-query variant forces.

Drops the unused `_cls_beacons_t` cache; the kernel reads directly from the `(2, N)` `self.beacons` that other beacon-related kernels already use.

## Bench (sims/sec, `profile_planner_envs --budget 1 --n-calls 5 --particles 200`)

Each measured against the bundle baseline (PR #123) on the same machine:

| change | env / planner               | before | after | Δ |
|--------|-----------------------------|------:|------:|--:|
| #1 `_resample` | ICVaR_PFT_DPW LightDark   |   333 |   426 | **+27.9%** |
| #1 `_resample` | ICVaR_PFT_DPW LaserTag    |   324 |   381 | **+17.6%** |
| #1 `_resample` | PFT_DPW LightDark         | 5,458 | 6,042 | **+10.7%** |
| #1 `_resample` | PFT_DPW LaserTag          | 3,531 | 3,803 | **+7.7%** |
| #2 beacon       | ICVaR_POMCPOW LightDark   | 1,305 | 1,382 | **+5.9%** |
| #2 beacon       | POMCPOW LightDark         |10,461 |11,533 | **+10.2%** |

Stack-up: any planner doing a particle-filter weight update (`update`) gets #1; any planner whose per-visit path touches `observation_log_probability_single` on ContinuousLightDark gets #2 (POMCPOW family). LaserTag cells are unchanged by #2 (no beacons).

cProfile after these land:
- `_resample` cum dropped **2.6×** on ICVaR_PFT_DPW LightDark (1.310s → 0.501s)
- `_is_near_beacon_scalar` dropped out of top-25 self-time (was 0.338s self / 100K calls)

## Test plan

- [x] 680 tests pass on impacted suites (`test_core/test_belief/`, `test_environments/test_light_dark_pomdp/`, all PFT-DPW + POMCPOW + ICVaR planner tests)
- [x] Pre-commit hooks (black, pylint, pyright) green
- [x] Bit-identical resample under fixed seed (kernel takes the uniform from the Python RNG)
- [ ] CI signals (full suite)

## Why not in PR #123

PR #123 was merged from a stale tip of `perf/icvar-bundle-2` before these two commits landed on the branch. Rather than re-open or revert that PR, this is a small follow-up.