### PR TITLE
feat(push): stochastic obstacle-collision penalty for risk-sensitive eval

### DIFF
--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -111,6 +111,25 @@ class ContinuousPushPOMDP(Environment):
     Actions: 2D numpy vectors
     Observations: [robot_x, robot_y, noisy_obj_x, noisy_obj_y, target_x, target_y]
 
+    Stochasticity:
+        The obstacle-collision penalty can be applied either
+        deterministically (the default) or stochastically. When
+        ``obstacle_hit_probability == 1.0`` (default), the penalty is
+        applied every time the post-action robot position overlaps an
+        obstacle AABB, matching legacy behavior. When
+        ``obstacle_hit_probability < 1.0``, the penalty is applied only
+        with that probability per ``reward()`` / ``reward_batch()`` call
+        (one Bernoulli draw per state), producing a heavy-tailed return
+        distribution suitable for benchmarking risk-sensitive planners
+        (e.g. ICVaR-aware MCTS) against expected-value MCTS on the same
+        env. Note that this makes ``reward(state, action)`` non-
+        deterministic given a state-action pair, so any external caching
+        that assumes deterministic rewards must be aware of this.
+        ``transition_log_probability`` is unaffected. When
+        ``obstacle_hit_probability < 1.0`` the native C++ rollout (which
+        deducts the penalty deterministically) is bypassed in favour of
+        the Python rollout so per-step Bernoulli draws survive.
+
     Example:
         >>> import numpy as np
         >>> np.random.seed(42)
@@ -136,6 +155,7 @@ class ContinuousPushPOMDP(Environment):
         observation_noise: float = 0.1,
         obstacles: Optional[List[Tuple[float, float, float]]] = None,
         obstacle_penalty: float = -10.0,
+        obstacle_hit_probability: float = 1.0,
         robot_radius: float = 0.3,
         state_transition_cov_matrix: np.ndarray = np.eye(2) * 0.1,
         initial_state: Optional[np.ndarray] = None,
@@ -144,12 +164,16 @@ class ContinuousPushPOMDP(Environment):
         debug: bool = False,
         use_queue_logger: bool = False,
     ):
+        if not 0.0 <= obstacle_hit_probability <= 1.0:
+            raise ValueError("obstacle_hit_probability must be between 0 and 1 (inclusive)")
+
         self.grid_size = grid_size
         self.push_threshold = push_threshold
         self.friction_coefficient = friction_coefficient
         self.max_push = max_push
         self.observation_noise = observation_noise
         self.obstacle_penalty = obstacle_penalty
+        self.obstacle_hit_probability = float(obstacle_hit_probability)
         self.robot_radius = robot_radius
         self.state_transition_cov_matrix = state_transition_cov_matrix
         self._initial_state = initial_state
@@ -398,6 +422,11 @@ class ContinuousPushPOMDP(Environment):
         if self.obstacles.shape[0] > 0:
             robot_after = states[:, :2] + action  # (N, 2)
             collide = self._batch_circle_obstacle_overlap(robot_after, self.robot_radius)
+            if self.obstacle_hit_probability < 1.0:
+                # Per-row Bernoulli mask: refund the penalty for rows that
+                # collide but lose the per-call coin flip.
+                applied = np.random.random(collide.shape[0]) < self.obstacle_hit_probability
+                collide = collide & applied
             if np.any(collide):
                 rewards[collide] += self.obstacle_penalty
 
@@ -497,7 +526,10 @@ class ContinuousPushPOMDP(Environment):
             return 0.0
 
         actions_array = self._get_rollout_actions_array()
