### PR TITLE
test(mcts-tree): add tree-structure coverage across MCTS planners

### DIFF
--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_beta_zero/test_beta_zero.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_beta_zero/test_beta_zero.py
@@ -15,7 +15,7 @@ import pytest
 
 from POMDPPlanners.core.belief import WeightedParticleBelief, get_initial_belief
 from POMDPPlanners.core.policy import PolicyRunData
-from POMDPPlanners.core.tree.arena import Tree
+from POMDPPlanners.core.tree.arena import ACTION, BELIEF, Tree
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
 from POMDPPlanners.planners.mcts_planners.beta_zero.beta_zero import BetaZero
 from POMDPPlanners.training import PolicyTrainer
@@ -539,3 +539,107 @@ class TestBetaZero:
 
         assert isinstance(cid, str)
         assert len(cid) > 0
+
+    def test_tree_structure_after_plan(self, tiger_planner, initial_belief):
+        """Test that the tree built by _learn_tree satisfies arena invariants.
+
+        Purpose: Validates that BetaZero's _learn_tree produces an arena tree
+        with the expected structural and bookkeeping invariants after a real
+        planning call.
+
+        Given: A BetaZero planner and an initial belief for TigerPOMDP.
+        When: _learn_tree(belief) is called and the resulting tree is walked
+              from the root via BFS.
+        Then: The root is a BELIEF node with no parent and no observation;
+              every non-root node has a parent; visit_count is non-negative
+              everywhere; BELIEF and ACTION kinds strictly alternate down the
+              tree; BELIEF nodes carry a belief and ACTION nodes carry an
+              action; the maximum BFS depth is bounded by 2*planner.depth + 2;
+              and parent visit_count is at least the sum of children visits.
+
+        Test type: unit
+        """
+        tree, root_id = tiger_planner._learn_tree(initial_belief)
+
+        # Root invariants.
+        assert tree.kind[root_id] == BELIEF
+        assert tree.parent_id[root_id] is None
+        assert tree.observation[root_id] is None
+        assert len(tree.children_ids[root_id]) > 0
+
+        # Walk the tree via BFS to check invariants and depth bound.
+        max_observed_depth = 0
+        frontier = [(root_id, 0)]
+        while frontier:
+            node_id, depth_d = frontier.pop()
+            max_observed_depth = max(max_observed_depth, depth_d)
+
+            # Visit count non-negative everywhere.
+            assert tree.visit_count[node_id] >= 0
+
+            node_kind = tree.kind[node_id]
+            if node_kind == BELIEF:
+                assert tree.belief[node_id] is not None
+            elif node_kind == ACTION:
+                assert tree.action[node_id] is not None
+            else:
+                pytest.fail(f"Unexpected node kind {node_kind} at node {node_id}")
+
+            children = tree.children_ids[node_id]
+
+            # BELIEF <-> ACTION alternation.
+            for child_id in children:
+                if node_kind == BELIEF:
+                    assert tree.kind[child_id] == ACTION, (
+                        f"BELIEF node {node_id} has non-ACTION child {child_id} "
+                        f"with kind {tree.kind[child_id]}"
+                    )
+                else:
+                    assert tree.kind[child_id] == BELIEF, (
+                        f"ACTION node {node_id} has non-BELIEF child {child_id} "
+                        f"with kind {tree.kind[child_id]}"
+                    )
+                assert tree.parent_id[child_id] is not None
+
+            # Parent visits >= sum of children visits.
+            if children:
+                children_visits_sum = sum(tree.visit_count[cid] for cid in children)
+                assert tree.visit_count[node_id] >= children_visits_sum, (
+                    f"Node {node_id} visit_count {tree.visit_count[node_id]} "
+                    f"< sum of children visits {children_visits_sum}"
+                )
+
+            for child_id in children:
+                frontier.append((child_id, depth_d + 1))
+
+        assert max_observed_depth <= 2 * tiger_planner.depth + 2
+
+    def test_action_priors_sum_to_one(self, tiger_planner):
+        """Test that _discrete_action_priors returns a valid probability vector.
+
+        Purpose: Validates that BetaZero's _discrete_action_priors normalizes
+        the network output to a non-negative vector that sums to one over the
+        belief node's action children.
+
+        Given: A manually constructed arena tree with a root belief node and
+               two valid Tiger action children (listen, open_left).
+        When: _discrete_action_priors(tree=tree, belief_id=root_id) is called.
+        Then: The returned array has length equal to the number of action
+              children; all entries are non-negative; and the entries sum to 1.
+
+        Test type: unit
+        """
+        particles = [["tiger_left"], ["tiger_right"]]
+        log_weights = np.log(np.array([0.5, 0.5]))
+        belief = WeightedParticleBelief(particles, log_weights)
+        tree = Tree()
+        root_id = tree.add_belief_node(belief)
+
+        tree.add_action_node(action="listen", parent_id=root_id)
+        tree.add_action_node(action="open_left", parent_id=root_id)
+
+        priors = tiger_planner._discrete_action_priors(tree=tree, belief_id=root_id)
+
+        assert len(priors) == len(tree.children_ids[root_id])
+        assert np.all(priors >= 0.0)
+        assert np.isclose(priors.sum(), 1.0, atol=1e-6)

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_constrained_zero/test_constrained_zero.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_constrained_zero/test_constrained_zero.py
@@ -15,7 +15,7 @@ import torch
 
 from POMDPPlanners.core.belief import WeightedParticleBelief, get_initial_belief
 from POMDPPlanners.core.simulation.history import History, StepData
