### PR TITLE
fix(env-metrics): TOTAL_* sum→mean + remove discrete-push duplicate counting; add cross-env sanity tests

### DIFF
--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -681,19 +681,19 @@ class ContinuousPushPOMDP(Environment):
             ),
             MetricValue(
                 ContinuousPushPOMDPMetrics.TOTAL_ROBOT_OBSTACLE_COLLISIONS.value,
-                sum(robot_col_list),
+                float(np.mean(robot_col_list)) if robot_col_list else 0.0,
                 tr_ci[0],
                 tr_ci[1],
             ),
             MetricValue(
                 ContinuousPushPOMDPMetrics.TOTAL_OBJECT_OBSTACLE_COLLISIONS.value,
-                sum(obj_col_list),
+                float(np.mean(obj_col_list)) if obj_col_list else 0.0,
                 to_ci[0],
                 to_ci[1],
             ),
             MetricValue(
                 ContinuousPushPOMDPMetrics.TOTAL_ALL_OBSTACLE_COLLISIONS.value,
-                sum(total_col_list),
+                float(np.mean(total_col_list)) if total_col_list else 0.0,
                 ta_ci[0],
                 ta_ci[1],
             ),

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -807,24 +807,6 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
                 robot_collisions.append(history_robot_collisions)
                 object_collisions.append(history_object_collisions)
                 total_collisions.append(history_robot_collisions + history_object_collisions)
-            history_robot_collisions = 0
-            history_object_collisions = 0
-            total_steps = len(history.history)
-
-            for step in history.history:
-                robot_pos = step.state[:2]  # [robot_x, robot_y]
-                object_pos = step.state[2:4]  # [object_x, object_y]
-
-                if self._is_colliding_with_obstacle(robot_pos):
-                    history_robot_collisions += 1
-
-                if self._is_colliding_with_obstacle(object_pos):
-                    history_object_collisions += 1
-
-            if total_steps > 0:
-                robot_collisions.append(history_robot_collisions)
-                object_collisions.append(history_object_collisions)
-                total_collisions.append(history_robot_collisions + history_object_collisions)
 
         total_steps_all = sum(len(history.history) for history in histories)
         avg_robot_collisions = sum(robot_collisions) / total_steps_all if total_steps_all > 0 else 0
@@ -881,19 +863,19 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             ),
             MetricValue(
                 name=PushPOMDPMetrics.TOTAL_ROBOT_OBSTACLE_COLLISIONS.value,
-                value=sum(robot_collisions),
+                value=float(np.mean(robot_collisions)) if robot_collisions else 0.0,
                 lower_confidence_bound=total_robot_collisions_ci[0],
                 upper_confidence_bound=total_robot_collisions_ci[1],
             ),
             MetricValue(
                 name=PushPOMDPMetrics.TOTAL_OBJECT_OBSTACLE_COLLISIONS.value,
-                value=sum(object_collisions),
+                value=float(np.mean(object_collisions)) if object_collisions else 0.0,
                 lower_confidence_bound=total_object_collisions_ci[0],
                 upper_confidence_bound=total_object_collisions_ci[1],
             ),
             MetricValue(
                 name=PushPOMDPMetrics.TOTAL_ALL_OBSTACLE_COLLISIONS.value,
-                value=sum(total_collisions),
+                value=float(np.mean(total_collisions)) if total_collisions else 0.0,
                 lower_confidence_bound=total_all_collisions_ci[0],
                 upper_confidence_bound=total_all_collisions_ci[1],
             ),

--- a/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
+++ b/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
@@ -365,13 +365,13 @@ class SafeAntVelocityPOMDP(DiscreteActionsEnvironment):
             ),
             MetricValue(
                 name=SafeAntVelocityPOMDPMetrics.TOTAL_SAFETY_VIOLATIONS.value,
-                value=sum(safety_violations),
+                value=float(np.mean(safety_violations)) if safety_violations else 0.0,
                 lower_confidence_bound=total_safety_violations_ci[0],
                 upper_confidence_bound=total_safety_violations_ci[1],
             ),
             MetricValue(
                 name=SafeAntVelocityPOMDPMetrics.TOTAL_CRITICAL_VIOLATIONS.value,
-                value=sum(critical_violations),
+                value=float(np.mean(critical_violations)) if critical_violations else 0.0,
                 lower_confidence_bound=total_critical_violations_ci[0],
                 upper_confidence_bound=total_critical_violations_ci[1],
             ),

--- a/POMDPPlanners/tests/test_core/test_belief/test_belief_environment_integration.py
+++ b/POMDPPlanners/tests/test_core/test_belief/test_belief_environment_integration.py
@@ -43,6 +43,9 @@ from POMDPPlanners.environments import (
 )
 from POMDPPlanners.environments.pacman_pomdp import create_simple_maze_pacman
 from POMDPPlanners.environments.rock_sample_pomdp import create_random_rock_sample
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_belief_invariants,
+)
 
 NUM_PARTICLES = 10
 NUM_STATE_UPDATE_PARTICLES = 3
@@ -150,6 +153,7 @@ class TestWeightedParticleBeliefAllEnvironments:
 
         log_weights = np.full(len(particles), -np.log(len(particles)))
         belief = WeightedParticleBelief(particles=particles, log_weights=log_weights)
+        verify_belief_invariants(belief, expected_n_particles=len(particles))
 
         updated = belief.update(action=action, observation=observation, pomdp=env)
 
@@ -157,6 +161,7 @@ class TestWeightedParticleBeliefAllEnvironments:
         assert len(updated.particles) == len(particles)
         sample = updated.sample()
         assert sample is not None
+        verify_belief_invariants(updated, expected_n_particles=len(particles))
 
 
 class TestWeightedParticleBeliefStateUpdateAllEnvironments:
@@ -242,6 +247,7 @@ class TestUnweightedParticleBeliefStateUpdateAllEnvironments:
         assert belief.weights_sum == NUM_STATE_UPDATE_PARTICLES
         sample = belief.sample()
         assert sample is not None
+        verify_belief_invariants(belief, expected_n_particles=NUM_STATE_UPDATE_PARTICLES)
 
 
 # ---------------------------------------------------------------------------

--- a/POMDPPlanners/tests/test_core/test_belief/test_particle_beliefs.py
+++ b/POMDPPlanners/tests/test_core/test_belief/test_particle_beliefs.py
@@ -26,6 +26,9 @@ from POMDPPlanners.core.tree import ActionNode, BeliefNode
 from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
 from POMDPPlanners.environments.sanity_pomdp import SanityPOMDP
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_belief_invariants,
+)
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -665,6 +668,7 @@ def test_belief_update_basic():
     particles = [0, 1, 0, 1]  # Mix of states
     log_weights = np.array([0.1, 0.1, 0.1, 0.1])  # Non-zero weights
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights, resampling=False)
+    verify_belief_invariants(belief, expected_n_particles=len(particles))
 
     # Perform an update
     action = 0
@@ -680,6 +684,7 @@ def test_belief_update_basic():
 
     # Check that weights are still valid (not all zero)
     assert np.any(updated_belief.log_weights > -np.inf)
+    verify_belief_invariants(updated_belief, expected_n_particles=len(particles))
 
 
 def test_belief_update_with_resampling():
@@ -705,6 +710,7 @@ def test_belief_update_with_resampling():
     # Check that weights are normalized after resampling
     normalized_weights = np.exp(updated_belief.log_weights - np.max(updated_belief.log_weights))
     assert np.isclose(np.sum(normalized_weights), len(updated_belief.particles))
+    verify_belief_invariants(updated_belief, expected_n_particles=len(particles))
 
 
 def test_belief_update_state_transitions():
@@ -758,6 +764,7 @@ def test_belief_update_with_tiger_pomdp():
 
     # Check that weights have been updated
     assert not np.array_equal(updated_belief.log_weights, belief.log_weights)
+    verify_belief_invariants(updated_belief, expected_n_particles=len(particles))
 
 
 def test_belief_update_preserves_particle_count():
@@ -774,6 +781,7 @@ def test_belief_update_preserves_particle_count():
     updated_belief = belief.update(action=action, observation=observation, pomdp=env)
 
     assert len(updated_belief.particles) == n_particles
+    verify_belief_invariants(updated_belief, expected_n_particles=n_particles)
 
 
 def test_belief_update_weight_normalization():

--- a/POMDPPlanners/tests/test_core/test_belief/test_vectorized_weighted_particle_belief.py
+++ b/POMDPPlanners/tests/test_core/test_belief/test_vectorized_weighted_particle_belief.py
@@ -13,6 +13,9 @@ from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
 from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
     VectorizedWeightedParticleBelief,
 )
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_belief_invariants,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +93,7 @@ class TestConstruction:
         assert uniform_belief.particles.shape == (100, 2)
         assert uniform_belief.log_weights.shape == (100,)
         np.testing.assert_allclose(uniform_belief.normalized_weights.sum(), 1.0, atol=1e-12)
+        verify_belief_invariants(uniform_belief, expected_n_particles=100)
 
     def test_particles_must_be_ndarray(self):
         """Test that non-ndarray particles raise TypeError.
@@ -245,6 +249,7 @@ class TestUpdate:
         )
         assert isinstance(new_belief, VectorizedWeightedParticleBelief)
         assert new_belief is not uniform_belief
+        verify_belief_invariants(new_belief, expected_n_particles=uniform_belief.n_particles)
 
     def test_update_transitions_particles(self, uniform_belief):
         """Test that update transitions particles via the updater.
