### PR TITLE
fix(lasertag-cont): scalar/batch symmetry — kernel.log_probability + terminal-sentinel guard (B1+B2)

### DIFF
--- a/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
@@ -527,6 +527,24 @@ class ContinuousLaserTagTransitionCpp {
 
 class ContinuousLaserTagObservationCpp {
   public:
+    // Shared terminal-sentinel predicates so kernel.probability and
+    // kernel.batch_log_likelihood agree on the contract:
+    //   - next_state terminal (flag != 0) AND obs is the all--1 sentinel ->
+    //     prob = 1.0 (log = 0.0): certainty.
+    //   - next_state terminal XOR obs sentinel -> prob = 0.0 (log = -inf):
+    //     impossible.
+    //   - both non-terminal -> Gaussian PDF.
+    static bool is_terminal_state(const double *state) { return state[4] != 0.0; }
+
+    static bool is_terminal_sentinel_obs(const double *obs) {
+        for (std::size_t d = 0; d < kObsDim; ++d) {
+            if (std::abs(obs[d] - (-1.0)) > 1e-8) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     ContinuousLaserTagObservationCpp(const py::object &next_state_obj,
                                      const py::object &action_obj, double measurement_noise,
                                      const py::array_t<double> &walls_arr,
@@ -574,24 +592,27 @@ class ContinuousLaserTagObservationCpp {
         auto batch = pomdp_native::extract_rows_nd(values, kObsDim);
         auto out = py::array_t<double>(static_cast<py::ssize_t>(batch.n));
         auto buf = out.mutable_unchecked<1>();
-        if (next_state_[4] != 0.0) {
+        const bool state_is_terminal = is_terminal_state(next_state_.data());
+        if (state_is_terminal) {
             for (std::size_t i = 0; i < batch.n; ++i) {
                 const double *obs = batch.flat.data() + i * kObsDim;
-                bool matches_terminal = true;
-                for (std::size_t d = 0; d < kObsDim; ++d) {
-                    if (std::abs(obs[d] - (-1.0)) > 1e-8) {
-                        matches_terminal = false;
-                        break;
-                    }
-                }
-                buf(static_cast<py::ssize_t>(i)) = matches_terminal ? 1.0 : 0.0;
+                buf(static_cast<py::ssize_t>(i)) = is_terminal_sentinel_obs(obs) ? 1.0 : 0.0;
             }
             return out;
         }
         double mean[kObsDim];  // NOLINT(modernize-avoid-c-arrays)
         compute_mean(next_state_.data(), mean);
         for (std::size_t i = 0; i < batch.n; ++i) {
-            buf(static_cast<py::ssize_t>(i)) = std::exp(log_pdf(batch.flat.data() + i * kObsDim, mean));
+            const double *obs = batch.flat.data() + i * kObsDim;
+            // Non-terminal next_state with the terminal sentinel observation
+            // is impossible per the kernel contract; return 0.0 so the
+            // Python wrapper's np.log(...) under errstate(divide="ignore")
+            // produces -inf, matching batch_log_likelihood's explicit guard.
+            if (is_terminal_sentinel_obs(obs)) {
+                buf(static_cast<py::ssize_t>(i)) = 0.0;
+                continue;
+            }
+            buf(static_cast<py::ssize_t>(i)) = std::exp(log_pdf(obs, mean));
         }
         return out;
     }
@@ -611,32 +632,28 @@ class ContinuousLaserTagObservationCpp {
         auto obs_view = observation.unchecked<1>();
 
         double obs[kObsDim];  // NOLINT(modernize-avoid-c-arrays)
-        bool obs_is_terminal = true;
         for (std::size_t d = 0; d < kObsDim; ++d) {
             obs[d] = obs_view(static_cast<py::ssize_t>(d));
-            if (std::abs(obs[d] - (-1.0)) > 1e-8) {
-                obs_is_terminal = false;
-            }
         }
+        const bool obs_is_terminal = is_terminal_sentinel_obs(obs);
 
         auto out = py::array_t<double>(static_cast<py::ssize_t>(n_rows));
         auto buf = out.mutable_unchecked<1>();
 
         const double neg_inf = -std::numeric_limits<double>::infinity();
         for (std::size_t i = 0; i < n_rows; ++i) {
-            const double terminal_flag =
-                part_view(static_cast<py::ssize_t>(i), static_cast<py::ssize_t>(4));
-            if (terminal_flag != 0.0) {
+            double state_row[kStateDim];  // NOLINT(modernize-avoid-c-arrays)
+            for (std::size_t d = 0; d < kStateDim; ++d) {
+                state_row[d] = part_view(static_cast<py::ssize_t>(i), static_cast<py::ssize_t>(d));
+            }
+            const bool state_is_terminal = is_terminal_state(state_row);
+            if (state_is_terminal) {
                 buf(static_cast<py::ssize_t>(i)) = obs_is_terminal ? 0.0 : neg_inf;
                 continue;
             }
             if (obs_is_terminal) {
                 buf(static_cast<py::ssize_t>(i)) = neg_inf;
                 continue;
-            }
-            double state_row[kStateDim];  // NOLINT(modernize-avoid-c-arrays)
-            for (std::size_t d = 0; d < kStateDim; ++d) {
-                state_row[d] = part_view(static_cast<py::ssize_t>(i), static_cast<py::ssize_t>(d));
             }
             double mean[kObsDim];  // NOLINT(modernize-avoid-c-arrays)
             compute_mean(state_row, mean);

--- a/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
@@ -596,6 +596,48 @@ class ContinuousLaserTagObservationCpp {
         return out;
     }
 
+    // B1 fix: return ``log_pdf`` directly without the exp/log round-trip
+    // performed by ``probability``. The exp(log_pdf) round-trip in the
+    // legacy ``probability`` path silently collapses to 0.0 for
+    // observations whose log_pdf is below the IEEE-754 double underflow
+    // boundary (~ -745), making the Python ``np.log(probability(...))``
+    // wrapper return -inf while the batched ``batch_log_likelihood``
+    // path returns the finite log_pdf. This entry point lets the Python
+    // wrapper preserve the finite log-likelihood for low-density obs.
+    //
+    // Terminal-sentinel handling mirrors ``probability``: when the
+    // stored next_state is terminal, the only matching observation is
+    // the all-(-1) sentinel — its prob is 1.0 (log = 0.0); any other
+    // observation has prob 0.0 (log = -inf). This branch is the B2
+    // surface and is intentionally left in lock-step with ``probability``
+    // for now (B2 owns it in a separate fix).
+    py::array_t<double> log_probability(const py::object &values) const {
+        auto batch = pomdp_native::extract_rows_nd(values, kObsDim);
+        auto out = py::array_t<double>(static_cast<py::ssize_t>(batch.n));
+        auto buf = out.mutable_unchecked<1>();
+        const double neg_inf = -std::numeric_limits<double>::infinity();
+        if (next_state_[4] != 0.0) {
+            for (std::size_t i = 0; i < batch.n; ++i) {
+                const double *obs = batch.flat.data() + i * kObsDim;
+                bool matches_terminal = true;
+                for (std::size_t d = 0; d < kObsDim; ++d) {
+                    if (std::abs(obs[d] - (-1.0)) > 1e-8) {
+                        matches_terminal = false;
+                        break;
+                    }
+                }
+                buf(static_cast<py::ssize_t>(i)) = matches_terminal ? 0.0 : neg_inf;
+            }
+            return out;
+        }
+        double mean[kObsDim];  // NOLINT(modernize-avoid-c-arrays)
+        compute_mean(next_state_.data(), mean);
+        for (std::size_t i = 0; i < batch.n; ++i) {
+            buf(static_cast<py::ssize_t>(i)) = log_pdf(batch.flat.data() + i * kObsDim, mean);
+        }
+        return out;
+    }
+
     py::array_t<double> batch_log_likelihood(
         const py::array_t<double, py::array::c_style | py::array::forcecast> &next_particles,
         const py::array_t<double, py::array::c_style | py::array::forcecast> &observation) const {
@@ -2235,6 +2277,8 @@ PYBIND11_MODULE(_native, m) {
              py::arg("walls"), py::arg("grid_size"), py::arg("opponent_radius"))
         .def("sample", &ContinuousLaserTagObservationCpp::sample, py::arg("n_samples") = 1)
         .def("probability", &ContinuousLaserTagObservationCpp::probability, py::arg("values"))
+        .def("log_probability", &ContinuousLaserTagObservationCpp::log_probability,
+             py::arg("values"))
         .def("batch_log_likelihood", &ContinuousLaserTagObservationCpp::batch_log_likelihood,
              py::arg("next_particles"), py::arg("observation"))
         .def("set_next_state", &ContinuousLaserTagObservationCpp::set_next_state,

--- a/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
@@ -651,10 +651,19 @@ class ContinuousLaserTagObservationCpp {
             }
             return out;
         }
+        // Non-terminal next_state: a terminal-sentinel observation is impossible
+        // under the Gaussian model. Mirror the guard B2 added to ``probability``
+        // and ``batch_log_likelihood`` so the scalar (log_probability) and batch
+        // paths stay symmetric on impossible terminal-sentinel events.
         double mean[kObsDim];  // NOLINT(modernize-avoid-c-arrays)
         compute_mean(next_state_.data(), mean);
         for (std::size_t i = 0; i < batch.n; ++i) {
-            buf(static_cast<py::ssize_t>(i)) = log_pdf(batch.flat.data() + i * kObsDim, mean);
+            const double *obs = batch.flat.data() + i * kObsDim;
+            if (is_terminal_sentinel_obs(obs)) {
+                buf(static_cast<py::ssize_t>(i)) = neg_inf;
+                continue;
+            }
+            buf(static_cast<py::ssize_t>(i)) = log_pdf(obs, mean);
         }
         return out;
     }

--- a/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
@@ -106,6 +106,10 @@ class ContinuousLaserTagObservationCpp:
         self,
         values: Union[Sequence[NDArray[np.floating]], NDArray[np.floating]],
     ) -> NDArray[np.float64]: ...
+    def log_probability(
+        self,
+        values: Union[Sequence[NDArray[np.floating]], NDArray[np.floating]],
+    ) -> NDArray[np.float64]: ...
     def batch_log_likelihood(
         self,
         next_particles: NDArray[np.floating],

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -27,7 +27,6 @@ Classes:
 
 from __future__ import annotations
 
-import math
 from enum import Enum
 from pathlib import Path
 from collections.abc import Hashable
@@ -337,24 +336,28 @@ class ContinuousLaserTagPOMDP(Environment):
     ) -> np.ndarray:
         kernel = self._get_obs_kernel(action)
         kernel.set_next_state(next_state)
-        # kernel.probability returns a C-contiguous float64 ndarray; skip
-        # the redundant np.asarray wrap.
-        probs = kernel.probability(observations)
-        with np.errstate(divide="ignore"):
-            return np.log(probs)
+        # B1 fix: call kernel.log_probability(...) directly instead of
+        # np.log(kernel.probability(...)). The legacy probability path
+        # round-trips log_pdf through std::exp, which underflows to 0.0
+        # for low-density observations and makes np.log return -inf,
+        # disagreeing with the batched
+        # ``observation_log_probability_per_state`` path that goes
+        # through ``batch_log_likelihood``. log_probability returns
+        # log_pdf directly, eliminating the round-trip.
+        return kernel.log_probability(observations)
 
     def observation_log_probability_single(
         self, next_state: Any, action: Any, observation: Any
     ) -> float:
         # Scalar fast-path for POMCPOW's WeightedParticleBeliefStateUpdate.
-        # Skips the size-1 np.asarray + np.errstate + np.log wrap that the
-        # batched path would do, and the [0] re-index in the base default.
+        # B1 fix: use kernel.log_probability so low-density observations
+        # whose log_pdf is below the IEEE-754 ``exp`` underflow boundary
+        # still return a finite, large-negative log-likelihood instead of
+        # collapsing to -inf via the legacy ``np.log(probability(...))``
+        # round-trip.
         kernel = self._get_obs_kernel(action)
         kernel.set_next_state(next_state)
-        prob = float(kernel.probability([observation])[0])
-        if prob <= 0.0:
-            return -math.inf
-        return math.log(prob)
+        return float(kernel.log_probability([observation])[0])
 
     def sample_next_state_batch(self, states: Any, action: np.ndarray) -> np.ndarray:
         # Short-circuit when the caller already hands us a C-contiguous

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
@@ -1069,6 +1069,120 @@ class TestObservationLogProbabilityTerminal:
         assert np.isneginf(actual[1])
 
 
+class TestObservationLogProbabilityScalarBatchTerminalParity:
+    """Parity tests for scalar/batch terminal-sentinel handling (regression for B2).
+
+    The scalar ``observation_log_probability`` path (which routes through the
+    C++ ``kernel.probability`` method) must agree with the batch
+    ``observation_log_probability_per_state`` path (which routes through
+    ``kernel.batch_log_likelihood``) on the three terminal-sentinel cases.
+
+    The batch path has had an explicit terminal-sentinel guard since the
+    native port; the scalar path historically computed the Gaussian PDF at
+    the all--1 sentinel against any non-terminal mean, returning a small
+    finite value (~exp(-139)) instead of -inf. This regression suite locks
+    in the corrected contract:
+      - next_state terminal AND obs terminal sentinel -> log = 0.0
+      - next_state terminal XOR obs terminal sentinel -> log = -inf
+    """
+
+    def _build_env(self) -> ContinuousLaserTagPOMDP:
+        return ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+
+    def test_scalar_matches_batch_nonterminal_state_terminal_obs(self) -> None:
+        """Non-terminal next_state with terminal-sentinel obs returns -inf on both paths.
+
+        Purpose: Validates that the scalar observation_log_probability path
+            agrees with the batch observation_log_probability_per_state path
+            when the next_state is non-terminal but the observation is the
+            all--1 terminal sentinel; both must return -inf (impossible).
+
+        Given: A non-terminal next_state, an arbitrary action, and the
+            terminal-sentinel observation [-1, ..., -1].
+        When: We query the scalar log-prob via observation_log_probability and
+            the batch log-prob via observation_log_probability_per_state with a
+            single-row particle batch.
+        Then: Both calls return -inf, and they agree.
+
+        Test type: unit
+        """
+        env = self._build_env()
+        next_state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([1.0, 0.0, 0.0])
+        terminal_obs = np.full(8, -1.0)
+
+        scalar = env.observation_log_probability(next_state, action, [terminal_obs])
+        batch = env.observation_log_probability_per_state(
+            np.tile(next_state, (1, 1)), action, terminal_obs
+        )
+
+        assert scalar.shape == (1,)
+        assert batch.shape == (1,)
+        assert np.isneginf(scalar[0])
+        assert np.isneginf(batch[0])
+        assert scalar[0] == batch[0]
+
+    def test_scalar_matches_batch_terminal_state_nonterminal_obs(self) -> None:
+        """Terminal next_state with non-sentinel obs returns -inf on both paths.
+
+        Purpose: Validates that the scalar observation_log_probability path
+            agrees with the batch observation_log_probability_per_state path
+            when the next_state is terminal but the observation is not the
+            terminal sentinel; both must return -inf (impossible).
+
+        Given: A terminal next_state (terminal_flag=1.0), an arbitrary action,
+            and a non-sentinel observation.
+        When: We query both the scalar and batch log-prob entry points.
+        Then: Both calls return -inf, and they agree.
+
+        Test type: unit
+        """
+        env = self._build_env()
+        terminal_state = np.array([3.0, 3.0, 8.0, 5.0, 1.0])
+        action = np.array([1.0, 0.0, 0.0])
+        non_terminal_obs = np.array([3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
+
+        scalar = env.observation_log_probability(terminal_state, action, [non_terminal_obs])
+        batch = env.observation_log_probability_per_state(
+            np.tile(terminal_state, (1, 1)), action, non_terminal_obs
+        )
+
+        assert scalar.shape == (1,)
+        assert batch.shape == (1,)
+        assert np.isneginf(scalar[0])
+        assert np.isneginf(batch[0])
+        assert scalar[0] == batch[0]
+
+    def test_scalar_matches_batch_terminal_state_terminal_obs(self) -> None:
+        """Terminal next_state with terminal-sentinel obs returns log(1)=0 on both paths.
+
+        Purpose: Validates that the scalar observation_log_probability path
+            agrees with the batch observation_log_probability_per_state path
+            when both the next_state and the observation are terminal; both
+            must return 0.0 (certainty).
+
+        Given: A terminal next_state and the terminal-sentinel observation.
+        When: We query both the scalar and batch log-prob entry points.
+        Then: Both calls return 0.0, and they agree exactly.
+
+        Test type: unit
+        """
+        env = self._build_env()
+        terminal_state = np.array([3.0, 3.0, 8.0, 5.0, 1.0])
+        action = np.array([1.0, 0.0, 0.0])
+        terminal_obs = np.full(8, -1.0)
+
+        scalar = env.observation_log_probability(terminal_state, action, [terminal_obs])
+        batch = env.observation_log_probability_per_state(
+            np.tile(terminal_state, (1, 1)), action, terminal_obs
+        )
+
+        assert scalar.shape == (1,)
+        assert batch.shape == (1,)
+        assert scalar[0] == 0.0
+        assert batch[0] == 0.0
+
+
 class TestContinuousLaserTagNativeRollout:
     """Tests for the native cont_simulate_rollout entry point."""
 

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
@@ -6,6 +6,8 @@ observation model, reward, terminal conditions, metrics, and
 registry integration.
 """
 
+import math
+
 import numpy as np
 import pytest
 
@@ -1258,3 +1260,106 @@ class TestContinuousLaserTagNativeRollout:
         )
 
         np.testing.assert_allclose(native_result, python_result, atol=1e-9)
+
+
+class TestObservationLogProbabilityLowDensityB1:
+    """Regression tests for B1 — scalar/batch log-prob underflow asymmetry."""
+
+    def test_scalar_log_probability_low_density_obs_matches_batch(self) -> None:
+        """Scalar observation_log_probability matches batch path on a low-density obs.
+
+        Purpose: Regression for B1. The scalar ``observation_log_probability``
+            previously round-tripped through ``np.exp(log_pdf)`` inside the C++
+            ``probability`` kernel and then took ``np.log`` in Python; for an
+            observation whose ``log_pdf`` is well below IEEE-754 double-precision
+            ``exp`` underflow (~ -745), ``exp(log_pdf)`` collapses to ``0.0`` and
+            the wrapper returned ``-inf``. Meanwhile the batched
+            ``observation_log_probability_per_state`` returns ``log_pdf``
+            directly via ``batch_log_likelihood``, never paying the round-trip.
+            After the fix, the scalar path must return the same finite,
+            large-negative value as the batch path.
+
+        Given: A ContinuousLaserTagPOMDP with no walls, a non-terminal
+            next_state, and a far-from-mean (non-terminal-sentinel) observation
+            chosen so that ``log_pdf`` is approximately -1e6 — well past the
+            ``exp`` underflow boundary.
+        When: We compute the log-probability of that single observation via
+            both the scalar ``env.observation_log_probability`` (passing a
+            list-of-one) and the batch
+            ``env.observation_log_probability_per_state`` (passing a
+            list-of-one next_state).
+        Then: The scalar value is finite (not ``-inf``), is large and negative
+            (less than ``-1e5``), and agrees with the batch value within
+            ``atol=1e-6``.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        action = np.array([1.0, 0.0, 0.0])
+        next_state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
+
+        # Compute the kernel mean so we can place the observation far from it
+        # without depending on internal layout. log_pdf for an 8-D Gaussian
+        # with sigma=1 is 8 * log_norm_1d_ - 0.5 * sum_sq_diff. With per-dim
+        # diff = 500, sum_sq_diff = 8 * 250000 = 2e6, so log_pdf is ~ -1e6.
+        kernel = env._get_obs_kernel(action)  # pylint: disable=protected-access
+        kernel.set_next_state(next_state)
+        mean = np.asarray(kernel.mean, dtype=np.float64)
+        far_obs = mean + 500.0
+        # Sanity: this is *not* the terminal sentinel (np.full(8, -1.0)),
+        # so we are exercising B1 (low-density Gaussian) and not B2.
+        assert not np.allclose(far_obs, -1.0)
+
+        scalar_log_probs = env.observation_log_probability(next_state, action, [far_obs])
+        batch_log_probs = env.observation_log_probability_per_state(
+            np.asarray([next_state], dtype=np.float64), action, far_obs
+        )
+
+        assert scalar_log_probs.shape == (1,)
+        assert batch_log_probs.shape == (1,)
+        assert np.isfinite(
+            scalar_log_probs[0]
+        ), f"scalar log-prob underflowed to {scalar_log_probs[0]} — B1 not fixed"
+        assert scalar_log_probs[0] < -1e5
+        np.testing.assert_allclose(scalar_log_probs[0], batch_log_probs[0], atol=1e-6)
+
+    def test_scalar_log_probability_single_low_density_obs_matches_batch(self) -> None:
+        """observation_log_probability_single returns finite value on low-density obs.
+
+        Purpose: Regression for B1 on the scalar fast-path used by POMCPOW's
+            ``WeightedParticleBeliefStateUpdate``. Pre-fix, this method called
+            ``kernel.probability([obs])[0]`` and clamped to ``-math.inf`` when
+            ``prob <= 0.0``, masking the underflow. Post-fix, it must return a
+            finite log-prob agreeing with the batch path.
+
+        Given: A ContinuousLaserTagPOMDP with no walls, a non-terminal
+            next_state, and a far-from-mean (non-terminal-sentinel) observation
+            with ``log_pdf`` well past the ``exp`` underflow boundary.
+        When: We compute the log-probability via
+            ``env.observation_log_probability_single`` and via
+            ``env.observation_log_probability_per_state`` (single-row batch).
+        Then: The scalar value is finite, large negative, and agrees with the
+            batch value within ``atol=1e-6``.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        action = np.array([1.0, 0.0, 0.0])
+        next_state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
+
+        kernel = env._get_obs_kernel(action)  # pylint: disable=protected-access
+        kernel.set_next_state(next_state)
+        mean = np.asarray(kernel.mean, dtype=np.float64)
+        far_obs = mean + 500.0
+        assert not np.allclose(far_obs, -1.0)
+
+        scalar_value = env.observation_log_probability_single(next_state, action, far_obs)
+        batch_log_probs = env.observation_log_probability_per_state(
+            np.asarray([next_state], dtype=np.float64), action, far_obs
+        )
+
+        assert math.isfinite(
+            scalar_value
+        ), f"scalar single log-prob underflowed to {scalar_value} — B1 not fixed"
+        assert scalar_value < -1e5
+        np.testing.assert_allclose(scalar_value, batch_log_probs[0], atol=1e-6)


### PR DESCRIPTION
## Summary

Integrates two parallel TDD fixes for `ContinuousLaserTagPOMDP`'s scalar/batch log-probability asymmetry:

- **B1**: scalar `observation_log_probability` returned `-inf` for low-density observations because the underlying `kernel.probability` C++ method computes `prob = std::exp(log_pdf)` and underflows to `0.0`, then `np.log(0.0) = -inf`. Batch `observation_log_probability_per_state` returned the raw finite `log_pdf` from `kernel.batch_log_likelihood`. Same kernel, gaps up to ~1e6 nats apart.
- **B2**: scalar `kernel.probability` treated the terminal-sentinel observation `[-1,-1,...,-1]` as a real observation, naively computing the Gaussian PDF against any non-terminal `next_state` mean and returning a small but finite value (~exp(-139)). The matching `kernel.batch_log_likelihood` had an explicit guard returning `-inf`. The pre-existing `test_batch_log_likelihood_terminal_semantics` confirms `-inf` is the documented contract.

## Fix

- B1 (commit `43c849a`): adds a new `ContinuousLaserTagObservationCpp::log_probability(values)` C++ method that returns `log_pdf` directly without the `exp` round-trip; updates `_native.pyi` and routes the Python wrapper at `continuous_laser_tag_pomdp.py` (`observation_log_probability` and `observation_log_probability_single`) through it.
- B2 (commit `7406075`): lifts `is_terminal_state` and `is_terminal_sentinel_obs` into shared static helpers on the observation kernel; applies the terminal-sentinel guard to `kernel.probability` so it agrees with `kernel.batch_log_likelihood`.
- Integration fix (commit `8bb254f`): applies B2's guard to B1's new `log_probability` method too — without it, the integration left `log_probability` mirroring the pre-B2 buggy behavior and `TestObservationLogProbabilityScalarBatchTerminalParity::test_scalar_matches_batch_nonterminal_state_terminal_obs` failed post-merge.

All three kernel methods (`probability`, `log_probability`, `batch_log_likelihood`) now share one contract:
- terminal next_state + sentinel obs → `0.0` (log 1)
- terminal next_state XOR sentinel obs → `-inf`
- both non-terminal → raw `log_pdf` from the Gaussian

## Tests (TDD, all written failing-first)

- `TestObservationLogProbabilityLowDensityB1` (B1) — 2 tests
- `TestObservationLogProbabilityScalarBatchTerminalParity` (B2) — 3 tests

## Verification
- pytest: 197/197 in `test_laser_tag_pomdp/` — 5 new + 192 pre-existing, no regressions
- Pre-existing `test_batch_log_likelihood_terminal_semantics` still passes (B2's contract preserved)
- pyright 0/0; pylint 9.95/10 (pre-existing pre-PR)

## Test plan
- [x] All new tests fail before their respective fix and pass after (TDD verified per branch)
- [x] Both fixes merge cleanly and the integration test in `TestObservationLogProbabilityScalarBatchTerminalParity` passes
- [x] No regressions in the broader laser_tag suite