### PR TITLE
fix(lasertag): pickle hooks for cached pybind11 refs (weekly slow tests)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,8 +84,14 @@ jobs:
         docker run --rm --entrypoint pyright pomdpplanners-test:latest POMDPPlanners/
 
     - name: Run unit tests inside Docker
+      # Run the full suite (slow tests included) on direct pushes to or PRs
+      # targeting master/develop, so regressions in slow integration tests
+      # are caught at PR time rather than by the weekly cron.
       run: |
-        if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+        if [ "${{ github.ref }}" = "refs/heads/master" ] \
+          || [ "${{ github.ref }}" = "refs/heads/develop" ] \
+          || [ "${{ github.base_ref }}" = "master" ] \
+          || [ "${{ github.base_ref }}" = "develop" ]; then
           docker run --rm --entrypoint pytest pomdpplanners-test:latest POMDPPlanners/tests/ -v --cov=POMDPPlanners --cov-report=xml --cov-report=term-missing
         else
           docker run --rm --entrypoint pytest pomdpplanners-test:latest POMDPPlanners/tests/ -v --cov=POMDPPlanners --cov-report=xml --cov-report=term-missing -m "not slow"

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -268,6 +268,23 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             a: [b for b in (0, 1, 2, 3) if b != a] for a in (0, 1, 2, 3)
         }
 