@@ -275,6 +280,7 @@ class TestUpdate:
         """
         new_belief = uniform_belief.update(action=np.zeros(2), observation=np.zeros(2), pomdp=None)
         assert new_belief.n_particles == uniform_belief.n_particles
+        verify_belief_invariants(new_belief, expected_n_particles=uniform_belief.n_particles)
 
 
 # ---------------------------------------------------------------------------
@@ -318,6 +324,7 @@ class TestResampling:
             np.ones(n) / n,
             atol=1e-12,
         )
+        verify_belief_invariants(new_belief, expected_n_particles=n)
 
     def test_no_resampling_when_disabled(self, uniform_belief):
         """Test that resampling does not occur when disabled.
@@ -350,6 +357,58 @@ class TestResampling:
             new_belief.normalized_weights,
             np.ones(50) / 50,
         )
+
+    def test_resampling_collapses_to_dominant_state(self):
+        """Test that resampling discards near-zero-weight particles in favor of the dominant state.
+
+        Purpose: Validates particle survival bias under degenerate weights — when one
+        particle holds essentially all the probability mass and all others are
+        negligible, the post-resample particle set should be dominated by copies of
+        the high-weight particle's state (this is the expected outcome of multinomial
+        resampling on a degenerate weight distribution).
+
+        Given: A belief with 100 distinct particles where particle 0 has log-weight 0.0
+            and all others have log-weight -100.0 (relative weight ~e^-100, negligible),
+            paired with a uniform-likelihood mock updater and a zero action so the
+            transition is the identity.
+        When: update() is called with resampling enabled (ess_factor=0.5).
+        Then: At least 95% of post-resample particles are exact copies of the dominant
+            particle's state, and the post-resample weights are uniform.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        n, d = 100, 2
+        # 100 distinct particles so we can identify which survives resampling.
+        particles = np.arange(n * d, dtype=float).reshape(n, d)
+        dominant_state = particles[0].copy()
+
+        # Degenerate log-weights: one near 0, the rest at -100 (~e^-100, negligible).
+        log_weights = np.full(n, -100.0)
+        log_weights[0] = 0.0
+
+        belief = VectorizedWeightedParticleBelief(
+            particles=particles,
+            log_weights=log_weights,
+            updater=_MockUpdater(),
+            resampling=True,
+            ess_factor=0.5,
+        )
+
+        new_belief = belief.update(
+            action=np.zeros(d),
+            observation=np.array([0.0, 0.0]),
+            pomdp=None,
+        )
+
+        matches = np.all(new_belief.particles == dominant_state, axis=1)
+        assert matches.sum() >= int(0.95 * n)
+        np.testing.assert_allclose(
+            new_belief.normalized_weights,
+            np.ones(n) / n,
+            atol=1e-12,
+        )
+        verify_belief_invariants(new_belief, expected_n_particles=n)
 
 
 # ---------------------------------------------------------------------------

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
@@ -7,6 +7,8 @@ This module tests the CartPole POMDP environment, focusing on:
 - Terminal conditions
 """
 
+# pylint: disable=too-many-lines
+
 import copy
 import random
 
@@ -842,6 +844,148 @@ def test_compute_metrics_goal_reaching():
     goal_rate = metrics_dict["goal_reaching_rate"]
     assert goal_rate.value == 2 / 3  # 2 out of 3 histories complete successfully
     assert goal_rate.lower_confidence_bound <= goal_rate.value <= goal_rate.upper_confidence_bound
+
+
+def test_compute_metrics_values_within_confidence_intervals():
+    """Test CartPolePOMDP metric values are inside CIs and pass invariants.
+
+    Purpose: Validates that metrics produced by compute_metrics lie inside
+        their CI bounds and that all structural invariants hold (rate-in-[0,1],
+        counts >= 0, finite CI for n>=2, returns inside reward bounds, and
+        return-shift linearity).
+
+    Given: A CartPolePOMDP and 3 hand-built histories with varied outcomes
+        (no-crash, no-crash, crash). Rewards are 0.0/1.0, inside the env's
+        declared reward_range = (0.0, 1.0).
+    When: compute_metrics is called and the four invariant helpers are run.
+    Then: All checks pass without raising.
+
+    Test type: integration
+    """
+    from POMDPPlanners.core.belief import (  # pylint: disable=import-outside-toplevel
+        WeightedParticleBelief,
+    )
+    from POMDPPlanners.core.policy import (  # pylint: disable=import-outside-toplevel
+        PolicyRunData,
+    )
+    from POMDPPlanners.core.simulation import (  # pylint: disable=import-outside-toplevel
+        History,
+        StepData,
+    )
+    from POMDPPlanners.tests.test_utils.confidence_interval_utils import (  # pylint: disable=import-outside-toplevel
+        verify_metrics_within_confidence_intervals,
+    )
+    from POMDPPlanners.tests.test_utils.metric_invariants_utils import (  # pylint: disable=import-outside-toplevel
+        verify_history_returns_bounded,
+        verify_metric_sanity,
+        verify_return_shift_linearity,
+    )
+
+    noise_cov = np.eye(4) * 0.1
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
+
+    def _make_belief(state: np.ndarray) -> WeightedParticleBelief:
+        return WeightedParticleBelief(
+            particles=[state], log_weights=np.array([1.0]), resampling=False
+        )
+
+    safe_state = np.array([0.0, 0.0, 0.0, 0.0])
+    crash_state = np.array([0.0, 0.0, 0.3, 0.0])  # theta > threshold
+
+    # History 0: no-crash, 3 steps.
+    no_crash_steps_a = [
+        StepData(
+            state=safe_state,
+            action=0,
+            next_state=safe_state,
+            observation=safe_state,
+            reward=1.0,
+            belief=_make_belief(safe_state),
+        ),
+        StepData(
+            state=safe_state,
+            action=1,
+            next_state=safe_state,
+            observation=safe_state,
+            reward=1.0,
+            belief=_make_belief(safe_state),
+        ),
+        StepData(
+            state=safe_state,
+            action=0,
+            next_state=safe_state,
+            observation=safe_state,
+            reward=1.0,
+            belief=_make_belief(safe_state),
+        ),
+    ]
+
+    # History 1: no-crash, 2 steps.
+    no_crash_steps_b = [
+        StepData(
+            state=safe_state,
+            action=1,
+            next_state=safe_state,
+            observation=safe_state,
+            reward=1.0,
+            belief=_make_belief(safe_state),
+        ),
+        StepData(
+            state=safe_state,
+            action=0,
+            next_state=safe_state,
+            observation=safe_state,
+            reward=1.0,
+            belief=_make_belief(safe_state),
+        ),
+    ]
+
+    # History 2: crash on second step.
+    crash_steps = [
+        StepData(
+            state=safe_state,
+            action=0,
+            next_state=crash_state,
+            observation=safe_state,
+            reward=1.0,
+            belief=_make_belief(safe_state),
+        ),
+        StepData(
+            state=crash_state,
+            action=0,
+            next_state=crash_state,
+            observation=crash_state,
+            reward=0.0,
+            belief=_make_belief(crash_state),
+        ),
+    ]
+
+    histories = []
+    for steps, reach_terminal in (
+        (no_crash_steps_a, False),
+        (no_crash_steps_b, False),
+        (crash_steps, True),
+    ):
+        histories.append(
+            History(
+                history=steps,
+                discount_factor=0.95,
+                average_state_sampling_time=0.0,
+                average_action_time=0.0,
+                average_observation_time=0.0,
+                average_belief_update_time=0.0,
+                average_reward_time=0.0,
+                actual_num_steps=len(steps),
+                reach_terminal_state=reach_terminal,
+                policy_run_data=[PolicyRunData(info_variables=[])],
+            )
+        )
+
+    metrics = env.compute_metrics(histories)
+    verify_metrics_within_confidence_intervals(metrics)
+    verify_metric_sanity(metrics, histories, env)
+    verify_history_returns_bounded(histories, env)
+    verify_return_shift_linearity(histories, env, shift=1.5)
 
 
 def test_reward_batch_matches_scalar_reward():

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
@@ -24,6 +24,11 @@ from POMDPPlanners.planners.planners_utils.rollout import python_random_rollout
 from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
     verify_metrics_within_confidence_intervals,
 )
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_history_returns_bounded,
+    verify_metric_sanity,
+    verify_return_shift_linearity,
+)
 
 
 @pytest.fixture
@@ -1145,6 +1150,10 @@ class TestMetrics:
 
         # With 3 episodes, confidence bounds should be finite (not -inf/inf)
         verify_metrics_within_confidence_intervals(metrics)
+        histories = [h1, h2, h3]
+        verify_metric_sanity(metrics, histories, env)
+        verify_history_returns_bounded(histories, env)
+        verify_return_shift_linearity(histories, env, shift=1.5)
         for m in metrics:
             assert np.isfinite(
                 m.lower_confidence_bound

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -26,6 +26,11 @@ from POMDPPlanners.simulations.episodes import run_episode
 from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
     verify_metrics_within_confidence_intervals,
 )
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_history_returns_bounded,
+    verify_metric_sanity,
+    verify_return_shift_linearity,
+)
 from POMDPPlanners.utils.logger import get_logger
 
 # Set seeds for reproducible tests
@@ -1785,6 +1790,9 @@ def test_metrics_confidence_intervals():
 
     # Use generic confidence interval verification
     verify_metrics_within_confidence_intervals(metrics)
+    verify_metric_sanity(metrics, histories, env)
+    verify_history_returns_bounded(histories, env)
+    verify_return_shift_linearity(histories, env, shift=1.5)
 
 
 class TestLaserTagRewardBatch:

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
@@ -24,6 +24,14 @@ from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.core.distributions import DiscreteDistribution
 from POMDPPlanners.core.policy import PolicyRunData
 from POMDPPlanners.core.simulation import History, StepData
