### PR TITLE
perf(planners,arena): O(log K) belief-child sampling for PFT variants

### DIFF
--- a/POMDPPlanners/core/tree/arena.py
+++ b/POMDPPlanners/core/tree/arena.py
@@ -87,6 +87,10 @@ class Tree:
         self.sample: List[List[Any]] = []
         # Per-parent CDF over children's weights, aligned with children_ids[parent].
         self.children_cdf: List[List[float]] = []
+        # Index of each child within its parent's children_ids list. Cached
+        # at allocation time so ``increment_weight`` can locate the CDF slot
+        # in O(1) instead of O(K) via ``children_ids.index``.
+        self.position_in_parent: List[int] = []
         # Hash-indexed children lookups; populated when the key is hashable.
         self.obs_child_lookup: Dict[Tuple[int, Any], int] = {}
         self.action_child_lookup: Dict[Tuple[int, Any], int] = {}
@@ -142,6 +146,7 @@ class Tree:
             self.data,
             self.sample,
             self.children_cdf,
+            self.position_in_parent,
         ]
         for column in columns:
             current_len = len(column)
@@ -171,6 +176,7 @@ class Tree:
             self.data[node_id] = None
             self.sample[node_id] = []
             self.children_cdf[node_id] = []
+            self.position_in_parent[node_id] = -1
         else:
             # Past the reserved zone — fall back to append.
             self.kind.append(kind)
@@ -190,9 +196,12 @@ class Tree:
             self.data.append(None)
             self.sample.append([])
             self.children_cdf.append([])
+            self.position_in_parent.append(-1)
         self._size += 1
         if parent_id is not None:
-            self.children_ids[parent_id].append(node_id)
+            siblings = self.children_ids[parent_id]
+            self.position_in_parent[node_id] = len(siblings)
+            siblings.append(node_id)
         return node_id
 
     # --- construction ---
@@ -316,9 +325,8 @@ class Tree:
         parent_id = self.parent_id[child_id]
         if parent_id is None:
             return
-        siblings = self.children_ids[parent_id]
         cdf = self.children_cdf[parent_id]
-        position = siblings.index(child_id)
+        position = self.position_in_parent[child_id]
         for index in range(position, len(cdf)):
             cdf[index] += delta
 

--- a/POMDPPlanners/planners/mcts_planners/icvar_pft_dpw.py
+++ b/POMDPPlanners/planners/mcts_planners/icvar_pft_dpw.py
@@ -148,23 +148,16 @@ class ICVaR_PFT_DPW(ArenaPathSimulationPolicyCostSetting):
         return is_terminal_belief(belief=belief, env=self.environment)
 
     def _sample_next_existing_belief(self, tree: Tree, action_id: int) -> int:
-        children = tree.children_ids[action_id]
-        n_children = len(children)
-        child_visit_counts = np.fromiter(
-            (tree.visit_count[cid] for cid in children),
-            dtype=np.float64,
-            count=n_children,
-        )
-        min_visit_idx = int(np.argmin(child_visit_counts))
-        if child_visit_counts[min_visit_idx] == 0:
-            return children[min_visit_idx]
-
-        cdf = np.cumsum(child_visit_counts)
-        total = float(cdf[-1])
-        chosen_idx = int(np.searchsorted(cdf, np.random.random() * total))
-        if chosen_idx >= n_children:
-            chosen_idx = n_children - 1
-        return children[chosen_idx]
+        # Belief children carry an arena-maintained CDF over their ``weight``
+        # values. ``add_belief_node`` initialises each child with weight=1.0
+        # (mirroring the +1 update_nodes increments at generation), so the
+        # weighted sample below is statistically equivalent to the previous
+        # ``np.cumsum(visit_count) → searchsorted`` path while running in
+        # O(log K) instead of O(K). The matching ``increment_weight`` keeps
+        # the CDF aligned with each child's running visit count.
+        sampled_id = tree.sample_belief_child(action_id)
+        tree.increment_weight(sampled_id, 1.0)
+        return sampled_id
 
     def _generate_belief(self, tree: Tree, action_id: int) -> int:
         parent_belief_id = tree.parent_id[action_id]