-        if actions_array is None:
+        if actions_array is None or self.obstacle_hit_probability < 1.0:
+            # Native kernel applies the obstacle penalty deterministically;
+            # fall back to the Python rollout so per-step Bernoulli draws
+            # against ``obstacle_hit_probability`` survive.
             return python_random_rollout(
                 state=state,
                 depth=depth,

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -133,6 +133,26 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
     - Obstacle collision detection with configurable penalties
     - Obstacles prevent robot and object movement through them
 
+    Stochasticity:
+        The obstacle-collision penalty can be applied either
+        deterministically (the default) or stochastically. When
+        ``obstacle_hit_probability == 1.0`` (default), the penalty is
+        applied every time the robot's intended next position lies inside
+        an obstacle, matching legacy behavior. When
+        ``obstacle_hit_probability < 1.0``, the penalty is applied only
+        with that probability per ``reward()`` / ``reward_batch()`` call
+        (one Bernoulli draw per state), producing a heavy-tailed return
+        distribution suitable for benchmarking risk-sensitive planners
+        (e.g. ICVaR-aware MCTS) against expected-value MCTS on the same
+        env. Note that this makes ``reward(state, action)`` non-
+        deterministic given a state-action pair, so any external caching
+        that assumes deterministic rewards must be aware of this.
+        ``transition_log_probability`` is unaffected; the obstacle still
+        deterministically blocks movement. When
+        ``obstacle_hit_probability < 1.0`` the native C++ rollout (which
+        deducts the penalty deterministically) is bypassed in favour of
+        the pure-Python rollout so per-step Bernoulli draws survive.
+
     Example:
         >>> import numpy as np
         >>> np.random.seed(42)  # For reproducible results
@@ -173,6 +193,7 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         obstacles: Optional[List[Tuple[float, float]]] = None,
         obstacle_radius: float = 0.5,
         obstacle_penalty: float = -10.0,
+        obstacle_hit_probability: float = 1.0,
         initial_state: Optional[np.ndarray] = None,
         transition_error_prob: float = 0.0,
         name: str = "PushPOMDP",
@@ -180,6 +201,9 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         debug: bool = False,
         use_queue_logger: bool = False,
     ):
+        if not 0.0 <= obstacle_hit_probability <= 1.0:
+            raise ValueError("obstacle_hit_probability must be between 0 and 1 (inclusive)")
+
         self.grid_size = grid_size
         self.push_threshold = push_threshold
         self.friction_coefficient = friction_coefficient
@@ -187,6 +211,7 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         self.obstacles: List[Tuple[float, float]] = obstacles if obstacles is not None else []
         self.obstacle_radius = obstacle_radius
         self.obstacle_penalty = obstacle_penalty
+        self.obstacle_hit_probability = float(obstacle_hit_probability)
         self._initial_state = initial_state
         self.transition_error_prob = transition_error_prob
 
@@ -531,7 +556,11 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             reward += 100.0
 
         if self._is_colliding_with_obstacle(state[:2], action):
-            reward += self.obstacle_penalty
+            if (
+                self.obstacle_hit_probability >= 1.0
+                or np.random.random() < self.obstacle_hit_probability
+            ):
+                reward += self.obstacle_penalty
 
         return float(reward)
 
@@ -609,6 +638,19 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         remaining = max_depth - depth
         if remaining <= 0 or self.is_terminal(state=state):
             return 0.0
+
+        if self.obstacle_hit_probability < 1.0:
+            # Native kernel applies the obstacle penalty deterministically;
+            # fall back to the Python rollout so per-step Bernoulli draws
+            # against ``obstacle_hit_probability`` survive.
+            actions = [self.actions[i] for i in np.random.randint(0, 4, size=remaining)]
+            return self._python_simulate_random_rollout(
+                state=state,
+                actions=actions,
+                max_depth=max_depth,
+                discount_factor=discount_factor,
+                depth=depth,
+            )
 
         action_indices = np.random.randint(0, 4, size=remaining, dtype=np.int64)
         obs_arr = self._get_native_rollout_obstacles()
@@ -732,6 +774,11 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         diff = intended[:, None, :] - obs_arr[None, :, :]  # (N, M, 2)
         dist_sq = np.sum(diff * diff, axis=2)  # (N, M)
         colliding = np.any(dist_sq <= self.obstacle_radius * self.obstacle_radius, axis=1)
