### PR TITLE
perf(icvar): Numba CVaR estimator + LCB kernel; drop np.fromiter on small lists

### DIFF
--- a/POMDPPlanners/planners/mcts_planners/icvar_pomcpow.py
+++ b/POMDPPlanners/planners/mcts_planners/icvar_pomcpow.py
@@ -38,7 +38,7 @@ from POMDPPlanners.planners.planners_utils.dpw import ActionSampler
 from POMDPPlanners.planners.planners_utils.path_simulations_policy_arena import (
     ArenaPathSimulationPolicyCostSetting,
 )
-from POMDPPlanners.utils.statistics_utils import cvar_estimator_from_dist_fast
+from POMDPPlanners.utils.numba_kernels import cvar_estimator_from_dist_fast_kernel
 
 
 class ICVaR_POMCPOW(ArenaPathSimulationPolicyCostSetting):
@@ -285,23 +285,24 @@ class ICVaR_POMCPOW(ArenaPathSimulationPolicyCostSetting):
             tree.q_value[action_id] = immediate_cost
             return
 
-        v_values = np.fromiter(
-            (tree.v_value[cid] for cid in visited_children),
-            dtype=np.float64,
-            count=n_visited,
-        )
-        weights = np.fromiter(
-            (tree.weight[cid] for cid in visited_children),
-            dtype=np.float64,
-            count=n_visited,
-        )
-        weights_sum = weights.sum()
-        if weights_sum > 0:
+        # Single Python loop fills both arrays — faster than two np.fromiter
+        # calls over a Python-list source for small N (typical here).
+        tree_v_value = tree.v_value
+        tree_weight = tree.weight
+        v_values = np.empty(n_visited, dtype=np.float64)
+        weights = np.empty(n_visited, dtype=np.float64)
+        weights_sum = 0.0
+        for i, cid in enumerate(visited_children):
+            v_values[i] = tree_v_value[cid]
+            w = tree_weight[cid]
+            weights[i] = w
+            weights_sum += w
+        if weights_sum > 0.0:
             weights = weights / weights_sum
         tree.q_value[action_id] = (
             immediate_cost
             + self.discount_factor
-            * cvar_estimator_from_dist_fast(values=v_values, weights=weights, alpha=self.alpha)
+            * cvar_estimator_from_dist_fast_kernel(v_values, weights, self.alpha)
         )
 
     def _update_v_value(self, tree: Tree, belief_id: int) -> None:

--- a/POMDPPlanners/planners/planners_utils/cvar_exploration.py
+++ b/POMDPPlanners/planners/planners_utils/cvar_exploration.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from POMDPPlanners.utils.numba_kernels import sparse_sampling_lcb_min_idx_kernel
 from POMDPPlanners.utils.statistics_utils import get_min_and_max_cost
 from POMDPPlanners.core.tree import BeliefNode, ActionNode
 from POMDPPlanners.core.tree.arena import Tree