+from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
+    verify_metrics_within_confidence_intervals,
+)
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_history_returns_bounded,
+    verify_metric_sanity,
+    verify_return_shift_linearity,
+)
 from POMDPPlanners.environments.light_dark_pomdp import _native
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDP,
@@ -521,6 +529,118 @@ def test_compute_metrics():
         <= obstacle_rate.value
         <= obstacle_rate.upper_confidence_bound
     )
+
+
+def test_compute_metrics_values_within_confidence_intervals():
+    """Test ContinuousLightDarkPOMDP metric values are inside CIs and pass invariants.
+
+    Purpose: Validates that metrics produced by compute_metrics lie inside
+        their CI bounds and that all structural invariants hold (rate-in-[0,1],
+        counts >= 0, finite CI for n>=2, returns inside reward bounds, and
+        return-shift linearity).
+
+    Given: A ContinuousLightDarkPOMDPDiscreteActions and 3 hand-built histories
+        with varied outcomes (goal-reaching, obstacle-hitting, all-safe).
+    When: compute_metrics is called and the four invariant helpers are run.
+    Then: All checks pass without raising.
+
+    Test type: integration
+    """
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95, goal_state_radius=1.5, obstacle_radius=1.5
+    )
+
+    def _make_belief(state: np.ndarray) -> WeightedParticleBelief:
+        return WeightedParticleBelief(
+            particles=[state], log_weights=np.array([1.0]), resampling=False
+        )
+
+    # History 0: reach goal.
+    goal_steps = [
+        StepData(
+            state=np.array([0, 5]),
+            action="right",
+            next_state=np.array([1, 5]),
+            observation=np.array([1, 5]),
+            reward=-2.0,
+            belief=_make_belief(np.array([0, 5])),
+        ),
+        StepData(
+            state=np.array([9, 5]),
+            action="right",
+            next_state=np.array([10, 5]),
+            observation=np.array([10, 5]),
+            reward=8.0,
+            belief=_make_belief(np.array([9, 5])),
+        ),
+    ]
+
+    # History 1: hit obstacle (within radius of obstacle at (5, 5)).
+    obstacle_steps = [
+        StepData(
+            state=np.array([0, 5]),
+            action="right",
+            next_state=np.array([1, 5]),
+            observation=np.array([1, 5]),
+            reward=-2.0,
+            belief=_make_belief(np.array([0, 5])),
+        ),
+        StepData(
+            state=np.array([4, 5]),
+            action="right",
+            next_state=np.array([5, 5]),
+            observation=np.array([5, 5]),
+            reward=-12.0,
+            belief=_make_belief(np.array([4, 5])),
+        ),
+    ]
+
+    # History 2: all-safe (no obstacle, no goal).
+    safe_steps = [
+        StepData(
+            state=np.array([0, 5]),
+            action="up",
+            next_state=np.array([0, 6]),
+            observation=np.array([0, 6]),
+            reward=-2.0,
+            belief=_make_belief(np.array([0, 5])),
+        ),
+        StepData(
+            state=np.array([0, 6]),
+            action="right",
+            next_state=np.array([1, 6]),
+            observation=np.array([1, 6]),
+            reward=-2.0,
+            belief=_make_belief(np.array([0, 6])),
+        ),
+    ]
+
+    histories = []
+    for steps, reach_terminal in (
+        (goal_steps, True),
+        (obstacle_steps, True),
+        (safe_steps, False),
+    ):
+        histories.append(
+            History(
+                history=steps,
+                discount_factor=0.95,
+                average_state_sampling_time=0.0,
+                average_action_time=0.0,
+                average_observation_time=0.0,
+                average_belief_update_time=0.0,
+                average_reward_time=0.0,
+                actual_num_steps=len(steps),
+                reach_terminal_state=reach_terminal,
+                policy_run_data=[PolicyRunData(info_variables=[])],
+            )
+        )
+
+    metrics = env.compute_metrics(histories)
+    verify_metrics_within_confidence_intervals(metrics)
+    verify_metric_sanity(metrics, histories, env)
+    verify_history_returns_bounded(histories, env)
+    verify_return_shift_linearity(histories, env, shift=1.5)
 
 
 def test_continuous_light_dark_pomdp_initialization(base_continuous_light_dark_pomdp):

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_pomdp.py
@@ -19,6 +19,14 @@ from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.core.distributions import DiscreteDistribution
 from POMDPPlanners.core.policy import PolicyRunData
 from POMDPPlanners.core.simulation import History, StepData
+from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
+    verify_metrics_within_confidence_intervals,
+)
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_history_returns_bounded,
+    verify_metric_sanity,
+    verify_return_shift_linearity,
+)
 from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
     DiscreteLightDarkPOMDP,
     ObservationModelType,
@@ -1256,6 +1264,123 @@ def test_compute_metrics():
         <= obstacle_rate.value
         <= obstacle_rate.upper_confidence_bound
     )
+
+
+def test_compute_metrics_values_within_confidence_intervals():
+    """Test DiscreteLightDarkPOMDP metric values are inside CIs and pass invariants.
+
+    Purpose: Validates that metrics produced by compute_metrics lie inside
+        their CI bounds and that all structural invariants hold (rate-in-[0,1],
+        counts >= 0, finite CI for n>=2, return-shift linearity).
+
+    Given: A DiscreteLightDarkPOMDP and 3 hand-built histories with varied
+        outcomes (goal-reaching, obstacle-hitting, all-safe).
+    When: compute_metrics is called and the four invariant helpers are run.
+    Then: All checks pass without raising.
+
+    Test type: integration
+    """
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+
+    def _make_belief(state: np.ndarray) -> WeightedParticleBelief:
+        return WeightedParticleBelief(
+            particles=[state], log_weights=np.array([1.0]), resampling=False
+        )
+
+    # History 0: reach goal cleanly.
+    goal_steps = [
+        StepData(
+            state=np.array([0, 5]),
+            action="right",
+            next_state=np.array([1, 5]),
+            observation=np.array([1, 5]),
+            reward=-2.0,
+            belief=_make_belief(np.array([0, 5])),
+        ),
+        StepData(
+            state=np.array([1, 5]),
+            action="right",
+            next_state=np.array([2, 5]),
+            observation=np.array([2, 5]),
+            reward=-2.0,
+            belief=_make_belief(np.array([1, 5])),
+        ),
+        StepData(
+            state=np.array([10, 5]),
+            action="right",
+            next_state=np.array([10, 5]),
+            observation=np.array([10, 5]),
+            reward=8.0,
+            belief=_make_belief(np.array([10, 5])),
+        ),
+    ]
+
+    # History 1: hit an obstacle at (5, 5).
+    obstacle_steps = [
+        StepData(
+            state=np.array([0, 5]),
+            action="right",
+            next_state=np.array([1, 5]),
+            observation=np.array([1, 5]),
+            reward=-2.0,
+            belief=_make_belief(np.array([0, 5])),
+        ),
+        StepData(
+            state=np.array([5, 5]),
+            action="right",
+            next_state=np.array([5, 5]),
+            observation=np.array([5, 5]),
+            reward=-12.0,
+            belief=_make_belief(np.array([5, 5])),
+        ),
+    ]
+
+    # History 2: all-safe (no goal, no obstacle).
+    safe_steps = [
+        StepData(
+            state=np.array([0, 5]),
+            action="up",
+            next_state=np.array([0, 6]),
+            observation=np.array([0, 6]),
+            reward=-2.0,
+            belief=_make_belief(np.array([0, 5])),
+        ),
+        StepData(
+            state=np.array([0, 6]),
+            action="right",
+            next_state=np.array([1, 6]),
+            observation=np.array([1, 6]),
+            reward=-2.0,
+            belief=_make_belief(np.array([0, 6])),
+        ),
+    ]
+
+    histories = []
+    for steps, reach_terminal in (
+        (goal_steps, True),
+        (obstacle_steps, True),
+        (safe_steps, False),
+    ):
+        histories.append(
+            History(
+                history=steps,
+                discount_factor=0.95,
+                average_state_sampling_time=0.0,
+                average_action_time=0.0,
+                average_observation_time=0.0,
+                average_belief_update_time=0.0,
+                average_reward_time=0.0,
+                actual_num_steps=len(steps),
+                reach_terminal_state=reach_terminal,
+                policy_run_data=[PolicyRunData(info_variables=[])],
+            )
+        )
+
+    metrics = env.compute_metrics(histories)
+    verify_metrics_within_confidence_intervals(metrics)
+    verify_metric_sanity(metrics, histories, env)
+    verify_history_returns_bounded(histories, env)
+    verify_return_shift_linearity(histories, env, shift=1.5)
 
 
 def test_normal_observation_model():

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
@@ -1141,6 +1141,145 @@ def test_compute_metrics_goal_reaching():
     assert goal_rate.lower_confidence_bound <= goal_rate.value <= goal_rate.upper_confidence_bound
 
 