+        if self.obstacle_hit_probability < 1.0:
+            # Per-row Bernoulli mask: refund the penalty for rows that collide
+            # but lose the per-call coin flip.
+            applied = np.random.random(len(states)) < self.obstacle_hit_probability
+            colliding = colliding & applied
         return np.where(colliding, self.obstacle_penalty, 0.0).astype(np.float64)
 
     def observation_log_probability_per_state(

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
@@ -671,6 +671,195 @@ class TestContinuousPushPOMDP:
         verify_return_shift_linearity(histories, self.env, shift=1.5)
 
 
+class TestContinuousPushStochasticObstacleHitProbability:
+    """Tests for ``obstacle_hit_probability`` on ``ContinuousPushPOMDP``.
+
+    Geometry: a single AABB obstacle centred at ``(5.0, 5.0)`` with
+    half-size ``0.5`` (extents ``[4.5, 5.5]^2``). The robot starts at
+    ``(4.0, 5.0)`` and the action ``(1.0, 0.0)`` puts the post-action
+    robot position at ``(5.0, 5.0)`` — well inside the AABB even after
+    accounting for ``robot_radius``. Transition covariance is set to a
+    near-zero diagonal so the distance-to-target term is effectively
+    deterministic and the obstacle penalty (-10.0) cleanly dominates the
+    decision boundary used to bucket "hit" vs. "no-hit" trials.
+    """
+
+    OBSTACLE_PENALTY = -10.0
+    COLLIDE_ACTION = np.array([1.0, 0.0])
+
+    @staticmethod
+    def _stochastic_env(hit_probability: float) -> ContinuousPushPOMDP:
+        return ContinuousPushPOMDP(
+            discount_factor=0.99,
+            grid_size=10,
+            obstacles=[(5.0, 5.0, 0.5)],
+            obstacle_penalty=TestContinuousPushStochasticObstacleHitProbability.OBSTACLE_PENALTY,
+            obstacle_hit_probability=hit_probability,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 1e-8,
+        )
+
+    @staticmethod
+    def _collide_state() -> np.ndarray:
+        # robot just left of obstacle AABB; object far from target so the
+        # distance-to-target term is well above 0.5 (no goal bonus).
+        return np.array([4.0, 5.0, 1.0, 1.0, 9.0, 9.0])
+
+    def test_default_hit_probability_is_one(self):
+        """Default hit probability preserves legacy deterministic behavior.
+
+        Purpose: Validates that omitting the new parameter keeps the
+            deterministic obstacle-collision penalty active.
+
+        Given: A ContinuousPushPOMDP with default parameters.
+        When: ``obstacle_hit_probability`` is read.
+        Then: It equals ``1.0``.
+
+        Test type: unit
+        """
+        env = ContinuousPushPOMDP(discount_factor=0.99)
+        assert env.obstacle_hit_probability == 1.0
+
+    def test_hit_probability_zero_never_applies_penalty(self):
+        """hit_probability=0 disables the obstacle-collision penalty.
+
+        Purpose: Validates the lower-bound of the stochastic penalty for
+            the continuous-action env.
+
+        Given: A robot moving right into an obstacle AABB with
+            hit_probability=0 and near-zero transition noise.
+        When: ``reward()`` is called many times.
+        Then: Every reward sits above the (baseline - penalty/2) midpoint
+            — i.e. no obstacle penalty was applied.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.0)
+        state = self._collide_state()
+        # With p=0 the reward equals the baseline distance term up to the
+        # tiny transition-noise jitter (cov 1e-8). A midpoint between
+        # baseline and (baseline + obstacle_penalty) cleanly separates the
+        # two regimes regardless of where the absolute baseline sits.
+        baseline = env.reward(state, self.COLLIDE_ACTION)
+        midpoint = baseline + self.OBSTACLE_PENALTY / 2.0
+        np.random.seed(0)
+        for _ in range(200):
+            r = env.reward(state, self.COLLIDE_ACTION)
+            assert r > midpoint
+
+    def test_hit_probability_one_always_applies_penalty(self):
+        """hit_probability=1 matches legacy deterministic penalty.
+
+        Purpose: Regression check that the default behavior is preserved
+            when hit_probability=1.0 is passed explicitly.
+
+        Given: A robot moving right into an obstacle AABB with
+            hit_probability=1.0 and near-zero transition noise.
+        When: ``reward()`` is called many times.
+        Then: Every reward includes the full obstacle penalty.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=1.0)
+        state = self._collide_state()
+        # Compare against the same env with p=0 to isolate the penalty.
+        env_no_pen = self._stochastic_env(hit_probability=0.0)
+        baseline = env_no_pen.reward(state, self.COLLIDE_ACTION)
+        for _ in range(50):
+            r = env.reward(state, self.COLLIDE_ACTION)
+            assert r == pytest.approx(baseline + self.OBSTACLE_PENALTY, abs=1e-3)
+
+    def test_hit_probability_zero_three_empirical_rate(self):
+        """Empirical hit rate matches hit_probability over many calls.
+
+        Purpose: Validates that the per-call Bernoulli draw matches the
+            configured probability over a large sample.
+
+        Given: A robot moving into an obstacle with hit_probability=0.3.
+        When: ``reward()`` is called 5000 times.
+        Then: Empirical hit rate is within 0.05 of 0.3.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.3)
+        state = self._collide_state()
+        env_no_pen = self._stochastic_env(hit_probability=0.0)
+        baseline = env_no_pen.reward(state, self.COLLIDE_ACTION)
+        midpoint = baseline + self.OBSTACLE_PENALTY / 2.0
+        np.random.seed(123)
+        n_trials = 5000
+        hits = 0
+        for _ in range(n_trials):
+            if env.reward(state, self.COLLIDE_ACTION) < midpoint:
+                hits += 1
+        empirical_rate = hits / n_trials
+        assert abs(empirical_rate - 0.3) < 0.05
+
+    def test_reward_batch_honours_hit_probability(self):
+        """reward_batch applies stochastic penalty consistently.
+
+        Purpose: Validates that the batched reward path uses the same
+            Bernoulli mechanism as the single-state path.
+
+        Given: 5000 copies of a state moving into an obstacle with
+            hit_probability=0.3.
+        When: ``reward_batch()`` is called once.
+        Then: Empirical hit rate across the batch is within 0.05 of 0.3.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.3)
+        state = self._collide_state()
+        env_no_pen = self._stochastic_env(hit_probability=0.0)
+        baseline = env_no_pen.reward(state, self.COLLIDE_ACTION)
+        midpoint = baseline + self.OBSTACLE_PENALTY / 2.0
+        n_trials = 5000
+        states = np.tile(state, (n_trials, 1))
+        np.random.seed(456)
+        rewards = env.reward_batch(states, self.COLLIDE_ACTION)
+        hits = int(np.sum(rewards < midpoint))
+        empirical_rate = hits / n_trials
+        assert abs(empirical_rate - 0.3) < 0.05
+
+    def test_reward_batch_zero_probability_never_applies_penalty(self):
+        """reward_batch with hit_probability=0 returns no obstacle penalty.
+
+        Purpose: Validates the lower-bound of the stochastic penalty in
+            the batched path.
+
+        Given: A batch of in-zone next-state states with
+            hit_probability=0.0.
+        When: ``reward_batch()`` is called.
+        Then: All returned rewards exceed the obstacle-penalty floor.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.0)
+        state = self._collide_state()
+        env_no_pen = self._stochastic_env(hit_probability=0.0)
+        baseline = env_no_pen.reward(state, self.COLLIDE_ACTION)
+        midpoint = baseline + self.OBSTACLE_PENALTY / 2.0
+        states = np.tile(state, (200, 1))
+        np.random.seed(789)
+        rewards = env.reward_batch(states, self.COLLIDE_ACTION)
+        assert np.all(rewards > midpoint)
+
+    @pytest.mark.parametrize("bad_value", [-0.1, 1.5, 2.0, -1.0])
+    def test_invalid_hit_probability_raises(self, bad_value: float):
+        """Out-of-range hit_probability raises ValueError.
+
+        Purpose: Validates input validation on the new parameter.
+
+        Given: A hit_probability value outside [0, 1].
+        When: ContinuousPushPOMDP is constructed.
+        Then: ValueError is raised mentioning the parameter name.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="obstacle_hit_probability"):
+            ContinuousPushPOMDP(discount_factor=0.99, obstacle_hit_probability=bad_value)
+
+
 # ------------------------------------------------------------------
 # Discrete Actions
 # ------------------------------------------------------------------

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
@@ -1237,6 +1237,178 @@ class TestPushPOMDPStateTransition:
             )
 
 