+    def __getstate__(self) -> Dict[str, Any]:
+        # The native step / rollout / reward_batch caches and the vectorized
+        # updater cache hold pybind11 module/function references that aren't
+        # picklable (and would crash joblib's task-cache hashing — see the
+        # weekly-slow-tests JoblibTaskManager regression). Drop them at
+        # serialization time; the lazy ``_get_*`` accessors rebuild them on
+        # demand after unpickling.
+        state = self.__dict__.copy()
+        state.pop("_cached_native_step_params", None)
+        state.pop("_cached_native_rollout_params", None)
+        state.pop("_cached_native_reward_batch", None)
+        state.pop("_cached_vectorized_updater", None)
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        vars(self).update(state)
+
     def _is_valid_position_inline(self, pos: Tuple[int, int]) -> bool:
         row, col = pos
         return (

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -2087,6 +2087,68 @@ class TestNativeDiscreteRollout:
         assert abs(result) <= max_abs + 1e-9
 
 
+class TestLaserTagPOMDPPickling:
+    """Regression tests for joblib-hashing/pickling LaserTagPOMDP after the
+    cached-pybind11-kernel perf work landed (see issue: weekly-slow-tests
+    failing with PicklingError on pybind11_detail_function_record).
+    """
+
+    def test_joblib_hash_after_native_kernel_warmup(self):
+        """Hashing a LaserTagPOMDP whose native caches were populated must not raise.
+
+        Purpose: Regression for JoblibTaskManager memoize crash where the
+            cached pybind11 module/function references on LaserTagPOMDP made
+            the env unhashable for joblib.
+
+        Given: A LaserTagPOMDP whose native step / rollout / reward_batch
+            caches have been warmed by exercising the public API
+        When: joblib.hash and pickle.dumps are called on the env
+        Then: Both succeed (no PicklingError on pybind11 internals)
+
+        Test type: unit
+        """
+        # pylint: disable=import-outside-toplevel
+        import pickle
+
+        import joblib
+
+        env = _make_env()
+        # Warm every cache that previously held a pybind11 reference.
+        env._get_native_step_params()  # type: ignore[attr-defined]  # pylint: disable=protected-access
+        env._get_native_rollout_params()  # type: ignore[attr-defined]  # pylint: disable=protected-access
+        env._get_native_reward_batch()  # type: ignore[attr-defined]  # pylint: disable=protected-access
+        # Vectorized updater is built lazily by sample_next_state_batch.
+        state = env.initial_state_dist().sample()[0]
+        env.sample_next_state_batch(np.asarray([state]), action=0)
+
+        joblib.hash(env)
+        pickle.loads(pickle.dumps(env))
+
+    def test_unpickled_env_rebuilds_caches(self):
+        """A LaserTagPOMDP round-tripped through pickle still works.
+
+        Purpose: After __setstate__ drops the pybind11 caches, calling the
+            native fast paths on the restored env must lazily rebuild them
+            without error.
+
+        Given: A pickled-then-unpickled LaserTagPOMDP
+        When: A native fast-path entry point is invoked
+        Then: It returns a valid result identical in shape/type to the original
+
+        Test type: unit
+        """
+        # pylint: disable=import-outside-toplevel
+        import pickle
+
+        env = _make_env()
+        env._get_native_step_params()  # type: ignore[attr-defined]  # pylint: disable=protected-access
+        restored: LaserTagPOMDP = pickle.loads(pickle.dumps(env))
+        state = restored.initial_state_dist().sample()[0]
+        next_state = restored.sample_next_state(state, action=0, n_samples=1)
+        assert isinstance(next_state, np.ndarray)
+        assert next_state.shape == state.shape
+
+
 if __name__ == "__main__":
     # Run tests if script is executed directly
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Fixes the pickling crash that broke the **Weekly Slow Tests** workflow on 2026-04-27 and 2026-05-04 (runs [24978609938](https://github.com/yaacovpariente/POMDPPlanners/actions/runs/24978609938) and [25303413391](https://github.com/yaacovpariente/POMDPPlanners/actions/runs/25303413391)).
- Adds `__getstate__` / `__setstate__` to `LaserTagPOMDP` that drop the four cached pybind11 references (`_cached_native_step_params`, `_cached_native_rollout_params`, `_cached_native_reward_batch`, `_cached_vectorized_updater`) at serialization time. The lazy `_get_*` accessors rebuild them on demand. Mirrors the pattern already in `cartpole`, `mountain_car`, `push`, `pacman`, `rock_sample`, `continuous_laser_tag`, etc.
- Extends `tests.yml` to run the full suite (slow tests included) on direct pushes to **and** PRs targeting `master`/`develop`, so a regression like this is caught at PR time instead of waiting for the Monday 03:00 UTC cron.

## Root cause

`JoblibTaskManager._cached_run = self.memory.cache(self._run_single_task)` joblib-hashes `{'self': task_manager, 'task': EpisodeSimulationTask}` on every call. For tasks whose env is a `LaserTagPOMDP` whose native fast paths have run at least once, the hash walker hits the cached pybind11 module/function references and crashes:

```
_pickle.PicklingError: Can't pickle <class 'pybind11_builtins.pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1'>
```

The recent perf commits between Apr 20 and Apr 27 added the caches but did not pair them with `__getstate__` / `__setstate__` on this one env. Every sister env that did the same perf work already had the hooks, so `LaserTagPOMDP` was the lone outlier.

## Test plan

- [x] New `TestLaserTagPOMDPPickling` regression: warms every native cache, then asserts `joblib.hash` and `pickle.dumps` succeed; round-trips through pickle and re-exercises the native fast path to prove the caches rebuild lazily. Confirmed failing on master (same `pybind11_detail_function_record_v1*` PicklingError as CI), passing after the fix.
- [x] Both originally-failing slow tests now pass locally:
  - `test_simulations/test_hyper_parameter_tuning_simulations.py::TestSingleEnvironmentOptimizationSmoke::test_single_environment_optimization_laser_tag_pft_dpw`
  - `test_simulations/test_simulations_apis/test_local_simulations_api.py::TestLocalSimulationsAPIIntegration::test_run_all_hyperparameter_benchmarks_integration`
- [x] All 210 `test_laser_tag_pomdp/` tests pass.
- [x] Whole-tree pyright clean (only the pre-existing `core/environment.py:345` warning).
- [x] Pylint 10.00/10 on the modified source file.
- [x] CI (`tests.yml`) on this PR will now exercise the slow suite end-to-end against this branch — the real verification that the regression is gone.