### PR TITLE
build: require setuptools>=77 for PEP 639 license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=65.0.0", "wheel", "pybind11>=2.12"]
+requires = ["setuptools>=77.0.0", "wheel", "pybind11>=2.12"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -64,7 +64,7 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "nbval>=0.9.6",
     "papermill>=2.6.0",
-    "setuptools>=65.0.0",
+    "setuptools>=77.0.0",
     "ipykernel>=6.0.0",
     "jupyter-client>=7.0.0",
     "nbformat>=5.0.0",


### PR DESCRIPTION
## Summary
- Bump build-system `setuptools` floor from `>=65.0.0` to `>=77.0.0` in `pyproject.toml`, and the matching dev-extra entry, so isolated PEP 517 build envs can parse the project's SPDX `license = \"MIT\"` and `license-files = [\"LICENSE.md\"]` metadata (PEP 639).
- Unblocks downstream `pip install` from source: with the previous floor, a fresh build env could resolve an older setuptools that rejects the SPDX expression with "license must be a TOML table" / "expected dict, got string" errors.

## Why
PEP 639 SPDX license expressions and the `license-files` key were added to setuptools in 77.0.0. The build environment is isolated by default (PEP 517), so it does **not** inherit the user's local setuptools — it resolves whatever `[build-system].requires` allows. The prior `>=65.0.0` floor permitted ancient setuptools that fail on the modern license metadata that landed in this repo on 2026-03-03 (commit 0368c95).

## Test plan
- [x] `pip install -e .` succeeds in a clean venv
- [x] `python -m build --sdist --wheel` succeeds (sdist + wheel both build)
- [x] CI green