### PR TITLE
feat(push): add dangerous areas across all Push variants

### DIFF
--- a/POMDPPlanners/environments/push_pomdp/_cpp/continuous_push.cpp
+++ b/POMDPPlanners/environments/push_pomdp/_cpp/continuous_push.cpp
@@ -513,6 +513,40 @@ std::vector<double> load_discrete_obstacles(const py::array_t<double> &obstacles
     return out;
 }
 
+// Load dangerous-area centres: shape (K, 2), (0, 2), or (0,) 1-D for empty.
+// Returns flat (cx, cy) pairs.
+std::vector<double> load_dangerous_areas(const py::array_t<double> &areas) {
+    if (areas.ndim() == 1 && areas.shape(0) == 0) {
+        return {};
+    }
+    if (areas.ndim() != 2 || areas.shape(1) != 2) {
+        throw std::invalid_argument("dangerous_areas must have shape (K, 2)");
+    }
+    const auto k = static_cast<std::size_t>(areas.shape(0));
+    std::vector<double> out(k * 2);
+    auto u = areas.unchecked<2>();
+    for (std::size_t i = 0; i < k; ++i) {
+        out[i * 2 + 0] = u(static_cast<py::ssize_t>(i), 0);
+        out[i * 2 + 1] = u(static_cast<py::ssize_t>(i), 1);
+    }
+    return out;
+}
+
+// Returns true if (px, py) is within dangerous_area_radius_sq of any centre.
+static inline bool point_in_dangerous_areas(double px, double py,
+                                            const std::vector<double> &areas,
+                                            double radius_sq) noexcept {
+    const std::size_t k = areas.size() / 2;
+    for (std::size_t i = 0; i < k; ++i) {
+        const double dx = px - areas[i * 2 + 0];
+        const double dy = py - areas[i * 2 + 1];
+        if (dx * dx + dy * dy <= radius_sq) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // Returns true if (px, py) is within obstacle_radius_sq of any obstacle.
 static inline bool discrete_collides(double px, double py,
                                      const std::vector<double> &obstacles,
@@ -538,6 +572,9 @@ static double discrete_step(const double *state, int action_idx, double *next_st
                              double push_scale, double obstacle_radius_sq,
                              const std::vector<double> &obstacles,
                              double obstacle_penalty,
+                             const std::vector<double> &dangerous_areas,
+                             double dangerous_area_radius_sq,
+                             double dangerous_area_penalty,
                              pomdp_native::RNGState &rng,
                              double transition_error_prob) {
     // Resolve action error ---------------------------------------------------
@@ -621,16 +658,22 @@ static double discrete_step(const double *state, int action_idx, double *next_st
     // Obstacle penalty: applied if the INTENDED robot position (state[:2]+dxy)
     // collides with an obstacle — mirrors _reward_from_next_state which calls
     // _is_colliding_with_obstacle(state[:2], action).
+    const int rdx_int = kDiscreteDXY[static_cast<std::size_t>(action_idx)][0];
+    const int rdy_int = kDiscreteDXY[static_cast<std::size_t>(action_idx)][1];
+    const double intended_rx = rx + static_cast<double>(rdx_int);
+    const double intended_ry = ry + static_cast<double>(rdy_int);
     if (!obstacles.empty()) {
-        // intended_robot = (state[0] + dx, state[1] + dy) — uses original
-        // action's dx/dy (action_idx, not actual_idx, because reward checks
-        // the intended move, not the noise-corrupted one).
-        const int rdx_int = kDiscreteDXY[static_cast<std::size_t>(action_idx)][0];
-        const int rdy_int = kDiscreteDXY[static_cast<std::size_t>(action_idx)][1];
-        const double intended_rx = rx + static_cast<double>(rdx_int);
-        const double intended_ry = ry + static_cast<double>(rdy_int);
         if (discrete_collides(intended_rx, intended_ry, obstacles, obstacle_radius_sq)) {
             reward += obstacle_penalty;
+        }
+    }
+    // Dangerous-area penalty: applied at most once per step when the intended
+    // robot position lies inside any dangerous area. Penalty is additive (negative)
+    // and parallels the obstacle penalty above.
+    if (!dangerous_areas.empty()) {
+        if (point_in_dangerous_areas(intended_rx, intended_ry, dangerous_areas,
+                                     dangerous_area_radius_sq)) {
+            reward += dangerous_area_penalty;
         }
     }
     return reward;
@@ -837,7 +880,10 @@ double simulate_rollout_discrete(
     int max_depth, int depth, double discount, double grid_size,
     double push_threshold, double friction_coefficient,
     py::array_t<double, py::array::c_style | py::array::forcecast> obstacles_arr,
-    double obstacle_radius, double obstacle_penalty, double transition_error_prob) {
+    double obstacle_radius, double obstacle_penalty,
+    py::array_t<double, py::array::c_style | py::array::forcecast> dangerous_areas_arr,
+    double dangerous_area_radius, double dangerous_area_penalty,
+    double transition_error_prob) {
     if (state_arr.ndim() != 1 || state_arr.shape(0) != 6) {
         throw std::invalid_argument("state must be a 1-D array of length 6");
     }
@@ -853,12 +899,16 @@ double simulate_rollout_discrete(
     const double push_threshold_sq = push_threshold * push_threshold;
     const double push_scale = 1.0 - friction_coefficient;
     const double obstacle_radius_sq = obstacle_radius * obstacle_radius;
+    const double dangerous_area_radius_sq = dangerous_area_radius * dangerous_area_radius;
 
     // Load obstacles (M, 2) flat.
     std::vector<double> obstacles;
     if (!(obstacles_arr.ndim() == 1 && obstacles_arr.shape(0) == 0)) {
         obstacles = load_discrete_obstacles(obstacles_arr);
     }
+
+    // Load dangerous areas (K, 2) flat.
+    std::vector<double> dangerous_areas = load_dangerous_areas(dangerous_areas_arr);
 
     // Copy initial state into a mutable buffer.
     double cur[6];  // NOLINT(modernize-avoid-c-arrays)
@@ -882,8 +932,11 @@ double simulate_rollout_discrete(
         const double r = discrete_step(cur, action_idx, nxt, grid_max,
                                        push_threshold_sq, push_scale,
                                        obstacle_radius_sq, obstacles,
-                                       obstacle_penalty, rng,
-                                       transition_error_prob);
+                                       obstacle_penalty,
+                                       dangerous_areas,
+                                       dangerous_area_radius_sq,
+                                       dangerous_area_penalty,
+                                       rng, transition_error_prob);
         total += gamma_power * r;
         gamma_power *= discount;
         std::copy(nxt, nxt + 6, cur);
@@ -1049,6 +1102,8 @@ double cont_simulate_rollout(
     double grid_size, double push_threshold, double friction_coefficient,
     double max_push, double robot_radius, double obstacle_penalty,
     const py::array_t<double, py::array::c_style | py::array::forcecast> &obstacles,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &dangerous_areas,
+    double dangerous_area_radius, double dangerous_area_penalty,
     const py::array_t<double> &covariance) {
 
     if (initial_state.ndim() != 1 ||
@@ -1080,6 +1135,9 @@ double cont_simulate_rollout(
             obs_flat[i * 4 + 3] = obs_v(static_cast<py::ssize_t>(i), 3);
         }
     }
+
+    std::vector<double> dangerous_flat = load_dangerous_areas(dangerous_areas);
+    const double dangerous_area_radius_sq = dangerous_area_radius * dangerous_area_radius;
 
     const auto noise = pomdp_native::GaussianND<kNoiseDim>::from_covariance(covariance);
 
@@ -1126,14 +1184,25 @@ double cont_simulate_rollout(
             reward += 100.0;
         }
 
+        double robot_after[kNoiseDim] = {  // NOLINT(modernize-avoid-c-arrays)
+            state[0] + action[0], state[1] + action[1]};
         if (n_obs > 0 && obstacle_penalty != 0.0) {
-            double robot_after[kNoiseDim] = {  // NOLINT(modernize-avoid-c-arrays)
-                state[0] + action[0], state[1] + action[1]};
             for (std::size_t i = 0; i < n_obs; ++i) {
                 if (cont_circle_aabb_overlap(robot_after, robot_radius, &obs_flat[i * 4])) {
                     reward += obstacle_penalty;
                     break;
                 }
+            }
+        }
+        // Dangerous-area penalty: applied at most once when the post-action
+        // robot position lies inside any dangerous area. Mirrors the Python
+        // ``_reward_batch_array`` block that calls
+        // ``_batch_robot_in_dangerous_areas``.
+        if (!dangerous_flat.empty() && dangerous_area_penalty != 0.0) {
+            if (point_in_dangerous_areas(robot_after[0], robot_after[1],
+                                         dangerous_flat,
+                                         dangerous_area_radius_sq)) {
+                reward += dangerous_area_penalty;
             }
         }
 
@@ -1401,19 +1470,30 @@ PYBIND11_MODULE(_native, m) {
           py::arg("max_depth"), py::arg("start_depth"), py::arg("discount_factor"),
           py::arg("grid_size"), py::arg("push_threshold"), py::arg("friction_coefficient"),
           py::arg("max_push"), py::arg("robot_radius"), py::arg("obstacle_penalty"),
-          py::arg("obstacles"), py::arg("covariance"),
+          py::arg("obstacles"), py::arg("dangerous_areas"),
+          py::arg("dangerous_area_radius"), py::arg("dangerous_area_penalty"),
+          py::arg("covariance"),
           "Native random rollout for ContinuousPushPOMDP. "
           "Returns discounted return from initial_state. "
           "action_indices must be a pre-drawn int32 array of shape (steps_left,). "
-          "obstacles must have shape (M, 4) with rows (cx, cy, hx, hy).");
+          "obstacles must have shape (M, 4) with rows (cx, cy, hx, hy). "
+          "dangerous_areas must have shape (K, 2) (or (0, 2) when empty); each "
+          "row is the (x, y) centre of a circular dangerous area of radius "
+          "``dangerous_area_radius``. Robots inside any zone after the action "
+          "incur ``dangerous_area_penalty`` (at most once per step).");
 
     m.def("simulate_rollout_discrete", &simulate_rollout_discrete,
           py::arg("state"), py::arg("action_indices"), py::arg("max_depth"),
           py::arg("depth"), py::arg("discount"), py::arg("grid_size"),
           py::arg("push_threshold"), py::arg("friction_coefficient"),
           py::arg("obstacles"), py::arg("obstacle_radius"),
-          py::arg("obstacle_penalty"), py::arg("transition_error_prob"),
-          "Run a full discrete Push rollout in C++. Returns discounted reward sum.");
+          py::arg("obstacle_penalty"),
+          py::arg("dangerous_areas"), py::arg("dangerous_area_radius"),
+          py::arg("dangerous_area_penalty"),
+          py::arg("transition_error_prob"),
+          "Run a full discrete Push rollout in C++. Returns discounted reward sum. "
+          "dangerous_areas must have shape (K, 2) (or empty). Penalty applied "
+          "once per step when the intended robot position lies in any zone.");
 
     m.def("belief_batch_transition_discrete", &belief_batch_transition_discrete,
           py::arg("particles"), py::arg("action_idx"), py::arg("transition_error_prob"),

--- a/POMDPPlanners/environments/push_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/push_pomdp/_native.pyi
@@ -28,12 +28,20 @@ def simulate_rollout_discrete(
     obstacles: NDArray[np.float64],
     obstacle_radius: float,
     obstacle_penalty: float,
+    dangerous_areas: NDArray[np.floating],
+    dangerous_area_radius: float,
+    dangerous_area_penalty: float,
     transition_error_prob: float,
 ) -> float:
     """Run a full discrete Push POMDP rollout in C++.
 
     Returns the discounted sum of immediate rewards along the sampled
     trajectory, using pre-drawn action indices supplied by the caller.
+
+    ``dangerous_areas`` must have shape ``(K, 2)`` (rows ``(cx, cy)``) or
+    be empty. The penalty is applied at most once per step when the
+    intended robot position falls inside any zone of radius
+    ``dangerous_area_radius``.
     """
     ...
 
@@ -51,6 +59,9 @@ def cont_simulate_rollout(
     robot_radius: float,
     obstacle_penalty: float,
     obstacles: NDArray[np.floating],
+    dangerous_areas: NDArray[np.floating],
+    dangerous_area_radius: float,
+    dangerous_area_penalty: float,
     covariance: NDArray[np.floating],
 ) -> float:
     """Native random rollout for ContinuousPushPOMDP.
@@ -59,6 +70,11 @@ def cont_simulate_rollout(
     ``action_indices`` must be a pre-drawn int32 array of shape
     ``(steps_left,)``.  ``obstacles`` must have shape ``(M, 4)`` with
     rows ``(cx, cy, hx, hy)``.
+
+    ``dangerous_areas`` must have shape ``(K, 2)`` (rows ``(cx, cy)``) or
+    be empty. The penalty is applied at most once per step when the
+    post-action robot position lies inside any zone of radius
+    ``dangerous_area_radius``.
     """
     ...
 

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -57,6 +57,8 @@ class ContinuousPushPOMDPMetrics(Enum):
     TOTAL_ROBOT_OBSTACLE_COLLISIONS = "total_robot_obstacle_collisions"
     TOTAL_OBJECT_OBSTACLE_COLLISIONS = "total_object_obstacle_collisions"
     TOTAL_ALL_OBSTACLE_COLLISIONS = "total_all_obstacle_collisions"
+    DANGEROUS_AREA_RATE = "dangerous_area_rate"
+    TOTAL_DANGEROUS_AREA_STEPS = "total_dangerous_area_steps"
 
 
 class _FixedStateDistribution(Distribution):
@@ -130,6 +132,21 @@ class ContinuousPushPOMDP(Environment):
         deducts the penalty deterministically) is bypassed in favour of
         the Python rollout so per-step Bernoulli draws survive.
 
+    Dangerous areas:
+        ``dangerous_areas`` is a separate, additive concept from
+        ``obstacles``. Each entry is a circular region centred at
+        ``(x, y)`` with radius ``dangerous_area_radius``. Entering a
+        dangerous area applies ``dangerous_area_penalty`` (a negative
+        number, added to reward) but does NOT block movement (unlike
+        obstacles, which act as walls in the continuous variant). The
+        penalty fires when the post-action robot position lies inside
+        any dangerous area; the object position is ignored. At most one
+        ``dangerous_area_penalty`` is applied per step even when
+        multiple zones overlap. Like obstacles, the penalty supports a
+        Bernoulli ``dangerous_area_hit_probability`` (default 1.0) for
+        risk-sensitive planning; ``< 1.0`` bypasses the deterministic
+        native rollout in favour of the Python rollout.
+
     Example:
         >>> import numpy as np
         >>> np.random.seed(42)
@@ -145,7 +162,7 @@ class ContinuousPushPOMDP(Environment):
         False
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments,too-many-locals
         self,
         discount_factor: float,
         grid_size: int = 10,
@@ -156,6 +173,10 @@ class ContinuousPushPOMDP(Environment):
         obstacles: Optional[List[Tuple[float, float, float]]] = None,
         obstacle_penalty: float = -10.0,
         obstacle_hit_probability: float = 1.0,
+        dangerous_areas: Optional[List[Tuple[float, float]]] = None,
+        dangerous_area_radius: float = 0.5,
+        dangerous_area_penalty: float = -10.0,
+        dangerous_area_hit_probability: float = 1.0,
         robot_radius: float = 0.3,
         state_transition_cov_matrix: np.ndarray = np.eye(2) * 0.1,
         initial_state: Optional[np.ndarray] = None,
@@ -166,6 +187,8 @@ class ContinuousPushPOMDP(Environment):
     ):
         if not 0.0 <= obstacle_hit_probability <= 1.0:
             raise ValueError("obstacle_hit_probability must be between 0 and 1 (inclusive)")
+        if not 0.0 <= dangerous_area_hit_probability <= 1.0:
+            raise ValueError("dangerous_area_hit_probability must be between 0 and 1 (inclusive)")
 
         self.grid_size = grid_size
         self.push_threshold = push_threshold
@@ -182,6 +205,19 @@ class ContinuousPushPOMDP(Environment):
             obstacles if obstacles is not None else []
         )
         self.obstacles = self._build_obstacle_array(self._obstacle_tuples)
+
+        self.dangerous_areas: List[Tuple[float, float]] = (
+            list(dangerous_areas) if dangerous_areas is not None else []
+        )
+        self.dangerous_area_radius = float(dangerous_area_radius)
+        self.dangerous_area_penalty = float(dangerous_area_penalty)
+        self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
+        if self.dangerous_areas:
+            self._dangerous_areas_arr: np.ndarray = np.ascontiguousarray(
+                np.asarray(self.dangerous_areas, dtype=np.float64).reshape(-1, 2)
+            )
+        else:
+            self._dangerous_areas_arr = np.empty((0, 2), dtype=np.float64)
 
         self.target_pos = np.array([grid_size - 1.0, grid_size - 1.0])
 
@@ -217,6 +253,8 @@ class ContinuousPushPOMDP(Environment):
         )
         max_distance = np.sqrt(2) * (grid_size - 1)
         min_reward = -max_distance + self.obstacle_penalty
+        if self.dangerous_areas:
+            min_reward += min(0.0, self.dangerous_area_penalty)
         max_reward = 100.0
 
         super().__init__(
@@ -430,7 +468,28 @@ class ContinuousPushPOMDP(Environment):
             if np.any(collide):
                 rewards[collide] += self.obstacle_penalty
 
+        # Dangerous-area penalty: post-action robot position vs. circular
+        # zones. At most one penalty per row even when zones overlap.
+        if self._dangerous_areas_arr.shape[0] > 0:
+            robot_after = states[:, :2] + action  # (N, 2)
+            in_zone = self._batch_robot_in_dangerous_areas(robot_after)
+            if self.dangerous_area_hit_probability < 1.0:
+                applied = np.random.random(in_zone.shape[0]) < self.dangerous_area_hit_probability
+                in_zone = in_zone & applied
+            if np.any(in_zone):
+                rewards[in_zone] += self.dangerous_area_penalty
+
         return rewards
+
+    def _batch_robot_in_dangerous_areas(self, positions: np.ndarray) -> np.ndarray:
+        """Vectorised point-in-circle test against ``self._dangerous_areas_arr``.
+
+        ``positions`` is shape ``(N, 2)``. Returns an ``(N,)`` boolean mask
+        flagging rows that fall inside any dangerous-area circle.
+        """
+        diff = positions[:, None, :] - self._dangerous_areas_arr[None, :, :]
+        dist_sq = np.einsum("ijk,ijk->ij", diff, diff)
+        return np.any(dist_sq <= self.dangerous_area_radius * self.dangerous_area_radius, axis=1)
 
     def _batch_circle_obstacle_overlap(self, positions: np.ndarray, radius: float) -> np.ndarray:
         """Vectorised circle-vs-AABB overlap test against ``self.obstacles``.
@@ -526,10 +585,14 @@ class ContinuousPushPOMDP(Environment):
             return 0.0
 
         actions_array = self._get_rollout_actions_array()
-        if actions_array is None or self.obstacle_hit_probability < 1.0:
-            # Native kernel applies the obstacle penalty deterministically;
-            # fall back to the Python rollout so per-step Bernoulli draws
-            # against ``obstacle_hit_probability`` survive.
+        if (
+            actions_array is None
+            or self.obstacle_hit_probability < 1.0
+            or self.dangerous_area_hit_probability < 1.0
+        ):
+            # Native kernel applies the obstacle and dangerous-area penalties
+            # deterministically; fall back to the Python rollout so per-step
+            # Bernoulli draws against the configured hit probabilities survive.
             return python_random_rollout(
                 state=state,
                 depth=depth,
@@ -558,6 +621,9 @@ class ContinuousPushPOMDP(Environment):
                 robot_radius=float(self.robot_radius),
                 obstacle_penalty=float(self.obstacle_penalty),
                 obstacles=np.ascontiguousarray(self.obstacles, dtype=np.float64),
+                dangerous_areas=self._dangerous_areas_arr,
+                dangerous_area_radius=float(self.dangerous_area_radius),
+                dangerous_area_penalty=float(self.dangerous_area_penalty),
                 covariance=self._trans_cov_view,
             )
         )
@@ -625,6 +691,13 @@ class ContinuousPushPOMDP(Environment):
                 return True
         return False
 
+    def _is_robot_in_dangerous_area(self, pos: np.ndarray) -> bool:
+        if self._dangerous_areas_arr.shape[0] == 0:
+            return False
+        r_sq = self.dangerous_area_radius * self.dangerous_area_radius
+        diff = self._dangerous_areas_arr - np.asarray(pos, dtype=np.float64)
+        return bool(np.any(np.einsum("ij,ij->i", diff, diff) <= r_sq))
+
     # ------------------------------------------------------------------
     # Metrics
     # ------------------------------------------------------------------
@@ -637,16 +710,20 @@ class ContinuousPushPOMDP(Environment):
         """
         return [m.value for m in ContinuousPushPOMDPMetrics]
 
-    def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
+    def compute_metrics(  # pylint: disable=too-many-locals
+        self, histories: List[History]
+    ) -> List[MetricValue]:
         goal_reached_list: List[int] = []
         robot_col_list: List[int] = []
         obj_col_list: List[int] = []
         total_col_list: List[int] = []
+        dangerous_steps_list: List[int] = []
 
         for history in histories:
             goal_hit = False
             r_cols = 0
             o_cols = 0
+            d_steps = 0
 
             for step in history.history:
                 if self.is_terminal(step.state):
@@ -655,24 +732,32 @@ class ContinuousPushPOMDP(Environment):
                     r_cols += 1
                 if self._is_point_colliding_with_obstacle(step.state[2:4]):
                     o_cols += 1
+                if self._is_robot_in_dangerous_area(step.state[:2]):
+                    d_steps += 1
 
             goal_reached_list.append(1 if goal_hit else 0)
             robot_col_list.append(r_cols)
             obj_col_list.append(o_cols)
             total_col_list.append(r_cols + o_cols)
+            dangerous_steps_list.append(d_steps)
 
         total_steps = sum(len(h.history) for h in histories)
         avg_r = sum(robot_col_list) / total_steps if total_steps > 0 else 0
         avg_o = sum(obj_col_list) / total_steps if total_steps > 0 else 0
         avg_t = sum(total_col_list) / total_steps if total_steps > 0 else 0
+        avg_d = sum(dangerous_steps_list) / total_steps if total_steps > 0 else 0
 
         r_rates = [c / len(h.history) for c, h in zip(robot_col_list, histories) if len(h.history)]
         o_rates = [c / len(h.history) for c, h in zip(obj_col_list, histories) if len(h.history)]
         t_rates = [c / len(h.history) for c, h in zip(total_col_list, histories) if len(h.history)]
+        d_rates = [
+            c / len(h.history) for c, h in zip(dangerous_steps_list, histories) if len(h.history)
+        ]
 
         r_ci = confidence_interval(data=r_rates, confidence=0.95) if r_rates else (0, 0)
         o_ci = confidence_interval(data=o_rates, confidence=0.95) if o_rates else (0, 0)
         t_ci = confidence_interval(data=t_rates, confidence=0.95) if t_rates else (0, 0)
+        d_ci = confidence_interval(data=d_rates, confidence=0.95) if d_rates else (0, 0)
 
         tr_ci = (
             confidence_interval(data=robot_col_list, confidence=0.95) if robot_col_list else (0, 0)
@@ -680,6 +765,11 @@ class ContinuousPushPOMDP(Environment):
         to_ci = confidence_interval(data=obj_col_list, confidence=0.95) if obj_col_list else (0, 0)
         ta_ci = (
             confidence_interval(data=total_col_list, confidence=0.95) if total_col_list else (0, 0)
+        )
+        td_ci = (
+            confidence_interval(data=dangerous_steps_list, confidence=0.95)
+            if dangerous_steps_list
+            else (0, 0)
         )
 
         avg_goal = float(np.mean(goal_reached_list)) if goal_reached_list else 0.0
@@ -729,6 +819,18 @@ class ContinuousPushPOMDP(Environment):
                 ta_ci[0],
                 ta_ci[1],
             ),
+            MetricValue(
+                ContinuousPushPOMDPMetrics.DANGEROUS_AREA_RATE.value,
+                avg_d,
+                d_ci[0],
+                d_ci[1],
+            ),
+            MetricValue(
+                ContinuousPushPOMDPMetrics.TOTAL_DANGEROUS_AREA_STEPS.value,
+                float(np.mean(dangerous_steps_list)) if dangerous_steps_list else 0.0,
+                td_ci[0],
+                td_ci[1],
+            ),
         ]
 
 
@@ -754,7 +856,7 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
         False
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments,too-many-locals
         self,
         discount_factor: float,
         grid_size: int = 10,
@@ -765,6 +867,10 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
         obstacles: Optional[List[Tuple[float, float, float]]] = None,
         obstacle_penalty: float = -10.0,
         obstacle_hit_probability: float = 1.0,
+        dangerous_areas: Optional[List[Tuple[float, float]]] = None,
+        dangerous_area_radius: float = 0.5,
+        dangerous_area_penalty: float = -10.0,
+        dangerous_area_hit_probability: float = 1.0,
         robot_radius: float = 0.3,
         state_transition_cov_matrix: np.ndarray = np.eye(2) * 0.1,
         initial_state: Optional[np.ndarray] = None,
@@ -783,6 +889,10 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
             obstacles=obstacles,
             obstacle_penalty=obstacle_penalty,
             obstacle_hit_probability=obstacle_hit_probability,
+            dangerous_areas=dangerous_areas,
+            dangerous_area_radius=dangerous_area_radius,
+            dangerous_area_penalty=dangerous_area_penalty,
+            dangerous_area_hit_probability=dangerous_area_hit_probability,
             robot_radius=robot_radius,
             state_transition_cov_matrix=state_transition_cov_matrix,
             initial_state=initial_state,

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp_visualizer.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp_visualizer.py
@@ -58,6 +58,8 @@ class ContinuousPushPOMDPVisualizer:
         self.push_threshold = env.push_threshold
         self.obstacles = env.obstacles
         self.robot_radius = env.robot_radius
+        self.dangerous_areas = env.dangerous_areas
+        self.dangerous_area_radius = env.dangerous_area_radius
 
     def create_visualization(self, history: List[StepData], cache_path: Path) -> None:
         """Create animated visualization of a Continuous Push POMDP episode.
@@ -80,6 +82,7 @@ class ContinuousPushPOMDPVisualizer:
         robot_scatter, object_scatter, target_scatter = self._initialize_entity_scatters(ax)
         robot_circle_patch = self._initialize_robot_circle(ax)
         self._initialize_obstacles(ax)
+        self._initialize_dangerous_areas(ax)
         push_arrow, connection_line = self._initialize_push_visuals(ax)
         action_arrow = self._initialize_action_arrow(ax)
         step_text, distance_text, reward_text, success_text, collision_text = (
@@ -241,6 +244,19 @@ class ContinuousPushPOMDPVisualizer:
             ax.add_patch(rect)
             if i == 0:
                 ax.scatter(cx, cy, s=1, c="red", label="Obstacles")
+
+    def _initialize_dangerous_areas(self, ax: Axes) -> None:
+        for i, (cx, cy) in enumerate(self.dangerous_areas):
+            danger_circle = Circle(
+                (cx, cy),
+                float(self.dangerous_area_radius),  # type: ignore[arg-type]
+                facecolor="red",
+                edgecolor="none",
+                alpha=0.3,
+                zorder=1,
+                label="Dangerous Areas" if i == 0 else "",
+            )
+            ax.add_patch(danger_circle)
 
     def _initialize_push_visuals(self, ax: Axes) -> Tuple[Any, Line2D]:
         push_arrow = ax.annotate(

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -53,6 +53,8 @@ class PushPOMDPMetrics(Enum):
     TOTAL_ROBOT_OBSTACLE_COLLISIONS = "total_robot_obstacle_collisions"
     TOTAL_OBJECT_OBSTACLE_COLLISIONS = "total_object_obstacle_collisions"
     TOTAL_ALL_OBSTACLE_COLLISIONS = "total_all_obstacle_collisions"
+    DANGEROUS_AREA_RATE = "dangerous_area_rate"
+    TOTAL_DANGEROUS_AREA_STEPS = "total_dangerous_area_steps"
 
 
 class FixedStateDistribution(Distribution):
@@ -153,6 +155,21 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         deducts the penalty deterministically) is bypassed in favour of
         the pure-Python rollout so per-step Bernoulli draws survive.
 
+    Dangerous areas:
+        ``dangerous_areas`` is a separate, additive concept from
+        ``obstacles``. Each entry is a circular region centred at
+        ``(x, y)`` with radius ``dangerous_area_radius``. Entering a
+        dangerous area applies ``dangerous_area_penalty`` (a negative
+        number, added to reward — same sign convention as
+        ``obstacle_penalty``) but does NOT block movement. Penalty fires
+        when the robot's intended next position lies inside any
+        dangerous area; the object position is ignored. At most one
+        ``dangerous_area_penalty`` is applied per step even when
+        multiple zones overlap. Like obstacles, the penalty supports a
+        Bernoulli ``dangerous_area_hit_probability`` (default 1.0) for
+        risk-sensitive planning; ``< 1.0`` bypasses the deterministic
+        native rollout in favour of the Python path.
+
     Example:
         >>> import numpy as np
         >>> np.random.seed(42)  # For reproducible results
@@ -183,7 +200,7 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         "left": (-1, 0),
     }
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments,too-many-locals
         self,
         discount_factor: float,
         grid_size: int = 10,
@@ -194,6 +211,10 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         obstacle_radius: float = 0.5,
         obstacle_penalty: float = -10.0,
         obstacle_hit_probability: float = 1.0,
+        dangerous_areas: Optional[List[Tuple[float, float]]] = None,
+        dangerous_area_radius: float = 0.5,
+        dangerous_area_penalty: float = -10.0,
+        dangerous_area_hit_probability: float = 1.0,
         initial_state: Optional[np.ndarray] = None,
         transition_error_prob: float = 0.0,
         name: str = "PushPOMDP",
@@ -203,6 +224,8 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
     ):
         if not 0.0 <= obstacle_hit_probability <= 1.0:
             raise ValueError("obstacle_hit_probability must be between 0 and 1 (inclusive)")
+        if not 0.0 <= dangerous_area_hit_probability <= 1.0:
+            raise ValueError("dangerous_area_hit_probability must be between 0 and 1 (inclusive)")
 
         self.grid_size = grid_size
         self.push_threshold = push_threshold
@@ -212,6 +235,12 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         self.obstacle_radius = obstacle_radius
         self.obstacle_penalty = obstacle_penalty
         self.obstacle_hit_probability = float(obstacle_hit_probability)
+        self.dangerous_areas: List[Tuple[float, float]] = (
+            list(dangerous_areas) if dangerous_areas is not None else []
+        )
+        self.dangerous_area_radius = float(dangerous_area_radius)
+        self.dangerous_area_penalty = float(dangerous_area_penalty)
+        self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
         self._initial_state = initial_state
         self.transition_error_prob = transition_error_prob
 
@@ -231,13 +260,17 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             observation_space=SpaceType.CONTINUOUS,  # Observation space is positions with noise
         )
         # Calculate reward range based on maximum distance to target plus the
-        # additive obstacle penalty when obstacles are configured. Without the
-        # obstacle term, any robot action that drives the robot onto an obstacle
-        # produces a reward strictly more negative than the advertised lower
-        # bound (reward = -dist_to_target + obstacle_penalty < -max_distance).
-        # Maximum distance is diagonal from corner to corner: sqrt(2) * (grid_size - 1).
+        # additive obstacle and dangerous-area penalties when configured.
+        # Without those terms, any robot action that drives the robot into a
+        # penalised region produces a reward strictly more negative than the
+        # advertised lower bound. Maximum distance is diagonal from corner to
+        # corner: sqrt(2) * (grid_size - 1).
         max_distance = np.sqrt(2) * (grid_size - 1)
-        min_reward = -max_distance + min(0.0, obstacle_penalty if self.obstacles else 0.0)
+        min_reward = (
+            -max_distance
+            + min(0.0, obstacle_penalty if self.obstacles else 0.0)
+            + min(0.0, dangerous_area_penalty if self.dangerous_areas else 0.0)
+        )
         max_reward = 100.0  # Best case: at target with bonus reward
 
         super().__init__(
@@ -280,6 +313,15 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             ).ravel()
         else:
             self._obstacles_flat_arr = np.empty((0,), dtype=np.float64)
+
+        # (K, 2) float64 buffer of dangerous-area centres for the native
+        # rollout kernel. Empty (0, 2) when no dangerous areas configured.
+        if self.dangerous_areas:
+            self._dangerous_areas_arr: np.ndarray = np.ascontiguousarray(
+                np.asarray(self.dangerous_areas, dtype=np.float64).reshape(-1, 2)
+            )
+        else:
+            self._dangerous_areas_arr = np.empty((0, 2), dtype=np.float64)
 
         # Per-action C++ transition kernel cache. Built lazily on first
         # dispatch so the env survives pickling without bundling pybind11
@@ -437,6 +479,30 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
                 return True
         return False
 
+    def _is_in_dangerous_area(self, position: np.ndarray, action: Optional[str] = None) -> bool:
+        """Check if ``position`` (optionally after ``action``) lies in any dangerous area."""
+        if not self.dangerous_areas:
+            return False
+        if action is not None:
+            dx, dy = self._ACTION_TO_DXY[action]
+            check_x = float(position[0]) + dx
+            check_y = float(position[1]) + dy
+        else:
+            check_x = float(position[0])
+            check_y = float(position[1])
+        return self._is_in_dangerous_area_scalar(check_x, check_y)
+
+    def _is_in_dangerous_area_scalar(self, pos_x: float, pos_y: float) -> bool:
+        if not self.dangerous_areas:
+            return False
+        r_sq = self.dangerous_area_radius * self.dangerous_area_radius
+        for danger_x, danger_y in self.dangerous_areas:
+            ddx = pos_x - danger_x
+            ddy = pos_y - danger_y
+            if ddx * ddx + ddy * ddy <= r_sq:
+                return True
+        return False
+
     def sample_observation(self, next_state: np.ndarray, action: str, n_samples: int = 1) -> Any:
         if n_samples == 1:
             return self._sample_one_observation(next_state)
@@ -562,6 +628,13 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             ):
                 reward += self.obstacle_penalty
 
+        if self._is_in_dangerous_area(state[:2], action):
+            if (
+                self.dangerous_area_hit_probability >= 1.0
+                or np.random.random() < self.dangerous_area_hit_probability
+            ):
+                reward += self.dangerous_area_penalty
+
         return float(reward)
 
     def is_terminal(self, state: np.ndarray) -> bool:
@@ -639,10 +712,10 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         if remaining <= 0 or self.is_terminal(state=state):
             return 0.0
 
-        if self.obstacle_hit_probability < 1.0:
-            # Native kernel applies the obstacle penalty deterministically;
-            # fall back to the Python rollout so per-step Bernoulli draws
-            # against ``obstacle_hit_probability`` survive.
+        if self.obstacle_hit_probability < 1.0 or self.dangerous_area_hit_probability < 1.0:
+            # Native kernel applies the obstacle and dangerous-area penalties
+            # deterministically; fall back to the Python rollout so per-step
+            # Bernoulli draws against the configured hit probabilities survive.
             actions = [self.actions[i] for i in np.random.randint(0, 4, size=remaining)]
             return self._python_simulate_random_rollout(
                 state=state,
@@ -669,6 +742,9 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
                 obstacles=obs_arr,
                 obstacle_radius=float(self.obstacle_radius),
                 obstacle_penalty=float(self.obstacle_penalty),
+                dangerous_areas=self._dangerous_areas_arr,
+                dangerous_area_radius=float(self.dangerous_area_radius),
+                dangerous_area_penalty=float(self.dangerous_area_penalty),
                 transition_error_prob=float(self.transition_error_prob),
             )
         )
@@ -761,6 +837,7 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         rewards = -dist
         rewards = np.where(dist < 0.5, rewards + 100.0, rewards)
         rewards += self._obstacle_penalty_batch(states, action)
+        rewards += self._dangerous_area_penalty_batch(states, action)
         return rewards.astype(np.float64)
 
     def _obstacle_penalty_batch(self, states: np.ndarray, action: str) -> np.ndarray:
@@ -780,6 +857,19 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             applied = np.random.random(len(states)) < self.obstacle_hit_probability
             colliding = colliding & applied
         return np.where(colliding, self.obstacle_penalty, 0.0).astype(np.float64)
+
+    def _dangerous_area_penalty_batch(self, states: np.ndarray, action: str) -> np.ndarray:
+        if not self.dangerous_areas or action not in self._ACTION_TO_DXY:
+            return np.zeros(len(states), dtype=np.float64)
+        dx, dy = self._ACTION_TO_DXY[action]
+        intended = states[:, :2] + np.array([dx, dy], dtype=float)
+        diff = intended[:, None, :] - self._dangerous_areas_arr[None, :, :]
+        dist_sq = np.sum(diff * diff, axis=2)
+        in_zone = np.any(dist_sq <= self.dangerous_area_radius * self.dangerous_area_radius, axis=1)
+        if self.dangerous_area_hit_probability < 1.0:
+            applied = np.random.random(len(states)) < self.dangerous_area_hit_probability
+            in_zone = in_zone & applied
+        return np.where(in_zone, self.dangerous_area_penalty, 0.0).astype(np.float64)
 
     def observation_log_probability_per_state(
         self, next_states: Any, action: str, observation: Any
@@ -823,16 +913,20 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         """
         return [metric.value for metric in PushPOMDPMetrics]
 
-    def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
+    def compute_metrics(  # pylint: disable=too-many-locals
+        self, histories: List[History]
+    ) -> List[MetricValue]:
         goal_reached = []
         robot_collisions = []
         object_collisions = []
         total_collisions = []
+        dangerous_steps_per_history: List[int] = []
 
         for history in histories:
             goal_reached_in_history = False
             history_robot_collisions = 0
             history_object_collisions = 0
+            history_dangerous_steps = 0
             total_steps = len(history.history)
 
             for step in history.history:
@@ -849,11 +943,15 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
                 if self._is_colliding_with_obstacle(object_pos):
                     history_object_collisions += 1
 
+                if self._is_in_dangerous_area(robot_pos):
+                    history_dangerous_steps += 1
+
             goal_reached.append(1 if goal_reached_in_history else 0)
             if total_steps > 0:
                 robot_collisions.append(history_robot_collisions)
                 object_collisions.append(history_object_collisions)
                 total_collisions.append(history_robot_collisions + history_object_collisions)
+                dangerous_steps_per_history.append(history_dangerous_steps)
 
         total_steps_all = sum(len(history.history) for history in histories)
         avg_robot_collisions = sum(robot_collisions) / total_steps_all if total_steps_all > 0 else 0
@@ -861,6 +959,9 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             sum(object_collisions) / total_steps_all if total_steps_all > 0 else 0
         )
         avg_total_collisions = sum(total_collisions) / total_steps_all if total_steps_all > 0 else 0
+        avg_dangerous_rate = (
+            sum(dangerous_steps_per_history) / total_steps_all if total_steps_all > 0 else 0
+        )
 
         robot_collision_rates = [
             c / len(history.history) for c, history in zip(robot_collisions, histories)
@@ -871,14 +972,27 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         total_collision_rates = [
             c / len(history.history) for c, history in zip(total_collisions, histories)
         ]
+        dangerous_rates = [
+            c / len(history.history) for c, history in zip(dangerous_steps_per_history, histories)
+        ]
 
         robot_collisions_ci = confidence_interval(data=robot_collision_rates, confidence=0.95)
         object_collisions_ci = confidence_interval(data=object_collision_rates, confidence=0.95)
         total_collisions_ci = confidence_interval(data=total_collision_rates, confidence=0.95)
+        dangerous_rate_ci = (
+            confidence_interval(data=dangerous_rates, confidence=0.95)
+            if dangerous_rates
+            else (0, 0)
+        )
 
         total_robot_collisions_ci = confidence_interval(data=robot_collisions, confidence=0.95)
         total_object_collisions_ci = confidence_interval(data=object_collisions, confidence=0.95)
         total_all_collisions_ci = confidence_interval(data=total_collisions, confidence=0.95)
+        total_dangerous_steps_ci = (
+            confidence_interval(data=dangerous_steps_per_history, confidence=0.95)
+            if dangerous_steps_per_history
+            else (0, 0)
+        )
 
         avg_goal_reached = float(np.mean(goal_reached))
         goal_reached_ci = confidence_interval(data=goal_reached, confidence=0.95)
@@ -925,5 +1039,21 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
                 value=float(np.mean(total_collisions)) if total_collisions else 0.0,
                 lower_confidence_bound=total_all_collisions_ci[0],
                 upper_confidence_bound=total_all_collisions_ci[1],
+            ),
+            MetricValue(
+                name=PushPOMDPMetrics.DANGEROUS_AREA_RATE.value,
+                value=avg_dangerous_rate,
+                lower_confidence_bound=dangerous_rate_ci[0],
+                upper_confidence_bound=dangerous_rate_ci[1],
+            ),
+            MetricValue(
+                name=PushPOMDPMetrics.TOTAL_DANGEROUS_AREA_STEPS.value,
+                value=(
+                    float(np.mean(dangerous_steps_per_history))
+                    if dangerous_steps_per_history
+                    else 0.0
+                ),
+                lower_confidence_bound=total_dangerous_steps_ci[0],
+                upper_confidence_bound=total_dangerous_steps_ci[1],
             ),
         ]

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp_visualizer.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp_visualizer.py
@@ -50,6 +50,8 @@ class PushPOMDPVisualizer:
         self.push_threshold = env.push_threshold
         self.obstacles = env.obstacles
         self.obstacle_radius = env.obstacle_radius
+        self.dangerous_areas = env.dangerous_areas
+        self.dangerous_area_radius = env.dangerous_area_radius
 
     def create_visualization(self, history: List[StepData], cache_path: Path) -> None:
         """Create animated visualization of a Push POMDP episode.
@@ -70,6 +72,7 @@ class PushPOMDPVisualizer:
         fig, ax = self._setup_visualization_figure()
         robot_scatter, object_scatter, target_scatter = self._initialize_entity_scatters(ax)
         self._initialize_obstacles(ax)
+        self._initialize_dangerous_areas(ax)
         push_arrow, connection_line = self._initialize_push_visuals(ax)
         action_arrow = self._initialize_action_arrow(ax)
         step_text, distance_text, reward_text, success_text, collision_text = (
@@ -191,6 +194,19 @@ class PushPOMDPVisualizer:
             ax.add_patch(obstacle_circle)
             if i == 0:  # Label only the first obstacle for legend
                 ax.scatter(obs_x, obs_y, s=1, c="red", label="Obstacles")
+
+    def _initialize_dangerous_areas(self, ax: Axes) -> None:
+        for i, (cx, cy) in enumerate(self.dangerous_areas):
+            danger_circle = plt.Circle(  # type: ignore[attr-defined]
+                (cx, cy),
+                float(self.dangerous_area_radius),  # type: ignore[arg-type]
+                facecolor="red",
+                edgecolor="none",
+                alpha=0.3,
+                zorder=1,
+                label="Dangerous Areas" if i == 0 else "",
+            )
+            ax.add_patch(danger_circle)
 
     def _initialize_push_visuals(self, ax: Axes) -> Tuple[Any, Line2D]:
         push_arrow = ax.annotate(

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
@@ -861,6 +861,477 @@ class TestContinuousPushStochasticObstacleHitProbability:
 
 
 # ------------------------------------------------------------------
+# Dangerous areas (continuous variant)
+# ------------------------------------------------------------------
+
+
+class TestContinuousPushDangerousAreas:
+    """Tests for ``dangerous_areas`` on ``ContinuousPushPOMDP``.
+
+    Geometry: a single circular zone centred at ``(5.0, 5.0)`` with
+    radius ``0.5``. The robot at ``(4.0, 5.0)`` taking action
+    ``(1.0, 0.0)`` lands at post-action position ``(5.0, 5.0)`` — inside
+    the zone. Transition covariance is set to a near-zero diagonal so
+    distance-to-target stays effectively constant and the dangerous-area
+    penalty cleanly separates hit from no-hit trials.
+    """
+
+    DANGER_PENALTY = -7.0
+    DANGER_ACTION = np.array([1.0, 0.0])
+
+    @staticmethod
+    def _danger_env(hit_probability: float = 1.0) -> ContinuousPushPOMDP:
+        return ContinuousPushPOMDP(
+            discount_factor=0.99,
+            grid_size=10,
+            dangerous_areas=[(5.0, 5.0)],
+            dangerous_area_radius=0.5,
+            dangerous_area_penalty=TestContinuousPushDangerousAreas.DANGER_PENALTY,
+            dangerous_area_hit_probability=hit_probability,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 1e-8,
+        )
+
+    @staticmethod
+    def _enter_state() -> np.ndarray:
+        return np.array([4.0, 5.0, 1.0, 1.0, 9.0, 9.0])
+
+    @staticmethod
+    def _safe_state() -> np.ndarray:
+        # robot far from the zone AND from the object so tiny native-RNG noise
+        # cannot tip the post-action robot in/out of the push threshold
+        # (which would perturb the distance-to-target term across runs).
+        return np.array([1.0, 1.0, 8.0, 8.0, 9.0, 9.0])
+
+    def test_dangerous_area_penalty_applied(self):
+        """Penalty fires when post-action robot position lies in a zone.
+
+        Purpose: Validates the deterministic dangerous-area penalty path
+            in ``_reward_batch_array``.
+
+        Given: A ContinuousPushPOMDP with one zone; robot at (4, 5);
+            action (1, 0) lands at (5, 5).
+        When: ``reward()`` is called and compared against an env with no
+            zone.
+        Then: The configured-env reward is more negative by
+            ``DANGER_PENALTY`` (within transition-noise tolerance).
+
+        Test type: unit
+        """
+        env = self._danger_env()
+        env_safe = ContinuousPushPOMDP(
+            discount_factor=0.99,
+            grid_size=10,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 1e-8,
+        )
+        state = self._enter_state()
+        np.random.seed(0)
+        baseline = env_safe.reward(state, self.DANGER_ACTION)
+        np.random.seed(0)
+        with_danger = env.reward(state, self.DANGER_ACTION)
+        assert with_danger == pytest.approx(baseline + self.DANGER_PENALTY, abs=1e-3)
+
+    def test_dangerous_area_default_empty(self):
+        """Default constructor leaves dangerous-area attributes empty.
+
+        Purpose: Validates backward-compatible defaults.
+
+        Given: A ContinuousPushPOMDP constructed with default parameters.
+        When: The dangerous-area attributes are inspected.
+        Then: ``dangerous_areas`` is empty, the packed array has shape
+            ``(0, 2)``, and ``dangerous_area_hit_probability`` is 1.0.
+
+        Test type: unit
+        """
+        env = ContinuousPushPOMDP(discount_factor=0.99)
+        assert not env.dangerous_areas
+        assert env._dangerous_areas_arr.shape == (0, 2)
+        assert env.dangerous_area_hit_probability == 1.0
+
+    def test_reward_batch_dangerous_area(self):
+        """Vectorised reward_batch applies the penalty per-row.
+
+        Purpose: Validates that the batched reward path matches the
+            single-state path on a mixed batch.
+
+        Given: A two-row batch (one in-zone, one safe) and a configured
+            danger env.
+        When: ``reward_batch`` is called.
+        Then: The in-zone row receives the penalty and the safe row does
+            not (within transition-noise tolerance).
+
+        Test type: unit
+        """
+        env = self._danger_env()
+        env_safe = ContinuousPushPOMDP(
+            discount_factor=0.99,
+            grid_size=10,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 1e-8,
+        )
+        states = np.stack([self._enter_state(), self._safe_state()])
+        np.random.seed(0)
+        baselines = env_safe.reward_batch(states, self.DANGER_ACTION)
+        np.random.seed(0)
+        rewards = env.reward_batch(states, self.DANGER_ACTION)
+        assert rewards[0] == pytest.approx(baselines[0] + self.DANGER_PENALTY, abs=1e-3)
+        assert rewards[1] == pytest.approx(baselines[1], abs=1e-3)
+
+    def test_dangerous_area_single_penalty_for_overlapping_zones(self):
+        """Overlapping zones apply the penalty at most once per step.
+
+        Purpose: Validates that even when the post-action robot position
+            lies in multiple overlapping zones, only one
+            ``dangerous_area_penalty`` is applied per step (matches Push's
+            existing single-penalty obstacle convention and avoids
+            ambiguous accumulation semantics).
+
+        Given: A ContinuousPushPOMDP with two zones whose circles overlap
+            at the post-action robot position.
+        When: ``reward()`` is called.
+        Then: Exactly one penalty is applied (not two).
+
+        Test type: unit
+        """
+        env = ContinuousPushPOMDP(
+            discount_factor=0.99,
+            grid_size=10,
+            dangerous_areas=[(5.0, 5.0), (5.1, 5.0)],
+            dangerous_area_radius=0.5,
+            dangerous_area_penalty=self.DANGER_PENALTY,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 1e-8,
+        )
+        env_safe = ContinuousPushPOMDP(
+            discount_factor=0.99,
+            grid_size=10,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 1e-8,
+        )
+        state = self._enter_state()
+        np.random.seed(0)
+        baseline = env_safe.reward(state, self.DANGER_ACTION)
+        np.random.seed(0)
+        with_danger = env.reward(state, self.DANGER_ACTION)
+        # Single penalty, not 2x.
+        assert with_danger == pytest.approx(baseline + self.DANGER_PENALTY, abs=1e-3)
+
+    def test_compute_metrics_dangerous_area_steps(self):
+        """compute_metrics reports dangerous-area step counts.
+
+        Purpose: Validates the ``dangerous_area_rate`` and
+            ``total_dangerous_area_steps`` metrics on the continuous
+            variant.
+
+        Given: A ContinuousPushPOMDP with one zone and a hand-built
+            three-step history (two in-zone, one safe).
+        When: ``compute_metrics`` is called on a single-history list.
+        Then: Both metrics are present and reflect the correct counts.
+
+        Test type: unit
+        """
+        env = self._danger_env()
+        in_zone = np.array([5.0, 5.0, 1.0, 1.0, 9.0, 9.0])
+        out_zone = np.array([1.0, 1.0, 2.0, 2.0, 9.0, 9.0])
+        steps = [
+            StepData(
+                state=in_zone,
+                action=self.DANGER_ACTION,
+                next_state=in_zone,
+                observation=in_zone,
+                reward=0.0,
+                belief=None,  # type: ignore[arg-type]
+            ),
+            StepData(
+                state=in_zone,
+                action=self.DANGER_ACTION,
+                next_state=in_zone,
+                observation=in_zone,
+                reward=0.0,
+                belief=None,  # type: ignore[arg-type]
+            ),
+            StepData(
+                state=out_zone,
+                action=self.DANGER_ACTION,
+                next_state=out_zone,
+                observation=out_zone,
+                reward=0.0,
+                belief=None,  # type: ignore[arg-type]
+            ),
+        ]
+        history = History(
+            history=steps,
+            discount_factor=0.99,
+            average_state_sampling_time=0.0,
+            average_action_time=0.0,
+            average_observation_time=0.0,
+            average_belief_update_time=0.0,
+            average_reward_time=0.0,
+            actual_num_steps=len(steps),
+            reach_terminal_state=False,
+            policy_run_data=[PolicyRunData(info_variables=[])],
+        )
+        metrics = {m.name: m for m in env.compute_metrics([history])}
+        assert "dangerous_area_rate" in metrics
+        assert "total_dangerous_area_steps" in metrics
+        assert metrics["total_dangerous_area_steps"].value == pytest.approx(2.0)
+        assert metrics["dangerous_area_rate"].value == pytest.approx(2.0 / 3.0)
+
+    def test_native_rollout_bypassed_when_hit_probability_lt_one(self, monkeypatch):
+        """Native rollout is bypassed when dangerous_area_hit_probability < 1.
+
+        Purpose: Validates that ``simulate_random_rollout`` falls back to
+            the Python rollout so per-step Bernoulli draws survive.
+
+        Given: A ContinuousPushPOMDPDiscreteActions with
+            ``dangerous_area_hit_probability=0.5``.
+        When: ``simulate_random_rollout`` is invoked after monkeypatching
+            ``_native.cont_simulate_rollout`` to raise.
+        Then: No exception is raised because the native path was bypassed.
+
+        Test type: unit
+        """
+        env = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99,
+            grid_size=10,
+            dangerous_areas=[(5.0, 5.0)],
+            dangerous_area_radius=0.5,
+            dangerous_area_penalty=self.DANGER_PENALTY,
+            dangerous_area_hit_probability=0.5,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 1e-8,
+        )
+
+        def _explode(**_kwargs):
+            raise AssertionError("native cont_simulate_rollout must not be called")
+
+        monkeypatch.setattr(_native, "cont_simulate_rollout", _explode)
+
+        class _Sampler:
+            def sample(self):
+                return "right"
+
+        env.simulate_random_rollout(
+            state=self._safe_state(),
+            action_sampler=_Sampler(),
+            max_depth=5,
+            discount_factor=0.99,
+        )
+
+
+class TestContinuousPushDangerousHitProbability:
+    """Tests for ``dangerous_area_hit_probability`` on ``ContinuousPushPOMDP``."""
+
+    DANGER_PENALTY = -7.0
+    DANGER_ACTION = np.array([1.0, 0.0])
+
+    @staticmethod
+    def _danger_env(hit_probability: float) -> ContinuousPushPOMDP:
+        return ContinuousPushPOMDP(
+            discount_factor=0.99,
+            grid_size=10,
+            dangerous_areas=[(5.0, 5.0)],
+            dangerous_area_radius=0.5,
+            dangerous_area_penalty=TestContinuousPushDangerousHitProbability.DANGER_PENALTY,
+            dangerous_area_hit_probability=hit_probability,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 1e-8,
+        )
+
+    @staticmethod
+    def _enter_state() -> np.ndarray:
+        return np.array([4.0, 5.0, 1.0, 1.0, 9.0, 9.0])
+
+    def test_default_hit_probability_is_one(self):
+        """Default dangerous_area_hit_probability is 1.0.
+
+        Purpose: Validates the default value preserves deterministic
+            penalty semantics.
+
+        Given: A ContinuousPushPOMDP with default parameters.
+        When: ``dangerous_area_hit_probability`` is read.
+        Then: It equals 1.0.
+
+        Test type: unit
+        """
+        env = ContinuousPushPOMDP(discount_factor=0.99)
+        assert env.dangerous_area_hit_probability == 1.0
+
+    def test_hit_probability_zero_never_applies_penalty(self):
+        """hit_probability=0 disables the dangerous-area penalty.
+
+        Purpose: Validates lower bound of the stochastic regime.
+
+        Given: A ContinuousPushPOMDP with hit_probability=0.0.
+        When: ``reward()`` is called many times on an in-zone state.
+        Then: Every reward sits above the (baseline - penalty/2) midpoint.
+
+        Test type: unit
+        """
+        env = self._danger_env(hit_probability=0.0)
+        state = self._enter_state()
+        baseline = env.reward(state, self.DANGER_ACTION)
+        midpoint = baseline + self.DANGER_PENALTY / 2.0
+        np.random.seed(0)
+        for _ in range(200):
+            r = env.reward(state, self.DANGER_ACTION)
+            assert r > midpoint
+
+    def test_hit_probability_one_always_applies(self):
+        """hit_probability=1 applies the penalty deterministically.
+
+        Purpose: Validates upper bound of the stochastic regime.
+
+        Given: A ContinuousPushPOMDP with hit_probability=1.0 and an
+            in-zone state.
+        When: ``reward()`` is called many times.
+        Then: Every reward is below the (baseline - penalty/2) midpoint.
+
+        Test type: unit
+        """
+        env = self._danger_env(hit_probability=1.0)
+        state = self._enter_state()
+        env_no_pen = self._danger_env(hit_probability=0.0)
+        baseline = env_no_pen.reward(state, self.DANGER_ACTION)
+        for _ in range(50):
+            r = env.reward(state, self.DANGER_ACTION)
+            assert r == pytest.approx(baseline + self.DANGER_PENALTY, abs=1e-3)
+
+    def test_hit_probability_empirical_rate(self):
+        """Empirical hit rate matches hit_probability over many calls.
+
+        Purpose: Validates per-call Bernoulli draw frequency.
+
+        Given: A ContinuousPushPOMDP with hit_probability=0.3 on an
+            in-zone state.
+        When: ``reward()`` is called 2000 times with a fixed seed.
+        Then: Empirical hit rate is within 0.05 of 0.3.
+
+        Test type: unit
+        """
+        env = self._danger_env(hit_probability=0.3)
+        state = self._enter_state()
+        env_no_pen = self._danger_env(hit_probability=0.0)
+        baseline = env_no_pen.reward(state, self.DANGER_ACTION)
+        midpoint = baseline + self.DANGER_PENALTY / 2.0
+        np.random.seed(123)
+        n_trials = 2000
+        hits = 0
+        for _ in range(n_trials):
+            if env.reward(state, self.DANGER_ACTION) < midpoint:
+                hits += 1
+        empirical = hits / n_trials
+        assert abs(empirical - 0.3) < 0.05
+
+    @pytest.mark.parametrize("bad_value", [-0.1, 1.5, float("nan")])
+    def test_invalid_hit_probability_raises(self, bad_value: float):
+        """Invalid dangerous_area_hit_probability raises ValueError.
+
+        Purpose: Validates input validation on the new probability parameter.
+
+        Given: A hit_probability outside [0, 1].
+        When: ContinuousPushPOMDP is constructed.
+        Then: ValueError is raised mentioning the parameter name.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="dangerous_area_hit_probability"):
+            ContinuousPushPOMDP(discount_factor=0.99, dangerous_area_hit_probability=bad_value)
+
+    def test_reward_batch_honours_hit_probability_zero(self):
+        """Batch reward with hit_probability=0 applies no dangerous-area penalty.
+
+        Purpose: Validates the lower-bound of the stochastic regime in
+            the batch path.
+
+        Given: A 200-row batch in-zone with hit_probability=0.
+        When: ``reward_batch`` is called.
+        Then: All returned rewards exceed the penalty floor.
+
+        Test type: unit
+        """
+        env = self._danger_env(hit_probability=0.0)
+        state = self._enter_state()
+        env_no_pen = self._danger_env(hit_probability=0.0)
+        baseline = env_no_pen.reward(state, self.DANGER_ACTION)
+        midpoint = baseline + self.DANGER_PENALTY / 2.0
+        states = np.tile(state, (200, 1))
+        np.random.seed(789)
+        rewards = env.reward_batch(states, self.DANGER_ACTION)
+        assert np.all(rewards > midpoint)
+
+
+class TestContinuousPushPOMDPDiscreteActionsDangerousAreas:
+    """Tests that the discrete-actions wrapper inherits dangerous-area behaviour."""
+
+    DANGER_PENALTY = -7.0
+
+    def test_kwarg_forwarded_to_parent_attribute(self):
+        """Subclass forwards dangerous-area kwargs to the parent class.
+
+        Purpose: Validates that the discrete-action subclass exposes the
+            same dangerous-area state as the base ``ContinuousPushPOMDP``.
+
+        Given: A ContinuousPushPOMDPDiscreteActions constructed with
+            dangerous-area kwargs.
+        When: The dangerous-area attributes are read.
+        Then: They reflect the values passed to the constructor.
+
+        Test type: unit
+        """
+        env = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99,
+            dangerous_areas=[(3.0, 3.0)],
+            dangerous_area_radius=0.4,
+            dangerous_area_penalty=self.DANGER_PENALTY,
+            dangerous_area_hit_probability=0.7,
+        )
+        assert env.dangerous_areas == [(3.0, 3.0)]
+        assert env.dangerous_area_radius == 0.4
+        assert env.dangerous_area_penalty == self.DANGER_PENALTY
+        assert env.dangerous_area_hit_probability == 0.7
+        assert env._dangerous_areas_arr.shape == (1, 2)
+
+    def test_dangerous_area_penalty_via_string_action(self):
+        """Penalty fires when reward is invoked with a string action label.
+
+        Purpose: Validates that the discrete-action wrapper resolves the
+            string action to a unit vector and the dangerous-area penalty
+            still fires when the resulting post-action position is inside
+            a zone.
+
+        Given: A ContinuousPushPOMDPDiscreteActions with one zone at
+            (5, 5) radius 0.5; robot at (4, 5); action ``"right"``.
+        When: ``reward`` is called with the string action.
+        Then: Reward includes the dangerous-area penalty.
+
+        Test type: unit
+        """
+        env = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99,
+            grid_size=10,
+            dangerous_areas=[(5.0, 5.0)],
+            dangerous_area_radius=0.5,
+            dangerous_area_penalty=self.DANGER_PENALTY,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 1e-8,
+        )
+        env_safe = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99,
+            grid_size=10,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 1e-8,
+        )
+        state = np.array([4.0, 5.0, 1.0, 1.0, 9.0, 9.0])
+        np.random.seed(0)
+        baseline = env_safe.reward(state, "right")
+        np.random.seed(0)
+        with_danger = env.reward(state, "right")
+        assert with_danger == pytest.approx(baseline + self.DANGER_PENALTY, abs=1e-3)
+
+
+# ------------------------------------------------------------------
 # Discrete Actions
 # ------------------------------------------------------------------
 