-from POMDPPlanners.core.tree.arena import Tree
+from POMDPPlanners.core.tree.arena import ACTION, BELIEF, Tree
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
 from POMDPPlanners.planners.mcts_planners.beta_zero.beta_zero import BetaZero
 from POMDPPlanners.planners.mcts_planners.constrained_zero.constrained_training_buffer import (
@@ -546,3 +546,123 @@ class TestConstrainedZeroFit:
         metrics = trainer.train()
 
         assert "failure_loss" in metrics
+
+
+class TestConstrainedZeroTreeStructure:
+    """Tests for tree structure and statistics after a real plan."""
+
+    def test_tree_structure_after_plan(self, tiger_planner, initial_belief):
+        """Test arena tree has well-formed structure after _learn_tree.
+
+        Purpose: Validates root-node invariants, BELIEF/ACTION alternation,
+        per-node payload presence, depth bound, and visit-count monotonicity.
+
+        Given: A ConstrainedZero planner and an initial belief.
+        When: _learn_tree is called to build the search tree.
+        Then: The root is a BELIEF with no parent and no observation; every
+              non-root node has a parent; visit counts are non-negative;
+              BELIEF and ACTION nodes alternate; BELIEF nodes carry a belief
+              and ACTION nodes carry an action; BFS-depth from root is at
+              most 2 * planner.depth + 2; and every node's visit_count is
+              at least the sum of its children's visit_counts.
+
+        Test type: unit
+        """
+        tree, root_id = tiger_planner._learn_tree(initial_belief)
+
+        assert tree.kind[root_id] == BELIEF
+        assert tree.parent_id[root_id] is None
+        assert tree.observation[root_id] is None
+        assert len(tree.children_ids[root_id]) > 0
+
+        max_observed_depth = 0
+        frontier = [(root_id, 0)]
+        visited_ids = []
+        while frontier:
+            node_id, d = frontier.pop()
+            visited_ids.append(node_id)
+            max_observed_depth = max(max_observed_depth, d)
+            for cid in tree.children_ids[node_id]:
+                frontier.append((cid, d + 1))
+
+        for node_id in visited_ids:
+            assert tree.visit_count[node_id] >= 0
+            if node_id != root_id:
+                assert tree.parent_id[node_id] is not None
+            if tree.kind[node_id] == BELIEF:
+                assert tree.belief[node_id] is not None
+                for cid in tree.children_ids[node_id]:
+                    assert tree.kind[cid] == ACTION
+            else:
+                assert tree.kind[node_id] == ACTION
+                assert tree.action[node_id] is not None
+                for cid in tree.children_ids[node_id]:
+                    assert tree.kind[cid] == BELIEF
+
+            children = tree.children_ids[node_id]
+            if children:
+                children_visit_sum = sum(tree.visit_count[c] for c in children)
+                assert tree.visit_count[node_id] >= children_visit_sum
+
+        assert max_observed_depth <= 2 * tiger_planner.depth + 2
+
+    def test_failure_dict_populated_after_plan(self, tiger_planner, initial_belief):
+        """Test _failure_dict has entries for every visited action node.
+
+        Purpose: Validates the failure-tracking dict is populated for all
+        action nodes that were actually visited during MCTS, with values in
+        the valid probability range [0.0, 1.0].
+
+        Given: A ConstrainedZero planner and an initial belief.
+        When: _learn_tree is called to build the search tree.
+        Then: _failure_dict is non-empty, and every ACTION node with
+              visit_count > 0 in the tree has an entry in _failure_dict
+              whose value lies in [0.0, 1.0].
+
+        Test type: unit
+        """
+        tree, _ = tiger_planner._learn_tree(initial_belief)
+
+        assert len(tiger_planner._failure_dict) > 0
+
+        for node_id in range(len(tree)):
+            if tree.kind[node_id] != ACTION:
+                continue
+            if tree.visit_count[node_id] <= 0:
+                continue
+            assert node_id in tiger_planner._failure_dict
+            failure_value = tiger_planner._failure_dict[node_id]
+            assert 0.0 <= failure_value <= 1.0
+
+    def test_v_value_matches_max_q_of_children(self, tiger_planner, initial_belief):
+        """Test v_value of each visited belief equals max q over its children.
+
+        Purpose: Validates the ConstrainedZero v-value update rule
+        (_update_node_statistics_constrained) which sets
+        v_value[belief] = max(q_value[c] for c in children).
+
+        Given: A ConstrainedZero planner and an initial belief.
+        When: _learn_tree is called to build the search tree.
+        Then: For every BELIEF node with at least one action child where
+              some child has visit_count > 0, the stored v_value matches
+              the max of q_values over ALL children (unvisited children
+              contribute q_value=0.0 by default).
+
+        Test type: unit
+        """
+        tree, _ = tiger_planner._learn_tree(initial_belief)
+
+        checked_any = False
+        for node_id in range(len(tree)):
+            if tree.kind[node_id] != BELIEF:
+                continue
+            children = tree.children_ids[node_id]
+            if not children:
+                continue
+            if not any(tree.visit_count[c] > 0 for c in children):
+                continue
+            expected = max(tree.q_value[c] for c in children)
+            assert np.isclose(tree.v_value[node_id], expected)
+            checked_any = True
+
+        assert checked_any

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pft_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pft_dpw.py
@@ -6,7 +6,7 @@ import pytest
 
 from POMDPPlanners.core.environment import SpaceType
 from POMDPPlanners.core.belief import WeightedParticleBelief, get_initial_belief
-from POMDPPlanners.core.tree.arena import BELIEF, Tree
+from POMDPPlanners.core.tree.arena import ACTION, BELIEF, Tree
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDP,
 )