@@ -109,34 +110,38 @@ def _sparse_sampling_guarantees_exploration_v2_arena(
     """Arena variant of :func:`_get_sparse_sampling_guarantees_exploration_v2`."""
     children = tree.children_ids[belief_id]
     n_children = len(children)
-    visit_count_array = np.fromiter(
-        (tree.visit_count[cid] for cid in children),
-        dtype=np.float64,
-        count=n_children,
-    )
-    unvisited_indices = np.where(visit_count_array >= 1)[0]
-    if len(unvisited_indices) > 0:
+    # Single Python loop fills both arrays — faster than two np.fromiter
+    # calls over a Python-list source for small N (typical here).
+    tree_visits = tree.visit_count
+    tree_q = tree.q_value
+    visit_count_array = np.empty(n_children, dtype=np.float64)
+    q_values = np.empty(n_children, dtype=np.float64)
+    has_visited = False
+    for i, cid in enumerate(children):
+        v = tree_visits[cid]
+        visit_count_array[i] = v
+        q_values[i] = tree_q[cid]
+        if v >= 1:
+            has_visited = True
+    if has_visited:
+        # Preserve original behaviour: pick a random visited child when any
+        # have been visited (the np.where(>= 1) branch in the prior code).
+        unvisited_indices = np.where(visit_count_array >= 1)[0]
         return children[int(np.random.choice(unvisited_indices))]
 
-    visit_count_penalty_array = 1 / (np.sqrt(visit_count_array) + 1)
-
-    belief_visits = tree.visit_count[belief_id]
-    x1 = 1 - belief_visits**horizon
-    x2 = delta * (1 - belief_visits)
-    x3 = np.log(x1 / x2)
-    x4 = alpha * visit_count_array
-
-    guarantees_bound = (max_cost - min_cost) * np.sqrt(x3 / x4)
-
-    q_values = np.fromiter(
-        (tree.q_value[cid] for cid in children),
-        dtype=np.float64,
-        count=n_children,
+    best_idx = sparse_sampling_lcb_min_idx_kernel(
+        visit_count_array,
+        q_values,
+        float(tree.visit_count[belief_id]),
+        int(horizon),
+        float(alpha),
+        float(delta),
+        float(min_cost),
+        float(max_cost),
+        float(exploration_constant),
+        float(visit_count_penalty),
     )
-    lower_confidence_bounds = q_values - exploration_constant * guarantees_bound
-    return children[
-        int(np.argmin(lower_confidence_bounds + visit_count_penalty * visit_count_penalty_array))
-    ]
+    return children[best_idx]
 
 
 def get_explored_action_node_arena(  # pylint: disable=too-many-arguments
@@ -155,15 +160,16 @@ def get_explored_action_node_arena(  # pylint: disable=too-many-arguments
 ) -> int:
     """Arena variant of :func:`get_explored_action_node`. Returns action-node ID."""
     children = tree.children_ids[belief_id]
-    n_children = len(children)
-    action_visits = np.fromiter(
-        (tree.visit_count[cid] for cid in children),
-        dtype=np.int64,
-        count=n_children,
-    )
-    unvisited_indices = np.where(action_visits == 0)[0]
-    if len(unvisited_indices) > 0:
-        return children[int(np.random.choice(unvisited_indices))]
+    # Plain loop is faster than np.fromiter over a Python-list source for
+    # the small N (action children) here. Builds the unvisited index set in
+    # one pass; np.fromiter + np.where would do the same work in two.
+    tree_visits = tree.visit_count
+    unvisited_local: list = []
+    for i, cid in enumerate(children):
+        if tree_visits[cid] == 0:
+            unvisited_local.append(i)
+    if unvisited_local:
+        return children[unvisited_local[int(np.random.randint(len(unvisited_local)))]]
 
     if tree.parent_id[belief_id] is None:
         for cid in children:

--- a/POMDPPlanners/utils/numba_kernels.py
+++ b/POMDPPlanners/utils/numba_kernels.py
@@ -28,6 +28,10 @@ Public kernels
   pre-drawn standard normals and a transposed Cholesky factor.
 - :func:`systematic_resample_kernel` — fused log-weight normalization,
   ESS check, and systematic resampling index draw for particle filters.
+- :func:`cvar_estimator_from_dist_fast_kernel` — CVaR over a small
+  discrete distribution via a single argsort + linear tail aggregation.
+- :func:`sparse_sampling_lcb_min_idx_kernel` — argmin over the lower
+  confidence bound used by ICVaR action progressive widening.
 """
 
 from typing import Tuple
@@ -188,3 +192,88 @@ def systematic_resample_kernel(
         idx[i] = j
     new_log_weights = np.full(n, -np.log(n))
     return idx, True, new_log_weights
+
+
+@njit(cache=True)  # type: ignore[misc]
+def cvar_estimator_from_dist_fast_kernel(
+    values: np.ndarray, weights: np.ndarray, alpha: float
+) -> float:
+    """CVaR over a small discrete distribution. Caller guarantees ``weights`` sums to 1.
+
+    Hot-path variant of the upper-tail CVaR estimator used inside MCTS
+    backups. ``values`` is small (typically ≤ 30 elements) and ``weights``
+    is already normalized. Replaces the per-call numpy chain
+    (``argsort`` + fancy-index + ``cumsum`` + ``searchsorted`` + ``sum``)
+    with a single sort plus two linear scans, fused into one kernel.
+
+    Returns the conditional expectation of ``values`` over the worst-alpha
+    probability mass (upper tail when interpreting values as costs).
+    """
+    n = values.shape[0]
+    if n == 1:
+        return float(values[0])
+
+    sort_idx = np.argsort(values)
+    sorted_values = values[sort_idx]
+    sorted_weights = weights[sort_idx]
+
+    threshold = 1.0 - alpha
+    cum = 0.0
+    var_idx = n - 1
+    for i in range(n):
+        cum += sorted_weights[i]
+        if cum >= threshold:
+            var_idx = i
+            break
+
+    value_at_risk = sorted_values[var_idx]
+    tail_weight = 0.0
+    tail_sum = 0.0
+    for i in range(var_idx, n):
+        tail_weight += sorted_weights[i]
+        tail_sum += sorted_values[i] * sorted_weights[i]
+    correction = (tail_weight - alpha) * value_at_risk
+    return (tail_sum - correction) / alpha
+
+
+@njit(cache=True)  # type: ignore[misc]
+def sparse_sampling_lcb_min_idx_kernel(
+    visit_counts: np.ndarray,
+    q_values: np.ndarray,
+    belief_visits: float,
+    horizon: int,
+    alpha: float,
+    delta: float,
+    min_cost: float,
+    max_cost: float,
+    exploration_constant: float,
+    visit_count_penalty: float,
+) -> int:
+    """argmin over the LCB used by ICVaR action progressive widening.
+
+    Replaces the numpy chain in ``_sparse_sampling_guarantees_exploration_v2_arena``
+    (``np.fromiter`` × 2, ``np.sqrt``, ``np.log``, vector arithmetic, ``np.argmin``)
+    with a single fused loop over the ``N`` action children. ``N`` is small
+    (typically ≤ k_a × belief_visits**alpha_a, in practice ≤ ~30).
+
+    Returns the index into ``visit_counts`` / ``q_values`` whose lower
+    confidence bound (Q − exploration_constant·bound + visit_count_penalty/(√N+1))
+    is smallest.
+    """
+    n = visit_counts.shape[0]
+    x1 = 1.0 - belief_visits**horizon
+    x2 = delta * (1.0 - belief_visits)
+    x3 = np.log(x1 / x2)
+    cost_range = max_cost - min_cost
+    best_idx = 0
+    best_score = np.inf
+    for i in range(n):
+        nv = visit_counts[i]
+        x4 = alpha * nv
+        bound = cost_range * np.sqrt(x3 / x4)
+        penalty = visit_count_penalty / (np.sqrt(nv) + 1.0)
+        score = q_values[i] - exploration_constant * bound + penalty
+        if score < best_score:
+            best_score = score
+            best_idx = i
+    return best_idx


### PR DESCRIPTION
## Summary

Four planner-side acceleration targets (recommendations 1–4 from the post-bundle profile) for ICVaR_POMCPOW, all landing in this single PR because they cluster on the same hot path (`_backpropagate_values` → `_update_q_value` → CVaR estimator, plus `_select_action_with_progressive_widening` → exploration helpers).

### Changes

**Two new Numba kernels** in `POMDPPlanners/utils/numba_kernels.py`:

- `cvar_estimator_from_dist_fast_kernel`: bit-identical Numba port of `statistics_utils.cvar_estimator_from_dist_fast`. Single argsort + two linear scans, fused.
- `sparse_sampling_lcb_min_idx_kernel`: argmin over the LCB used by ICVaR action progressive widening. (Branch is currently unreached on the default code path due to a pre-existing `>= 1` mask in the Python caller; kept the kernel to preserve the algorithmic intent in case that mask is ever fixed.)

**`icvar_pomcpow._update_q_value`**: two `np.fromiter(generator, ...)` → one `np.empty + Python loop` that fills both `v_values` and `weights` in a single pass. Faster than `np.fromiter` for small N when the source is a Python list. Kernel replaces the prior `cvar_estimator_from_dist_fast` import.

**`cvar_exploration.get_explored_action_node_arena` and `_sparse_sampling_guarantees_exploration_v2_arena`**: same `np.fromiter` → plain loop swap. The prior code did `np.fromiter` to build an array, then `np.where` to filter — a Python `enumerate` + conditional append does both in one pass.

## Bench (sims/sec, `profile_planner_envs --budget 1 --n-calls 5 --particles 200`)

| env / planner               | before | after | Δ |
|-----------------------------|------:|------:|--:|
| ICVaR_POMCPOW Tiger         |  1,058 | 1,217 | **+15.0%** |
| ICVaR_POMCPOW ContinuousLightDark | 1,382 | 1,529 | **+10.6%** |
| ICVaR_POMCPOW ContinuousLaserTag  | 1,379 | 1,551 | **+12.5%** |
| ICVaR_PFT_DPW Tiger         |    325 |   324 | flat |
| ICVaR_PFT_DPW ContinuousLightDark |   426 |   407 | within noise |
| ICVaR_PFT_DPW ContinuousLaserTag  |   381 |   359 | within noise |

ICVaR_PFT_DPW is unchanged because it doesn't touch the modified functions — its time is in the belief update / cost evaluation path (already optimized in PR #122 / #123).

## Notes on the dead `>= 1` branch

While porting `_sparse_sampling_guarantees_exploration_v2_arena` I noticed:
```python
unvisited_indices = np.where(visit_count_array >= 1)[0]
if len(unvisited_indices) > 0:
    return children[int(np.random.choice(unvisited_indices))]
```
This branch is always entered when the function is called: by the time `_sparse_sampling_*` runs, `get_explored_action_node_arena` has already short-circuited on any `visit_count == 0` child, so all remaining children have `visits >= 1`. The function therefore always returns a random visited child — **the LCB calculation underneath is dead code**. Variable name `unvisited_indices` with `>= 1` is also clearly contradictory.

I preserved the existing behavior (the random-pick path) and added the LCB Numba kernel anyway, so a future fix to the mask just has to change one line. **Did not** fix the apparent bug in this PR — out of scope and possibly intentional in some way I'm missing.

## Test plan

- [x] 90 tests pass on impacted planner suites (POMCPOW, PFT-DPW, ICVaR variants)
- [x] Bit-identical CVaR equivalence verified across 5 random distributions (max abs diff = 0.0)
- [x] Pre-commit hooks (black, pylint, pyright) green
- [ ] CI signals (full suite)

Stacks on PR #125 (Numba beacon + resample). If #125 lands first, this PR's diff narrows to just the planner-side changes.