### PR TITLE
feat(rocksample): stochastic dangerous-area penalty for risk-sensitive eval

### DIFF
--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -111,6 +111,22 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
     must navigate a grid, use sensors to evaluate rocks, and decide which ones
     to sample while balancing exploration costs and sampling rewards.
 
+    Stochasticity:
+        The dangerous-area penalty can be applied either deterministically
+        (the default) or stochastically. When
+        ``dangerous_area_hit_probability == 1.0`` (default), the penalty is
+        applied every time the robot's next position lies inside a
+        dangerous area, matching legacy behavior. When
+        ``dangerous_area_hit_probability < 1.0``, the penalty is applied
+        only with that probability per ``reward()`` / ``reward_batch()``
+        call (one Bernoulli draw per state), producing a heavy-tailed
+        return distribution suitable for benchmarking risk-sensitive
+        planners (e.g. ICVaR-aware MCTS) against expected-value MCTS on
+        the same env. Note that this makes ``reward(state, action)``
+        non-deterministic given a state-action pair, so any external
+        caching that assumes deterministic rewards must be aware of this.
+        ``transition_log_probability`` is unaffected.
+
     Attributes:
         map_size: Grid dimensions as (rows, cols)
         rock_positions: List of rock positions as (row, col) tuples
@@ -156,6 +172,7 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         dangerous_areas: Optional[List[Tuple[int, int]]] = None,
         dangerous_area_radius: float = 1.0,
         dangerous_area_penalty: float = 5.0,
+        dangerous_area_hit_probability: float = 1.0,
         discount_factor: float = 0.95,
         name: str = "RockSample",
         output_dir: Optional[Path] = None,
@@ -177,11 +194,23 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
             dangerous_areas: List of dangerous area center positions as (row, col) tuples. Defaults to None.
             dangerous_area_radius: Radius around dangerous area centers. Defaults to 1.0.
             dangerous_area_penalty: Penalty magnitude applied randomly when in dangerous areas. Defaults to 5.0.
