### PR TITLE
fix(icvar): unvisited-child mask + LCB guard against belief_visits == 1

### DIFF
--- a/POMDPPlanners/planners/planners_utils/cvar_exploration.py
+++ b/POMDPPlanners/planners/planners_utils/cvar_exploration.py
@@ -17,9 +17,20 @@ def _get_sparse_sampling_guarantees_exploration_v2(
     visit_count_penalty: float = 0.0,
 ) -> ActionNode:
     visit_count_array = np.array([child.visit_count for child in belief_node.children])
-    unvisited_action_indices = np.where(visit_count_array >= 1)[0]
+    # Bug-fix: the original predicate was `visit_count_array >= 1` with
+    # variable name `unvisited_action_indices` — that always returned
+    # visited children and skipped the LCB calculation entirely. Correct
+    # semantic is "if any child is unvisited, explore it randomly".
+    unvisited_action_indices = np.where(visit_count_array == 0)[0]
     if len(unvisited_action_indices) > 0:
         return belief_node.children[np.random.choice(unvisited_action_indices)]
+
+    # Guard: the LCB formula below has `delta * (1 - belief_visits)` in the
+    # denominator, which is 0 when belief_visits == 1 (the second visit to
+    # this belief node). Fall back to random visited-child selection in
+    # that edge case; LCB only becomes well-defined for belief_visits >= 2.
+    if belief_node.visit_count <= 1:
+        return belief_node.children[int(np.random.randint(len(belief_node.children)))]
 
     visit_count_penalty_array = 1 / (np.sqrt(visit_count_array) + 1)
 
