### PR TITLE
feat(lasertag-cont): stochastic dangerous-area penalty for risk-sensitive eval

### DIFF
--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -46,6 +46,7 @@ from POMDPPlanners.environments.laser_tag_pomdp import _native
 from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_visualizer import (
     ContinuousLaserTagVisualizer,
 )
+from POMDPPlanners.planners.planners_utils.rollout import python_random_rollout
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 from POMDPPlanners.utils.statistics_utils import confidence_interval
 
@@ -99,6 +100,22 @@ class ContinuousLaserTagPOMDP(Environment):
     navigate to tag an opponent.  The robot receives noisy 8-direction
     laser range observations.
 
+    Stochasticity:
+        The dangerous-area penalty can be applied either deterministically
+        (the default) or stochastically.  When
+        ``dangerous_area_hit_probability == 1.0`` (default), the kernel's
+        deterministic deduction is preserved verbatim, matching legacy
+        behavior.  When ``dangerous_area_hit_probability < 1.0``, the
+        accumulated dangerous-area deduction is applied to the reward only
+        with that probability per ``reward()`` call, producing a
+        heavy-tailed return distribution suitable for benchmarking
+        risk-sensitive planners (e.g. ICVaR-aware MCTS) against
+        expected-value MCTS on the same env.  Note that this makes
+        ``reward(state, action)`` non-deterministic given a state-action
+        pair, so any external caching that assumes deterministic rewards
+        must be aware of this.  ``transition_log_probability`` is
+        unaffected.
+
     Example:
         >>> import numpy as np
         >>> np.random.seed(42)
@@ -116,6 +133,16 @@ class ContinuousLaserTagPOMDP(Environment):
         >>> # Check terminal condition
         >>> env.is_terminal(initial_state)
         False
+
+    Example:
+        Risk-sensitive evaluation -- a 10%-tail-risk environment suitable
+        for benchmarking ICVaR-aware planners against expected-value MCTS::
+
+            >>> env = ContinuousLaserTagPOMDP(
+            ...     discount_factor=0.95,
+            ...     dangerous_area_penalty=150.0,
+            ...     dangerous_area_hit_probability=0.1,
+            ... )
     """
 
     def __init__(
@@ -137,6 +164,7 @@ class ContinuousLaserTagPOMDP(Environment):
         dangerous_areas: Optional[List[Tuple[float, float]]] = None,
         dangerous_area_radius: float = 1.0,
         dangerous_area_penalty: float = 5.0,
+        dangerous_area_hit_probability: float = 1.0,
         output_dir: Optional[Path] = None,
         debug: bool = False,
         use_queue_logger: bool = False,
@@ -162,6 +190,13 @@ class ContinuousLaserTagPOMDP(Environment):
             dangerous_areas: Dangerous area centers as ``(x, y)`` tuples.
             dangerous_area_radius: Radius of dangerous areas.
             dangerous_area_penalty: Penalty for being in a dangerous area.
+            dangerous_area_hit_probability: Probability that the
+                dangerous-area penalty is actually applied to the reward
+                when the robot is inside a dangerous area.  Must lie in
+                ``[0, 1]``.  Defaults to ``1.0`` (deterministic penalty,
+                matching legacy behavior).  Values below ``1.0`` make the
+                reward stochastic, useful for risk-sensitive planning
+                benchmarks.
             output_dir: Optional logging directory.
             debug: Enable debug logging.
             use_queue_logger: Use queue-based logger.
@@ -169,6 +204,8 @@ class ContinuousLaserTagPOMDP(Environment):
         """
         if not 0.0 <= discount_factor <= 1.0:
             raise ValueError("discount_factor must be between 0 and 1 (inclusive)")
+        if not 0.0 <= dangerous_area_hit_probability <= 1.0:
+            raise ValueError("dangerous_area_hit_probability must be between 0 and 1 (inclusive)")
 
         space_info = SpaceInfo(
             action_space=SpaceType.CONTINUOUS,
@@ -201,6 +238,7 @@ class ContinuousLaserTagPOMDP(Environment):
         )
         self.dangerous_area_radius = dangerous_area_radius
         self.dangerous_area_penalty = dangerous_area_penalty