@@ -204,6 +204,120 @@ def test_progressive_widening_constraints(planner, belief):
 
     assert belief_count >= 1, "Tree should contain at least the root belief node"
     assert action_count >= 0, "Tree should contain zero or more action nodes"
+
+
+def test_tree_structure_comprehensive(planner, belief):
+    """Comprehensive structural validation of the iCVaR PFT-DPW search tree.
+
+    Purpose: Validates that the search tree built by ICVaR_PFT_DPW respects all
+    structural invariants: root metadata, BELIEF/ACTION kind alternation, parent
+    pointers, value/visit-count consistency, the cost-channel V=min(Q) backup at
+    BELIEF nodes (note: min, not max, since iCVaR is a cost channel), BFS depth
+    bounds, and progressive widening bounds for both action and observation
+    branches.
+
+    Given: An ICVaR_PFT_DPW planner with progressive-widening parameters and a
+    WeightedParticleBelief with two particles in the continuous light-dark POMDP.
+    When: A full search tree is constructed via planner._learn_tree(belief) and
+    every node is visited via BFS with depth tracking.
+    Then: All structural invariants hold simultaneously across every node in
+    the tree, and the cost-channel V=min(Q) backup matches within float
+    tolerance at every BELIEF node with at least one visited action child.
+
+    Test type: unit
+    """
+    tree, root_id = planner._learn_tree(belief=belief)
+
+    # Root-level invariants
+    assert tree.kind[root_id] == BELIEF
+    assert tree.parent_id[root_id] is None
+    assert tree.observation[root_id] is None
+    assert len(tree.children_ids[root_id]) > 0
+
+    # BFS walk tracking depth
+    max_bfs_depth = 0
+    frontier: list[tuple[int, int]] = [(root_id, 0)]
+    while frontier:
+        node_id, depth = frontier.pop(0)
+        max_bfs_depth = max(max_bfs_depth, depth)
+        _assert_node_invariants(tree, node_id, root_id)
+        _assert_pw_bounds(tree, node_id, planner)
+        for child_id in tree.children_ids[node_id]:
+            frontier.append((child_id, depth + 1))
+
+    max_depth_bound = 2 * planner.depth + 2
+    assert max_bfs_depth <= max_depth_bound, (
+        f"Max BFS depth {max_bfs_depth} exceeds bound {max_depth_bound} "
+        f"(2 * planner.depth + 2 with planner.depth={planner.depth})"
+    )
+
+
+def _assert_node_invariants(tree, node_id, root_id):
+    assert (
+        tree.visit_count[node_id] >= 0
+    ), f"Node {node_id} has negative visit_count {tree.visit_count[node_id]}"
+    if node_id != root_id:
+        assert tree.parent_id[node_id] is not None, f"Non-root node {node_id} has no parent"
+
+    children = tree.children_ids[node_id]
+    node_kind = tree.kind[node_id]
+
+    if node_kind == BELIEF:
+        assert tree.belief[node_id] is not None, f"BELIEF node {node_id} has no belief"
+        assert tree.v_value[node_id] is not None, f"BELIEF node {node_id} has no v_value"
+        for child_id in children:
+            assert (
+                tree.kind[child_id] == ACTION
+            ), f"Child {child_id} of BELIEF node {node_id} is not ACTION"
+        _assert_v_min_backup(tree, node_id, children)
+    else:
+        assert node_kind == ACTION
+        assert tree.action[node_id] is not None, f"ACTION node {node_id} has no action"
+        assert tree.q_value[node_id] is not None, f"ACTION node {node_id} has no q_value"
+        for child_id in children:
+            assert (
+                tree.kind[child_id] == BELIEF
+            ), f"Child {child_id} of ACTION node {node_id} is not BELIEF"
+
+    if children:
+        children_visit_sum = sum(tree.visit_count[c] for c in children)
+        assert tree.visit_count[node_id] >= children_visit_sum, (
+            f"Node {node_id} visit_count {tree.visit_count[node_id]} is less than "
+            f"sum of children visit counts {children_visit_sum}"
+        )
+
+
+def _assert_v_min_backup(tree, belief_node_id, children):
+    visited_action_children = [c for c in children if tree.visit_count[c] > 0]
+    if not visited_action_children:
+        return
+    expected_v = min(tree.q_value[c] for c in visited_action_children)
+    actual_v = tree.v_value[belief_node_id]
+    assert actual_v == pytest.approx(expected_v), (
+        f"BELIEF node {belief_node_id}: v_value={actual_v} does not equal "
+        f"min over visited action children q_values={expected_v}"
+    )
+
+
+def _assert_pw_bounds(tree, node_id, planner):
+    visit_count = tree.visit_count[node_id]
+    if visit_count <= 0:
+        return
+    children = tree.children_ids[node_id]
+    if tree.kind[node_id] == BELIEF:
+        max_allowed = int(planner.k_a * (visit_count**planner.alpha_a)) + 1
+        assert len(children) <= max_allowed, (
+            f"BELIEF node {node_id} has {len(children)} children, exceeds "
+            f"PW bound {max_allowed} (k_a={planner.k_a}, alpha_a={planner.alpha_a}, "
+            f"visit_count={visit_count})"
+        )
+    else:
+        max_allowed = int(planner.k_o * (visit_count**planner.alpha_o)) + 1
+        assert len(children) <= max_allowed, (
+            f"ACTION node {node_id} has {len(children)} children, exceeds "
+            f"PW bound {max_allowed} (k_o={planner.k_o}, alpha_o={planner.alpha_o}, "
+            f"visit_count={visit_count})"
+        )
 
 
 class TestICVaR_PFT_DPWEpisodeTests:

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pomcpow.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pomcpow.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from POMDPPlanners.core.belief import WeightedParticleBelief, get_initial_belief
-from POMDPPlanners.core.tree.arena import BELIEF, Tree
+from POMDPPlanners.core.tree.arena import ACTION, BELIEF, Tree
 from POMDPPlanners.environments import TigerPOMDP, DiscreteLightDarkPOMDP
 from POMDPPlanners.utils.action_samplers import DiscreteActionSampler
 from POMDPPlanners.simulations.episodes import run_episode