+def test_compute_metrics_values_within_confidence_intervals():
+    """Test MountainCarPOMDP metric values are inside CIs and pass invariants.
+
+    Purpose: Validates that metrics produced by compute_metrics lie inside
+        their CI bounds and that all structural invariants hold (rate-in-[0,1],
+        counts >= 0, finite CI for n>=2, returns inside reward bounds, and
+        return-shift linearity).
+
+    Given: A MountainCarPOMDP and 3 hand-built histories with varied outcomes
+        (goal-reaching, almost-goal, never-near-goal). Rewards lie in [-1.0, 0.0]
+        as declared by the env's reward_range.
+    When: compute_metrics is called and the four invariant helpers are run.
+    Then: All checks pass without raising.
+
+    Test type: integration
+    """
+    # Local imports needed because file does not import these at module level.
+    from POMDPPlanners.core.belief import (  # pylint: disable=import-outside-toplevel
+        WeightedParticleBelief,
+    )
+    from POMDPPlanners.core.policy import (  # pylint: disable=import-outside-toplevel
+        PolicyRunData,
+    )
+    from POMDPPlanners.core.simulation import (  # pylint: disable=import-outside-toplevel
+        History,
+        StepData,
+    )
+    from POMDPPlanners.tests.test_utils.confidence_interval_utils import (  # pylint: disable=import-outside-toplevel
+        verify_metrics_within_confidence_intervals,
+    )
+    from POMDPPlanners.tests.test_utils.metric_invariants_utils import (  # pylint: disable=import-outside-toplevel
+        verify_history_returns_bounded,
+        verify_metric_sanity,
+        verify_return_shift_linearity,
+    )
+
+    env = MountainCarPOMDP(discount_factor=0.95)
+
+    def _make_belief(state: np.ndarray) -> WeightedParticleBelief:
+        return WeightedParticleBelief(
+            particles=[state], log_weights=np.array([1.0]), resampling=False
+        )
+
+    # History 0: reach goal at last step.
+    goal_steps = [
+        StepData(
+            state=np.array([0.0, 0.0]),
+            action=1,
+            next_state=np.array([0.1, 0.01]),
+            observation=np.array([0.1, 0.01]),
+            reward=-1.0,
+            belief=_make_belief(np.array([0.0, 0.0])),
+        ),
+        StepData(
+            state=np.array([0.55, 0.02]),
+            action=1,
+            next_state=np.array([0.6, 0.03]),
+            observation=np.array([0.6, 0.03]),
+            reward=0.0,
+            belief=_make_belief(np.array([0.55, 0.02])),
+        ),
+    ]
+
+    # History 1: almost reach goal but not quite.
+    almost_steps = [
+        StepData(
+            state=np.array([0.0, 0.0]),
+            action=1,
+            next_state=np.array([0.1, 0.01]),
+            observation=np.array([0.1, 0.01]),
+            reward=-1.0,
+            belief=_make_belief(np.array([0.0, 0.0])),
+        ),
+        StepData(
+            state=np.array([0.4, 0.02]),
+            action=1,
+            next_state=np.array([0.45, 0.02]),
+            observation=np.array([0.45, 0.02]),
+            reward=-1.0,
+            belief=_make_belief(np.array([0.4, 0.02])),
+        ),
+    ]
+
+    # History 2: never near goal.
+    far_steps = [
+        StepData(
+            state=np.array([-0.5, 0.0]),
+            action=-1,
+            next_state=np.array([-0.6, -0.01]),
+            observation=np.array([-0.6, -0.01]),
+            reward=-1.0,
+            belief=_make_belief(np.array([-0.5, 0.0])),
+        ),
+        StepData(
+            state=np.array([-0.7, -0.02]),
+            action=-1,
+            next_state=np.array([-0.8, -0.03]),
+            observation=np.array([-0.8, -0.03]),
+            reward=-1.0,
+            belief=_make_belief(np.array([-0.7, -0.02])),
+        ),
+        StepData(
+            state=np.array([-0.9, -0.04]),
+            action=0,
+            next_state=np.array([-0.9, -0.04]),
+            observation=np.array([-0.9, -0.04]),
+            reward=-1.0,
+            belief=_make_belief(np.array([-0.9, -0.04])),
+        ),
+    ]
+
+    histories = []
+    for steps, reach_terminal in (
+        (goal_steps, True),
+        (almost_steps, False),
+        (far_steps, False),
+    ):
+        histories.append(
+            History(
+                history=steps,
+                discount_factor=0.95,
+                average_state_sampling_time=0.0,
+                average_action_time=0.0,
+                average_observation_time=0.0,
+                average_belief_update_time=0.0,
+                average_reward_time=0.0,
+                actual_num_steps=len(steps),
+                reach_terminal_state=reach_terminal,
+                policy_run_data=[PolicyRunData(info_variables=[])],
+            )
+        )
+
+    metrics = env.compute_metrics(histories)
+    verify_metrics_within_confidence_intervals(metrics)
+    verify_metric_sanity(metrics, histories, env)
+    verify_history_returns_bounded(histories, env)
+    verify_return_shift_linearity(histories, env, shift=1.5)
+
+
 def test_reward_batch_matches_scalar_reward():
     """Test that reward_batch returns results consistent with scalar reward.
 

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
@@ -17,6 +17,14 @@ import pytest
 from POMDPPlanners.core.belief import Belief, WeightedParticleBelief
 from POMDPPlanners.core.environment import SpaceType
 from POMDPPlanners.core.simulation import History, StepData
+from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
+    verify_metrics_within_confidence_intervals,
+)
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_history_returns_bounded,
+    verify_metric_sanity,
+    verify_return_shift_linearity,
+)
 from POMDPPlanners.environments.pacman_pomdp import (
     PacManPOMDP,
     create_simple_maze_pacman,
@@ -1401,6 +1409,134 @@ class TestPacManPOMDPMetrics:
         # Should have confidence bounds
         assert collision_metric.lower_confidence_bound is not None
         assert collision_metric.upper_confidence_bound is not None
+
+    def test_compute_metrics_values_within_confidence_intervals(self):
+        """Test PacManPOMDP metric values are inside CIs and pass invariants.
+
+        Purpose: Validates that metrics produced by compute_metrics lie inside
+            their CI bounds and that all structural invariants hold (rate-in-[0,1],
+            counts >= 0, finite CI for n>=2, returns inside reward bounds, and
+            return-shift linearity).
+
+        Given: A PacManPOMDP and 3 hand-built histories with varied outcomes
+            (win, loss, in-progress). Rewards lie inside reward_range.
+        When: compute_metrics is called and the four invariant helpers are run.
+        Then: All checks pass without raising.
+
+        Test type: integration
+        """
+        dummy_belief = Mock(spec=Belief)
+
+        # History 0: win (no pellets remaining)
+        win_state = self.pomdp.make_state(
+            pacman_pos=(2, 2),
+            ghost_positions=((0, 0),),
+            pellets=(),
+            terminal=True,
+            score=100,
+        )
+        win_steps = [
+            StepData(
+                state=win_state,
+                action=None,
+                next_state=win_state,
+                observation=None,
+                reward=10.0,
+                belief=dummy_belief,
+            ),
+            StepData(
+                state=win_state,
+                action=None,
+                next_state=win_state,
+                observation=None,
+                reward=99.0,  # well within reward_range = (-101, 109)
+                belief=dummy_belief,
+            ),
+        ]
+
+        # History 1: loss (collision with ghost, pellets remaining)
+        loss_state = self.pomdp.make_state(
+            pacman_pos=(1, 1),
+            ghost_positions=((1, 1),),
+            pellets=((1, 1),),
+            terminal=True,
+            score=10.0,
+        )
+        loss_steps = [
+            StepData(
+                state=loss_state,
+                action=None,
+                next_state=loss_state,
+                observation=None,
+                reward=-1.0,
+                belief=dummy_belief,
+            ),
+            StepData(
+                state=loss_state,
+                action=None,
+                next_state=loss_state,
+                observation=None,
+                reward=-100.0,
+                belief=dummy_belief,
+            ),
+        ]
+
+        # History 2: in-progress (no terminal, pellets remaining, no collisions)
+        progress_state_a = self.pomdp.make_state(
+            pacman_pos=(0, 0),
+            ghost_positions=((4, 4),),
+            pellets=((1, 1), (3, 3)),
+        )
+        progress_state_b = self.pomdp.make_state(
+            pacman_pos=(0, 1),
+            ghost_positions=((4, 4),),
+            pellets=((1, 1), (3, 3)),
+        )
+        progress_steps = [
+            StepData(
+                state=progress_state_a,
+                action=None,
+                next_state=progress_state_b,
+                observation=None,
+                reward=-1.0,
+                belief=dummy_belief,
+            ),
+            StepData(
+                state=progress_state_b,
+                action=None,
+                next_state=progress_state_b,
+                observation=None,
+                reward=-1.0,
+                belief=dummy_belief,
+            ),
+        ]
+
+        histories = []
+        for steps, reach_terminal in (
+            (win_steps, True),
+            (loss_steps, True),
+            (progress_steps, False),
+        ):
+            histories.append(
+                History(
+                    history=steps,
+                    discount_factor=0.95,
+                    average_state_sampling_time=0.0,
+                    average_action_time=0.0,
+                    average_observation_time=0.0,
+                    average_belief_update_time=0.0,
+                    average_reward_time=0.0,
+                    actual_num_steps=len(steps),
+                    reach_terminal_state=reach_terminal,
+                    policy_run_data=[],
+                )
+            )
+
+        metrics = self.pomdp.compute_metrics(histories)
+        verify_metrics_within_confidence_intervals(metrics)
+        verify_metric_sanity(metrics, histories, self.pomdp)
+        verify_history_returns_bounded(histories, self.pomdp)
+        verify_return_shift_linearity(histories, self.pomdp, shift=1.5)
 
 
 class TestCreateSimpleMazePacman:

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
@@ -22,6 +22,14 @@ from POMDPPlanners.environments.push_pomdp.continuous_push_pomdp import (
     ContinuousPushPOMDP,
     ContinuousPushPOMDPDiscreteActions,
 )
+from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
+    verify_metrics_within_confidence_intervals,
+)
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_history_returns_bounded,
+    verify_metric_sanity,
+    verify_return_shift_linearity,
+)
 
 
 def _make_env(**overrides) -> ContinuousPushPOMDP:
@@ -531,6 +539,136 @@ class TestContinuousPushPOMDP:
         metric_names = {m.name for m in metrics}
         assert "goal_reaching_rate" in metric_names
         assert "robot_obstacle_collision_rate" in metric_names
+
+    def test_compute_metrics_values_within_confidence_intervals(self):
+        """Test full-metric CI containment + structural invariants.
+
+        Purpose: Broad property check that every metric's value is inside its
+            own CI and that all structural invariants on the metric set and
+            histories hold (rate-in-[0,1], counts >= 0, finite CI for n>=2,
+            per-step-counts <= total_steps, discounted return inside reward
+            bounds, return shifts linearly with reward shift).
+
+        Given: 5 hand-built histories with varied collision/goal patterns
+            (all-safe, robot-only collisions, object-only collisions, both,
+            and a terminal-reaching episode).
+        When: compute_metrics is called.
+        Then: All four invariant helpers pass without raising.
+
+        Test type: integration
+        """
+        target = np.array([9.0, 9.0])
+        obstacle_center = np.array([5.0, 5.0])
+        safe_robot = np.array([1.0, 1.0])
+        safe_object = np.array([1.0, 1.0])
+
+        # History 0: all-safe (no collisions, no goal)
+        all_safe_steps = [
+            StepData(
+                state=np.concatenate([safe_robot, safe_object, target]),
+                action=np.array([0.0, 0.0]),
+                next_state=np.concatenate([safe_robot, safe_object, target]),
+                observation=np.concatenate([safe_robot, safe_object, target]),
+                reward=0.0,
+                belief=None,  # type: ignore[arg-type]
+            )
+            for _ in range(4)
+        ]
+
+        # History 1: robot-only collisions on first 2 of 4 steps.
+        robot_only_steps = []
+        for step_index in range(4):
+            robot_pos = obstacle_center if step_index < 2 else safe_robot
+            state = np.concatenate([robot_pos, safe_object, target])
+            robot_only_steps.append(
+                StepData(
+                    state=state,
+                    action=np.array([0.0, 0.0]),
+                    next_state=state,
+                    observation=state,
+                    reward=-1.0,
+                    belief=None,  # type: ignore[arg-type]
+                )
+            )
+
+        # History 2: object-only collisions on first 3 of 5 steps.
+        object_only_steps = []
+        for step_index in range(5):
+            object_pos = obstacle_center if step_index < 3 else safe_object
+            state = np.concatenate([safe_robot, object_pos, target])
+            object_only_steps.append(
+                StepData(
+                    state=state,
+                    action=np.array([0.0, 0.0]),
+                    next_state=state,
+                    observation=state,
+                    reward=-1.0,
+                    belief=None,  # type: ignore[arg-type]
+                )
+            )
+
+        # History 3: both robot AND object colliding on 1 of 3 steps.
+        both_steps = []
+        for step_index in range(3):
+            robot_pos = obstacle_center if step_index == 0 else safe_robot
+            object_pos = obstacle_center if step_index == 0 else safe_object
+            state = np.concatenate([robot_pos, object_pos, target])
+            both_steps.append(
+                StepData(
+                    state=state,
+                    action=np.array([0.0, 0.0]),
+                    next_state=state,
+                    observation=state,
+                    reward=-2.0,
+                    belief=None,  # type: ignore[arg-type]
+                )
+            )
+
+        # History 4: terminal-reaching (object placed at target).
+        # is_terminal triggers when ||object - target|| < 0.5 (typical thresh).
+        terminal_steps = []
+        for step_index in range(3):
+            object_pos = target if step_index == 2 else safe_object
+            state = np.concatenate([safe_robot, object_pos, target])
+            terminal_steps.append(
+                StepData(
+                    state=state,
+                    action=np.array([0.0, 0.0]),
+                    next_state=state,
+                    observation=state,
+                    reward=0.0,
+                    belief=None,  # type: ignore[arg-type]
+                )
+            )
+
+        histories = []
+        for steps, reach_terminal in (
+            (all_safe_steps, False),
+            (robot_only_steps, False),
+            (object_only_steps, False),
+            (both_steps, False),
+            (terminal_steps, True),
+        ):
+            histories.append(
+                History(
+                    history=steps,
+                    discount_factor=0.99,
+                    average_state_sampling_time=0.0,
+                    average_action_time=0.0,
+                    average_observation_time=0.0,
+                    average_belief_update_time=0.0,
+                    average_reward_time=0.0,
+                    actual_num_steps=len(steps),
+                    reach_terminal_state=reach_terminal,
+                    policy_run_data=[PolicyRunData(info_variables=[])],
+                )
+            )
+
+        metrics = self.env.compute_metrics(histories)
+        verify_metrics_within_confidence_intervals(metrics)
+        verify_metric_sanity(metrics, histories, self.env)
+        verify_history_returns_bounded(histories, self.env)
+        verify_return_shift_linearity(histories, self.env, shift=1.5)
 
 
 # ------------------------------------------------------------------

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
@@ -13,7 +13,17 @@ import random
 import numpy as np
 import pytest
 
+from POMDPPlanners.core.policy import PolicyRunData
+from POMDPPlanners.core.simulation import History, StepData
 from POMDPPlanners.environments.push_pomdp import PushPOMDP, _native as push_native
+from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
+    verify_metrics_within_confidence_intervals,
+)
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_history_returns_bounded,
+    verify_metric_sanity,
+    verify_return_shift_linearity,
+)
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -1619,3 +1629,126 @@ class TestPushNativeSimulateRollout:
             discount_factor=env.discount_factor,
         )
         assert result == 0.0
+
+
+def test_compute_metrics_values_within_confidence_intervals():
+    """Test PushPOMDP metric values fall inside CIs and pass invariants.
+
+    Purpose: Validates that PushPOMDP compute_metrics produces metrics whose
+        values lie inside their CI bounds, satisfy structural invariants
+        (rate-in-[0,1], counts >= 0, finite CI for n>=2, per-step-counts
+        bounded by total steps), and that the underlying histories satisfy
+        discounted-return bounds and return-shift linearity.
+
+    Given: A PushPOMDP with two obstacles and 4 hand-built histories with
+        varied collision/goal patterns (all-safe, robot-only, object-only,
+        and a goal-reaching episode).
+    When: compute_metrics is called and the four invariant helpers are run.
+    Then: All checks pass without raising.
+
+    Test type: integration
+    """
+    env = PushPOMDP(
+        discount_factor=0.95,
+        grid_size=10,
+        push_threshold=1.0,
+        friction_coefficient=0.3,
+        observation_noise=0.1,
+        obstacles=[(3.0, 3.0), (7.0, 7.0)],
+        obstacle_radius=0.5,
+        obstacle_penalty=-10.0,
+    )
+
+    target = np.array([9.0, 9.0])
+    obstacle = np.array([3.0, 3.0])
+    safe_robot = np.array([1.0, 1.0])
+    safe_object = np.array([2.0, 2.0])
+
+    # History 0: all-safe
+    all_safe_steps = [
+        StepData(
+            state=np.concatenate([safe_robot, safe_object, target]),
+            action="up",
+            next_state=np.concatenate([safe_robot, safe_object, target]),
+            observation=np.concatenate([safe_robot, safe_object, target]),
+            reward=-1.0,
+            belief=None,  # type: ignore[arg-type]
+        )
+        for _ in range(4)
+    ]
+
+    # History 1: robot-only collisions for first 2 of 4 steps.
+    robot_only_steps = []
+    for step_index in range(4):
+        robot_pos = obstacle if step_index < 2 else safe_robot
+        state = np.concatenate([robot_pos, safe_object, target])
+        robot_only_steps.append(
+            StepData(
+                state=state,
+                action="up",
+                next_state=state,
+                observation=state,
+                reward=-2.0,
+                belief=None,  # type: ignore[arg-type]
+            )
+        )
+
+    # History 2: object-only collisions for first 1 of 3 steps.
+    object_only_steps = []
+    for step_index in range(3):
+        object_pos = obstacle if step_index == 0 else safe_object
+        state = np.concatenate([safe_robot, object_pos, target])
+        object_only_steps.append(
+            StepData(
+                state=state,
+                action="up",
+                next_state=state,
+                observation=state,
+                reward=-1.5,
+                belief=None,  # type: ignore[arg-type]
+            )
+        )
+
+    # History 3: terminal-reaching (object very close to target on last step).
+    terminal_steps = []
+    for step_index in range(3):
+        object_pos = target if step_index == 2 else safe_object
+        state = np.concatenate([safe_robot, object_pos, target])
+        terminal_steps.append(
+            StepData(
+                state=state,
+                action="up",
+                next_state=state,
+                observation=state,
+                reward=-1.0,
+                belief=None,  # type: ignore[arg-type]
+            )
+        )
+
+    histories = []
+    for steps, reach_terminal in (
+        (all_safe_steps, False),
+        (robot_only_steps, False),
+        (object_only_steps, False),
+        (terminal_steps, True),
+    ):
+        histories.append(
+            History(
+                history=steps,
+                discount_factor=0.95,
+                average_state_sampling_time=0.0,
+                average_action_time=0.0,
+                average_observation_time=0.0,
+                average_belief_update_time=0.0,
+                average_reward_time=0.0,
+                actual_num_steps=len(steps),
+                reach_terminal_state=reach_terminal,
+                policy_run_data=[PolicyRunData(info_variables=[])],
+            )
+        )
+
+    metrics = env.compute_metrics(histories)
+    verify_metrics_within_confidence_intervals(metrics)
+    verify_metric_sanity(metrics, histories, env)
+    verify_history_returns_bounded(histories, env)
+    verify_return_shift_linearity(histories, env, shift=1.5)

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
@@ -26,7 +26,15 @@ from POMDPPlanners.environments.rock_sample_pomdp import (
     get_rocks,
     states_equal,
 )
+from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
+    verify_metrics_within_confidence_intervals,
+)
 from POMDPPlanners.tests.test_utils.history_builders import build_test_history
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_history_returns_bounded,
+    verify_metric_sanity,
+    verify_return_shift_linearity,
+)
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -1096,6 +1104,100 @@ class TestMetricsComputation:
         exit_metric = next((m for m in metrics if m.name == "exit_success_rate"), None)
         assert exit_metric is not None
         assert exit_metric.value == 0.5  # 1/2 successful exits
+
+    def test_compute_metrics_values_within_confidence_intervals(self):
+        """Test RockSamplePOMDP metric values are inside CIs and pass invariants.
+
+        Purpose: Validates that metrics produced by compute_metrics lie inside
+            their CI bounds and that all structural invariants hold (rate-in-[0,1],
+            counts >= 0, finite CI for n>=2, returns inside reward bounds, and
+            return-shift linearity).
+
+        Given: A RockSamplePOMDP and 3 hand-built histories with varied
+            outcomes (sample-and-exit, traverse, no-action). Rewards lie within
+            reward_range = (-10, 10).
+        When: compute_metrics is called and the four invariant helpers are run.
+        Then: All checks pass without raising.
+
+        Test type: integration
+        """
+        pomdp = RockSamplePOMDP()
+
+        # History 0: sample once and exit successfully.
+        sample_state = create_rock_sample_state((0, 0), (True, True))
+        terminal_state = create_rock_sample_state((-1, -1), (True, False))
+        sample_exit_steps = [
+            StepData(
+                state=sample_state,
+                action=0,  # Sample
+                next_state=sample_state,
+                observation="none",
+                reward=10.0,
+                belief=Mock(spec=Belief),
+            ),
+            StepData(
+                state=terminal_state,
+                action=1,
+                next_state=terminal_state,
+                observation="none",
+                reward=10.0,  # exit reward
+                belief=Mock(spec=Belief),
+            ),
+        ]
+
+        # History 1: traverse without sampling, no exit.
+        traverse_state = create_rock_sample_state((2, 2), (True, False))
+        traverse_steps = [
+            StepData(
+                state=traverse_state,
+                action=1,
+                next_state=traverse_state,
+                observation="none",
+                reward=0.0,
+                belief=Mock(spec=Belief),
+            ),
+            StepData(
+                state=traverse_state,
+                action=2,
+                next_state=traverse_state,
+                observation="none",
+                reward=0.0,
+                belief=Mock(spec=Belief),
+            ),
+        ]
+
+        # History 2: sample twice, no exit.
+        sample_twice_state = create_rock_sample_state((1, 1), (False, False))
+        sample_twice_steps = [
+            StepData(
+                state=sample_twice_state,
+                action=0,
+                next_state=sample_twice_state,
+                observation="none",
+                reward=-10.0,  # bad rock penalty
+                belief=Mock(spec=Belief),
+            ),
+            StepData(
+                state=sample_twice_state,
+                action=0,
+                next_state=sample_twice_state,
+                observation="none",
+                reward=-10.0,
+                belief=Mock(spec=Belief),
+            ),
+        ]
+
+        histories = [
+            build_test_history(steps=sample_exit_steps, actual_num_steps=2, reach_terminal=True),
+            build_test_history(steps=traverse_steps, actual_num_steps=2, reach_terminal=False),
+            build_test_history(steps=sample_twice_steps, actual_num_steps=2, reach_terminal=False),
+        ]
+
+        metrics = pomdp.compute_metrics(histories)
+        verify_metrics_within_confidence_intervals(metrics)
+        verify_metric_sanity(metrics, histories, pomdp)
+        verify_history_returns_bounded(histories, pomdp)
+        verify_return_shift_linearity(histories, pomdp, shift=1.5)
 
 
 class TestRandomRockSample:

--- a/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp.py
@@ -18,6 +18,14 @@ from POMDPPlanners.core.belief import Belief
 from POMDPPlanners.core.policy import PolicyRunData
 from POMDPPlanners.core.simulation import History, StepData
 from POMDPPlanners.environments.safety_ant_velocity_pomdp import SafeAntVelocityPOMDP
+from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
+    verify_metrics_within_confidence_intervals,
+)
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_history_returns_bounded,
+    verify_metric_sanity,
+    verify_return_shift_linearity,
+)
 
 # Set seeds for reproducible tests
 
@@ -493,6 +501,107 @@ def test_compute_metrics():
         metrics_dict["critical_violation_rate"].upper_confidence_bound
         >= metrics_dict["critical_violation_rate"].value
     )
+
+
+def test_compute_metrics_values_within_confidence_intervals():
+    """Test SafeAntVelocityPOMDP metric values are inside CIs and pass invariants.
+
+    Purpose: Validates that metrics produced by compute_metrics lie inside
+        their CI bounds and that all structural invariants hold (rate-in-[0,1],
+        counts >= 0, finite CI for n>=2, returns inside reward bounds, and
+        return-shift linearity).
+
+    Given: A SafeAntVelocityPOMDP and 3 hand-built histories with varied
+        velocity profiles (all-safe, mixed, critical). Rewards lie in
+        [-100, 3.0] as declared by reward_range.
+    When: compute_metrics is called and the four invariant helpers are run.
+    Then: All checks pass without raising.
+
+    Test type: integration
+    """
+    env = SafeAntVelocityPOMDP(
+        discount_factor=0.95,
+        safe_velocity_threshold=2.0,
+    )
+
+    # History 0: all-safe.
+    safe_steps = [
+        StepData(
+            state=np.array([0.0, 0.0, 1.0, 1.0]),
+            action=1,
+            observation=np.array([0.0, 0.0, 1.0, 1.0]),
+            reward=1.0,
+            next_state=np.array([0.1, 0.1, 1.1, 1.1]),
+            belief=Mock(spec=Belief),
+        ),
+        StepData(
+            state=np.array([0.1, 0.1, 1.1, 1.1]),
+            action=1,
+            observation=np.array([0.1, 0.1, 1.1, 1.1]),
+            reward=1.0,
+            next_state=np.array([0.2, 0.2, 1.2, 1.2]),
+            belief=Mock(spec=Belief),
+        ),
+    ]
+
+    # History 1: mixed (one safety violation, no critical).
+    mixed_steps = [
+        StepData(
+            state=np.array([0.0, 0.0, 1.0, 1.0]),
+            action=1,
+            observation=np.array([0.0, 0.0, 1.0, 1.0]),
+            reward=1.0,
+            next_state=np.array([0.1, 0.1, 1.1, 1.1]),
+            belief=Mock(spec=Belief),
+        ),
+        StepData(
+            state=np.array([0.1, 0.1, 2.1, 2.1]),
+            action=3,
+            observation=np.array([0.1, 0.1, 2.1, 2.1]),
+            reward=-100.0,
+            next_state=np.array([0.2, 0.2, 1.2, 1.2]),
+            belief=Mock(spec=Belief),
+        ),
+    ]
+
+    # History 2: critical violation.
+    critical_steps = [
+        StepData(
+            state=np.array([0.0, 0.0, 3.1, 3.1]),
+            action=3,
+            observation=np.array([0.0, 0.0, 3.1, 3.1]),
+            reward=-100.0,
+            next_state=np.array([0.1, 0.1, 3.2, 3.2]),
+            belief=Mock(spec=Belief),
+        ),
+    ]
+
+    histories = []
+    for steps, reach_terminal in (
+        (safe_steps, False),
+        (mixed_steps, False),
+        (critical_steps, True),
+    ):
+        histories.append(
+            History(
+                history=steps,
+                discount_factor=0.95,
+                average_state_sampling_time=0.0,
+                average_action_time=0.0,
+                average_observation_time=0.0,
+                average_belief_update_time=0.0,
+                average_reward_time=0.0,
+                actual_num_steps=len(steps),
+                reach_terminal_state=reach_terminal,
+                policy_run_data=[PolicyRunData(info_variables=[])],
+            )
+        )
+
+    metrics = env.compute_metrics(histories)
+    verify_metrics_within_confidence_intervals(metrics)
+    verify_metric_sanity(metrics, histories, env)
+    verify_history_returns_bounded(histories, env)
+    verify_return_shift_linearity(histories, env, shift=1.5)
 
 
 def test_environment_equality():

--- a/POMDPPlanners/tests/test_environments/test_tiger_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_tiger_pomdp.py
@@ -12,6 +12,11 @@ from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
     verify_metrics_within_confidence_intervals,
 )
 from POMDPPlanners.tests.test_utils.history_builders import build_test_history
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_history_returns_bounded,
+    verify_metric_sanity,
+    verify_return_shift_linearity,
+)
 
 np.random.seed(42)
 random.seed(42)
@@ -656,6 +661,9 @@ def test_metrics_confidence_intervals(tiger_pomdp):
 
     # Use generic confidence interval verification
     verify_metrics_within_confidence_intervals(metrics)
+    verify_metric_sanity(metrics, histories, tiger_pomdp)
+    verify_history_returns_bounded(histories, tiger_pomdp)
+    verify_return_shift_linearity(histories, tiger_pomdp, shift=1.5)
 
 
 def test_metric_name_consistency(tiger_pomdp):

--- a/POMDPPlanners/tests/test_utils/metric_invariants_utils.py
+++ b/POMDPPlanners/tests/test_utils/metric_invariants_utils.py
@@ -1,0 +1,305 @@
+"""Metric / history sanity-check helpers shared across env tests.
+
+These helpers complement
+:func:`POMDPPlanners.tests.test_utils.confidence_interval_utils.verify_metrics_within_confidence_intervals`,
+which only checks that each MetricValue's value lies inside its CI bounds. The
+helpers here add structural invariants that should hold for any well-formed
+``compute_metrics`` output and for any history compatible with its env's
+declared reward range and discount factor.
+"""
+
+import math
+from typing import List, Optional
+
+import numpy as np
+
+from POMDPPlanners.core.environment import Environment
+from POMDPPlanners.core.simulation import History, MetricValue
+
+
+_RATE_SUFFIX = "_rate"
+_TOTAL_PREFIX = "total_"
+_COUNT_PREFIXES = ("total_", "count_", "num_")
+# Per-step-bound metrics: a sum-over-episodes of per-step booleans/counts. Each
+# such metric is bounded above by the sum of episode lengths (one count per
+# step at most). Name hints — collisions / violations / hits / steps — come
+# from the env enums in this codebase.
+_PER_STEP_BOUND_KEYWORDS = ("collision", "violation", "hit", "_steps")
+
+
+def verify_metric_sanity(
+    metrics: List[MetricValue],
+    histories: List[History],
+    env: Environment,
+) -> None:
+    """Run structural invariants over a compute_metrics output.
+
+    Applies four checks driven by metric-name conventions used in this codebase:
+
+    - any metric whose name ends with ``_rate`` has value in [0, 1]
+    - any metric whose name starts with ``total_`` / ``count_`` / ``num_`` has
+      value >= 0
+    - both CI bounds are finite when n_episodes >= 2
+    - any "per-step-count over episodes" metric (name starts with ``total_``
+      and contains a per-step keyword like ``collision``/``violation``/``hit``,
+      and is NOT itself a rate) has value <= sum(episode lengths)
+
+    Args:
+        metrics: The MetricValue list returned by ``env.compute_metrics``.
+        histories: The histories that were passed to ``compute_metrics``.
+        env: The environment instance (kept in the signature so callers thread
+            it through; currently unused but reserved for env-aware extensions).
+
+    Raises:
+        AssertionError: If any invariant is violated. Message identifies the
+            metric, value, and which invariant failed.
+    """
+    del env  # reserved
+    n_episodes = len(histories)
+    total_steps = sum(len(h.history) for h in histories)
+
+    for metric in metrics:
+        _check_rate_in_unit_interval(metric)
+        _check_count_non_negative(metric)
+        _check_ci_finite_for_multi_episode(metric, n_episodes)
+        _check_per_step_count_bounded(metric, total_steps)
+
+
+def verify_history_returns_bounded(
+    histories: List[History],
+    env: Environment,
+    rtol: float = 1e-9,
+    atol: float = 1e-6,
+) -> None:
+    """Each history's discounted return must lie inside the env-declared bounds.
+
+    For an env with ``reward_range = (r_min, r_max)`` and discount ``gamma`` and
+    a history of length H, the discounted return G = sum_{t=0..H-1} gamma^t * r_t
+    satisfies:
+        - gamma == 1.0:  H * r_min  <= G <= H * r_max
+        - gamma <  1.0:  r_min*(1-gamma^H)/(1-gamma) <= G <= r_max*(1-gamma^H)/(1-gamma)
+
+    Skips histories with no rewards available. Skips envs that don't declare a
+    reward_range (the helper would have nothing to check against).
+
+    Args:
+        histories: The histories to validate.
+        env: The environment whose ``reward_range`` and ``discount_factor``
+            define the bounds.
+        rtol: Relative tolerance forwarded to ``math.isclose`` (currently unused
+            but kept for symmetry with absolute-tolerance check).
+        atol: Absolute tolerance for floating-point slack at the bounds.
+
+    Raises:
+        AssertionError: If a history's discounted return falls outside its
+            theoretical bounds.
+    """
+    del rtol  # reserved
+    if env.reward_range is None:
+        return
+
+    r_min, r_max = env.reward_range
+    gamma = env.discount_factor
+
+    for history_index, history in enumerate(histories):
+        rewards = [float(step.reward) for step in history.history if step.reward is not None]
+        if not rewards:
+            continue
+
+        horizon = len(rewards)
+        lower_bound, upper_bound = _discounted_return_bounds(r_min, r_max, gamma, horizon)
+        discounted_return = _discounted_return(rewards, gamma)
+
+        assert lower_bound - atol <= discounted_return <= upper_bound + atol, (
+            f"history[{history_index}]: discounted return {discounted_return:.6f} "
+            f"outside bounds [{lower_bound:.6f}, {upper_bound:.6f}] "
+            f"(reward_range=({r_min}, {r_max}), gamma={gamma}, horizon={horizon})"
+        )
+
+
+def verify_return_shift_linearity(
+    histories: List[History],
+    env: Environment,
+    shift: float = 1.0,
+    atol: float = 1e-9,
+) -> None:
+    """Adding constant ``shift`` to every reward shifts the discounted return.
+
+    Property test: G(rewards + c) - G(rewards) == c * sum(gamma^t for t in 0..H-1).
+    Catches discount-factor confusion or off-by-one in horizon accounting.
+
+    Args:
+        histories: Histories whose rewards drive the property test.
+        env: Environment supplying ``discount_factor``.
+        shift: Constant added to every reward.
+        atol: Absolute tolerance for the equality.
+
+    Raises:
+        AssertionError: If the shift in discounted return does not match
+            ``shift * sum(gamma^t)`` for any history.
+    """
+    gamma = env.discount_factor
+
+    for history_index, history in enumerate(histories):
+        rewards = [float(step.reward) for step in history.history if step.reward is not None]
+        if not rewards:
+            continue
+        horizon = len(rewards)
+        baseline = _discounted_return(rewards, gamma)
+        shifted = _discounted_return([r + shift for r in rewards], gamma)
+        expected_delta = shift * _geometric_sum(gamma, horizon)
+        actual_delta = shifted - baseline
+        assert math.isclose(actual_delta, expected_delta, abs_tol=atol), (
+            f"history[{history_index}]: shifted return delta {actual_delta:.9f} "
+            f"!= expected {expected_delta:.9f} (shift={shift}, gamma={gamma}, "
+            f"horizon={horizon})"
+        )
+
+
+def verify_belief_invariants(
+    belief: object,
+    *,
+    expected_n_particles: Optional[int] = None,
+    weight_atol: float = 1e-6,
+) -> None:
+    """Structural invariants for particle beliefs.
+
+    Applies whichever invariants the belief object supports:
+
+    - if it exposes ``log_weights`` or ``weights``: weights are non-negative
+      and sum to 1 (within ``weight_atol``); ESS is in [1, N]
+    - if it exposes ``particles``: particle count matches ``expected_n_particles``
+      when supplied, and is positive otherwise
+
+    Args:
+        belief: A particle belief (weighted or unweighted). Anything that
+            doesn't expose the relevant attributes is silently skipped per
+            attribute, so this helper is safe to call on heterogeneous objects.
+        expected_n_particles: If given, asserts ``len(particles) ==
+            expected_n_particles``. Useful for confirming particle count is
+            stable across a belief update.
+        weight_atol: Absolute tolerance for the "weights sum to 1" check.
+
+    Raises:
+        AssertionError: If any present invariant is violated. Belief objects
+            without the relevant attributes contribute no checks (no failure).
+    """
+    particles = getattr(belief, "particles", None)
+    if particles is not None:
+        n_particles = len(particles)
+        assert n_particles > 0, "belief has zero particles"
+        if expected_n_particles is not None:
+            assert (
+                n_particles == expected_n_particles
+            ), f"particle count {n_particles} != expected {expected_n_particles}"
+
+    weights = _resolve_weights(belief)
+    if weights is None:
+        return
+
+    assert np.all(
+        weights >= -weight_atol
+    ), f"belief weights contain negatives: min={float(np.min(weights))}"
+    weight_sum = float(np.sum(weights))
+    assert math.isclose(
+        weight_sum, 1.0, abs_tol=weight_atol
+    ), f"belief weights sum to {weight_sum}, expected 1.0 (atol={weight_atol})"
+
+    n_particles = weights.shape[0]
+    if n_particles == 0:
+        return
+    ess = 1.0 / float(np.sum(weights * weights)) if np.any(weights > 0) else 0.0
+    assert (
+        1.0 - weight_atol <= ess <= n_particles + weight_atol
+    ), f"ESS {ess} outside [1, {n_particles}]"
+
+
+# --------------------------------------------------------------------------- #
+# Internals
+# --------------------------------------------------------------------------- #
+
+
+def _check_rate_in_unit_interval(metric: MetricValue) -> None:
+    if not metric.name.endswith(_RATE_SUFFIX):
+        return
+    assert 0.0 <= metric.value <= 1.0, (
+        f"{metric.name}: value {metric.value} outside [0, 1] "
+        f"(rate metrics must be in the unit interval)"
+    )
+
+
+def _check_count_non_negative(metric: MetricValue) -> None:
+    if not metric.name.startswith(_COUNT_PREFIXES) or metric.name.endswith(_RATE_SUFFIX):
+        return
+    assert metric.value >= 0.0, (
+        f"{metric.name}: value {metric.value} < 0 " f"(count / total metrics must be non-negative)"
+    )
+
+
+def _check_ci_finite_for_multi_episode(metric: MetricValue, n_episodes: int) -> None:
+    if n_episodes < 2:
+        return
+    assert math.isfinite(metric.lower_confidence_bound), (
+        f"{metric.name}: lower bound is non-finite "
+        f"({metric.lower_confidence_bound}) with n_episodes={n_episodes}"
+    )
+    assert math.isfinite(metric.upper_confidence_bound), (
+        f"{metric.name}: upper bound is non-finite "
+        f"({metric.upper_confidence_bound}) with n_episodes={n_episodes}"
+    )
+
+
+def _check_per_step_count_bounded(metric: MetricValue, total_steps: int) -> None:
+    if not metric.name.startswith(_TOTAL_PREFIX):
+        return
+    if metric.name.endswith(_RATE_SUFFIX):
+        return
+    if not any(keyword in metric.name for keyword in _PER_STEP_BOUND_KEYWORDS):
+        return
+    assert metric.value <= total_steps + 1e-9, (
+        f"{metric.name}: value {metric.value} > total_steps {total_steps} "
+        f"(per-step-count over episodes cannot exceed sum of episode lengths)"
+    )
+
+
+def _discounted_return(rewards: List[float], gamma: float) -> float:
+    if gamma == 1.0:
+        return float(sum(rewards))
+    total = 0.0
+    factor = 1.0
+    for reward in rewards:
+        total += factor * reward
+        factor *= gamma
+    return total
+
+
+def _discounted_return_bounds(r_min: float, r_max: float, gamma: float, horizon: int) -> tuple:
+    if gamma >= 1.0:
+        return horizon * r_min, horizon * r_max
+    geometric = _geometric_sum(gamma, horizon)
+    return r_min * geometric, r_max * geometric
+
+
+def _geometric_sum(gamma: float, horizon: int) -> float:
+    if gamma >= 1.0:
+        return float(horizon)
+    return float((1.0 - gamma**horizon) / (1.0 - gamma))
+
+
+def _resolve_weights(belief: object) -> Optional[np.ndarray]:
+    log_weights = getattr(belief, "log_weights", None)
+    if log_weights is not None:
+        log_weights_array = np.asarray(log_weights, dtype=float)
+        # Stable softmax via shift; avoids overflow when log_weights are large.
+        shifted = log_weights_array - float(np.max(log_weights_array))
+        exp_weights = np.exp(shifted)
+        denom = float(np.sum(exp_weights))
+        if denom <= 0.0:
+            return None
+        return exp_weights / denom
+
+    weights = getattr(belief, "weights", None)
+    if weights is None:
+        return None
+    weights_array = np.asarray(weights, dtype=float)
+    return weights_array

--- a/POMDPPlanners/tests/test_utils/test_belief_factory.py
+++ b/POMDPPlanners/tests/test_utils/test_belief_factory.py
@@ -11,6 +11,9 @@ from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
 from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
     VectorizedWeightedParticleBelief,
 )
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_belief_invariants,
+)
 from POMDPPlanners.utils.belief_factory import BeliefType, create_environment_belief
 
 
@@ -105,6 +108,7 @@ class TestFallbackEnvironments:
         """
         belief = create_environment_belief(tiger_env, n_particles=50)
         assert isinstance(belief, WeightedParticleBelief)