+            dangerous_area_hit_probability: Probability that the dangerous-area
+                penalty is actually applied to the reward when the robot's
+                next position is inside a dangerous area. Must lie in
+                ``[0, 1]``. Defaults to ``1.0`` (deterministic penalty,
+                matching legacy behavior). Values below ``1.0`` make the
+                reward stochastic (per-call Bernoulli draw), useful for
+                risk-sensitive planning benchmarks. Note that this makes
+                ``reward(state, action)`` non-deterministic given a
+                state-action pair.
             discount_factor: Discount factor. Defaults to 0.95.
             name: Environment name. Defaults to "RockSample".
             output_dir: Output directory for logging. Defaults to None.
             debug: Enable debug logging. Defaults to False.
         """
+        if not 0.0 <= dangerous_area_hit_probability <= 1.0:
+            raise ValueError("dangerous_area_hit_probability must be between 0 and 1 (inclusive)")
+
         # Calculate reward range based on parameters
         min_reward = step_penalty + bad_rock_penalty + sensor_use_penalty
         max_reward = step_penalty + exit_reward
@@ -216,6 +245,7 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         )
         self.dangerous_area_radius = dangerous_area_radius
         self.dangerous_area_penalty = dangerous_area_penalty
+        self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
 
         # Validate parameters
         self._validate_parameters()
@@ -322,7 +352,11 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
             total_reward += self.sensor_use_penalty
 
         if self._is_in_dangerous_area(get_robot_pos(next_state)):
-            total_reward += self.dangerous_area_penalty
+            if (
+                self.dangerous_area_hit_probability >= 1.0
+                or np.random.random() < self.dangerous_area_hit_probability
+            ):
+                total_reward += self.dangerous_area_penalty
 
         return total_reward
 
@@ -384,8 +418,11 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
             return rewards
 
         next_robot_rows, next_robot_cols = self._closed_form_next_robot_pos(states, action)
+        deterministic = self.dangerous_area_hit_probability >= 1.0
         for j in range(n):
-            if self._is_in_dangerous_area((next_robot_rows[j], next_robot_cols[j])):
+            if not self._is_in_dangerous_area((next_robot_rows[j], next_robot_cols[j])):
+                continue
+            if deterministic or np.random.random() < self.dangerous_area_hit_probability:
                 rewards[j] += self.dangerous_area_penalty
 
         return rewards

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
@@ -975,6 +975,165 @@ class TestDangerousArea:
         assert pomdp._is_in_dangerous_area((3, 2)) is False
 
 
+class TestStochasticDangerousAreaPenalty:
+    """Tests for the ``dangerous_area_hit_probability`` parameter.
+
+    Geometry: dangerous area centred at ``(2, 0)`` with radius 1.0; the
+    test fixtures place the robot at ``(1, 0)`` and use action 3 (south)
+    so the next-state position ``(2, 0)`` lies inside the zone. Action 3
+    avoids the action-2 (east-exit) early-return branch in
+    ``_reward_batch_vectorized``.
+    """
+
+    SOUTH_ACTION = 3
+
+    @staticmethod
+    def _stochastic_env(hit_probability: float, penalty: float = 5.0) -> RockSamplePOMDP:
+        return RockSamplePOMDP(
+            map_size=(5, 5),
+            rock_positions=[(4, 4)],
+            init_pos=(1, 0),
+            dangerous_areas=[(2, 0)],
+            dangerous_area_radius=1.0,
+            dangerous_area_penalty=penalty,
+            dangerous_area_hit_probability=hit_probability,
+            step_penalty=0.0,
+        )
+
+    def test_default_hit_probability_is_one(self):
+        """Default hit probability preserves legacy deterministic behavior.
+
+        Purpose: Validates that omitting the new parameter keeps the
+            deterministic dangerous-area penalty active.
+
+        Given: A RockSamplePOMDP constructed with default parameters.
+        When: ``dangerous_area_hit_probability`` is read.
+        Then: It equals ``1.0`` (deterministic-penalty regime).
+
+        Test type: unit
+        """
+        env = RockSamplePOMDP()
+        assert env.dangerous_area_hit_probability == 1.0
+
+    def test_hit_probability_zero_never_applies_penalty(self):
+        """hit_probability=0 disables the dangerous-area penalty.
+
+        Purpose: Validates the lower-bound of the stochastic penalty.
+
+        Given: A robot moving south from (1, 0) into the (2, 0)
+            dangerous area with hit_probability=0.
+        When: ``reward()`` is called many times.
+        Then: The dangerous-area penalty is never added.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.0)
+        state = create_rock_sample_state((1, 0), (True,))
+        np.random.seed(0)
+        for _ in range(200):
+            assert env.reward(state, self.SOUTH_ACTION) == 0.0
+
+    def test_hit_probability_one_matches_deterministic(self):
+        """hit_probability=1 matches legacy deterministic penalty.
+
+        Purpose: Regression check that the default behavior is preserved
+            when hit_probability=1.0 is passed explicitly.
+
+        Given: A robot moving south from (1, 0) into the (2, 0)
+            dangerous area with hit_probability=1.0.
+        When: ``reward()`` is called many times.
+        Then: The dangerous-area penalty is always applied.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=1.0)
+        state = create_rock_sample_state((1, 0), (True,))
+        for _ in range(50):
+            assert env.reward(state, self.SOUTH_ACTION) == pytest.approx(5.0)
+
+    def test_hit_probability_zero_three_empirical_rate(self):
+        """Empirical hit rate matches hit_probability over many calls.
+
+        Purpose: Validates that the per-call Bernoulli draw matches the
+            configured probability over a large sample.
+
+        Given: A robot moving into a dangerous area with
+            hit_probability=0.3.
+        When: ``reward()`` is called 5000 times.
+        Then: Empirical hit rate is within 0.05 of 0.3.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.3)
+        state = create_rock_sample_state((1, 0), (True,))
+        np.random.seed(123)
+        n_trials = 5000
+        hits = 0
+        for _ in range(n_trials):
+            if env.reward(state, self.SOUTH_ACTION) == pytest.approx(5.0):
+                hits += 1
+        empirical_rate = hits / n_trials
+        assert abs(empirical_rate - 0.3) < 0.05
+
+    def test_reward_batch_honours_hit_probability(self):
+        """reward_batch applies stochastic penalty consistently with single-state.
+
+        Purpose: Validates that the batched reward path uses the same
+            Bernoulli mechanism as the single-state path.
+
+        Given: 5000 copies of a state moving into a dangerous area with
+            hit_probability=0.3.
+        When: ``reward_batch()`` is called once.
+        Then: Empirical hit rate across the batch is within 0.05 of 0.3.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.3)
+        state = create_rock_sample_state((1, 0), (True,))
+        n_trials = 5000
+        states = np.tile(state, (n_trials, 1))
+        np.random.seed(456)
+        rewards = env.reward_batch(states, self.SOUTH_ACTION)
+        hits = int(np.sum(np.isclose(rewards, 5.0)))
+        empirical_rate = hits / n_trials
+        assert abs(empirical_rate - 0.3) < 0.05
+
+    def test_reward_batch_zero_probability_never_applies_penalty(self):
+        """reward_batch with hit_probability=0 returns zero penalty for all rows.
+
+        Purpose: Validates the lower-bound of the stochastic penalty in
+            the batched path.
+
+        Given: A batch of in-zone next-state states with
+            hit_probability=0.0 and step_penalty=0.
+        When: ``reward_batch()`` is called.
+        Then: All returned rewards equal 0.0.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.0)
+        state = create_rock_sample_state((1, 0), (True,))
+        states = np.tile(state, (200, 1))
+        np.random.seed(789)
+        rewards = env.reward_batch(states, self.SOUTH_ACTION)
+        assert np.all(rewards == 0.0)
+
+    @pytest.mark.parametrize("bad_value", [-0.1, 1.5, 2.0, -1.0])
+    def test_invalid_hit_probability_raises(self, bad_value: float):
+        """Out-of-range hit_probability raises ValueError.
+
+        Purpose: Validates input validation on the new parameter.
+
+        Given: A hit_probability value outside [0, 1].
+        When: RockSamplePOMDP is constructed.
+        Then: ValueError is raised mentioning the parameter name.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="dangerous_area_hit_probability"):
+            RockSamplePOMDP(dangerous_area_hit_probability=bad_value)
+
+
 class TestMetricsComputation:
     """Test metrics computation."""
 


### PR DESCRIPTION
## Summary

- Adds `dangerous_area_hit_probability` parameter to `RockSamplePOMDP` (default `1.0` preserves legacy deterministic behavior).
- When `< 1.0`, the dangerous-area penalty is applied stochastically per call (Bernoulli draw), making rewards heavy-tailed for risk-sensitive planning benchmarks (ICVaR-aware MCTS vs. expected-value MCTS).
- Mirrors the existing `ContinuousLaserTagPOMDP.dangerous_area_hit_probability` (#135).

## Why this is a pure-Python change

RockSample's C++ kernels never computed the dangerous-area penalty:

- `RockSampleTransitionCpp` / `RockSampleObservationCpp` — transitions/observations only, no reward.
- `_native.simulate_rollout_discrete` — only invoked when `not self.dangerous_areas`; `simulate_random_rollout` falls back to Python (`python_random_rollout`) whenever dangerous areas are configured.

So the Bernoulli draw was added directly to `_reward_from_next_state` (single-state) and `_reward_batch_vectorized` (batch). No `.so` / `_cpp/` / `_native.pyi` changes.

## Tests

New `TestStochasticDangerousAreaPenalty` class (10 tests):

- Default value preserves legacy behavior (`p == 1.0`).
- `p = 0.0` never applies penalty (single-state and batch).
- `p = 1.0` always applies penalty (regression for legacy semantics).
- Empirical hit rate at `p = 0.3` within 0.05 of target over 5000 trials, both for `reward()` and `reward_batch()`.
- Parametrized validation: `ValueError` on out-of-range values (`-1.0`, `-0.1`, `1.5`, `2.0`).

## Test plan

- [x] All 10 new tests pass on `origin/develop` baseline.
- [x] Pre-existing dangerous-area / reward-function tests (16) still pass — no regressions.
- [x] `pyright`: 0 errors, 0 warnings on both source and test file.
- [x] `pylint`: source `10.00/10`. Test-file pre-existing warnings unchanged (my added code introduces zero new warnings).
- [x] Pre-commit hooks (black, pylint, pyright) passed.