@@ -116,23 +127,32 @@ def _sparse_sampling_guarantees_exploration_v2_arena(
     tree_q = tree.q_value
     visit_count_array = np.empty(n_children, dtype=np.float64)
     q_values = np.empty(n_children, dtype=np.float64)
-    has_visited = False
+    unvisited_local: list = []
     for i, cid in enumerate(children):
         v = tree_visits[cid]
         visit_count_array[i] = v
         q_values[i] = tree_q[cid]
-        if v >= 1:
-            has_visited = True
-    if has_visited:
-        # Preserve original behaviour: pick a random visited child when any
-        # have been visited (the np.where(>= 1) branch in the prior code).
-        unvisited_indices = np.where(visit_count_array >= 1)[0]
-        return children[int(np.random.choice(unvisited_indices))]
+        if v == 0:
+            unvisited_local.append(i)
+    if unvisited_local:
+        # Bug-fix: the original predicate was `visit_count_array >= 1` with
+        # variable name `unvisited_indices` — that always returned visited
+        # children and skipped the LCB calculation entirely. The intended
+        # semantic is "if any child is unvisited, explore it randomly".
+        return children[unvisited_local[int(np.random.randint(len(unvisited_local)))]]
+
+    # Guard: the LCB formula below has `delta * (1 - belief_visits)` in the
+    # denominator, which is 0 when belief_visits == 1 (the second visit to
+    # this belief node). Fall back to random visited-child selection in
+    # that edge case; LCB only becomes well-defined for belief_visits >= 2.
+    belief_visits = tree.visit_count[belief_id]
+    if belief_visits <= 1:
+        return children[int(np.random.randint(n_children))]
 
     best_idx = sparse_sampling_lcb_min_idx_kernel(
         visit_count_array,
         q_values,
-        float(tree.visit_count[belief_id]),
+        float(belief_visits),
         int(horizon),
         float(alpha),
         float(delta),

--- a/POMDPPlanners/tests/test_planners/test_planners_utils/test_cvar_exploration.py
+++ b/POMDPPlanners/tests/test_planners/test_planners_utils/test_cvar_exploration.py
@@ -1,0 +1,112 @@
+"""Tests for cvar_exploration LCB action selection."""
+
+import numpy as np
+
+from POMDPPlanners.core.belief import WeightedParticleBeliefStateUpdate
+from POMDPPlanners.core.tree.arena import Tree
+from POMDPPlanners.planners.planners_utils.cvar_exploration import (
+    _sparse_sampling_guarantees_exploration_v2_arena,
+)
+
+
+def _build_tree_with_visited_action_children(q_values, visit_counts):
+    tree = Tree()
+    parent_id = tree.add_belief_node(
+        belief=WeightedParticleBeliefStateUpdate(particles=[], weights=[]),
+        parent_id=None,
+        weight=1.0,
+    )
+    tree.visit_count[parent_id] = 100
+    child_ids = []
+    for i, (q, v) in enumerate(zip(q_values, visit_counts)):
+        cid = tree.add_action_node(action=i, parent_id=parent_id)
+        tree.visit_count[cid] = v
+        tree.q_value[cid] = float(q)
+        child_ids.append(cid)
+    return tree, parent_id, child_ids
+
+
+def test_sparse_sampling_lcb_is_deterministic_when_no_unvisited_children():
+    """Picks lowest-LCB child when all action children have visit_count >= 1.
+
+    Purpose: Validates the LCB code path actually fires once every action
+    child has been visited at least once. With a clear Q-value gap and a
+    small exploration_constant, LCB selection is deterministic, so the
+    same call under different RNG seeds must return the same child.
+
+    Given: A belief node with 3 visited action children. Two have
+        q_value=5.0 and one has q_value=0.1; all share visit_count=10
+        so the per-child exploration term collapses to a constant. The
+        lowest-Q child therefore has the lowest LCB.
+    When: _sparse_sampling_guarantees_exploration_v2_arena is called
+        repeatedly under different np.random seeds.
+    Then: Every call returns the same child (the lowest-Q one).
+
+    Test type: unit
+    """
+    tree, parent_id, child_ids = _build_tree_with_visited_action_children(
+        q_values=[5.0, 5.0, 0.1],
+        visit_counts=[10, 10, 10],
+    )
+    expected = child_ids[2]
+    results = set()
+    for seed in range(20):
+        np.random.seed(seed)
+        results.add(
+            _sparse_sampling_guarantees_exploration_v2_arena(
+                tree=tree,
+                belief_id=parent_id,
+                exploration_constant=0.1,
+                alpha=0.1,
+                min_cost=-10.0,
+                max_cost=10.0,
+                horizon=5,
+                delta=0.1,
+                visit_count_penalty=0.0,
+            )
+        )
+    assert results == {
+        expected
+    }, f"expected deterministic LCB pick of child[2]={expected}; got {results}"
+
+
+def test_sparse_sampling_lcb_prefers_less_visited_child_when_q_tied():
+    """With Q-values tied, LCB selection favors the least-visited child.
+
+    Purpose: Validates that the per-child exploration bound (which scales
+    with 1/sqrt(child_visits) inside the guarantees-bound formula)
+    actually drives the choice toward less-visited children when Q is
+    not a differentiator.
+
+    Given: Three action children with identical q_value=1.0 but visit
+        counts [50, 10, 100]; child[1] is the least visited.
+    When: _sparse_sampling_guarantees_exploration_v2_arena is called
+        with a large exploration_constant so the bonus dominates.
+    Then: Every call returns child[1] regardless of RNG seed.
+
+    Test type: unit
+    """
+    tree, parent_id, child_ids = _build_tree_with_visited_action_children(
+        q_values=[1.0, 1.0, 1.0],
+        visit_counts=[50, 10, 100],
+    )
+    expected = child_ids[1]
+    results = set()
+    for seed in range(20):
+        np.random.seed(seed)
+        results.add(
+            _sparse_sampling_guarantees_exploration_v2_arena(
+                tree=tree,
+                belief_id=parent_id,
+                exploration_constant=5.0,
+                alpha=0.1,
+                min_cost=-10.0,
+                max_cost=10.0,
+                horizon=5,
+                delta=0.1,
+                visit_count_penalty=0.0,
+            )
+        )
+    assert results == {expected}, (
+        f"expected deterministic LCB pick of least-visited child[1]={expected}; " f"got {results}"
+    )


### PR DESCRIPTION
## Summary

Two coupled bugs in `_get_sparse_sampling_guarantees_exploration_v2` (and its arena variant) that together hid the function's LCB-based exploration:

### Bug 1 — inverted unvisited-children mask

```python
visit_count_array = np.array([child.visit_count for child in belief_node.children])
unvisited_action_indices = np.where(visit_count_array >= 1)[0]   # ← bug
if len(unvisited_action_indices) > 0:
    return belief_node.children[np.random.choice(unvisited_action_indices)]
```

The variable name says **un**visited, but the predicate matches **visited** children (`>= 1`). So this branch always fired (after the caller's own filter, every child has `visits >= 1`) and the LCB calculation below was never reached. Fixed: `== 0`.

### Bug 2 — LCB divides by zero when `belief_visits == 1`

The LCB formula:
```python
x2 = delta * (1 - belief_visits)        # = 0 when belief_visits == 1
x3 = np.log(x1 / x2)                    # → inf
guarantees_bound = (max_cost - min_cost) * np.sqrt(x3 / x4)   # ZeroDivisionError
```

`belief_visits == 1` is reachable on the second visit to a belief node — and bug #1 was masking this because the LCB block was dead. Adding a guard that falls back to random visited-child selection when `belief_visits <= 1` (LCB only becomes well-defined for `belief_visits >= 2`).

## Restored algorithm semantics

1. If any child is unvisited → explore it (random pick among unvisited).
2. Else if `belief_visits <= 1` → random visited-child (LCB undefined here).
3. Else → LCB selection (intended exploration term, lowest-LCB child).

## How I found this

While porting `_sparse_sampling_guarantees_exploration_v2_arena`'s np.fromiter to a faster loop in PR #126, the inverted predicate was suspicious. Wrote a test that asserts the LCB pick is deterministic under different RNG seeds when all children are visited (only RNG enters the random-pick branch), confirmed it failed under the buggy code, then started this fix.

## Test plan

- [x] **New** `test_cvar_exploration.py`:
   - `test_sparse_sampling_lcb_is_deterministic_when_no_unvisited_children` — Q-dominated case, asserts LCB picks the lowest-Q child deterministically across 20 seeds. Fails under bug #1.
   - `test_sparse_sampling_lcb_prefers_less_visited_child_when_q_tied` — Q-tied, asserts LCB picks the least-visited child deterministically. Fails under bug #1.
- [x] All 1328 planner / simulation / core tests pass on the fixed branch
- [x] Pre-commit hooks (black, pylint, pyright) green
- [ ] CI signals (full suite)

## Risks / behavioral change

The function previously **always** returned a random visited child once any child had been visited. Algorithms that have been calibrated against that effective-random behavior (planner hyperparameters in tests, benchmark results) may shift. The change is correctness-preserving in the sense that it restores the intended algorithm; downstream tuning may need a re-look. None of the existing 1328 tests fail.