### PR TITLE
test(icvar-pomcpow): pin down paper-formula backup helpers

### DIFF
--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pomcpow.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pomcpow.py
@@ -1,11 +1,17 @@
 # pylint: disable=protected-access,too-many-lines,broad-exception-caught,unused-argument,import-outside-toplevel
 from logging import getLogger
 import inspect
+import math
 
 import numpy as np
 import pytest
 
-from POMDPPlanners.core.belief import WeightedParticleBelief, get_initial_belief
+from POMDPPlanners.core.belief import (
+    WeightedParticleBelief,
+    WeightedParticleBeliefStateUpdate,
+    get_initial_belief,
+)
+from POMDPPlanners.core.cost import belief_expectation_cost
 from POMDPPlanners.core.tree.arena import ACTION, BELIEF, Tree
 from POMDPPlanners.environments import TigerPOMDP, DiscreteLightDarkPOMDP
 from POMDPPlanners.utils.action_samplers import DiscreteActionSampler
@@ -206,6 +212,34 @@ def create_weighted_belief(particles, log_weights=None):
         # Uniform log-weights
         log_weights = np.log(np.ones(n) / n)
     return WeightedParticleBelief(particles=particles, log_weights=log_weights)
+
+
+def _make_planner_for_backup_test(env, action_sampler, alpha, discount_factor):
+    """Build a minimal ICVaR_POMCPOW with the specified ``alpha`` and ``γ``.
+
+    Used by the ``_update_q_value`` paper-formula tests, which need control
+    over α and γ to assert closed-form expected Q-values; the rest of the
+    constructor arguments are filler that does not influence the backup
+    arithmetic exercised here.
+    """
+    return ICVaR_POMCPOW(
+        environment=env,
+        discount_factor=discount_factor,
+        depth=3,
+        exploration_constant=1.0,
+        k_o=1.0,
+        k_a=1.0,
+        alpha_o=0.5,
+        alpha_a=0.5,
+        min_immediate_cost=-10.0,
+        max_immediate_cost=10.0,
+        min_visit_count_per_action=1,
+        delta=0.1,
+        name="test_icvar_pomcpow_backup",
+        action_sampler=action_sampler,
+        n_simulations=1,
+        alpha=alpha,
+    )
 
 
 def _iter_node_ids(tree: Tree, root_id: int):
@@ -500,6 +534,523 @@ class TestICVaR_POMCPOWCoreFunctionality:
                 f"Error: {e}"
             )
             pytest.fail(error_msg)