+        self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
         # Packed (K, 2) float64 dangerous-area array; reused by the C++ reward kernel.
         self._dangerous_areas_arr = (
             np.ascontiguousarray(np.asarray(self.dangerous_areas, dtype=np.float64).reshape(-1, 2))
@@ -427,7 +465,22 @@ class ContinuousLaserTagPOMDP(Environment):
         buffer, and runs the full discounted-return loop inside C++. Results are
         numerically identical to the :meth:`Environment.simulate_random_rollout`
         Python fallback.
+
+        When ``dangerous_area_hit_probability < 1.0``, falls back to the
+        Python rollout: the native kernel applies the dangerous-area
+        penalty deterministically per step, which contradicts the
+        stochastic semantics; routing through Python ``reward()`` keeps
+        the per-step Bernoulli intact.
         """
+        if self.dangerous_area_hit_probability < 1.0:
+            return python_random_rollout(
+                state=state,
+                depth=depth,
+                action_sampler=action_sampler,
+                environment=self,
+                discount_factor=discount_factor,
+                max_depth=max_depth,
+            )
         steps_left = max_depth - depth
         if steps_left <= 0 or bool(state[4]):
             return 0.0
@@ -480,7 +533,21 @@ class ContinuousLaserTagPOMDP(Environment):
             self.dangerous_area_radius,
             self.dangerous_area_penalty,
         )
-        return float(rewards[0])
+        base = float(rewards[0])
+        # Stochastic-penalty refund: the kernel always deducts the
+        # dangerous-area penalty deterministically; when
+        # ``dangerous_area_hit_probability < 1.0`` we cancel the deduction
+        # with probability ``1 - p`` per call.
+        if self.dangerous_area_hit_probability >= 1.0:
+            return base
+        if state_arr[0, 4] != 0.0:
+            return base
+        n_matches = self._count_dangerous_area_matches(state_arr[0, :2])
+        if n_matches == 0:
+            return base
+        if np.random.random() >= self.dangerous_area_hit_probability:
+            return base + n_matches * self.dangerous_area_penalty
+        return base
 
     def reward_batch(
         self,
@@ -516,7 +583,7 @@ class ContinuousLaserTagPOMDP(Environment):
             action_arr = action
         else:
             action_arr = np.ascontiguousarray(np.asarray(action, dtype=np.float64)).ravel()
-        return _native.reward_batch(
+        rewards = _native.reward_batch(
             states_arr,
             action_arr,
             self.tag_radius,
@@ -527,6 +594,35 @@ class ContinuousLaserTagPOMDP(Environment):
             self.dangerous_area_radius,
             self.dangerous_area_penalty,
         )
+        return self._apply_stochastic_dangerous_refund(rewards, states_arr)
+
+    def _apply_stochastic_dangerous_refund(
+        self, rewards: np.ndarray, states_arr: np.ndarray
+    ) -> np.ndarray:
+        if self.dangerous_area_hit_probability >= 1.0 or self._dangerous_areas_arr.size == 0:
+            return rewards
+        positions = states_arr[:, :2]
+        centers = self._dangerous_areas_arr.reshape(-1, 2)
+        deltas = positions[:, None, :] - centers[None, :, :]
+        in_zone = np.sum(deltas * deltas, axis=2) <= (
+            self.dangerous_area_radius * self.dangerous_area_radius
+        )
+        # Terminal rows contribute zero reward and never get a deduction.
+        terminal_mask = states_arr[:, 4] != 0.0
+        if terminal_mask.any():
+            in_zone = in_zone.copy()
+            in_zone[terminal_mask, :] = False
+        match_counts = np.sum(in_zone, axis=1)
+        any_match = match_counts > 0
+        # One Bernoulli per state: when miss, refund the full deterministic
+        # deduction (n_matches * penalty). Mirrors the semantics of
+        # ``reward()`` so single- and batch-paths agree statistically.
+        miss = np.random.random(states_arr.shape[0]) >= self.dangerous_area_hit_probability
+        refund_mask = any_match & miss
+        if not refund_mask.any():
+            return rewards
+        refunds = match_counts.astype(np.float64) * float(self.dangerous_area_penalty)
+        return rewards + np.where(refund_mask, refunds, 0.0)
 
     def is_terminal(self, state: np.ndarray) -> bool:
         return bool(state[4])
@@ -643,6 +739,14 @@ class ContinuousLaserTagPOMDP(Environment):
             ):
                 return True
         return False
+
+    def _count_dangerous_area_matches(self, position: np.ndarray) -> int:
+        if self._dangerous_areas_arr.size == 0:
+            return 0
+        centers = self._dangerous_areas_arr.reshape(-1, 2)
+        dx = centers[:, 0] - float(position[0])
+        dy = centers[:, 1] - float(position[1])
+        return int(np.sum(dx * dx + dy * dy <= self.dangerous_area_radius**2))
 
     def _collect_episode_data(self, histories: List[History]) -> Dict[str, list]:
         data: Dict[str, list] = {
@@ -768,6 +872,7 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
         dangerous_areas: Optional[List[Tuple[float, float]]] = None,
         dangerous_area_radius: float = 1.0,
         dangerous_area_penalty: float = 5.0,
+        dangerous_area_hit_probability: float = 1.0,
         output_dir: Optional[Path] = None,
         debug: bool = False,
         use_queue_logger: bool = False,
@@ -791,6 +896,7 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
             dangerous_areas=dangerous_areas,
             dangerous_area_radius=dangerous_area_radius,
             dangerous_area_penalty=dangerous_area_penalty,
+            dangerous_area_hit_probability=dangerous_area_hit_probability,
             output_dir=output_dir,
             debug=debug,
             use_queue_logger=use_queue_logger,
@@ -895,6 +1001,15 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
         discount_factor: float,
         depth: int = 0,
     ) -> float:
+        if self.dangerous_area_hit_probability < 1.0:
+            return python_random_rollout(
+                state=state,
+                depth=depth,
+                action_sampler=action_sampler,
+                environment=self,
+                discount_factor=discount_factor,
+                max_depth=max_depth,
+            )
         steps_left = max_depth - depth
         if steps_left <= 0 or bool(state[4]):
             return 0.0

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
@@ -333,6 +333,191 @@ class TestReward:
         assert r == -env.step_cost - 5.0
 
 
+class TestStochasticDangerousAreaPenalty:
+    """Tests for the ``dangerous_area_hit_probability`` parameter."""
+
+    @staticmethod
+    def _stochastic_env(hit_probability: float, penalty: float = 5.0) -> ContinuousLaserTagPOMDP:
+        return ContinuousLaserTagPOMDP(
+            discount_factor=0.95,
+            walls=[],
+            dangerous_areas=[(5.0, 3.0)],
+            dangerous_area_radius=1.0,
+            dangerous_area_penalty=penalty,
+            dangerous_area_hit_probability=hit_probability,
+        )
+
+    def test_default_hit_probability_is_one(self, env_default):
+        """Test that the default hit probability preserves legacy behavior.
+
+        Purpose: Validates that omitting the new parameter keeps the
+        deterministic dangerous-area penalty active.
+
+        Given: An env constructed with default parameters.
+        When: ``dangerous_area_hit_probability`` is read.
+        Then: It equals ``1.0`` (deterministic-penalty regime).
+
+        Test type: unit
+        """
+        assert env_default.dangerous_area_hit_probability == 1.0
+
+    def test_hit_probability_zero_never_applies_penalty(self):
+        """Test that hit_probability=0 disables the dangerous-area penalty.
+
+        Purpose: Validates the lower-bound of the stochastic penalty.
+
+        Given: A state inside a dangerous area and hit_probability=0.
+        When: reward() is called many times.
+        Then: The dangerous-area penalty is never applied.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.0)
+        state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([1.0, 0.0, 0.0])
+        np.random.seed(0)
+        for _ in range(200):
+            assert env.reward(state, action) == -env.step_cost
+
+    def test_hit_probability_one_matches_deterministic(self):
+        """Test that hit_probability=1 matches the legacy deterministic penalty.
+
+        Purpose: Validates the upper-bound of the stochastic penalty
+        (regression check that the default behavior is preserved).
+
+        Given: A state inside a dangerous area and hit_probability=1.
+        When: reward() is called many times.
+        Then: The dangerous-area penalty is always applied.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=1.0)
+        state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([1.0, 0.0, 0.0])
+        for _ in range(50):
+            assert env.reward(state, action) == -env.step_cost - 5.0
+
+    def test_hit_probability_zero_three_empirical_rate(self):
+        """Test empirical hit rate matches hit_probability over many calls.
+
+        Purpose: Validates that the per-call Bernoulli draw matches the
+        configured probability over a large sample.
+
+        Given: An in-zone state and hit_probability=0.3.
+        When: reward() is called 5000 times.
+        Then: Empirical hit rate is within 0.05 of 0.3.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.3)
+        state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([1.0, 0.0, 0.0])
+        np.random.seed(123)
+        n_trials = 5000
+        hits = 0
+        penalty_reward = -env.step_cost - 5.0
+        for _ in range(n_trials):
+            if env.reward(state, action) == penalty_reward:
+                hits += 1
+        empirical_rate = hits / n_trials
+        assert abs(empirical_rate - 0.3) < 0.05
+
+    def test_reward_batch_honours_hit_probability(self):
+        """Test that reward_batch applies stochastic penalty consistently.
+
+        Purpose: Validates that the batched reward path uses the same
+        Bernoulli mechanism as the single-state path.
+
+        Given: 5000 copies of an in-zone state and hit_probability=0.3.
+        When: reward_batch() is called once.
+        Then: Empirical hit rate across the batch is within 0.05 of 0.3.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.3)
+        state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([1.0, 0.0, 0.0])
+        n_trials = 5000
+        states = np.tile(state, (n_trials, 1))
+        np.random.seed(456)
+        rewards = env.reward_batch(states, action)
+        penalty_reward = -env.step_cost - 5.0
+        hits = int(np.sum(np.isclose(rewards, penalty_reward)))
+        empirical_rate = hits / n_trials
+        assert abs(empirical_rate - 0.3) < 0.05
+
+    def test_reward_batch_terminal_states_unaffected(self):
+        """Test that terminal rows in reward_batch ignore the stochastic refund.
+
+        Purpose: Validates that the kernel's zero-reward semantics for
+        terminal states is preserved under the Python refund pass.
+
+        Given: A batch with mixed terminal/non-terminal in-zone states.
+        When: reward_batch() is called with hit_probability=0.0.
+        Then: Terminal rows return 0.0 unchanged; non-terminal rows
+              return only the step cost (full refund).
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.0)
+        states = np.array(
+            [
+                [5.0, 3.0, 8.0, 5.0, 0.0],
+                [5.0, 3.0, 8.0, 5.0, 1.0],
+            ]
+        )
+        action = np.array([1.0, 0.0, 0.0])
+        rewards = env.reward_batch(states, action)
+        assert rewards[0] == -env.step_cost
+        assert rewards[1] == 0.0
+
+    @pytest.mark.parametrize("bad_value", [-0.1, 1.5, 2.0, -1.0])
+    def test_invalid_hit_probability_raises(self, bad_value: float):
+        """Test that out-of-range hit_probability raises ValueError.
+
+        Purpose: Validates input validation on the new parameter.
+
+        Given: A hit_probability value outside [0, 1].
+        When: ContinuousLaserTagPOMDP is constructed.
+        Then: ValueError is raised.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="dangerous_area_hit_probability"):
+            ContinuousLaserTagPOMDP(
+                discount_factor=0.95,
+                dangerous_area_hit_probability=bad_value,
+            )
+
+    def test_discrete_actions_wrapper_forwards_hit_probability(self):
+        """Test that the discrete-actions wrapper forwards the new parameter.
+
+        Purpose: Validates that constructing
+        ``ContinuousLaserTagPOMDPDiscreteActions`` with a custom
+        ``dangerous_area_hit_probability`` propagates to the underlying
+        reward path.
+
+        Given: A discrete-actions env with hit_probability=0.0 and an
+            in-zone state.
+        When: reward() is called many times with the ``"up"`` action.
+        Then: No dangerous-area penalty is ever applied.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDPDiscreteActions(
+            discount_factor=0.95,
+            walls=[],
+            dangerous_areas=[(5.0, 3.0)],
+            dangerous_area_radius=1.0,
+            dangerous_area_penalty=5.0,
+            dangerous_area_hit_probability=0.0,
+        )
+        assert env.dangerous_area_hit_probability == 0.0
+        state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        for _ in range(100):
+            assert env.reward(state, "up") == -env.step_cost
+
+
 class TestRewardBatch:
     """Tests for reward_batch."""
 