+class TestStochasticObstacleHitProbability:
+    """Tests for the ``obstacle_hit_probability`` parameter on ``PushPOMDP``.
+
+    Geometry: a single obstacle centred at ``(3.0, 3.0)`` with radius
+    ``0.5``; the robot starts at ``(2.0, 3.0)`` and the action ``"right"``
+    drives the intended next-position to ``(3.0, 3.0)`` (inside the
+    obstacle). The object is parked far away so it never affects the
+    distance-to-target term in cross-call comparisons.
+    """
+
+    COLLIDE_ACTION = "right"
+    OBSTACLE_PENALTY = -10.0
+
+    @staticmethod
+    def _stochastic_env(hit_probability: float) -> PushPOMDP:
+        return PushPOMDP(
+            discount_factor=0.95,
+            grid_size=10,
+            obstacles=[(3.0, 3.0)],
+            obstacle_radius=0.5,
+            obstacle_penalty=TestStochasticObstacleHitProbability.OBSTACLE_PENALTY,
+            obstacle_hit_probability=hit_probability,
+            transition_error_prob=0.0,
+        )
+
+    @staticmethod
+    def _collide_state() -> np.ndarray:
+        # robot just left of obstacle; object far away from target stays put
+        return np.array([2.0, 3.0, 8.0, 8.0, 9.0, 9.0])
+
+    def test_default_hit_probability_is_one(self):
+        """Default hit probability preserves legacy deterministic behavior.
+
+        Purpose: Validates that omitting the new parameter keeps the
+            deterministic obstacle-collision penalty active.
+
+        Given: A PushPOMDP constructed with default parameters.
+        When: ``obstacle_hit_probability`` is read.
+        Then: It equals ``1.0`` (deterministic-penalty regime).
+
+        Test type: unit
+        """
+        env = PushPOMDP(discount_factor=0.95)
+        assert env.obstacle_hit_probability == 1.0
+
+    def test_hit_probability_zero_never_applies_penalty(self):
+        """hit_probability=0 disables the obstacle-collision penalty.
+
+        Purpose: Validates the lower-bound of the stochastic penalty.
+
+        Given: A robot moving right from (2, 3) into the (3, 3) obstacle
+            with hit_probability=0.
+        When: ``reward()`` is called many times.
+        Then: The obstacle penalty is never added; reward equals the
+            base distance term.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.0)
+        state = self._collide_state()
+        np.random.seed(0)
+        # baseline distance-to-target reward (object stays at (8, 8); target (9, 9))
+        expected = -float(np.linalg.norm(state[2:4] - state[4:6]))
+        for _ in range(200):
+            assert env.reward(state, self.COLLIDE_ACTION) == pytest.approx(expected)
+
+    def test_hit_probability_one_matches_deterministic(self):
+        """hit_probability=1 matches legacy deterministic penalty.
+
+        Purpose: Regression check that the default behavior is preserved
+            when hit_probability=1.0 is passed explicitly.
+
+        Given: A robot moving right from (2, 3) into the (3, 3) obstacle
+            with hit_probability=1.0.
+        When: ``reward()`` is called many times.
+        Then: The obstacle penalty is always applied.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=1.0)
+        state = self._collide_state()
+        expected = -float(np.linalg.norm(state[2:4] - state[4:6])) + self.OBSTACLE_PENALTY
+        for _ in range(50):
+            assert env.reward(state, self.COLLIDE_ACTION) == pytest.approx(expected)
+
+    def test_hit_probability_zero_three_empirical_rate(self):
+        """Empirical hit rate matches hit_probability over many calls.
+
+        Purpose: Validates that the per-call Bernoulli draw matches the
+            configured probability over a large sample.
+
+        Given: A robot moving into an obstacle with hit_probability=0.3.
+        When: ``reward()`` is called 5000 times.
+        Then: Empirical hit rate is within 0.05 of 0.3.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.3)
+        state = self._collide_state()
+        baseline = -float(np.linalg.norm(state[2:4] - state[4:6]))
+        np.random.seed(123)
+        n_trials = 5000
+        hits = 0
+        for _ in range(n_trials):
+            r = env.reward(state, self.COLLIDE_ACTION)
+            if r == pytest.approx(baseline + self.OBSTACLE_PENALTY):
+                hits += 1
+        empirical_rate = hits / n_trials
+        assert abs(empirical_rate - 0.3) < 0.05
+
+    def test_reward_batch_honours_hit_probability(self):
+        """reward_batch applies stochastic penalty consistently with single-state.
+
+        Purpose: Validates that the batched reward path uses the same
+            Bernoulli mechanism as the single-state path.
+
+        Given: 5000 copies of a state moving into an obstacle with
+            hit_probability=0.3.
+        When: ``reward_batch()`` is called once.
+        Then: Empirical hit rate across the batch is within 0.05 of 0.3.
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.3)
+        state = self._collide_state()
+        baseline = -float(np.linalg.norm(state[2:4] - state[4:6]))
+        n_trials = 5000
+        states = np.tile(state, (n_trials, 1))
+        np.random.seed(456)
+        rewards = env.reward_batch(states, self.COLLIDE_ACTION)
+        hits = int(np.sum(np.isclose(rewards, baseline + self.OBSTACLE_PENALTY)))
+        empirical_rate = hits / n_trials
+        assert abs(empirical_rate - 0.3) < 0.05
+
+    def test_reward_batch_zero_probability_never_applies_penalty(self):
+        """reward_batch with hit_probability=0 returns no obstacle penalty.
+
+        Purpose: Validates the lower-bound of the stochastic penalty in
+            the batched path.
+
+        Given: A batch of in-zone next-state states with
+            hit_probability=0.0.
+        When: ``reward_batch()`` is called.
+        Then: All returned rewards equal the baseline distance reward
+            (no obstacle penalty added).
+
+        Test type: unit
+        """
+        env = self._stochastic_env(hit_probability=0.0)
+        state = self._collide_state()
+        baseline = -float(np.linalg.norm(state[2:4] - state[4:6]))
+        states = np.tile(state, (200, 1))
+        np.random.seed(789)
+        rewards = env.reward_batch(states, self.COLLIDE_ACTION)
+        assert np.allclose(rewards, baseline)
+
+    @pytest.mark.parametrize("bad_value", [-0.1, 1.5, 2.0, -1.0])
+    def test_invalid_hit_probability_raises(self, bad_value: float):
+        """Out-of-range hit_probability raises ValueError.
+
+        Purpose: Validates input validation on the new parameter.
+
+        Given: A hit_probability value outside [0, 1].
+        When: PushPOMDP is constructed.
+        Then: ValueError is raised mentioning the parameter name.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="obstacle_hit_probability"):
+            PushPOMDP(discount_factor=0.95, obstacle_hit_probability=bad_value)
+
+
 class TestSampleNextStepEquivalence:
     """Test that the optimized sample_next_step produces identical results to the base class."""
 


### PR DESCRIPTION
## Summary
- Adds ``obstacle_hit_probability`` parameter (default ``1.0``) to both ``PushPOMDP`` and ``ContinuousPushPOMDP``, mirroring the rock-sample (#138) and laser-tag (#135) pattern. Below ``1.0``, the obstacle-collision penalty is applied stochastically per ``reward()`` / ``reward_batch()`` call (per-row Bernoulli draw), producing a heavy-tailed return distribution suitable for benchmarking risk-sensitive planners (e.g. ICVaR-aware MCTS) against expected-value MCTS on the same env.
- Implementation is pure-Python: the Bernoulli draw lives in ``_reward_from_next_state`` and ``_obstacle_penalty_batch`` (PushPOMDP) and ``_reward_batch_array`` (ContinuousPushPOMDP). The native C++ rollouts apply the penalty deterministically, so when ``p < 1.0`` the rollout dispatcher in both envs falls back to the Python rollout to preserve per-step Bernoulli draws. ``transition_log_probability`` is unaffected; the obstacle still deterministically blocks movement.
- Adds ``TestStochasticObstacleHitProbability`` and ``TestContinuousPushStochasticObstacleHitProbability`` (7 tests each, 20 total including parametrized cases): default value, p=0 / p=1 boundaries, empirical hit-rate at p=0.3 (single + batch), batch zero-output check, and out-of-range validation.

## Test plan
- [x] Pyright: 0 errors / 0 warnings on changed source + test files
- [x] Pylint: 10.00/10 on changed source files; test-file score improved (9.74 → 9.77, all remaining warnings pre-existing in untouched code)
- [x] ``pytest POMDPPlanners/tests/test_environments/test_push_pomdp/`` — 224 passed (including the 20 new stochastic-penalty tests)
- [x] Default behavior byte-identical when ``obstacle_hit_probability`` is omitted (legacy callers see no change; native C++ rollout fast path is preserved)