@@ -1268,6 +1268,68 @@ class TestICVaR_POMCPOWEpisodeTests:
         else:
             # If not terminal, should have used all steps
             assert len(history.history) == num_steps
+
+
+class TestICVaR_POMCPOWArenaInvariants:
+    """Test class for arena tree invariants beyond visit/PW/Q-V relationships."""
+
+    def test_observation_cdf_consistency(self, planner, belief):
+        """Test the per-parent children_cdf invariants on the iCVaR-POMCPOW arena tree.
+
+        Purpose: Validates the arena tree's ``children_cdf`` (used by
+        ``sample_belief_child`` for O(log K) weighted sampling at observation-widening
+        action nodes) is monotonically non-decreasing and totals to the sum of
+        children weights for every parent in the tree.
+
+        Given: ICVaR_POMCPOW planner with default fixture parameters and an initial
+        belief; tree is built by running 100 ``_simulate_path`` calls from the root
+        (matching the existing comprehensive test setup).
+        When: Every parent in the arena (belief and action) is walked.
+        Then: For every parent with children, the CDF length matches children count,
+        is monotonically non-decreasing, and ``cdf[-1]`` equals the sum of children
+        weights within absolute tolerance ``1e-6``. At least one action node has
+        multiple belief children.
+
+        Test type: unit
+        """
+        tree = Tree()
+        root_id = tree.add_belief_node(belief)
+
+        n_sims = 100
+        for _ in range(n_sims):
+            planner._simulate_path(tree=tree, belief_id=root_id, depth=0)
+
+        multi_child_action_seen = False
+        for parent_id in _iter_node_ids(tree, root_id):
+            children = tree.children_ids[parent_id]
+            if not children:
+                continue
+            cdf = tree.children_cdf[parent_id]
+
+            assert len(cdf) == len(children), (
+                f"Parent {parent_id} (kind={tree.kind[parent_id]}) has {len(children)} "
+                f"children but CDF has {len(cdf)} entries"
+            )
+
+            for i in range(1, len(cdf)):
+                assert cdf[i] >= cdf[i - 1] - 1e-9, (
+                    f"Parent {parent_id} CDF not monotone at index {i}: "
+                    f"cdf[{i - 1}]={cdf[i - 1]}, cdf[{i}]={cdf[i]}"
+                )
+
+            total_weight = sum(tree.weight[cid] for cid in children)
+            assert abs(cdf[-1] - total_weight) < 1e-6, (
+                f"Parent {parent_id} CDF total {cdf[-1]} != sum of child weights "
+                f"{total_weight} (kind={tree.kind[parent_id]})"
+            )
+
+            if tree.kind[parent_id] == ACTION and len(children) >= 2:
+                multi_child_action_seen = True
+
+        assert multi_child_action_seen, (
+            "No action node with multiple belief children found; observation-widening "
+            "CDF invariant is vacuous on this tree. Increase n_sims."
+        )
 
 
 if __name__ == "__main__":

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py
@@ -856,3 +856,130 @@ def test_random_rollout_depth_semantics_preserved(
         f"Depth semantics changed: self.depth={self_depth}, entry_depth={entry_depth}, "
         f"expected {expected_steps} steps, got {env.sample_next_state_calls}."
     )
