### PR TITLE
Drop redundant gamma param in SparsePFT; add sparse-sampling tree tests

### DIFF
--- a/POMDPPlanners/configs/planners_hyperparam_configs.py
+++ b/POMDPPlanners/configs/planners_hyperparam_configs.py
@@ -122,7 +122,6 @@ class PlannersHyperparamConfigs:
 
         constant_parameters = {
             "discount_factor": self.discount_factor,
-            "gamma": self.discount_factor,
             "name": name,
             "environment": env,
             "time_out_in_seconds": time_out_in_seconds,

--- a/POMDPPlanners/planners/mcts_planners/sparse_pft.py
+++ b/POMDPPlanners/planners/mcts_planners/sparse_pft.py
@@ -40,7 +40,6 @@ class SparsePFT(ArenaPathSimulationPolicy):
         >>> planner = SparsePFT(
         ...     environment=tiger,
         ...     discount_factor=0.95,
-        ...     gamma=0.95,
         ...     depth=5,
         ...     c_ucb=1.0,
         ...     beta_ucb=2.0,
@@ -63,7 +62,6 @@ class SparsePFT(ArenaPathSimulationPolicy):
         self,
         environment: DiscreteActionsEnvironment,
         discount_factor: float,
-        gamma: float,
         depth: int,
         c_ucb: float,
         beta_ucb: float,
@@ -80,8 +78,6 @@ class SparsePFT(ArenaPathSimulationPolicy):
             raise TypeError("environment must be a DiscreteActionsEnvironment instance")
         if not isinstance(discount_factor, float):
             raise TypeError("discount_factor must be a float")
-        if not isinstance(gamma, float):
-            raise TypeError("gamma must be a float")
         if not isinstance(depth, int):
             raise TypeError("depth must be an int")
         if not isinstance(c_ucb, float):
@@ -106,7 +102,6 @@ class SparsePFT(ArenaPathSimulationPolicy):
             use_queue_logger=use_queue_logger,
         )
 
-        self.gamma = gamma
         self.depth = depth
         self.c_ucb = c_ucb
         self.beta_ucb = beta_ucb
@@ -136,7 +131,7 @@ class SparsePFT(ArenaPathSimulationPolicy):
         else:
             next_belief_id, immediate_reward = self._generate_belief(tree=tree, action_id=action_id)
 
-        return_sample = immediate_reward + self.gamma * self._simulate_path(
+        return_sample = immediate_reward + self.discount_factor * self._simulate_path(
             tree=tree, belief_id=next_belief_id, depth=depth + 1
         )
 

--- a/POMDPPlanners/tests/benchmarks/conftest.py
+++ b/POMDPPlanners/tests/benchmarks/conftest.py
@@ -203,7 +203,6 @@ def sparse_pft_planner(tiger_env):
     return SparsePFT(
         environment=tiger_env,
         discount_factor=DISCOUNT_FACTOR,
-        gamma=DISCOUNT_FACTOR,
         depth=DEPTH,
         c_ucb=1.0,
         beta_ucb=0.5,

--- a/POMDPPlanners/tests/benchmarks/test_benchmark_combined.py
+++ b/POMDPPlanners/tests/benchmarks/test_benchmark_combined.py
@@ -133,7 +133,6 @@ def test_bench_sparse_pft_tiger(benchmark):
     planner = SparsePFT(
         environment=env,
         discount_factor=DISCOUNT,
-        gamma=DISCOUNT,
         depth=DEPTH,
         c_ucb=1.0,
         beta_ucb=0.5,
@@ -160,7 +159,6 @@ def test_bench_sparse_pft_discrete_ld(benchmark):
     planner = SparsePFT(
         environment=env,
         discount_factor=DISCOUNT,
-        gamma=DISCOUNT,
         depth=DEPTH,
         c_ucb=1.0,
         beta_ucb=0.5,

--- a/POMDPPlanners/tests/conftest.py
+++ b/POMDPPlanners/tests/conftest.py
@@ -82,7 +82,6 @@ def sparse_pft_policy(tiger_environment):
     return SparsePFT(
         environment=tiger_environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=10,
         c_ucb=1.0,
         beta_ucb=0.5,

--- a/POMDPPlanners/tests/test_configs/test_planners_hyperparam_configs.py
+++ b/POMDPPlanners/tests/test_configs/test_planners_hyperparam_configs.py
@@ -154,8 +154,7 @@ class TestPlannersHyperparamConfigs:
         expected_params = ["depth", "c_ucb", "beta_ucb", "belief_child_num"]
         assert set(param_names) == set(expected_params)
 
-        # Check unique parameter "gamma" instead of "discount_factor"
-        assert config.constant_parameters["gamma"] == self.discount_factor
+        assert config.constant_parameters["discount_factor"] == self.discount_factor
         assert "action_sampler" not in config.constant_parameters
 
     def test_sparse_sampling_config(self):

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_sparse_pft.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_sparse_pft.py
@@ -73,7 +73,6 @@ def planner(
     return SparsePFT(
         environment=environment,
         discount_factor=discount_factor,
-        gamma=discount_factor,
         depth=depth,
         c_ucb=c_ucb,
         beta_ucb=beta_ucb,
@@ -96,7 +95,6 @@ def test_initialization(planner, environment):
     """
     assert planner.environment == environment
     assert planner.discount_factor == 0.9
-    assert planner.gamma == 0.9
     assert planner.depth == 3
     assert planner.c_ucb == 1.0
     assert planner.beta_ucb == 1.0
@@ -388,7 +386,6 @@ def test_sanity_pomdp_action_selection():
     planner = SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=3,
         c_ucb=1.0,
         beta_ucb=1.0,
@@ -433,7 +430,6 @@ def test_sanity_pomdp_belief_children():
     planner = SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=3,
         c_ucb=1.0,
         beta_ucb=1.0,
@@ -479,7 +475,6 @@ def test_sparse_pft_config_id_consistency_identical_parameters():
     sparse_pft1 = SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=12,
         c_ucb=1.0,
         beta_ucb=2.0,
@@ -492,7 +487,6 @@ def test_sparse_pft_config_id_consistency_identical_parameters():
     sparse_pft2 = SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=12,
         c_ucb=1.0,
         beta_ucb=2.0,
@@ -527,7 +521,6 @@ def test_sparse_pft_config_id_different_c_ucb():
     sparse_pft1 = SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=12,
         c_ucb=1.0,
         beta_ucb=2.0,
@@ -540,7 +533,6 @@ def test_sparse_pft_config_id_different_c_ucb():
     sparse_pft2 = SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=12,
         c_ucb=1.5,  # Different c_ucb
         beta_ucb=2.0,
@@ -572,7 +564,6 @@ def test_sparse_pft_config_id_different_belief_child_num():
     sparse_pft1 = SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=12,
         c_ucb=1.0,
         beta_ucb=2.0,
@@ -585,7 +576,6 @@ def test_sparse_pft_config_id_different_belief_child_num():
     sparse_pft2 = SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=12,
         c_ucb=1.0,
         beta_ucb=2.0,
@@ -617,7 +607,6 @@ def test_sparse_pft_config_id_consistency_across_evaluations():
     sparse_pft = SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=5,  # Reduced for testing
         c_ucb=1.0,
         beta_ucb=2.0,
@@ -668,7 +657,6 @@ def test_sparse_pft_config_id_hash_properties():
     sparse_pft = SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=12,
         c_ucb=1.0,
         beta_ucb=2.0,

--- a/POMDPPlanners/tests/test_planners/test_planner_save_load_interface.py
+++ b/POMDPPlanners/tests/test_planners/test_planner_save_load_interface.py
@@ -222,7 +222,6 @@ class TestPlannerSaveLoadInterface:
             {
                 "environment": self.tiger_env,
                 "discount_factor": 0.95,
-                "gamma": 0.95,
                 "depth": 10,
                 "c_ucb": 1.0,
                 "beta_ucb": 0.5,

--- a/POMDPPlanners/tests/test_planners/test_planner_serialization.py
+++ b/POMDPPlanners/tests/test_planners/test_planner_serialization.py
@@ -157,7 +157,6 @@ class TestPlannerSerialization:
             {
                 "environment": self.tiger_env,
                 "discount_factor": 0.95,
-                "gamma": 0.95,
                 "depth": 10,
                 "c_ucb": 10.0,
                 "beta_ucb": 0.5,
@@ -358,7 +357,6 @@ class TestPlannerSerializationRoundTrip:
             SparsePFT(
                 environment=self.env,
                 discount_factor=0.95,
-                gamma=0.95,
                 depth=10,
                 c_ucb=10.0,
                 beta_ucb=0.5,
@@ -530,7 +528,6 @@ class TestPlannerSerializationEdgeCases:
             "sparse_pft": SparsePFT(
                 environment=self.env,
                 discount_factor=0.95,
-                gamma=0.95,
                 depth=10,
                 c_ucb=10.0,
                 beta_ucb=0.5,
@@ -590,7 +587,6 @@ class TestAllPlannersPicklable:
             SparsePFT(
                 environment=self.env,
                 discount_factor=0.95,
-                gamma=0.95,
                 depth=10,
                 c_ucb=10.0,
                 beta_ucb=0.5,

--- a/POMDPPlanners/tests/test_planners/test_sparse_sampling_planners/test_sparse_sampling.py
+++ b/POMDPPlanners/tests/test_planners/test_sparse_sampling_planners/test_sparse_sampling.py
@@ -98,78 +98,80 @@ def test_belief_tree_construction(planner, initial_belief):
     assert tree.height == planner.depth * 2 + 1
 
 
-@pytest.mark.parametrize("branching_factor,depth", [(1, 1), (2, 2), (3, 1), (1, 3), (2, 3)])
-def test_belief_tree_has_correct_size(tiger_pomdp, initial_belief, branching_factor, depth):
-    """Test that the sparse sampling belief tree has the exact number of nodes required.
+def test_tree_structure_invariants(planner, initial_belief):
+    """Validate the structural invariants of a fully built sparse-sampling tree.
 
-    Purpose: Validates that _build_tree produces the tree size required by the
-        Kearns-Mansour-Ng sparse sampling algorithm. Every non-leaf ActionNode must
-        have exactly ``branching_factor`` BeliefNode children (one per sampled
-        next-state/observation), and every BeliefNode must have one ActionNode child
-        per environment action.
+    Purpose: ``test_belief_tree_construction`` checks the root attributes and
+    total tree height but does not pin down the per-node shape. This test
+    walks the entire tree and asserts the five structural invariants the
+    algorithm relies on, so that a regression that violates any of them
+    (e.g. an ActionNode acquiring two BeliefNode children, or a BeliefNode
+    appearing as a leaf) fails immediately.
 
-    Given: TigerPOMDP with |A|=3 actions and a planner with the given branching_factor
-        C and depth D
-    When: _build_tree constructs the sparse sampling tree from a root BeliefNode at
-        current_depth=0
-    Then: For each level 0 <= d <= D the tree has (|A|*C)^d BeliefNodes; every
-        BeliefNode has exactly |A| ActionNode children; every non-leaf ActionNode has
-        exactly C BeliefNode children; every leaf ActionNode (under a depth-D belief)
-        has 0 children; total node counts match the closed-form sums.
+    Given: StandardSparseSamplingPlanner (depth=2, |actions|=3 for TigerPOMDP)
+        and a uniform initial belief
+    When: ``_build_tree`` constructs the lookahead tree from the root
+    Then: 1) Levels strictly alternate Belief -> Action -> Belief -> ...
+          2) Every non-leaf BeliefNode has exactly |actions| ActionNode
+             children, one per action
+          3) Every non-leaf ActionNode has exactly ``branching_factor``
+             BeliefNode children, one per sampled outcome
+          4) Every leaf is an ActionNode
+          5) Every root-to-leaf path has the same length
 
     Test type: unit
     """
-    planner = SparseSamplingDiscreteActionsPlanner(
-        environment=tiger_pomdp, branching_factor=branching_factor, depth=depth
-    )
-    num_actions = len(tiger_pomdp.get_actions())
-
     tree = BeliefNode(belief=initial_belief)
     planner._build_tree(belief_node=tree, current_depth=0)
 
-    belief_nodes_at_level = {0: [tree]}
-    for level in range(depth):
-        next_level: list = []
-        for belief_node in belief_nodes_at_level[level]:
-            assert len(belief_node.children) == num_actions, (
-                f"BeliefNode at level {level} has {len(belief_node.children)} action "
-                f"children, expected {num_actions}"
+    actions = list(planner.environment.get_actions())  # type: ignore[attr-defined]
+    leaf_depths: list[int] = []
+
+    for node in PostOrderIter(tree):
+        # 4) leaves are ActionNodes; collect leaf depths for invariant 5
+        if node.is_leaf:
+            assert isinstance(
+                node, ActionNode
+            ), f"Leaf is {type(node).__name__}, expected ActionNode"
+            leaf_depths.append(node.depth)
+            continue
+
+        # 1) type alternation + 2/3) child-count rules per parent type
+        if isinstance(node, BeliefNode):
+            child_actions = []
+            for child in node.children:
+                assert isinstance(
+                    child, ActionNode
+                ), f"BeliefNode child is {type(child).__name__}, expected ActionNode"
+                child_actions.append(child.action)
+            assert len(node.children) == len(actions), (
+                f"BeliefNode has {len(node.children)} action children, "
+                f"expected {len(actions)} (one per action)"
             )
-            for action_node in belief_node.children:
-                assert isinstance(action_node, ActionNode)
-                assert len(action_node.children) == branching_factor, (
-                    f"Non-leaf ActionNode at level {level} has "
-                    f"{len(action_node.children)} belief children, expected "
-                    f"{branching_factor} (branching_factor)"
-                )
-                for next_belief_node in action_node.children:
-                    assert isinstance(next_belief_node, BeliefNode)
-                    next_level.append(next_belief_node)
-        belief_nodes_at_level[level + 1] = next_level
+            assert set(child_actions) == set(actions), (
+                f"BeliefNode action children {child_actions} do not cover the "
+                f"action set {actions}"
+            )
+        elif isinstance(node, ActionNode):
+            assert len(node.children) == planner.branching_factor, (
+                f"Non-leaf ActionNode has {len(node.children)} belief children, "
+                f"expected {planner.branching_factor} (one per sampled outcome)"
+            )
+            for child in node.children:
+                assert isinstance(
+                    child, BeliefNode
+                ), f"ActionNode child is {type(child).__name__}, expected BeliefNode"
+        else:
+            raise AssertionError(f"Unknown node type: {type(node).__name__}")
 
-    for belief_node in belief_nodes_at_level[depth]:
-        assert len(belief_node.children) == num_actions
-        for leaf_action_node in belief_node.children:
-            assert isinstance(leaf_action_node, ActionNode)
-            assert len(leaf_action_node.children) == 0
-
-    expected_belief_count = sum((num_actions * branching_factor) ** d for d in range(depth + 1))
-    expected_non_leaf_action_count = num_actions * sum(
-        (num_actions * branching_factor) ** d for d in range(depth)
-    )
-    expected_leaf_action_count = num_actions * (num_actions * branching_factor) ** depth
-
-    actual_belief_count = sum(1 for node in PostOrderIter(tree) if isinstance(node, BeliefNode))
-    actual_action_count = sum(1 for node in PostOrderIter(tree) if isinstance(node, ActionNode))
-    actual_leaf_action_count = sum(
-        1
-        for node in PostOrderIter(tree)
-        if isinstance(node, ActionNode) and len(node.children) == 0
-    )
-
-    assert actual_belief_count == expected_belief_count
-    assert actual_action_count == expected_non_leaf_action_count + expected_leaf_action_count
-    assert actual_leaf_action_count == expected_leaf_action_count
+    # 5) every root-to-leaf path is the same length
+    assert leaf_depths, "Tree has no leaves"
+    assert len(set(leaf_depths)) == 1, f"Leaves at differing depths: {sorted(set(leaf_depths))}"
+    # Sanity-check the leaf depth: belief at depth 2k, action at depth 2k+1.
+    expected_leaf_depth = planner.depth * 2 + 1
+    assert (
+        leaf_depths[0] == expected_leaf_depth
+    ), f"Leaf depth {leaf_depths[0]} != expected {expected_leaf_depth}"
 
 
 def test_node_statistics(planner, initial_belief):
@@ -222,6 +224,34 @@ def test_leaf_node_statistics(planner, initial_belief):
             assert isinstance(node, ActionNode)
             assert node.visit_count == 1
             assert node.q_value == node.immediate_cost
+
+
+def test_no_redundant_scans_after_tree_construction(planner, initial_belief):
+    """Validates that tree construction visits every ActionNode exactly once.
+
+    Purpose: ``_update_non_leaf_action_node_statistics`` increments
+    ``visit_count`` with ``+= 1`` so the counter doubles as a canary for
+    redundant scans. After a single ``PostOrderIter`` pass over a freshly
+    constructed tree every ``ActionNode`` (leaf or non-leaf) must end at
+    ``visit_count == 1``; any value > 1 means the node was revisited and tree
+    construction did wasted work.
+
+    Given: StandardSparseSamplingPlanner with uniform initial belief, learned
+        belief tree with depth=2
+    When: _learn_belief_tree constructs the full tree and runs node statistics
+        once
+    Then: Every ActionNode in the tree has visit_count == 1
+
+    Test type: unit
+    """
+    tree = planner._learn_belief_tree(initial_belief)
+
+    for node in PostOrderIter(tree):
+        if isinstance(node, ActionNode):
+            assert node.visit_count == 1, (
+                f"ActionNode revisited during tree construction: "
+                f"visit_count={node.visit_count} > 1"
+            )
 
 
 def test_non_leaf_action_node_statistics(planner, initial_belief):
@@ -497,7 +527,7 @@ def test_sparse_sampling_config_id_consistency_across_evaluations(tiger_pomdp):
     initial_belief = get_initial_belief(tiger_pomdp, n_particles=50)
 
     # Perform multiple policy evaluations
-    for _ in range(3):
+    for i in range(3):
         action, run_data = planner.action(initial_belief)
 
         # Check config_id remains the same

--- a/POMDPPlanners/tests/test_simulations/test_simulations_apis/test_local_simulations_api.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_apis/test_local_simulations_api.py
@@ -480,7 +480,6 @@ def sparse_pft_policy(tiger_environment):
     return SparsePFT(
         environment=tiger_environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=10,
         c_ucb=1.0,
         beta_ucb=0.5,

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_cache_dbs.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_cache_dbs.py
@@ -65,7 +65,6 @@ def policy(environment):
     return SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=3,
         c_ucb=1.0,
         beta_ucb=0.5,

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_task_managers.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_task_managers.py
@@ -58,7 +58,6 @@ def policy(environment):
     return SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=3,
         c_ucb=1.0,
         beta_ucb=0.5,

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_episode_simulation_task.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_episode_simulation_task.py
@@ -72,7 +72,6 @@ def policy(environment):
     return SparsePFT(
         environment=environment,
         discount_factor=0.95,
-        gamma=0.95,
         depth=3,
         c_ucb=1.0,
         beta_ucb=0.5,
@@ -731,7 +730,6 @@ def test_episode_simulation_task_log_only_on_failure_successful_episode_no_logs(
     test_policy = SparsePFT(
         environment=test_env,
         discount_factor=0.95,
-        gamma=0.95,
         depth=3,
         c_ucb=1.0,
         beta_ucb=0.5,
@@ -864,7 +862,6 @@ def test_episode_simulation_task_log_only_on_failure_false_always_logs(tmp_path)
     test_policy = SparsePFT(
         environment=test_env,
         discount_factor=0.95,
-        gamma=0.95,
         depth=3,
         c_ucb=1.0,
         beta_ucb=0.5,

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_task_serialization.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_task_serialization.py
@@ -52,7 +52,6 @@ class TestEpisodeSimulationTaskSerialization:
         self.policy = SparsePFT(
             environment=self.env,
             discount_factor=0.95,
-            gamma=0.95,
             depth=3,
             c_ucb=1.0,
             beta_ucb=0.5,
@@ -456,7 +455,6 @@ class TestTaskSerializationRoundTrip:
         self.policy = SparsePFT(
             environment=self.env,
             discount_factor=0.95,
-            gamma=0.95,
             depth=3,
             c_ucb=1.0,
             beta_ucb=0.5,
@@ -839,7 +837,6 @@ class TestTaskSerializationEdgeCases:
         self.policy = SparsePFT(
             environment=self.env,
             discount_factor=0.95,
-            gamma=0.95,
             depth=3,
             c_ucb=1.0,
             beta_ucb=0.5,

--- a/bench_planner_sims_per_sec.py
+++ b/bench_planner_sims_per_sec.py
@@ -230,7 +230,6 @@ def bench_sparse_pft(time_budget_s: float = 1.0, repeats: int = 3) -> None:
         return SparsePFT(
             environment=env,
             discount_factor=PLANNER_PARAMS["discount_factor"],
-            gamma=PLANNER_PARAMS["discount_factor"],
             depth=PLANNER_PARAMS["depth"],
             c_ucb=1.0,
             beta_ucb=2.0,


### PR DESCRIPTION
## Summary

Two themed commits on top of `develop`:

- **refactor(sparse_pft):** drop redundant `gamma` constructor parameter. SparsePFT used `self.gamma` for in-tree backups and `self.discount_factor` for rollout, with no validation they were equal — callers could silently configure inconsistent discounting. Now uses only `discount_factor` everywhere.
- **test(sparse_sampling):** add two tests for `BaseSparseSamplingDiscreteActionsPlanner`:
  - `test_no_redundant_scans_after_tree_construction` — exercises the intentional `+= 1` canary in `_update_non_leaf_action_node_statistics`. Any node ending at `visit_count > 1` means tree construction did wasted work; without this test a regression slips past CI.
  - `test_tree_structure_invariants` — walks the tree once and pins down level alternation, per-parent child counts (incl. the new `branching_factor` semantics from #149), leaf type, and uniform leaf depth.

## Test plan
- [x] `python -m pyright POMDPPlanners/` clean on touched files (2 pre-existing errors in `cpomcpow.py` unrelated)
- [x] `pytest POMDPPlanners/tests/test_planners/test_sparse_sampling_planners/` — all green
- [x] `pytest POMDPPlanners/tests/test_planners/test_mcts_planners/test_sparse_pft.py POMDPPlanners/tests/test_configs/test_planners_hyperparam_configs.py` — all green
- [x] CI green on PR