### PR DESCRIPTION
## Summary
- Add `dangerous_area_hit_probability` (default `1.0`) to `ContinuousLaserTagPOMDP` and `ContinuousLaserTagPOMDPDiscreteActions`, mirroring `ContinuousLightDarkPOMDP.obstacle_hit_probability`. When `p < 1.0` the kernel-deducted dangerous-area penalty is refunded with probability `1 - p` per reward call, producing a heavy-tailed return distribution suitable for benchmarking ICVaR-aware planners against expected-value MCTS.
- Keep the C++ reward and rollout kernels untouched: the refund is applied in Python after the kernel call. `simulate_random_rollout` falls back to `python_random_rollout` when `p < 1.0` so the per-step Bernoulli is honoured; with the default `p = 1.0` the native C++ rollout fast path is preserved byte-for-byte.
- `transition_log_probability` is unaffected. Validation rejects values outside `[0, 1]`.

## Why
`ContinuousLaserTagPOMDP._is_in_dangerous_area` was deterministic, so PFT-DPW / POMCPOW and ICVaR_PFT_DPW / ICVaR_POMCPOW make the same decision — avoid the circle. Across 80 episodes (4 planners × 20) all four planners had `average_dangerous_area_steps == 0`, so the env couldn't distinguish risk-sensitive planning from expected-value planning. Adding stochasticity to the penalty gives ICVaR-aware planners tail risk to exploit, the same trick `ContinuousLightDarkPOMDP` already uses via `obstacle_hit_probability`.