@@ -1525,3 +1996,97 @@ class TestNativeRolloutEquivalence:
             discount_factor=0.95,
         )
         assert np.isfinite(result)
+
+    def test_cont_simulate_rollout_with_dangerous_areas(self):
+        """Native rollout deducts dangerous-area penalty when zones present.
+
+        Purpose: Validates that ``cont_simulate_rollout`` applies the
+            ``dangerous_area_penalty`` per step when the post-action robot
+            position lies in a configured zone.
+
+        Given: Two ContinuousPushPOMDPDiscreteActions envs that differ
+            only in whether ``dangerous_areas`` is configured. The robot
+            starts at (4, 5); action ``"right"`` (resolved to (1, 0))
+            sends the robot to (5, 5) — inside the zone.
+        When: A single-step ``simulate_random_rollout`` is invoked on
+            each env after seeding the native RNG identically.
+        Then: The configured-env return is more negative by exactly the
+            dangerous-area penalty (within tolerance accounting for the
+            tiny transition noise).
+
+        Test type: integration
+        """
+        env_safe = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99,
+            grid_size=10,
+            push_threshold=1.0,
+            friction_coefficient=0.3,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 1e-8,
+        )
+        env_danger = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99,
+            grid_size=10,
+            push_threshold=1.0,
+            friction_coefficient=0.3,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            dangerous_areas=[(5.0, 5.0)],
+            dangerous_area_radius=0.5,
+            dangerous_area_penalty=-7.0,
+        )
+        state = np.array([4.0, 5.0, 1.0, 1.0, 9.0, 9.0])
+        sampler = _FixedActionSampler(["right"])
+        # Seed both runs identically so the post-noise robot lands at the
+        # same place; the only difference is the danger-zone penalty.
+        _native.set_seed(42)
+        np.random.seed(42)
+        return_safe = env_safe.simulate_random_rollout(
+            state=state, action_sampler=sampler, max_depth=1, discount_factor=0.99
+        )
+        _native.set_seed(42)
+        np.random.seed(42)
+        return_danger = env_danger.simulate_random_rollout(
+            state=state, action_sampler=sampler, max_depth=1, discount_factor=0.99
+        )
+        assert return_danger == pytest.approx(return_safe - 7.0, abs=1e-3)
+
+    def test_cont_simulate_rollout_without_dangerous_areas_is_unchanged(self):
+        """Native rollout without dangerous areas matches a fresh rollout.
+
+        Purpose: Backward-compat sanity. Adding the new pybind11 args with
+            an empty (0, 2) array must not change the discounted return
+            for envs that do not configure dangerous zones.
+
+        Given: Two ContinuousPushPOMDPDiscreteActions envs both with no
+            dangerous areas (default), under the same seed.
+        When: ``simulate_random_rollout`` runs on each.
+        Then: The discounted returns are identical.
+
+        Test type: integration
+        """
+        env_a = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99,
+            grid_size=10,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 0.01,
+        )
+        env_b = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99,
+            grid_size=10,
+            robot_radius=0.3,
+            state_transition_cov_matrix=np.eye(2) * 0.01,
+        )
+        state = np.array([2.0, 2.0, 6.0, 6.0, 9.0, 9.0])
+        sampler = _FixedActionSampler(["right"] * 8)
+        _native.set_seed(123)
+        np.random.seed(123)
+        return_a = env_a.simulate_random_rollout(
+            state=state, action_sampler=sampler, max_depth=8, discount_factor=0.99
+        )
+        _native.set_seed(123)
+        np.random.seed(123)
+        return_b = env_b.simulate_random_rollout(
+            state=state, action_sampler=sampler, max_depth=8, discount_factor=0.99
+        )
+        assert return_a == return_b

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
@@ -1409,6 +1409,326 @@ class TestStochasticObstacleHitProbability:
             PushPOMDP(discount_factor=0.95, obstacle_hit_probability=bad_value)
 
 
