### PR TITLE
fix(cvar_exploration): restore -1 in numerator of LCB log term

### DIFF
--- a/POMDPPlanners/planners/planners_utils/cvar_exploration.py
+++ b/POMDPPlanners/planners/planners_utils/cvar_exploration.py
@@ -44,13 +44,14 @@ def _get_sparse_sampling_guarantees_exploration_v2(
         ]
 
     # Log-space evaluation of x3 = log((belief_visits**horizon - 1) /
-    # (delta * (belief_visits - 1))). The naive form overflows float64
-    # for ``horizon * log10(belief_visits) > 308`` (silently returning
-    # index 0); the equivalent log-space expansion stays finite for any
-    # ``belief_visits >= 2`` and any non-negative ``horizon``. The
-    # ``visit_count <= 1`` guard above already rules out the singular
-    # log(0) case below.
-    x3 = horizon * np.log(belief_node.visit_count) - np.log(delta * (belief_node.visit_count - 1))
+    # (delta * (belief_visits - 1))) — the bound's per-action confidence
+    # term from Theorem 1 of the ICVaR paper. The naive direct form
+    # overflows float64 for ``horizon * log10(belief_visits) > 308``;
+    # this expansion stays finite for any ``belief_visits >= 2`` and any
+    # non-negative ``horizon``, and keeps the ``- 1`` in the numerator
+    # accurate at small horizons via ``log1p(-exp(-h*log v))``.
+    log_v_h = horizon * np.log(belief_node.visit_count)
+    x3 = log_v_h + np.log1p(-np.exp(-log_v_h)) - np.log(delta * (belief_node.visit_count - 1))
     x4 = alpha * visit_count_array
 
     guarantees_bound = (max_cost - min_cost) * np.sqrt(x3 / x4)

--- a/POMDPPlanners/tests/test_planners/test_planners_utils/test_cvar_exploration.py
+++ b/POMDPPlanners/tests/test_planners/test_planners_utils/test_cvar_exploration.py
@@ -11,14 +11,14 @@ from POMDPPlanners.planners.planners_utils.cvar_exploration import (
 )
 
 
-def _build_tree_with_visited_action_children(q_values, visit_counts):
+def _build_tree_with_visited_action_children(q_values, visit_counts, belief_visits=100):
     tree = Tree()
     parent_id = tree.add_belief_node(
         belief=WeightedParticleBeliefStateUpdate(particles=[], weights=[]),
         parent_id=None,
         weight=1.0,
     )
-    tree.visit_count[parent_id] = 100
+    tree.visit_count[parent_id] = belief_visits
     child_ids = []
     for i, (q, v) in enumerate(zip(q_values, visit_counts)):
         cid = tree.add_action_node(action=i, parent_id=parent_id)
@@ -264,4 +264,69 @@ def test_sparse_sampling_lcb_matches_log_space_formula_on_safe_inputs():
         f"log-space LCB should match the analytic argmin; "
         f"got {result} (children={child_ids}, expected child[{expected_idx}]={expected}, "
         f"scores={expected_scores})"
+    )
+
+
+def test_sparse_sampling_lcb_matches_paper_formula_at_small_horizon():
+    """LCB term inside the log is ``(N_b^{T-t} - 1) / (delta * (N_b - 1))``.
+
+    Purpose: Pins the log-space expansion of the per-action confidence
+    bound to the formula from Theorem 1 of the ICVaR paper:
+    ``sqrt(ln((N_b^{T-t} - 1) / (delta * (N_b - 1))) / (2 N_b))``.
+    Under that formula, ``log((N_b^{T-t} - 1) / (delta * (N_b - 1)))``
+    must be used — *with* the ``- 1`` in the numerator. A previous
+    implementation dropped the ``- 1`` and used ``log(N_b^{T-t} / (delta
+    (N_b - 1)))`` instead, which collapses to ``T-t * log(N_b)`` for
+    small horizons and overstates the bound (e.g., for ``N_b = 2``,
+    ``T-t = 1``, the term is ``log(2) ≈ 0.693`` instead of the correct
+    ``log(1/0.5) = log(2)`` — wait this is the same — let me redo:
+    correct = log((2^1 - 1) / (0.5 * (2 - 1))) = log(2);
+    buggy   = log((2^1)     / (0.5 * (2 - 1))) = log(4) = 2*log(2)).
+    The 2x factor inside the sqrt is enough to flip the argmin between
+    two action children with carefully chosen ``q`` and visit counts.
+
+    Given: A belief node with ``visit_count = 2`` and two action
+        children (A: q=0.0, visits=4; B: q=1.0, visits=1), with
+        ``alpha=1.0``, ``delta=0.5``, ``min_cost=-1``, ``max_cost=1``,
+        ``horizon=1``, ``exploration_constant=1.0``.
+    When: ``_sparse_sampling_guarantees_exploration_v2_arena`` is called.
+    Then: Returns child A (q=0). Under the correct formula
+        ``x3 = log(2)``, child A's LCB ≈ -0.832 vs child B's ≈ -0.665,
+        so A wins. Under the buggy ``x3 = log(4)`` formula, child B's
+        LCB ≈ -1.354 vs child A's ≈ -1.177, so B would (wrongly) win.
+
+    Test type: unit
+    """
+    tree, parent_id, child_ids = _build_tree_with_visited_action_children(
+        q_values=[0.0, 1.0],
+        visit_counts=[4, 1],
+        belief_visits=2,
+    )
+    expected = child_ids[0]
+
+    # Closed-form check on the paper formula, included as documentation:
+    v, h, delta = 2, 1, 0.5
+    x3_correct = math.log((v**h - 1) / (delta * (v - 1)))
+    cost_range = 2.0  # max_cost - min_cost
+    bound_a = cost_range * math.sqrt(x3_correct / (1.0 * 4))
+    bound_b = cost_range * math.sqrt(x3_correct / (1.0 * 1))
+    lcb_a = 0.0 - 1.0 * bound_a
+    lcb_b = 1.0 - 1.0 * bound_b
+    assert lcb_a < lcb_b, "test setup error: correct formula should pick child A"
+
+    np.random.seed(0)
+    result = _sparse_sampling_guarantees_exploration_v2_arena(
+        tree=tree,
+        belief_id=parent_id,
+        exploration_constant=1.0,
+        alpha=1.0,
+        min_cost=-1.0,
+        max_cost=1.0,
+        horizon=h,
+        delta=delta,
+        visit_count_penalty=0.0,
+    )
+    assert result == expected, (
+        f"LCB selector must use paper's log((N_b^h - 1) / (delta(N_b - 1))) "
+        f"formula; got child[{child_ids.index(result)}], expected child[0]"
     )