## What's in the diff
- `POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py`
  - New parameter on both env classes; validated `[0, 1]` at construction.
  - `reward()` and `reward_batch()` keep the C++ kernel as the hot path; a Python pass refunds the full deterministic deduction (`n_matches * penalty`) with probability `1 - p` per call (terminal rows skipped).
  - `simulate_random_rollout()` (parent and discrete wrapper) falls back to `python_random_rollout` when `p < 1.0`.
  - New helpers `_count_dangerous_area_matches()` and `_apply_stochastic_dangerous_refund()`.
  - Class docstring gains a `Stochasticity:` section and a risk-sensitive evaluation example.
- `POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py`
  - New `TestStochasticDangerousAreaPenalty` (11 cases): default value preserved, `p=0.0` never penalises, `p=1.0` always penalises (regression), `p=0.3` empirical hit rate within 0.05 over 5000 calls (single-state and batch), terminal rows unaffected by refund, parametrised `ValueError` on `[-1.0, -0.1, 1.5, 2.0]`, discrete-wrapper forwards the parameter.

## Backwards compatibility
Default `dangerous_area_hit_probability = 1.0` keeps every existing user of LaserTag on byte-identical reward and rollout behaviour.

## Test plan
- [x] `python -m pytest POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py::TestStochasticDangerousAreaPenalty -v` — 11 passed
- [x] `python -m pytest POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py::TestReward POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py::TestRewardBatch -v` — 7 passed (existing tests, no regressions at default `p=1.0`)
- [x] `python -m pyright` on both files — 0 errors, 0 warnings
- [x] `python -m pylint` on both files — only pre-existing warnings (`too-many-public-methods` 21/20 pre-existing on source; `too-many-lines` and two `import-outside-toplevel` pre-existing on tests)
- [ ] Reviewer: confirm a `ContinuousLaserTagPOMDPDiscreteActions(dangerous_area_hit_probability=0.1, dangerous_area_penalty=150.0, ...)` configuration shows non-zero, sub-100% empirical hit rates from ICVaR-vs-non-ICVaR rollouts.