--- a/POMDPPlanners/planners/mcts_planners/sparse_pft.py
+++ b/POMDPPlanners/planners/mcts_planners/sparse_pft.py
@@ -162,22 +162,14 @@ class SparsePFT(ArenaPathSimulationPolicy):
         return children[int(np.argmax(q_vals + sparse_addition))]
 
     def _sample_next_existing_belief(self, tree: Tree, action_id: int) -> Tuple[int, float]:
-        children = tree.children_ids[action_id]
-        n_children = len(children)
-        child_visits = np.fromiter(
-            (tree.visit_count[cid] for cid in children),
-            dtype=np.float64,
-            count=n_children,
-        )
-        total = float(child_visits.sum())
-        if total == 0.0:
-            chosen_idx = random.randrange(n_children)
-        else:
-            cdf = np.cumsum(child_visits)
-            chosen_idx = int(np.searchsorted(cdf, np.random.random() * total))
-            if chosen_idx >= n_children:
-                chosen_idx = n_children - 1
-        sampled_id = children[chosen_idx]
+        # Sample a belief child via the arena's maintained CDF — O(log K).
+        # ``add_belief_node`` defaults each child's ``weight`` to 1.0
+        # (matching the +1 update_nodes increments at generation), and
+        # ``increment_weight`` keeps weight ≡ visit_count thereafter, so
+        # ``sample_belief_child`` is statistically equivalent to the previous
+        # ``np.cumsum(visit_count) → searchsorted`` path.
+        sampled_id = tree.sample_belief_child(action_id)
+        tree.increment_weight(sampled_id, 1.0)
         immediate_cost = tree.immediate_cost[sampled_id]
         expected_reward = -immediate_cost if immediate_cost is not None else 0.0
         return sampled_id, expected_reward


### PR DESCRIPTION
## Summary

- `ICVaR_PFT_DPW._sample_next_existing_belief` and `SparsePFT._sample_next_existing_belief` previously rebuilt the children CDF every call (`np.fromiter` → `np.cumsum` → `np.searchsorted`). They now route through the arena's maintained CDF (`tree.sample_belief_child` + `tree.increment_weight`), dropping per-call cost from O(K) to O(log K) on the saturated-DPW path. Distribution is preserved: the arena's default `weight=1.0` mirrors the +1 `update_nodes` increment after generation, and `increment_weight` keeps `weight ≡ visit_count` thereafter.
- `Tree.increment_weight` no longer calls `children_ids.index(child_id)` (was O(K)). A new `position_in_parent` column caches each child's index at allocation time, so the CDF tail-patch starts in O(1).

## Benchmarks (sims/sec, median, paired same-machine, 2s × 10 beliefs, 200 particles)

| env                  | planner       | before  | after   | Δ     |
|----------------------|---------------|--------:|--------:|-------|
| TigerPOMDP           | POMCPOW       | 8,011   | 8,407   | +4.9% |
| TigerPOMDP           | PFT_DPW       | 4,578   | 4,814   | +5.2% |
| TigerPOMDP           | SparsePFT     | 3,503   | 3,805   | +8.6% |
| ContinuousLightDark  | POMCPOW       | 19,345  | 20,205  | +4.4% |
| ContinuousLightDark  | PFT_DPW       | 8,760   | 8,989   | +2.6% |
| ContinuousLightDark  | SparsePFT     | 4,983   | 5,310   | +6.6% |
| ContinuousLightDark  | ICVaR_PFT_DPW | 593     | 599     | +1.0% |
| ContinuousLightDark  | ICVaR_POMCPOW | 2,749   | 2,777   | +1.0% |

POMCPOW + iCVaR-POMCPOW gain comes from the cached `position_in_parent` (their existing `increment_weight` path is the hot one). iCVaR_PFT_DPW barely moves because cProfile shows `_sample_next_existing_belief` at <1% of total time — its bottleneck is `sample_next_state` and the CVaR backprop in `update_nodes`, not the sampling we touched.

## Test plan

- [x] `pytest POMDPPlanners/tests/test_core/` — 575 passed
- [x] `pytest POMDPPlanners/tests/test_planners/test_mcts_planners/test_arena_tree.py test_pomcpow.py test_pomcp.py test_pft_dpw.py test_sparse_pft.py test_icvar_pft_dpw.py test_icvar_pomcpow.py` — 146 passed
- [x] `python -m pyright` on the three changed files — 0 errors, 0 warnings
- [x] `python -m pylint` on the three changed files — 10.00/10