+
+    def test_update_belief_with_state_appends_particle_and_weight(
+        self, planner, belief, environment
+    ):
+        """Verify _update_belief_with_state mutates the child belief in place.
+
+        Purpose: Validates that _update_belief_with_state actually appends the
+        supplied state and its observation likelihood to the target child
+        belief, rather than merely reaching ``inplace_update`` without raising.
+
+        Given: A tree containing a root belief, an action node, and an empty
+            ``WeightedParticleBeliefStateUpdate`` registered as that action's
+            observation child.
+        When: ``_update_belief_with_state`` is called with a (state, action,
+            observation) triple sampled from the environment, and then again
+            with a second sampled triple targeting the same child belief.
+        Then: After the first call the child gains exactly one particle equal
+            to the supplied state, one weight equal to ``exp`` of the env's
+            observation log-probability, and ``weights_sum`` equal to that
+            weight; after the second call the particle/weight counts grow to
+            two and ``weights_sum`` equals the running total of both weights.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        tree = Tree()
+        root_id = tree.add_belief_node(belief)
+
+        action = environment.get_actions()[0]
+        action_id = tree.add_action_node(action=action, parent_id=root_id)
+
+        child_belief = WeightedParticleBeliefStateUpdate(particles=[], weights=[])
+        sampled_state = belief.sample()
+        next_state, observation, _ = environment.sample_next_step(
+            state=sampled_state, action=action
+        )
+        child_id = tree.add_belief_node(
+            belief=child_belief, observation=observation, parent_id=action_id
+        )
+
+        assert len(child_belief.particles) == 0
+        assert len(child_belief.weights) == 0
+        assert child_belief.weights_sum == 0
+
+        planner._update_belief_with_state(
+            tree=tree,
+            belief_id=child_id,
+            action_id=action_id,
+            observation=observation,
+            state=next_state,
+        )
+
+        first_log_p = environment.observation_log_probability_single(
+            next_state=next_state, action=action, observation=observation
+        )
+        first_weight = math.exp(first_log_p) if math.isfinite(first_log_p) else 0.0
+
+        assert len(child_belief.particles) == 1
+        assert child_belief.particles[-1] == next_state
+        assert len(child_belief.weights) == 1
+        assert child_belief.weights[-1] == pytest.approx(first_weight)
+        assert child_belief.weights_sum == pytest.approx(first_weight)
+
+        second_next_state, second_observation, _ = environment.sample_next_step(
+            state=next_state, action=action
+        )
+        planner._update_belief_with_state(
+            tree=tree,
+            belief_id=child_id,
+            action_id=action_id,
+            observation=second_observation,
+            state=second_next_state,
+        )
+        second_log_p = environment.observation_log_probability_single(
+            next_state=second_next_state, action=action, observation=second_observation
+        )
+        second_weight = math.exp(second_log_p) if math.isfinite(second_log_p) else 0.0
+
+        assert len(child_belief.particles) == 2
+        assert child_belief.particles[-1] == second_next_state
+        assert len(child_belief.weights) == 2
+        assert child_belief.weights[-1] == pytest.approx(second_weight)
+        assert child_belief.weights_sum == pytest.approx(first_weight + second_weight)
+
+    def test_update_immediate_cost_first_call_state_update_belief_uses_negative_reward(
+        self, planner, environment
+    ):
+        """First-call ``_update_immediate_cost`` on a state-update belief stores ``-reward``.
+
+        Purpose: Validates the first branch of the paper's running
+        weighted-average formula: when the action node has no cached
+        immediate cost yet and its child belief is a
+        ``WeightedParticleBeliefStateUpdate``, the cost is initialized to
+        ``-reward`` (i.e. ``c = -R`` per the paper's cost = negative reward
+        convention, matching algorithm line ``Imm(ha) ← (... + c·P)/W``
+        evaluated at ``W_old = 0``).
+
+        Given: A tree whose action node has ``immediate_cost = None`` and
+            whose child belief is a freshly populated
+            ``WeightedParticleBeliefStateUpdate`` with one particle.
+        When: ``_update_immediate_cost`` is called with a known reward.
+        Then: ``tree.immediate_cost[action_id]`` equals ``-reward`` exactly.
+
+        Test type: unit
+        """
+        tree = Tree()
+        action = environment.get_actions()[0]
+        sampled_state = environment.initial_state_dist().sample()[0]
+
+        root_belief = WeightedParticleBelief(
+            particles=[sampled_state, sampled_state], log_weights=np.log(np.array([0.5, 0.5]))
+        )
+        root_id = tree.add_belief_node(root_belief)
+        action_id = tree.add_action_node(action=action, parent_id=root_id)
+
+        child_belief = WeightedParticleBeliefStateUpdate(particles=[sampled_state], weights=[0.5])
+        child_id = tree.add_belief_node(belief=child_belief, observation="o", parent_id=action_id)
+
+        assert tree.immediate_cost[action_id] is None
+
+        reward = 3.5
+        planner._update_immediate_cost(
+            tree=tree, belief_id=child_id, action_id=action_id, reward=reward
+        )
+
+        assert tree.immediate_cost[action_id] == pytest.approx(-reward)
+
+    def test_update_immediate_cost_running_weighted_average(self, planner, environment):
+        """Subsequent ``_update_immediate_cost`` follows the paper's running weighted average.
+
+        Purpose: Validates the formula
+        ``Imm_new = (Imm_old · W_old + c · w_new) / W_new`` where
+        ``W_new = W_old + w_new``, ``c = -reward``, and ``w_new`` is the
+        weight of the most recently appended particle (i.e.
+        ``belief.weights[-1]``). This is the recursive form on line
+        :paper:`Imm(ha) ← (Imm·W_old + c·P) / W_new` of ICVaR-POMCPOW
+        Simulate.
+
+        Given: A tree whose action node already has a cached
+            ``immediate_cost`` (treated as the ``Imm_old`` from a previous
+            backup) and whose child belief is a
+            ``WeightedParticleBeliefStateUpdate`` populated with two
+            particles whose weights are explicit known values.
+        When: ``_update_immediate_cost`` is called with a known reward.
+        Then: ``tree.immediate_cost[action_id]`` equals the closed-form
+            running-average value computed independently in the test.
+
+        Test type: unit
+        """
+        tree = Tree()
+        action = environment.get_actions()[0]
+        sampled_state = environment.initial_state_dist().sample()[0]
+
+        root_belief = WeightedParticleBelief(
+            particles=[sampled_state, sampled_state], log_weights=np.log(np.array([0.5, 0.5]))
+        )
+        root_id = tree.add_belief_node(root_belief)
+        action_id = tree.add_action_node(action=action, parent_id=root_id)
+
+        weight_old = 0.7
+        weight_new = 0.4
+        child_belief = WeightedParticleBeliefStateUpdate(
+            particles=[sampled_state, sampled_state],
+            weights=[weight_old, weight_new],
+        )
+        assert child_belief.weights_sum == pytest.approx(weight_old + weight_new)
+
+        child_id = tree.add_belief_node(belief=child_belief, observation="o", parent_id=action_id)
+
+        imm_old = -1.25
+        tree.set_immediate_cost(action_id, imm_old)
+
+        reward = 2.0
+        planner._update_immediate_cost(
+            tree=tree, belief_id=child_id, action_id=action_id, reward=reward
+        )
+
+        expected = (imm_old * weight_old + (-reward) * weight_new) / (weight_old + weight_new)
+        assert tree.immediate_cost[action_id] == pytest.approx(expected)
+
+    def test_update_immediate_cost_recursive_calls_match_closed_form_weighted_average(
+        self, planner, environment
+    ):
+        """N sequential ``_update_immediate_cost`` calls compose into ``Σ(-r·w)/Σw``.
+
+        Purpose: Validates that the recursive update
+        ``Imm_new = (Imm_old·W_old + (-r_new)·w_new) / W_new`` (paper algo
+        line ``Imm(ha) ← (Imm·W_old + c·P)/W_new``) actually accumulates
+        across many particles into the same value as the explicit
+        weighted average ``Σ_i (-r_i)·w_i / Σ_i w_i``. The single-step
+        test pins down the formula on one update; this test pins down
+        that repeated application gives the closed-form answer over a
+        whole sequence — no per-step rounding drift, correct treatment
+        of the first-call special case (``Imm = -reward_1``).
+
+        Given: Three sequential particle additions with explicit
+            (reward, weight) pairs ``(1.0, 0.5)``, ``(3.0, 0.25)``,
+            ``(5.0, 0.25)``. Each iteration appends to the child belief
+            then calls ``_update_immediate_cost``.
+        When: ``_update_immediate_cost`` is invoked once after each
+            append, in order.
+        Then: After all three calls,
+            ``immediate_cost[action_id] = (-1·0.5 - 3·0.25 - 5·0.25) /
+            (0.5+0.25+0.25) = -2.5/1.0 = -2.5`` exactly.
+
+        Test type: unit
+        """
+        tree = Tree()
+        action = environment.get_actions()[0]
+        sampled_state = environment.initial_state_dist().sample()[0]
+
+        root_belief = WeightedParticleBelief(
+            particles=[sampled_state, sampled_state], log_weights=np.log(np.array([0.5, 0.5]))
+        )
+        root_id = tree.add_belief_node(root_belief)
+        action_id = tree.add_action_node(action=action, parent_id=root_id)
+
+        child_belief = WeightedParticleBeliefStateUpdate(particles=[], weights=[])
+        child_id = tree.add_belief_node(belief=child_belief, observation="o", parent_id=action_id)
+
+        rewards_and_weights = [(1.0, 0.5), (3.0, 0.25), (5.0, 0.25)]
+        for reward, weight in rewards_and_weights:
+            child_belief.particles.append(sampled_state)
+            child_belief.weights.append(weight)
+            child_belief.weights_sum += weight
+            planner._update_immediate_cost(
+                tree=tree, belief_id=child_id, action_id=action_id, reward=reward
+            )
+
+        # Closed form: Σ(-r·w) / Σw = (-0.5 - 0.75 - 1.25) / 1.0 = -2.5
+        assert tree.immediate_cost[action_id] == pytest.approx(-2.5)
+
+    def test_update_immediate_cost_root_belief_uses_belief_expectation_cost(
+        self, planner, belief, environment
+    ):
+        """Root-frame ``_update_immediate_cost`` delegates to ``belief_expectation_cost``.
+
+        Purpose: Validates that when the child belief is *not* a
+        ``WeightedParticleBeliefStateUpdate`` (i.e. the action node lives
+        directly under the root belief), the first-call path stores
+        ``belief_expectation_cost(belief, action, env)`` — the
+        expected-cost form ``Σ_j w̃^j c(x^j, a)`` of paper eq. (Qest).
+
+        Given: A tree whose action node has ``immediate_cost = None`` and
+            whose child belief is a regular ``WeightedParticleBelief``
+            (the root-frame belief type).
+        When: ``_update_immediate_cost`` is called with an arbitrary
+            reward (which the root path ignores).
+        Then: ``tree.immediate_cost[action_id]`` equals the value returned
+            by ``belief_expectation_cost(belief, action, env)``.
+
+        Test type: unit
+        """
+        tree = Tree()
+        action = environment.get_actions()[0]
+
+        root_id = tree.add_belief_node(belief)
+        action_id = tree.add_action_node(action=action, parent_id=root_id)
+
+        # Root-frame: child belief is a non-state-update belief.
+        child_belief = belief
+        child_id = tree.add_belief_node(belief=child_belief, observation="o", parent_id=action_id)
+
+        assert tree.immediate_cost[action_id] is None
+
+        planner._update_immediate_cost(
+            tree=tree, belief_id=child_id, action_id=action_id, reward=999.0
+        )
+
+        expected = belief_expectation_cost(belief=belief, action=action, env=environment)
+        assert tree.immediate_cost[action_id] == pytest.approx(expected)
+
+    def test_update_q_value_constant_v_children_yields_imm_plus_gamma_v(
+        self, environment, action_sampler, belief
+    ):
+        """Constant V-distribution: ``Q = Imm + γ·v`` for any α and any weights.
+
+        Purpose: Validates the action-value backup
+        ``Q(ba) = Imm(ha) + γ · Ĉ_α(V_children)`` (paper eq. 250) on the
+        degenerate-distribution case: when every child has the same V,
+        the upper-α CVaR equals that constant V, regardless of α or the
+        per-child sampling frequencies.
+
+        Given: A planner with α = 0.1, γ = 0.5; an action node with three
+            visited belief children that all have ``v_value = 4.0`` and
+            heterogeneous weights ``[1, 2, 3]``; ``immediate_cost = -1``.
+        When: ``_update_q_value`` is called.
+        Then: ``q_value[action] = -1 + 0.5 · 4.0 = 1.0`` exactly.
+
+        Test type: unit
+        """
+        local_planner = _make_planner_for_backup_test(
+            environment, action_sampler, alpha=0.1, discount_factor=0.5
+        )
+        tree = Tree()
+        action = environment.get_actions()[0]
+        root_id = tree.add_belief_node(belief)
+        action_id = tree.add_action_node(action=action, parent_id=root_id)
+
+        for w in (1.0, 2.0, 3.0):
+            child_belief = WeightedParticleBeliefStateUpdate(particles=[], weights=[])
+            cid = tree.add_belief_node(
+                belief=child_belief, observation=f"o_{w}", parent_id=action_id, weight=w
+            )
+            tree.v_value[cid] = 4.0
+            tree.visit_count[cid] = 1
+
+        tree.set_immediate_cost(action_id, -1.0)
+
+        local_planner._update_q_value(tree=tree, action_id=action_id)
+
+        assert tree.q_value[action_id] == pytest.approx(1.0)
+
+    def test_update_q_value_alpha_one_reduces_to_expected_value(
+        self, environment, action_sampler, belief
+    ):
+        """α = 1 case: ``Ĉ_1`` is the weighted mean, so ``Q = Imm + γ · E[V]``.
+
+        Purpose: Validates the paper's stated property (Section 6) that
+        ``α = 1`` recovers expectation-based planning. Under ``α = 1``,
+        ``Ĉ_α({(V_i, w_i)}) = Σ w_i V_i``, so the Q-update reduces to the
+        risk-neutral Bellman backup.
+
+        Given: A planner with α = 1.0, γ = 1.0; an action node with three
+            visited belief children with ``v_value = [1.0, 2.0, 3.0]`` and
+            tree weights ``[1, 1, 3]`` (normalized to ``[0.2, 0.2, 0.6]``);
+            ``immediate_cost = 0``.
+        When: ``_update_q_value`` is called.
+        Then: ``q_value = 0 + 1.0 · (0.2·1 + 0.2·2 + 0.6·3) = 2.4`` exactly.
+
+        Test type: unit
+        """
+        local_planner = _make_planner_for_backup_test(
+            environment, action_sampler, alpha=1.0, discount_factor=1.0
+        )
+        tree = Tree()
+        action = environment.get_actions()[0]
+        root_id = tree.add_belief_node(belief)
+        action_id = tree.add_action_node(action=action, parent_id=root_id)
+
+        v_values = [1.0, 2.0, 3.0]
+        weights = [1.0, 1.0, 3.0]  # normalize to [0.2, 0.2, 0.6]
+        for v, w in zip(v_values, weights):
+            child_belief = WeightedParticleBeliefStateUpdate(particles=[], weights=[])
+            cid = tree.add_belief_node(
+                belief=child_belief, observation=f"o_{v}", parent_id=action_id, weight=w
+            )
+            tree.v_value[cid] = v
+            tree.visit_count[cid] = 1
+
+        tree.set_immediate_cost(action_id, 0.0)
+
+        local_planner._update_q_value(tree=tree, action_id=action_id)
+
+        # E[V] = 0.2·1 + 0.2·2 + 0.6·3 = 0.2 + 0.4 + 1.8 = 2.4
+        assert tree.q_value[action_id] == pytest.approx(2.4)
+
+    def test_update_q_value_alpha_half_two_equal_weight_children_equals_max_v(
+        self, environment, action_sampler, belief
+    ):
+        """α=0.5, two equal-weight children: ``Ĉ_α`` = the larger V (top half).
+
+        Purpose: Validates the upper-α tail behavior of ``Ĉ_α`` on the
+        smallest non-trivial case. With two equal-weight children
+        (each weight 1/2 = α), the worst-α probability mass lies entirely
+        on the larger V, so ``Ĉ_α = max(V_1, V_2)``.
+
+        Given: A planner with α = 0.5, γ = 1.0; an action node with two
+            visited belief children with ``v_value = [3.0, 7.0]`` and
+            equal tree weights ``[1, 1]``; ``immediate_cost = -1``.
+        When: ``_update_q_value`` is called.
+        Then: ``q_value = -1 + 1.0 · 7.0 = 6.0`` exactly.
+
+        Test type: unit
+        """
+        local_planner = _make_planner_for_backup_test(
+            environment, action_sampler, alpha=0.5, discount_factor=1.0
+        )
+        tree = Tree()
+        action = environment.get_actions()[0]
+        root_id = tree.add_belief_node(belief)
+        action_id = tree.add_action_node(action=action, parent_id=root_id)
+
+        for v in (3.0, 7.0):
+            child_belief = WeightedParticleBeliefStateUpdate(particles=[], weights=[])
+            cid = tree.add_belief_node(
+                belief=child_belief, observation=f"o_{v}", parent_id=action_id, weight=1.0
+            )
+            tree.v_value[cid] = v
+            tree.visit_count[cid] = 1
+
+        tree.set_immediate_cost(action_id, -1.0)
+
+        local_planner._update_q_value(tree=tree, action_id=action_id)
+
+        assert tree.q_value[action_id] == pytest.approx(6.0)
+
+    def test_update_q_value_alpha_half_four_equal_weight_children_equals_mean_of_top_two(
+        self, environment, action_sampler, belief
+    ):
+        """α=0.5, four equal-weight children: ``Ĉ_α`` = mean of the two largest V's.
+
+        Purpose: Validates ``Ĉ_α`` aggregation when the upper-α tail
+        spans more than one outcome. With four equal-weight children
+        (each 1/4) and α = 0.5, the worst-α mass = 1/2 covers the two
+        largest V's exactly, so ``Ĉ_α = (V_top + V_2nd) / 2``.
+
+        Given: A planner with α = 0.5, γ = 0.5; an action node with four
+            visited belief children with ``v_value = [1.0, 2.0, 5.0, 8.0]``
+            and equal tree weights; ``immediate_cost = -2``.
+        When: ``_update_q_value`` is called.
+        Then: ``q_value = -2 + 0.5 · (5+8)/2 = -2 + 0.5 · 6.5 = 1.25``
+            exactly.
+
+        Test type: unit
+        """
+        local_planner = _make_planner_for_backup_test(
+            environment, action_sampler, alpha=0.5, discount_factor=0.5
+        )
+        tree = Tree()
+        action = environment.get_actions()[0]
+        root_id = tree.add_belief_node(belief)
+        action_id = tree.add_action_node(action=action, parent_id=root_id)
+
+        for v in (1.0, 2.0, 5.0, 8.0):
+            child_belief = WeightedParticleBeliefStateUpdate(particles=[], weights=[])
+            cid = tree.add_belief_node(
+                belief=child_belief, observation=f"o_{v}", parent_id=action_id, weight=1.0
+            )
+            tree.v_value[cid] = v
+            tree.visit_count[cid] = 1
+
+        tree.set_immediate_cost(action_id, -2.0)
+
+        local_planner._update_q_value(tree=tree, action_id=action_id)
+
+        assert tree.q_value[action_id] == pytest.approx(1.25)
+
+    def test_update_v_value_equals_min_q_over_visited_action_children(
+        self, planner, belief, environment
+    ):
+        """``V(b) = min_{a ∈ visited children of b} Q(ba)``: pure min over visited Q's.
+
+        Purpose: Validates the V-update of paper eq. (Vest) /
+        algorithm line ``V(h) ← min_{a ∈ Ch(h)} V(ha)``: the V-value at a
+        belief node equals the minimum Q-value over its visited action
+        children. Action children with ``visit_count == 0`` are excluded,
+        even when their (stale or default) Q-value is smaller than the
+        true minimum over visited children.
+
+        Given: A belief node with three visited action children with
+            ``q_value = [4.0, -1.0, 2.5]`` and one unvisited action child
+            with ``q_value = -999.0`` (must be ignored).
+        When: ``_update_v_value`` is called for the belief node.
+        Then: ``v_value[belief] = -1.0`` (the minimum over visited
+            children only); the unvisited ``-999.0`` is excluded.
+
+        Test type: unit
+        """
+        tree = Tree()
+        root_id = tree.add_belief_node(belief)
+
+        actions = environment.get_actions()
+        # Three visited action children with known Q-values.
+        visited_qs = [4.0, -1.0, 2.5]
+        for i, q in enumerate(visited_qs):
+            aid = tree.add_action_node(action=actions[i % len(actions)], parent_id=root_id)
+            tree.q_value[aid] = q
+            tree.visit_count[aid] = 1
+
+        # One unvisited action child whose smaller Q must be ignored.
+        unvisited_aid = tree.add_action_node(action=actions[0], parent_id=root_id)
+        tree.q_value[unvisited_aid] = -999.0
+        tree.visit_count[unvisited_aid] = 0
+
+        planner._update_v_value(tree=tree, belief_id=root_id)
+
+        assert tree.v_value[root_id] == pytest.approx(-1.0)
+
+    def test_update_q_value_no_visited_children_returns_immediate_cost(
+        self, planner, belief, environment
+    ):
+        """``_update_q_value`` falls back to ``immediate_cost`` when no children are visited.
+
+        Purpose: Validates the leaf-action edge case: if the action node
+        has no visited children (either because it has no children at all,
+        or because every child has ``visit_count == 0``), the Q-value is
+        set to the immediate cost alone — there is no CVaR term to add.
+
+        Given: A tree with an action node carrying a known
+            ``immediate_cost`` and a single belief child whose
+            ``visit_count`` is 0.
+        When: ``_update_q_value`` is called for that action node.
+        Then: ``tree.q_value[action_id]`` equals ``immediate_cost`` exactly
+            (no contribution from the unvisited child's V-value).
+
+        Test type: unit
+        """
+        tree = Tree()
+        action = environment.get_actions()[0]
+
+        root_id = tree.add_belief_node(belief)
+        action_id = tree.add_action_node(action=action, parent_id=root_id)
+
+        unvisited_belief = WeightedParticleBeliefStateUpdate(particles=[], weights=[])
+        unvisited_id = tree.add_belief_node(
+            belief=unvisited_belief, observation="o", parent_id=action_id, weight=1.0
+        )
+        tree.v_value[unvisited_id] = 42.0  # Must not influence the result.
+        tree.visit_count[unvisited_id] = 0
+
+        imm = -1.5
+        tree.set_immediate_cost(action_id, imm)
+
+        planner._update_q_value(tree=tree, action_id=action_id)
+
+        assert tree.q_value[action_id] == pytest.approx(imm)
 
 
 class TestICVaR_POMCPOWIntegration:


### PR DESCRIPTION
## Summary

Adds direct unit tests for `ICVaR_POMCPOW`'s protected backup helpers (`_update_belief_with_state`, `_update_immediate_cost`, `_update_q_value`, `_update_v_value`) so the paper's recursive-Imm, ICVaR Q-update, and min-Q V-update formulas are verified independently of the simulation loop. Previously only the V-min relationship was structurally checked end-to-end via `_simulate_path`; the running-average Imm formula and the ICVaR Q backup had no direct numeric tests, and the leaf-action and unvisited-child edge cases were unverified.

All Q-value tests use closed-form numeric examples computed by hand from the paper's CVaR definition (eq. 100), not by calling the same kernel the implementation uses — so a kernel regression would be caught.

### Tests added (in `TestICVaR_POMCPOWCoreFunctionality`)

- `test_update_belief_with_state_appends_particle_and_weight` — verifies `inplace_update` is reached and accumulates `particles`, `weights`, `weights_sum` correctly across two updates.
- `test_update_immediate_cost_first_call_state_update_belief_uses_negative_reward` — first-call branch sets `Imm = -reward` for `WeightedParticleBeliefStateUpdate`.
- `test_update_immediate_cost_running_weighted_average` — single recursive step matches the formula `(Imm·W_old + (-r)·w_new) / W_new`.
- `test_update_immediate_cost_recursive_calls_match_closed_form_weighted_average` — three sequential calls compose into `Σ(-rᵢ)wᵢ / Σwᵢ = -2.5` (closed form).
- `test_update_immediate_cost_root_belief_uses_belief_expectation_cost` — root-frame path delegates to `belief_expectation_cost` (paper eq. Qest's `Σⱼ w̃ʲ c(xʲ, a)`).
- `test_update_q_value_constant_v_children_yields_imm_plus_gamma_v` — degenerate distribution: all V's equal ⇒ Ĉ_α = V_const for any α; γ=0.5, Imm=−1, V=4 ⇒ Q=1.
- `test_update_q_value_alpha_one_reduces_to_expected_value` — α=1 ⇒ Ĉ_α = E[V]; weights `[0.2, 0.2, 0.6]` on V=`[1,2,3]` ⇒ Q=2.4.
- `test_update_q_value_alpha_half_two_equal_weight_children_equals_max_v` — α=0.5 over 2 equal-weight children ⇒ Ĉ_α = max; V=`[3,7]` ⇒ Q=6.
- `test_update_q_value_alpha_half_four_equal_weight_children_equals_mean_of_top_two` — α=0.5 over 4 equal-weight children ⇒ Ĉ_α = mean of top 2; V=`[1,2,5,8]`, γ=0.5, Imm=−2 ⇒ Q=1.25.
- `test_update_q_value_no_visited_children_returns_immediate_cost` — leaf-action edge case.
- `test_update_v_value_equals_min_q_over_visited_action_children` — V = min over visited children's Q's; an unvisited Q=−999 sibling is correctly excluded.

## Test plan
- [x] All new tests pass (`pytest TestICVaR_POMCPOWCoreFunctionality -v`)
- [x] Pyright clean (0 errors / 0 warnings / 0 informations) on the test file
- [x] Pylint 10.00/10 on the test file
- [x] CI green on PR