+
+
+def test_tree_structure_comprehensive(planner, initial_belief):
+    """Comprehensive structural invariants on a freshly-built PFT-DPW arena tree.
+
+    Purpose: Validates that ``_learn_tree`` produces an arena ``Tree`` whose
+        kind/parent/children/visit/value fields satisfy the documented invariants
+        for a PFT-DPW search: belief/action level alternation, populated payloads
+        per kind, non-negative visit counts, parent visits dominating the sum of
+        child visits, BFS depth bounded by ``2 * planner.depth + 2``, and
+        progressive widening bounds on per-node child counts.
+
+    Given: The ``planner`` fixture (PFT_DPW with depth=5, n_simulations=100,
+        k_a=k_o=1.0, alpha_a=alpha_o=0.5) and the ``initial_belief`` fixture
+        (continuous light-dark POMDP belief with 20 particles).
+    When: ``planner._learn_tree(initial_belief)`` builds the tree, then a BFS
+        from ``root_id`` collects ``(node_id, depth)`` tuples and per-node
+        invariants are checked across the full arena.
+    Then: Root is a BELIEF node with no parent/observation and at least one
+        child; every node has non-negative ``visit_count``; BELIEF nodes carry
+        a populated ``belief``; ACTION nodes carry a populated ``action`` and
+        ``q_value``; non-root nodes have a non-None parent; kinds alternate
+        along every parent-child edge; visit-count is conserved (parent >=
+        sum of children's visits); BFS depth <= ``2 * planner.depth + 2``;
+        and progressive-widening bounds hold at every visited node.
+
+    Test type: unit
+    """
+    tree, root_id = planner._learn_tree(initial_belief)
+
+    # Root invariants.
+    assert tree.kind[root_id] == BELIEF
+    assert tree.parent_id[root_id] is None
+    assert tree.observation[root_id] is None
+    assert len(tree.children_ids[root_id]) > 0
+
+    # BFS to collect (node_id, depth) for the bound check; meanwhile
+    # record per-node depth so kind alternation can be checked against it.
+    max_observed_depth = 0
+    frontier = [(root_id, 0)]
+    while frontier:
+        node_id, d = frontier.pop()
+        max_observed_depth = max(max_observed_depth, d)
+        for cid in tree.children_ids[node_id]:
+            frontier.append((cid, d + 1))
+
+    assert max_observed_depth <= 2 * planner.depth + 2
+
+    # Per-node invariants. Iterate over the full arena (every allocated id).
+    n_nodes = len(tree)
+    for node_id in range(n_nodes):
+        # Visit count non-negative everywhere.
+        assert tree.visit_count[node_id] >= 0
+
+        # Non-root nodes have a parent; root parent is None and was checked.
+        if node_id != root_id:
+            assert tree.parent_id[node_id] is not None
+
+        # Kind-specific payload presence.
+        if tree.kind[node_id] == BELIEF:
+            assert tree.belief[node_id] is not None
+        else:
+            assert tree.kind[node_id] == ACTION
+            assert tree.action[node_id] is not None
+            assert tree.q_value[node_id] is not None
+
+        # Kind alternation along every parent-child edge.
+        parent = tree.parent_id[node_id]
+        if parent is not None:
+            assert tree.kind[node_id] != tree.kind[parent]
+
+        # Visit-count consistency: parent visits >= sum of children's visits.
+        children = tree.children_ids[node_id]
+        if children:
+            child_visits_sum = sum(tree.visit_count[c] for c in children)
+            assert tree.visit_count[node_id] >= child_visits_sum
+
+        # Progressive-widening bounds at visited nodes only.
+        if tree.visit_count[node_id] > 0:
+            n_children = len(children)
+            if tree.kind[node_id] == BELIEF:
+                pw_bound = int(planner.k_a * (tree.visit_count[node_id] ** planner.alpha_a)) + 1
+                assert n_children <= pw_bound
+            else:
+                pw_bound = int(planner.k_o * (tree.visit_count[node_id] ** planner.alpha_o)) + 1
+                assert n_children <= pw_bound
+
+
+def test_q_value_v_value_consistency(planner, initial_belief):
+    """Verify ``v_value`` of every BELIEF node equals max ``q_value`` over its children.
+
+    Purpose: Pins down the contract enforced by ``_update_node_statistics``:
+        after every backup, the V-value at a belief node equals the max
+        Q-value across all of its action children (visited or not). This
+        guards against silent drift if a future change reorders updates,
+        filters by visit count, or computes a different aggregate.
+
+    Given: The ``planner`` fixture (PFT_DPW) and the ``initial_belief``
+        fixture; ``_learn_tree`` builds the arena tree.
+    When: Every BELIEF node with non-empty children is enumerated, and the
+        observed ``tree.v_value[belief_id]`` is compared against
+        ``max(tree.q_value[c] for c in tree.children_ids[belief_id])`` taken
+        over ALL children (no visit-count filter).
+    Then: The values agree within ``atol=1e-9`` (float-tolerant equality via
+        ``pytest.approx``).
+
+    Test type: unit
+    """
+    tree, root_id = planner._learn_tree(initial_belief)
+    assert tree.kind[root_id] == BELIEF  # sanity: root is a belief node
+
+    n_nodes = len(tree)
+    n_belief_nodes_checked = 0
+    for node_id in range(n_nodes):
+        if tree.kind[node_id] != BELIEF:
+            continue
+        children = tree.children_ids[node_id]
+        if not children:
+            continue
+        # PFT-DPW takes max over ALL children (including unvisited q=0.0).
+        expected_v = max(tree.q_value[c] for c in children)
+        observed_v = tree.v_value[node_id]
+        assert observed_v == pytest.approx(expected_v, abs=1e-9)
+        n_belief_nodes_checked += 1
+
+    # Sanity: at least the root should have been checked.
+    assert n_belief_nodes_checked >= 1

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp_dpw.py
@@ -1167,3 +1167,90 @@ def test_min_visit_count_per_action_enforcement(environment, discrete_action_sam
         assert (
             visits >= min_visit_count
         ), f"Action {tree.action[action_id]} has {visits} visits, expected at least {min_visit_count}"
+
+
+def test_observation_cdf_consistency(
+    environment,
+    discount_factor,
+    depth,
+    exploration_constant,
+    k_o,
+    k_a,
+    alpha_o,
+    alpha_a,
+):
+    """Test that the per-parent children_cdf invariants hold throughout the tree.
+
+    Purpose: Validates the arena tree's ``children_cdf`` (used by
+    ``sample_belief_child`` for O(log K) weighted sampling at observation-widening
+    action nodes) is monotonically non-decreasing and totals to the sum of
+    children weights for every parent in the tree.
+
+    Given: POMCP_DPW planner built with sufficient simulations to expand at least
+    one action node with multiple belief children (n_simulations=300). The action
+    sampler uses the environment's real action space so that observations are not
+    collapsed to a single sentinel by the environment.
+    When: The tree is built via ``_learn_tree`` and every parent (belief and
+    action) is walked.
+    Then: For every parent with children, the CDF length matches children count,
+    is monotonically non-decreasing, and ``cdf[-1]`` equals the sum of children
+    weights within absolute tolerance ``1e-6``. At least one action node has
+    multiple belief children (otherwise the OW invariant is vacuous).
+
+    Test type: unit
+    """
+    cdf_action_sampler = MockActionSampler(environment.get_actions())
+    planner = POMCP_DPW(
+        environment=environment,
+        discount_factor=discount_factor,
+        depth=depth,
+        exploration_constant=exploration_constant,
+        k_o=k_o,
+        k_a=k_a,
+        alpha_o=alpha_o,
+        alpha_a=alpha_a,
+        n_simulations=300,
+        action_sampler=cdf_action_sampler,
+        name="TestPOMCP_DPW_CDF",
+    )
+
+    n_particles = 100
+    belief = get_initial_belief(environment, n_particles=n_particles, resampling=True)
+
+    tree, root_id = planner._learn_tree(belief=belief)
+    del root_id  # walk all parents in the arena instead of subtree-only
+
+    multi_child_action_seen = False
+    for parent_id in range(len(tree)):
+        children = tree.children_ids[parent_id]
+        if not children:
+            continue
+        cdf = tree.children_cdf[parent_id]
+
+        # Length matches.
+        assert len(cdf) == len(children), (
+            f"Parent {parent_id} (kind={tree.kind[parent_id]}) has {len(children)} "
+            f"children but CDF has {len(cdf)} entries"
+        )
+
+        # Monotonic non-decreasing (allow tiny float slack).
+        for i in range(1, len(cdf)):
+            assert cdf[i] >= cdf[i - 1] - 1e-9, (
+                f"Parent {parent_id} CDF not monotone at index {i}: "
+                f"cdf[{i - 1}]={cdf[i - 1]}, cdf[{i}]={cdf[i]}"
+            )
+
+        # Total equals sum of children weights.
+        total_weight = sum(tree.weight[cid] for cid in children)
+        assert abs(cdf[-1] - total_weight) < 1e-6, (
+            f"Parent {parent_id} CDF total {cdf[-1]} != sum of child weights "
+            f"{total_weight} (kind={tree.kind[parent_id]})"
+        )
+
+        if tree.kind[parent_id] == ACTION and len(children) >= 2:
+            multi_child_action_seen = True
+
+    assert multi_child_action_seen, (
+        "No action node with multiple belief children found; observation-widening "
+        "CDF invariant is vacuous on this tree. Increase n_simulations."
+    )

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcpow.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcpow.py
@@ -1289,3 +1289,182 @@ def test_max_depth_reached_with_timeout():
     assert tree.observation[root_id] is None
     assert len(tree.children_ids[root_id]) > 0
     assert tree.visit_count[root_id] > 0
+
+
+def test_observation_cdf_consistency(
+    environment,
+    discount_factor,
+    depth,
+    exploration_constant,
+    k_o,
+    k_a,
+    alpha_o,
+    alpha_a,
+):
+    """Test the per-parent children_cdf invariants on the POMCPOW arena tree.
+
+    Purpose: Validates the arena tree's ``children_cdf`` (used by
+    ``sample_belief_child`` for O(log K) weighted sampling at observation-widening
+    action nodes) is monotonically non-decreasing and totals to the sum of
+    children weights for every parent in the tree.
+
+    Given: POMCPOW planner built with enough simulations to widen at least one
+    action node into multiple belief children (n_simulations=300). The action
+    sampler uses the environment's real action space so the environment yields
+    distinguishable observations.
+    When: ``_learn_tree`` builds the tree and every parent is walked.
+    Then: For every parent with children, the CDF length matches children count,
+    is monotonically non-decreasing, and ``cdf[-1]`` equals the sum of children
+    weights within absolute tolerance ``1e-6``. At least one action node has
+    multiple belief children.
+
+    Test type: unit
+    """
+    cdf_action_sampler = MockActionSampler(environment.get_actions())
+    planner = POMCPOW(
+        environment=environment,
+        discount_factor=discount_factor,
+        depth=depth,
+        exploration_constant=exploration_constant,
+        k_o=k_o,
+        k_a=k_a,
+        alpha_o=alpha_o,
+        alpha_a=alpha_a,
+        n_simulations=300,
+        action_sampler=cdf_action_sampler,
+        name="TestPOMCPOW_CDF",
+    )
+
+    n_particles = 100
+    belief = get_initial_belief(environment, n_particles=n_particles, resampling=True)
+
+    tree, root_id = planner._learn_tree(belief=belief)
+    del root_id
+
+    multi_child_action_seen = False
+    for parent_id in range(len(tree)):
+        children = tree.children_ids[parent_id]
+        if not children:
+            continue
+        cdf = tree.children_cdf[parent_id]
+
+        assert len(cdf) == len(children), (
+            f"Parent {parent_id} (kind={tree.kind[parent_id]}) has {len(children)} "
+            f"children but CDF has {len(cdf)} entries"
+        )
+
+        for i in range(1, len(cdf)):
+            assert cdf[i] >= cdf[i - 1] - 1e-9, (
+                f"Parent {parent_id} CDF not monotone at index {i}: "
+                f"cdf[{i - 1}]={cdf[i - 1]}, cdf[{i}]={cdf[i]}"
+            )
+
+        total_weight = sum(tree.weight[cid] for cid in children)
+        assert abs(cdf[-1] - total_weight) < 1e-6, (
+            f"Parent {parent_id} CDF total {cdf[-1]} != sum of child weights "
+            f"{total_weight} (kind={tree.kind[parent_id]})"
+        )
+
+        if tree.kind[parent_id] == ACTION and len(children) >= 2:
+            multi_child_action_seen = True
+
+    assert multi_child_action_seen, (
+        "No action node with multiple belief children found; observation-widening "
+        "CDF invariant is vacuous on this tree. Increase n_simulations."
+    )
+
+
+def test_tree_structure_comprehensive(planner, belief):
+    """Comprehensive arena tree-structure invariants for POMCPOW.
+
+    Purpose: Bundle root-, kind-alternation-, V/Q-relationship-, depth-, and
+    progressive-widening invariants for the POMCPOW arena tree into one walk.
+
+    Given: POMCPOW planner with default fixture parameters and an initial belief.
+    When: ``_learn_tree`` builds the tree and a BFS walk inspects every node.
+    Then: Root is BELIEF with parent None and observation None; every node has
+    visit_count >= 0; BELIEF/ACTION kinds alternate along every edge; every
+    non-root has a parent; BELIEF nodes have a non-None belief; ACTION nodes
+    have non-None action and q_value; node visit_count >= sum of children
+    visits; each BELIEF node with at least one visited action child has
+    v_value equal to the max q_value over visited action children (POMCPOW
+    max-Q backup); the BFS depth from root is at most ``2 * planner.depth + 2``;
+    PW bounds hold at every node with visit_count > 0.
+
+    Test type: unit
+    """
+    tree, root_id = planner._learn_tree(belief=belief)
+
+    assert tree.kind[root_id] == BELIEF
+    assert tree.parent_id[root_id] is None
+    assert tree.observation[root_id] is None
+
+    # BFS to bound depth and visit every node reachable from root.
+    max_observed_depth = 0
+    frontier = [(root_id, 0)]
+    visited_node_ids: list[int] = []
+    while frontier:
+        node_id, d = frontier.pop()
+        visited_node_ids.append(node_id)
+        max_observed_depth = max(max_observed_depth, d)
+        for cid in tree.children_ids[node_id]:
+            frontier.append((cid, d + 1))
+
+    assert max_observed_depth <= 2 * planner.depth + 2, (
+        f"Tree max depth ({max_observed_depth}) exceeded 2 * planner.depth + 2 "
+        f"({2 * planner.depth + 2})"
+    )
+
+    for node_id in visited_node_ids:
+        assert tree.visit_count[node_id] >= 0
+
+        if node_id != root_id:
+            assert tree.parent_id[node_id] is not None
+            parent_id = tree.parent_id[node_id]
+            # Kind alternation: BELIEF parent => ACTION child and vice versa.
+            assert tree.kind[node_id] != tree.kind[parent_id], (
+                f"Kind alternation violated at node {node_id} (kind={tree.kind[node_id]}, "
+                f"parent kind={tree.kind[parent_id]})"
+            )
+
+        children = tree.children_ids[node_id]
+
+        if tree.kind[node_id] == BELIEF:
+            assert tree.belief[node_id] is not None
+            # Q/V relationship: max-Q backup over visited action children.
+            visited_action_children = [cid for cid in children if tree.visit_count[cid] > 0]
+            if visited_action_children:
+                max_q = max(tree.q_value[cid] for cid in visited_action_children)
+                assert np.isclose(tree.v_value[node_id], max_q), (
+                    f"BELIEF node {node_id} v_value ({tree.v_value[node_id]}) != max q_value "
+                    f"of visited action children ({max_q})"
+                )
+        else:
+            assert tree.action[node_id] is not None
+            assert tree.q_value[node_id] is not None
+
+        # Visit-count consistency: parent visits >= sum of child visits.
+        if children:
+            total_child_visits = sum(tree.visit_count[cid] for cid in children)
+            assert tree.visit_count[node_id] >= total_child_visits, (
+                f"Node {node_id} (kind={tree.kind[node_id]}) visit_count "
+                f"({tree.visit_count[node_id]}) < sum of children visits ({total_child_visits})"
+            )
+
+        # Progressive widening bounds at any node with visits.
+        visit_count = tree.visit_count[node_id]
+        if visit_count > 0 and children:
+            if tree.kind[node_id] == BELIEF:
+                max_allowed = int(planner.k_a * (visit_count**planner.alpha_a)) + 1
+                assert len(children) <= max_allowed, (
+                    f"BELIEF node {node_id} has {len(children)} action children but "
+                    f"PW allows at most {max_allowed} (k_a={planner.k_a}, "
+                    f"alpha_a={planner.alpha_a}, visit_count={visit_count})"
+                )
+            else:
+                max_allowed = int(planner.k_o * (visit_count**planner.alpha_o)) + 1
+                assert len(children) <= max_allowed, (
+                    f"ACTION node {node_id} has {len(children)} belief children but "
+                    f"PW allows at most {max_allowed} (k_o={planner.k_o}, "
+                    f"alpha_o={planner.alpha_o}, visit_count={visit_count})"
+                )

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_sparse_pft.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_sparse_pft.py
@@ -687,3 +687,45 @@ def test_sparse_pft_config_id_hash_properties():
     # Should be a valid hexadecimal hash (SHA-256 produces 64 hex characters)
     assert len(config_id) == 64
     assert all(c in "0123456789abcdef" for c in config_id.lower())
+
+
+def test_q_value_v_value_consistency(planner, initial_belief):
+    """Verify ``v_value`` of every BELIEF node equals max ``q_value`` over its children.
+
+    Purpose: Pins down the contract enforced by ``update_nodes`` in SparsePFT:
+        after each backup, ``tree.v_value[belief_id]`` equals the max
+        ``tree.q_value[c]`` across all children of that belief node. This
+        guards against silent drift if a future refactor changes the
+        aggregator or filters children by visit count.
+
+    Given: The ``planner`` fixture (SparsePFT on TigerPOMDP, depth=3,
+        belief_child_num=2, n_simulations=100) and the ``initial_belief``
+        fixture; ``_learn_tree`` builds the arena tree.
+    When: Every BELIEF node with non-empty children is enumerated and the
+        observed ``tree.v_value[belief_id]`` is compared against
+        ``max(tree.q_value[c] for c in tree.children_ids[belief_id])`` taken
+        over ALL action children (no visit-count filter), matching the
+        ``update_nodes`` source behavior.
+    Then: The values agree within ``atol=1e-9`` (float-tolerant equality via
+        ``pytest.approx``).
+
+    Test type: unit
+    """
+    tree, root_id = planner._learn_tree(belief=initial_belief)
+    assert tree.kind[root_id] == BELIEF  # sanity: root is a belief node
+
+    n_nodes = len(tree)
+    n_belief_nodes_checked = 0
+    for node_id in range(n_nodes):
+        if tree.kind[node_id] != BELIEF:
+            continue
+        children = tree.children_ids[node_id]
+        if not children:
+            continue
+        expected_v = max(tree.q_value[c] for c in children)
+        observed_v = tree.v_value[node_id]
+        assert observed_v == pytest.approx(expected_v, abs=1e-9)
+        n_belief_nodes_checked += 1
+
+    # Sanity: at least the root should have been checked.
+    assert n_belief_nodes_checked >= 1


### PR DESCRIPTION
## Summary

Adds 13 tree-structure tests across 8 MCTS planner test files, closing coverage gaps identified in an audit of existing arena `Tree` structural assertions. No source code is modified — tests only.

## What's covered

| Planner | Test(s) added |
|---|---|
| BetaZero | `test_tree_structure_after_plan`, `test_action_priors_sum_to_one` |
| ConstrainedZero | `test_tree_structure_after_plan`, `test_failure_dict_populated_after_plan`, `test_v_value_matches_max_q_of_children` |
| POMCP_DPW | `test_observation_cdf_consistency` |
| POMCPOW | `test_observation_cdf_consistency`, `test_tree_structure_comprehensive` |
| iCVaR POMCPOW | `test_observation_cdf_consistency` |
| PFT_DPW | `test_tree_structure_comprehensive`, `test_q_value_v_value_consistency` |
| SparsePFT | `test_q_value_v_value_consistency` |
| iCVaR PFT_DPW | `test_tree_structure_comprehensive` |

## Invariants verified

- BELIEF↔ACTION kind alternation along every parent-child edge
- Root invariants (BELIEF kind, no parent, no observation, has children)
- Per-kind payload presence (`belief`/`v_value` for BELIEF, `action`/`q_value` for ACTION)
- Visit-count monotonicity (parent visits ≥ Σ children visits)
- BFS depth bound: `max_depth ≤ 2 · planner.depth + 2`
- Progressive widening bounds: `len(children) ≤ k · N^α + 1`
- Q/V backup consistency:
  - Reward-channel planners: `v_value = max(q_value of children)`
  - iCVaR PFT_DPW (cost channel): `v_value = min(q_value of visited children)`
- `children_cdf` monotonicity and agreement with stored child weights (OW planners)
- BetaZero action-prior sum-to-one (regression guard for the prior normalization in `_discrete_action_priors`)
- ConstrainedZero `_failure_dict` populated for every visited action node, values in `[0, 1]`

## Why CDF tests matter

DPW/OW planners use `tree.children_cdf` for O(log K) weighted observation sampling via `sample_belief_child`. A corrupted CDF would silently bias rollouts without any current test catching it. The new CDF tests assert (a) length agrees with `children_ids`, (b) CDF is monotonically non-decreasing, (c) the last entry equals the sum of stored child weights.

## Test plan

- [x] All 13 new tests pass on `develop` base (0.95s wall time)
- [x] Pyright: 0 errors / 0 warnings on every touched file
- [x] Pylint: 10.00/10 on the new test functions; baseline scores unchanged or improved on each file
- [x] Black formatting verified by pre-commit hook
- [x] No source code modified; tests-only PR