+class TestPushDangerousAreas:
+    """Tests for the ``dangerous_areas`` feature on ``PushPOMDP``.
+
+    Geometry: a single circular dangerous area centred at ``(3.0, 3.0)``
+    with radius ``0.5``; the robot at ``(2.0, 3.0)`` taking action
+    ``"right"`` lands at intended position ``(3.0, 3.0)`` (inside the
+    zone). The object is parked far from the target so the distance term
+    is constant across cross-call comparisons.
+    """
+
+    DANGER_ACTION = "right"
+    DANGER_PENALTY = -7.0
+
+    @staticmethod
+    def _danger_env(hit_probability: float = 1.0) -> PushPOMDP:
+        return PushPOMDP(
+            discount_factor=0.95,
+            grid_size=10,
+            dangerous_areas=[(3.0, 3.0)],
+            dangerous_area_radius=0.5,
+            dangerous_area_penalty=TestPushDangerousAreas.DANGER_PENALTY,
+            dangerous_area_hit_probability=hit_probability,
+            transition_error_prob=0.0,
+        )
+
+    @staticmethod
+    def _enter_state() -> np.ndarray:
+        # robot just left of zone; object far away from target so it stays put
+        return np.array([2.0, 3.0, 8.0, 8.0, 9.0, 9.0])
+
+    @staticmethod
+    def _safe_state() -> np.ndarray:
+        # robot far from any dangerous area
+        return np.array([6.0, 6.0, 8.0, 8.0, 9.0, 9.0])
+
+    def test_dangerous_area_penalty_applied_when_robot_enters_zone(self):
+        """Penalty fires when the robot's intended next position is in a zone.
+
+        Purpose: Validates that a robot stepping into a dangerous area
+            receives the configured negative reward in addition to the
+            base distance term.
+
+        Given: A PushPOMDP with one dangerous area at (3, 3) radius 0.5;
+            robot at (2, 3); action "right".
+        When: ``reward(state, action)`` is called.
+        Then: Reward equals the distance term plus the dangerous-area penalty.
+
+        Test type: unit
+        """
+        env = self._danger_env()
+        state = self._enter_state()
+        # Reference reward without dangerous area for comparison.
+        env_safe = PushPOMDP(discount_factor=0.95, grid_size=10)
+        np.random.seed(0)
+        baseline = env_safe.reward(state, self.DANGER_ACTION)
+        np.random.seed(0)
+        with_danger = env.reward(state, self.DANGER_ACTION)
+        assert with_danger == pytest.approx(baseline + self.DANGER_PENALTY)
+
+    def test_dangerous_area_no_penalty_outside_zone(self):
+        """Penalty is not applied when the intended next position is safe.
+
+        Purpose: Validates that the dangerous-area penalty does not fire
+            when the robot's intended position lies outside every zone.
+
+        Given: A PushPOMDP with one dangerous area at (3, 3); robot at
+            (6, 6) (far from the zone); action "right".
+        When: ``reward(state, action)`` is called and compared against
+            an env with no dangerous areas.
+        Then: Both rewards match exactly.
+
+        Test type: unit
+        """
+        env_danger = self._danger_env()
+        env_safe = PushPOMDP(discount_factor=0.95, grid_size=10)
+        state = self._safe_state()
+        np.random.seed(0)
+        baseline = env_safe.reward(state, self.DANGER_ACTION)
+        np.random.seed(0)
+        actual = env_danger.reward(state, self.DANGER_ACTION)
+        assert actual == pytest.approx(baseline)
+
+    def test_dangerous_area_default_is_empty(self):
+        """Default constructor leaves the dangerous-area set empty.
+
+        Purpose: Validates backward-compatible defaults — code that does
+            not pass ``dangerous_areas`` sees no behaviour change.
+
+        Given: A PushPOMDP constructed with default parameters.
+        When: The dangerous-area attributes are inspected.
+        Then: ``dangerous_areas`` is an empty list and the packed array
+            has shape ``(0, 2)``.
+
+        Test type: unit
+        """
+        env = PushPOMDP(discount_factor=0.95)
+        assert not env.dangerous_areas
+        assert env._dangerous_areas_arr.shape == (0, 2)
+        assert env.dangerous_area_hit_probability == 1.0
+
+    def test_reward_batch_dangerous_area(self):
+        """Batch reward applies the penalty per-row consistently.
+
+        Purpose: Validates the vectorised batch reward path applies the
+            dangerous-area penalty exactly to rows whose intended next
+            position lies inside a zone.
+
+        Given: A PushPOMDP with one zone; states batch with one in-zone
+            row and one safe row.
+        When: ``reward_batch`` is called.
+        Then: The in-zone row receives the penalty; the safe row does not.
+
+        Test type: unit
+        """
+        env = self._danger_env()
+        env_safe = PushPOMDP(discount_factor=0.95, grid_size=10)
+        states = np.stack([self._enter_state(), self._safe_state()])
+        np.random.seed(0)
+        baselines = env_safe.reward_batch(states, self.DANGER_ACTION)
+        np.random.seed(0)
+        rewards = env.reward_batch(states, self.DANGER_ACTION)
+        assert rewards[0] == pytest.approx(baselines[0] + self.DANGER_PENALTY)
+        assert rewards[1] == pytest.approx(baselines[1])
+
+    def test_dangerous_area_hit_probability_zero_never_applies(self):
+        """hit_probability=0 disables the dangerous-area penalty.
+
+        Purpose: Validates lower bound of the stochastic penalty regime.
+
+        Given: A PushPOMDP with one zone, hit_probability=0, and the
+            robot landing inside the zone.
+        When: ``reward()`` is called many times.
+        Then: No call ever adds the penalty.
+
+        Test type: unit
+        """
+        env = self._danger_env(hit_probability=0.0)
+        env_safe = PushPOMDP(discount_factor=0.95, grid_size=10)
+        state = self._enter_state()
+        baseline = env_safe.reward(state, self.DANGER_ACTION)
+        for _ in range(200):
+            assert env.reward(state, self.DANGER_ACTION) == pytest.approx(baseline)
+
+    def test_dangerous_area_hit_probability_one_always_applies(self):
+        """hit_probability=1 applies the penalty deterministically.
+
+        Purpose: Validates upper bound of the stochastic penalty regime.
+
+        Given: A PushPOMDP with hit_probability=1.0 and the robot in the zone.
+        When: ``reward()`` is called many times.
+        Then: Every call adds the penalty.
+
+        Test type: unit
+        """
+        env = self._danger_env(hit_probability=1.0)
+        env_safe = PushPOMDP(discount_factor=0.95, grid_size=10)
+        state = self._enter_state()
+        baseline = env_safe.reward(state, self.DANGER_ACTION)
+        expected = baseline + self.DANGER_PENALTY
+        for _ in range(50):
+            assert env.reward(state, self.DANGER_ACTION) == pytest.approx(expected)
+
+    def test_dangerous_area_hit_probability_empirical_rate(self):
+        """Empirical penalty rate matches the configured probability.
+
+        Purpose: Validates Bernoulli draw frequency for fractional probabilities.
+
+        Given: A PushPOMDP with hit_probability=0.3 and a fixed in-zone state.
+        When: ``reward()`` is called 2000 times with a deterministic seed.
+        Then: The empirical hit rate is within 0.05 of 0.3.
+
+        Test type: unit
+        """
+        env = self._danger_env(hit_probability=0.3)
+        env_safe = PushPOMDP(discount_factor=0.95, grid_size=10)
+        state = self._enter_state()
+        baseline = env_safe.reward(state, self.DANGER_ACTION)
+        np.random.seed(123)
+        hits = 0
+        trials = 2000
+        for _ in range(trials):
+            r = env.reward(state, self.DANGER_ACTION)
+            if r < baseline - abs(self.DANGER_PENALTY) / 2:
+                hits += 1
+        empirical = hits / trials
+        assert abs(empirical - 0.3) < 0.05
+
+    def test_compute_metrics_dangerous_area_steps(self):
+        """compute_metrics reports dangerous-area step counts.
+
+        Purpose: Validates that the new ``dangerous_area_rate`` and
+            ``total_dangerous_area_steps`` metrics are emitted.
+
+        Given: A PushPOMDP with one dangerous area and a hand-built
+            history with two steps inside the zone and one outside.
+        When: ``compute_metrics`` is called on a single-history list.
+        Then: Both metrics are present and ``total_dangerous_area_steps``
+            equals 2.
+
+        Test type: unit
+        """
+        env = self._danger_env()
+        # Three-step history: two in zone, one outside.
+        in_zone = np.array([3.0, 3.0, 8.0, 8.0, 9.0, 9.0])
+        out_zone = np.array([6.0, 6.0, 8.0, 8.0, 9.0, 9.0])
+        steps = [
+            StepData(
+                state=in_zone,
+                action="right",
+                next_state=in_zone,
+                observation=in_zone,
+                reward=0.0,
+                belief=None,  # type: ignore[arg-type]
+            ),
+            StepData(
+                state=in_zone,
+                action="right",
+                next_state=in_zone,
+                observation=in_zone,
+                reward=0.0,
+                belief=None,  # type: ignore[arg-type]
+            ),
+            StepData(
+                state=out_zone,
+                action="right",
+                next_state=out_zone,
+                observation=out_zone,
+                reward=0.0,
+                belief=None,  # type: ignore[arg-type]
+            ),
+        ]
+        history = History(
+            history=steps,
+            discount_factor=0.95,
+            average_state_sampling_time=0.0,
+            average_action_time=0.0,
+            average_observation_time=0.0,
+            average_belief_update_time=0.0,
+            average_reward_time=0.0,
+            actual_num_steps=len(steps),
+            reach_terminal_state=False,
+            policy_run_data=[PolicyRunData(info_variables=[])],
+        )
+        metrics = {m.name: m for m in env.compute_metrics([history])}
+        assert "dangerous_area_rate" in metrics
+        assert "total_dangerous_area_steps" in metrics
+        assert metrics["total_dangerous_area_steps"].value == pytest.approx(2.0)
+        assert metrics["dangerous_area_rate"].value == pytest.approx(2.0 / 3.0)
+
+    @pytest.mark.parametrize("bad_value", [-0.1, 1.1, float("nan")])
+    def test_invalid_dangerous_area_hit_probability_raises(self, bad_value: float):
+        """Invalid hit probabilities raise ValueError.
+
+        Purpose: Validates input validation on the new probability parameter.
+
+        Given: A hit_probability outside [0, 1] (or NaN).
+        When: PushPOMDP is constructed.
+        Then: ValueError is raised mentioning the parameter name.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="dangerous_area_hit_probability"):
+            PushPOMDP(discount_factor=0.95, dangerous_area_hit_probability=bad_value)
+
+    def test_native_rollout_bypassed_when_hit_probability_lt_one(self, monkeypatch):
+        """Stochastic dangerous-area hit probability bypasses native rollout.
+
+        Purpose: Validates that ``simulate_random_rollout`` falls back to
+            the Python rollout when ``dangerous_area_hit_probability < 1.0``,
+            so per-step Bernoulli draws are honoured.
+
+        Given: A PushPOMDP with ``dangerous_area_hit_probability=0.5``.
+        When: ``simulate_random_rollout`` is invoked after monkeypatching
+            ``_native.simulate_rollout_discrete`` to raise.
+        Then: No exception is raised because the native path was bypassed.
+
+        Test type: unit
+        """
+        env = self._danger_env(hit_probability=0.5)
+
+        def _explode(**_kwargs):
+            raise AssertionError("native simulate_rollout_discrete must not be called")
+
+        monkeypatch.setattr(push_native, "simulate_rollout_discrete", _explode)
+
+        class _Sampler:
+            def sample(self):
+                return random.choice(["up", "down", "right", "left"])
+
+        env.simulate_random_rollout(
+            state=self._safe_state(),
+            action_sampler=_Sampler(),
+            max_depth=5,
+            discount_factor=0.95,
+        )
+
+    def test_reward_range_includes_dangerous_area_penalty(self):
+        """Reward range lower bound shifts when a dangerous area is configured.
+
+        Purpose: Validates the advertised reward range accounts for the
+            additive dangerous-area penalty so it remains a true lower bound.
+
+        Given: Two PushPOMDPs differing only in whether ``dangerous_areas``
+            is configured (penalty is negative).
+        When: ``reward_range`` is read on both.
+        Then: The configured-env's lower bound is more negative by exactly
+            ``dangerous_area_penalty``.
+
+        Test type: unit
+        """
+        env_no = PushPOMDP(discount_factor=0.95, grid_size=10)
+        env_yes = PushPOMDP(
+            discount_factor=0.95,
+            grid_size=10,
+            dangerous_areas=[(2.0, 2.0)],
+            dangerous_area_penalty=-3.5,
+        )
+        assert env_yes.reward_range[0] == pytest.approx(env_no.reward_range[0] - 3.5)
+
+
 class TestSampleNextStepEquivalence:
     """Test that the optimized sample_next_step produces identical results to the base class."""
 
@@ -1684,6 +2004,9 @@ class TestPushNativeSimulateRollout:
                 obstacles=obs_arr,
                 obstacle_radius=float(env.obstacle_radius),
                 obstacle_penalty=float(env.obstacle_penalty),
+                dangerous_areas=env._dangerous_areas_arr,
+                dangerous_area_radius=float(env.dangerous_area_radius),
+                dangerous_area_penalty=float(env.dangerous_area_penalty),
                 transition_error_prob=float(env.transition_error_prob),
             )
         )
@@ -1751,6 +2074,9 @@ class TestPushNativeSimulateRollout:
                 obstacles=obs_arr,
                 obstacle_radius=float(env.obstacle_radius),
                 obstacle_penalty=float(env.obstacle_penalty),
+                dangerous_areas=env._dangerous_areas_arr,
+                dangerous_area_radius=float(env.dangerous_area_radius),
+                dangerous_area_penalty=float(env.dangerous_area_penalty),
                 transition_error_prob=float(env.transition_error_prob),
             )
         )
@@ -1801,6 +2127,159 @@ class TestPushNativeSimulateRollout:
             discount_factor=env.discount_factor,
         )
         assert result == 0.0
+
+    def test_native_rollout_includes_dangerous_area_penalty(self):
+        """Native rollout deducts dangerous-area penalty along the trajectory.
+
+        Purpose: Validates that the C++ ``simulate_rollout_discrete``
+            kernel applies ``dangerous_area_penalty`` when the intended
+            robot position lies in a configured zone, matching the
+            Python reference rollout reward.
+
+        Given: Two PushPOMDPs differing only in whether
+            ``dangerous_areas`` is configured. Action sequence is
+            crafted to drive the robot into the danger zone.
+        When: ``_python_simulate_random_rollout`` is invoked on both
+            (the native path is exercised separately by the existing
+            equivalence tests; here we validate the per-step reward
+            difference is exactly the cumulative penalty).
+        Then: The configured-env discounted return is more negative
+            than the safe-env return; the difference equals the sum of
+            discounted ``dangerous_area_penalty`` over steps that
+            entered the zone.
+
+        Test type: integration
+        """
+        _ACTIONS = ["up", "down", "right", "left"]
+        env_safe = PushPOMDP(
+            discount_factor=0.99,
+            grid_size=10,
+            push_threshold=1.0,
+            friction_coefficient=0.3,
+            observation_noise=0.1,
+            transition_error_prob=0.0,
+        )
+        env_danger = PushPOMDP(
+            discount_factor=0.99,
+            grid_size=10,
+            push_threshold=1.0,
+            friction_coefficient=0.3,
+            observation_noise=0.1,
+            transition_error_prob=0.0,
+            dangerous_areas=[(3.0, 3.0)],
+            dangerous_area_radius=0.5,
+            dangerous_area_penalty=-5.0,
+        )
+        # Robot at (2, 3) → action "right" → intended (3, 3) is in the zone.
+        initial_state = np.array([2.0, 3.0, 8.0, 8.0, 9.0, 9.0], dtype=np.float64)
+        # Single-step rollout with deterministic "right" action.
+        max_depth = 1
+        actions = ["right"]
+        action_indices = np.array([_ACTIONS.index(a) for a in actions], dtype=np.int64)
+        # Native paths
+        obs_arr_safe = env_safe._get_native_rollout_obstacles()
+        obs_arr_danger = env_danger._get_native_rollout_obstacles()
+        safe_return = float(
+            push_native.simulate_rollout_discrete(
+                state=initial_state,
+                action_indices=action_indices,
+                max_depth=max_depth,
+                depth=0,
+                discount=env_safe.discount_factor,
+                grid_size=float(env_safe.grid_size),
+                push_threshold=float(env_safe.push_threshold),
+                friction_coefficient=float(env_safe.friction_coefficient),
+                obstacles=obs_arr_safe,
+                obstacle_radius=float(env_safe.obstacle_radius),
+                obstacle_penalty=float(env_safe.obstacle_penalty),
+                dangerous_areas=env_safe._dangerous_areas_arr,
+                dangerous_area_radius=float(env_safe.dangerous_area_radius),
+                dangerous_area_penalty=float(env_safe.dangerous_area_penalty),
+                transition_error_prob=float(env_safe.transition_error_prob),
+            )
+        )
+        danger_return = float(
+            push_native.simulate_rollout_discrete(
+                state=initial_state,
+                action_indices=action_indices,
+                max_depth=max_depth,
+                depth=0,
+                discount=env_danger.discount_factor,
+                grid_size=float(env_danger.grid_size),
+                push_threshold=float(env_danger.push_threshold),
+                friction_coefficient=float(env_danger.friction_coefficient),
+                obstacles=obs_arr_danger,
+                obstacle_radius=float(env_danger.obstacle_radius),
+                obstacle_penalty=float(env_danger.obstacle_penalty),
+                dangerous_areas=env_danger._dangerous_areas_arr,
+                dangerous_area_radius=float(env_danger.dangerous_area_radius),
+                dangerous_area_penalty=float(env_danger.dangerous_area_penalty),
+                transition_error_prob=float(env_danger.transition_error_prob),
+            )
+        )
+        # Single step at depth 0 → discounted penalty == 1.0 * -5.0 = -5.0.
+        assert danger_return == pytest.approx(safe_return - 5.0, abs=1e-9)
+
+    def test_native_and_python_rollout_match_with_dangerous_areas(self):
+        """Native and Python rollout returns agree when zones are present.
+
+        Purpose: Regression check that the native rollout's dangerous-area
+            penalty path produces the same discounted return as the
+            Python reference.
+
+        Given: A PushPOMDP with one obstacle and one dangerous area, and
+            a 20-step deterministic action sequence.
+        When: Both native and Python rollouts execute from the same state.
+        Then: Returns agree to within ``atol=1e-9``.
+
+        Test type: integration
+        """
+        _ACTIONS = ["up", "down", "right", "left"]
+        env = PushPOMDP(
+            discount_factor=0.99,
+            grid_size=10,
+            push_threshold=1.0,
+            friction_coefficient=0.3,
+            observation_noise=0.1,
+            obstacles=[(7.0, 7.0)],
+            obstacle_radius=0.5,
+            obstacle_penalty=-10.0,
+            dangerous_areas=[(3.0, 3.0)],
+            dangerous_area_radius=0.5,
+            dangerous_area_penalty=-5.0,
+            transition_error_prob=0.0,
+        )
+        initial_state = np.array([2.0, 3.0, 2.5, 3.1, 9.0, 9.0], dtype=np.float64)
+        max_depth = 20
+        np.random.seed(7)
+        action_indices = np.random.randint(0, 4, size=max_depth, dtype=np.int64)
+        action_strings = [_ACTIONS[i] for i in action_indices]
+        python_return = env._python_simulate_random_rollout(
+            state=initial_state,
+            actions=action_strings,
+            max_depth=max_depth,
+            discount_factor=env.discount_factor,
+        )
+        native_return = float(
+            push_native.simulate_rollout_discrete(
+                state=initial_state,
+                action_indices=action_indices,
+                max_depth=max_depth,
+                depth=0,
+                discount=env.discount_factor,
+                grid_size=float(env.grid_size),
+                push_threshold=float(env.push_threshold),
+                friction_coefficient=float(env.friction_coefficient),
+                obstacles=env._get_native_rollout_obstacles(),
+                obstacle_radius=float(env.obstacle_radius),
+                obstacle_penalty=float(env.obstacle_penalty),
+                dangerous_areas=env._dangerous_areas_arr,
+                dangerous_area_radius=float(env.dangerous_area_radius),
+                dangerous_area_penalty=float(env.dangerous_area_penalty),
+                transition_error_prob=float(env.transition_error_prob),
+            )
+        )
+        np.testing.assert_allclose(native_return, python_return, atol=1e-9)
 
 
 def test_compute_metrics_values_within_confidence_intervals():


### PR DESCRIPTION
## Summary
- Adds new `dangerous_areas` kwarg (additive — does NOT touch existing `obstacles`) to `PushPOMDP`, `ContinuousPushPOMDP`, and `ContinuousPushPOMDPDiscreteActions`, mirroring the LaserTag dangerous-area design.
- Each entry is a circular zone that applies `dangerous_area_penalty` when the robot's intended/post-action position falls inside; movement is not blocked. Penalty applied at most once per step even when zones overlap.
- Stochastic `dangerous_area_hit_probability` (default `1.0`) for risk-sensitive planning. When `< 1.0`, the native C++ rollout is bypassed in favour of the Python rollout so per-step Bernoulli draws survive.
- C++ kernels (`simulate_rollout_discrete`, `cont_simulate_rollout`) extended with `dangerous_areas`, `dangerous_area_radius`, `dangerous_area_penalty` parameters; helpers `load_dangerous_areas` / `point_in_dangerous_areas` added in `_cpp/continuous_push.cpp`. Stub `_native.pyi` updated.
- Visualizers render danger zones as alpha-blended red circles (`facecolor="red"`, `alpha=0.3`).
- New metrics: `dangerous_area_rate`, `total_dangerous_area_steps` on both `PushPOMDPMetrics` and `ContinuousPushPOMDPMetrics`.
- Backward-compatible: defaults to no zones (`(0, 2)` empty array), so existing callers see zero behaviour change.

## Test plan
- [x] `pytest POMDPPlanners/tests/test_environments/test_push_pomdp/` — 267 passed
- [x] Cross-cutting Push consumers (env-API conformance, serialization, hash contracts, golden visualizations, env config tests) — 218 passed, 4 skipped, 10 xfailed
- [x] `pyright POMDPPlanners/environments/push_pomdp/` — 0 errors, 0 warnings
- [x] `pyright POMDPPlanners/tests/test_environments/test_push_pomdp/` — 0 errors, 0 warnings
- [x] Whole-tree `pyright POMDPPlanners/` — 0 errors (1 pre-existing warning in `core/environment.py:345` unrelated)
- [x] `pylint` on touched sources / tests — score improved vs. baseline; remaining warnings are pre-existing
- [x] Native rebuild via `pip install -e .`

## New tests
- `TestPushDangerousAreas` (13 tests): single-step penalty, batch reward, hit_probability ∈ {0, 1, 0.3 empirical}, default-empty, metrics, native bypass when `hit_probability < 1`, reward-range coverage, invalid-probability validation.
- `TestContinuousPushDangerousAreas` (6 tests): single-step, batch, default-empty, single-penalty for overlapping zones, metrics, native bypass.
- `TestContinuousPushDangerousHitProbability` (6 tests): default, p=0, p=1, empirical p=0.3, batch p=0, invalid-probability validation.
- `TestContinuousPushPOMDPDiscreteActionsDangerousAreas` (2 tests): kwarg forwarding, string-action penalty.
- `TestPushNativeSimulateRollout`: 2 new tests verifying native rollout deducts the penalty and matches the Python reference end-to-end.
- `TestNativeRolloutEquivalence`: 2 new tests for `cont_simulate_rollout` with/without dangerous areas (backward-compat sanity).