### PR TITLE
fix(beta_zero): drop log_std clip in continuous action sampler

### DIFF
--- a/POMDPPlanners/planners/mcts_planners/beta_zero/beta_zero.py
+++ b/POMDPPlanners/planners/mcts_planners/beta_zero/beta_zero.py
@@ -680,7 +680,11 @@ class BetaZero(ArenaDoubleProgressiveWideningMCTSPolicy, TrainablePolicy):
         half = len(policy_output) // 2
         mean = policy_output[:half]
         log_std = policy_output[half:]
-        std = np.exp(np.clip(log_std, -5.0, 2.0)) + 0.1
+        # No clip on log_std: the ``+ 0.1`` term already provides a positive
+        # std floor, and clipping here was inconsistent with the unclipped
+        # sampler in ``BetaZeroActionSampler._sample_continuous`` and the
+        # unclipped policy target in ``_compute_continuous_policy_target``.
+        std = np.exp(log_std) + 0.1
         return np.random.normal(mean, std).astype(np.float32)
 
     def _step_single_episode(self, episode: _BatchedEpisodeState, action: Any) -> None:

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_beta_zero/test_beta_zero.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_beta_zero/test_beta_zero.py
@@ -643,3 +643,45 @@ class TestBetaZero:
         assert len(priors) == len(tree.children_ids[root_id])
         assert np.all(priors >= 0.0)
         assert np.isclose(priors.sum(), 1.0, atol=1e-6)
+
+
+def test_sample_continuous_action_does_not_clip_log_std(tiger_planner):
+    """`_sample_continuous_action` must respect the network's `log_std` without clipping.
+
+    Purpose: Pins the continuous-action sampling formula to
+    ``std = exp(log_std) + 0.1`` (no clip on ``log_std``). Two other
+    code paths in this module — ``BetaZeroActionSampler._sample_continuous``
+    and ``_compute_continuous_policy_target`` — already store/sample
+    unclipped ``log_std``; a previous implementation of
+    ``_sample_continuous_action`` clipped to ``[-5, 2]``, producing a
+    train/sample mismatch where the policy target said one thing and
+    the sampler interpreted it as another.
+
+    Given: A BetaZero planner and a synthetic ``policy_output =
+        [mean=0, log_std=10]``. Under the clipped formula
+        ``std = exp(min(10, 2)) + 0.1 ≈ 7.49``; under the correct
+        formula ``std = exp(10) + 0.1 ≈ 22026.6``.
+    When: A large number of samples is drawn from
+        ``_sample_continuous_action(policy_output)``.
+    Then: The empirical std is consistent with the unclipped formula
+        (≫ 7.5), distinguishing it from the clipped path.
+
+    Test type: unit
+    """
+    np.random.seed(42)
+    mean_part = np.array([0.0], dtype=np.float64)
+    log_std_part = np.array([10.0], dtype=np.float64)
+    policy_output = np.concatenate([mean_part, log_std_part])
+
+    samples = np.array(
+        [tiger_planner._sample_continuous_action(policy_output)[0] for _ in range(10_000)]
+    )
+    empirical_std = float(samples.std())
+
+    # exp(2) + 0.1 ≈ 7.5 (clipped path); exp(10) + 0.1 ≈ 22026.6 (no clip).
+    # Use a generous lower bound that only the unclipped path can satisfy.
+    assert empirical_std > 1_000.0, (
+        f"sampler must not clip log_std; empirical std {empirical_std:.2f} "
+        f"is consistent with clipping (clipped expected ≈ 7.5, "
+        f"unclipped expected ≈ 22026)"
+    )


### PR DESCRIPTION
## Summary

Resolves audit issues #8 and #9 (same root cause). \`_sample_continuous_action\` clipped \`log_std\` to \`[-5, 2]\` before \`exp(...) + 0.1\`, but the two other paths in the module that emit/consume \`log_std\` did not:

- \`BetaZeroActionSampler._sample_continuous\` (line 126): no clip.
- \`_compute_continuous_policy_target\` (line 516): no clip.

So the policy target said one thing and the sampler interpreted another; high-variance targets were silently truncated to \`exp(2)+0.1 ≈ 7.5\` no matter what the network produced.

## Fix

Drops the clip in \`_sample_continuous_action\`. The \`+ 0.1\` term already provides a positive std floor, so the lower clip was redundant; the upper clip was a heuristic overflow guard with no benefit when the network outputs finite \`log_std\`.

## Test plan
- [x] New regression test \`test_sample_continuous_action_does_not_clip_log_std\`: drives the sampler with \`log_std=10\` and checks the empirical std of 10k samples. Under the clipped formula \`≈ 7.5\`; after the fix \`≈ 22026\`.
- [x] Confirmed both directions before committing (test fails on the clipped source, passes after the fix).
- [x] All 60 beta_zero tests pass.
- [x] Pyright clean on touched files.
- [x] CI green.