+        verify_belief_invariants(belief, expected_n_particles=50)
 
     def test_tiger_explicit_particle(self, tiger_env):
         """Test that Tiger POMDP accepts BeliefType.PARTICLE.
@@ -173,6 +177,7 @@ class TestCartPole:
         """
         belief = create_environment_belief(cartpole_env, n_particles=50)
         assert isinstance(belief, VectorizedWeightedParticleBelief)
+        verify_belief_invariants(belief, expected_n_particles=50)
 
     def test_particle_returns_weighted(self, cartpole_env):
         """Test CartPole PARTICLE type returns WeightedParticleBelief.
@@ -249,6 +254,7 @@ class TestMountainCar:
         """
         belief = create_environment_belief(mountain_car_env, n_particles=50)
         assert isinstance(belief, VectorizedWeightedParticleBelief)
+        verify_belief_invariants(belief, expected_n_particles=50)
 
     def test_sample_shape(self, mountain_car_env):
         """Test MountainCar belief sample has correct shape.
@@ -280,6 +286,7 @@ class TestContinuousLightDark:
         """
         belief = create_environment_belief(light_dark_env, n_particles=50)
         assert isinstance(belief, VectorizedWeightedParticleBelief)
+        verify_belief_invariants(belief, expected_n_particles=50)
 
     def test_gaussian_returns_gaussian_belief(self, light_dark_env):
         """Test Light-Dark GAUSSIAN type returns GaussianBelief.

--- a/POMDPPlanners/tests/test_utils/test_weighted_particle_belief.py
+++ b/POMDPPlanners/tests/test_utils/test_weighted_particle_belief.py
@@ -15,6 +15,9 @@ import pytest
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDPDiscreteActions,
 )
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_belief_invariants,
+)
 from POMDPPlanners.utils.weighted_particle_beliefs import (
     WeightedParticleBeliefContinuousLightDarkFullCoverage,
     WeightedParticleBeliefDiscreteLightDark,
@@ -57,6 +60,7 @@ def test_initialization():
     assert belief.reinvigoration_fraction == 0.2
     assert belief.actions == ["up", "down", "right", "left"]
     assert belief.action_to_vector["up"] == pytest.approx(np.array([0, 1]))
+    verify_belief_invariants(belief, expected_n_particles=n_particles)
 
 
 def test_reinvigoration():
@@ -99,6 +103,7 @@ def test_reinvigoration():
     # Check that some particles were reinvigorated
     n_reinvigorate = int(belief.reinvigoration_fraction * n_particles)
     assert n_reinvigorate > 0
+    verify_belief_invariants(reinvigorated_belief, expected_n_particles=n_particles)
 
 
 def test_invalid_initialization():
@@ -193,6 +198,7 @@ def test_full_coverage_initialization():
     assert belief.actions == ["up", "down", "right", "left"]
     assert belief.action_to_vector["up"] == pytest.approx(np.array([0, 1]))
     assert not belief.resampling  # Should be False as specified in __init__
+    verify_belief_invariants(belief, expected_n_particles=n_particles)
 
 
 def test_full_coverage_reinvigoration():
@@ -238,6 +244,7 @@ def test_full_coverage_reinvigoration():
 
     for i in range(n_states):
         assert np.array_equal(reinvigorated_belief.particles[-(i + 1)], expected_states[-(i + 1)])
+    verify_belief_invariants(reinvigorated_belief, expected_n_particles=n_particles)
 
 
 def test_full_coverage_invalid_initialization():
@@ -604,3 +611,4 @@ def test_continuous_full_coverage_particle_type_preservation_after_update():
     assert updated_belief.log_weights.shape == (
         n_particles,
     ), f"Log weights shape should be ({n_particles},), got {updated_belief.log_weights.shape}"
+    verify_belief_invariants(updated_belief, expected_n_particles=n_particles)


### PR DESCRIPTION
## Summary

Two source-side bug fixes caught by a new cross-env metric/CI sanity-check test suite.

## Bugs fixed

**1. TOTAL_*_OBSTACLE_COLLISIONS / TOTAL_*_VIOLATIONS — sum-vs-mean-CI scale mismatch**

These metrics reported `value = sum(per_episode_counts)` paired with `CI = confidence_interval(per_episode_counts)`, which is the t-CI for the per-episode *mean*. Value (sum) and bounds (around the mean ≈ sum/N) lived on different scales — bounds were ≈N× too tight to bracket the value.

Fix: change `value` to `float(np.mean(per_episode_counts))`. Value and CI now both describe the per-episode mean; bounds bracket value.

| Env | Metrics fixed |
|-----|---------------|
| `continuous_push_pomdp` | TOTAL_ROBOT_OBSTACLE_COLLISIONS, TOTAL_OBJECT_OBSTACLE_COLLISIONS, TOTAL_ALL_OBSTACLE_COLLISIONS |
| `push_pomdp` (discrete) | same three |
| `safety_ant_velocity_pomdp` | TOTAL_SAFETY_VIOLATIONS, TOTAL_CRITICAL_VIOLATIONS |

**2. `push_pomdp.py:compute_metrics` — duplicate counting loop**

The original `compute_metrics` iterated each history's steps **twice**: after appending per-episode counts the first time, the next block reset the counters, re-ran the same step loop, and appended counts a second time — doubling every per-episode collision count and corrupting every collision metric (rates *and* totals).

Fix: delete the duplicate counting block.

## New test infrastructure

`POMDPPlanners/tests/test_utils/metric_invariants_utils.py` — four shared helpers that iterate over `compute_metrics()` output and the input histories:

- `verify_metric_sanity(metrics, histories, env)` — `*_rate` ∈ [0, 1]; counts ≥ 0; CI bounds finite for n ≥ 2; per-step-count metrics ≤ sum of episode lengths.
- `verify_history_returns_bounded(histories, env)` — discounted return per history within `[r_min, r_max] × geometric_sum(γ, H)`.
- `verify_return_shift_linearity(histories, env, shift)` — adding constant `c` to every reward shifts return by exactly `c × geometric_sum(γ, H)`.
- `verify_belief_invariants(belief, ...)` — particle count > 0; weights ≥ 0 and sum to 1; ESS ∈ [1, N].

Wired into:
- 9 envs via new `test_compute_metrics_values_within_confidence_intervals` (continuous_light_dark, discrete_light_dark, mountain_car, cartpole, safety_ant, pacman, push, continuous_push, rock_sample).
- tiger and laser_tag (both variants) tests that already used `verify_metrics_within_confidence_intervals`.
- 22 `verify_belief_invariants` calls across 5 belief test files.

The helpers iterate over whatever `compute_metrics` returns, so they automatically catch new value/CI scale mismatches if any surface in future env changes.

## Verification

- All 118 tests across the three modified envs pass.
- 60+ tests across the new sanity-check suite pass (~90 ms wall time including pytest startup).
- 226 belief tests pass with the new invariant calls.
- pyright: 0 errors / 0 warnings on all modified sources and tests.
- pylint: passes pre-commit hook.

## Backward-compat

`TOTAL_*` metric *names* are unchanged. Their *values* change from sum-across-episodes to mean-per-episode — a numeric break for any downstream evaluation script reading these CSV columns. The pre-fix bound values were ≈N× too tight, so the change actually surfaces the per-episode summary that the metric implicitly already computes.

## Test plan

- [x] CI green
- [x] Confirm no downstream evaluation script depends on the pre-fix sum-across-episodes value of `total_*_obstacle_collisions` / `total_*_violations`.