--- a/POMDPPlanners/utils/numba_kernels.py
+++ b/POMDPPlanners/utils/numba_kernels.py
@@ -279,14 +279,16 @@ def sparse_sampling_lcb_min_idx_kernel(
                 best_idx = i
         return best_idx
     # Log-space evaluation of x3 = log((belief_visits**horizon - 1) /
-    # (delta * (belief_visits - 1))). The naive form overflows float64
-    # whenever horizon * log10(belief_visits) > 308 (e.g. belief_visits
-    # = 10_000 with horizon = 90), at which point x1 = -inf, the bound
-    # collapses to +inf, every per-action score becomes -inf, and the
-    # strict "<" comparison below never updates best_idx — the kernel
-    # silently returns index 0. The caller filters belief_visits <= 1,
-    # so log(belief_visits - 1) is finite.
-    x3 = horizon * np.log(belief_visits) - np.log(delta * (belief_visits - 1.0))
+    # (delta * (belief_visits - 1))) — the per-action confidence term
+    # from Theorem 1 of the ICVaR paper. The naive direct form overflows
+    # float64 whenever horizon * log10(belief_visits) > 308 (e.g.
+    # belief_visits = 10_000 with horizon = 90); this expansion stays
+    # finite for any belief_visits >= 2 and any non-negative horizon,
+    # and the ``log1p(-exp(-h*log v))`` term keeps the ``- 1`` in the
+    # numerator accurate at small horizons. The caller filters
+    # belief_visits <= 1, so log(belief_visits - 1) is finite.
+    log_v_h = horizon * np.log(belief_visits)
+    x3 = log_v_h + np.log1p(-np.exp(-log_v_h)) - np.log(delta * (belief_visits - 1.0))
     cost_range = max_cost - min_cost
     for i in range(n):
         nv = visit_counts[i]


### PR DESCRIPTION
## Summary

The log-space rewrite of the per-action LCB confidence term from Theorem 1 of the ICVaR paper dropped the `- 1` in the numerator:

- **Paper formula:** $\log\!\big((N_b^{T-t} - 1) / (\delta(N_b - 1))\big)$
- **Code computes:** $\log\!\big(N_b^{T-t} / (\delta(N_b - 1))\big)$

For large horizons the two are within floating-point noise; for small horizons (small $N_b$, small $T-t$) the discrepancy is meaningful — e.g. $N_b=2$, $T-t=1$ gives $\log 2$ for the correct formula vs. $\log 4 = 2\log 2$ for the buggy one, doubling the term inside the sqrt.

## Fix

Uses the standard $\log 1p(-\exp(-h\log v))$ expansion of $\log(v^h - 1)$, which stays accurate at both small and large horizons and does not overflow. Applied identically to:
- `POMDPPlanners/planners/planners_utils/cvar_exploration.py:53` (numpy path)
- `POMDPPlanners/utils/numba_kernels.py:289` (kernel path)

Adds `test_sparse_sampling_lcb_matches_paper_formula_at_small_horizon` — constructs a 2-child belief at $N_b=2$, $T-t=1$ where the inflated bound flips the LCB argmin between two children. Test fails on the buggy formula, passes on the fix.

## Test plan
- [x] New regression test fails on develop, passes after fix
- [x] All 6 cvar_exploration tests pass
- [x] 88/88 downstream icvar planner tests still pass
- [x] pyright clean on touched files
- [ ] CI green