### PR TITLE
fix(envs): correct CartPole obs dist + drop CLD sampler grid clip

### DIFF
--- a/POMDPPlanners/environments/cartpole_pomdp/__init__.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/__init__.py
@@ -10,6 +10,7 @@ Classes:
 """
 
 from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp import (
+    CartPoleInitialObservationDistribution,
     CartPoleInitialStateDistribution,
     CartPolePOMDP,
     CartPolePOMDPMetrics,
@@ -17,6 +18,7 @@ from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp import (
 
 __all__ = [
     "CartPolePOMDP",
+    "CartPoleInitialObservationDistribution",
     "CartPoleInitialStateDistribution",
     "CartPolePOMDPMetrics",
 ]

--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
@@ -87,6 +87,24 @@ class CartPoleInitialStateDistribution(Distribution):
         return list(samples_array)
 
 
+class CartPoleInitialObservationDistribution(Distribution):
+    """Initial observation distribution: state prior convolved with obs noise.
+
+    Marginal ``∫ p(o|s) p_0(s) ds`` produced by drawing a state from
+    :class:`CartPoleInitialStateDistribution` and adding zero-mean
+    Gaussian noise with the env's observation covariance.
+    """
+
+    def __init__(self, noise_cov: NDArray[np.floating[Any]]):
+        self._state_dist = CartPoleInitialStateDistribution()
+        self._obs_dist = CovarianceParameterizedMultivariateNormal(noise_cov)
+
+    def sample(self, n_samples: int = 1) -> List[np.ndarray]:
+        states = np.asarray(self._state_dist.sample(n_samples))
+        noise = self._obs_dist.sample(mean=np.zeros(states.shape[1]), n_samples=n_samples)
+        return list(states + noise)
+
+
 class CartPolePOMDP(DiscreteActionsEnvironment):
     """CartPole balancing task formulated as a POMDP.
 
@@ -399,13 +417,13 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
         return CartPoleInitialStateDistribution()
 
     def initial_observation_dist(self) -> Distribution:
-        return CartPoleInitialStateDistribution()
+        return CartPoleInitialObservationDistribution(self.noise_cov)
 
     def get_actions(self) -> List[int]:
         return [0, 1]
 
     def is_equal_observation(self, observation1: np.ndarray, observation2: np.ndarray) -> bool:
-        return np.array_equal(observation1, observation2)
+        return bool(np.allclose(observation1, observation2, rtol=1e-7, atol=1e-9))
 
     def hash_action(self, action: Any) -> Hashable:
         # Discrete int actions (0, 1); already hashable.

--- a/POMDPPlanners/environments/light_dark_pomdp/_cpp/continuous_light_dark.cpp
+++ b/POMDPPlanners/environments/light_dark_pomdp/_cpp/continuous_light_dark.cpp
@@ -9,7 +9,9 @@
 //   ``state + action``.
 // * observation covariance is state-dependent: particles within ``beacon_radius``
 //   of any beacon use a tighter ("near") Gaussian, all others use the ("far")
-//   Gaussian. Post-sampling, observations are clipped to ``[0, grid_size]``.
+//   Gaussian. Observations are NOT clipped: ``observation_log_probability``
+//   evaluates the unclipped Gaussian density, so clipping the sampler would
+//   break importance weights near grid edges.
 //   This fits ``StateDependentObservationModelCpp<2>`` via an
 //   ``is_near_next_state`` hook that scans the packed beacon positions.
 //
@@ -108,15 +110,14 @@ class ContinuousLightDarkObservationCpp
                                       const py::array_t<double> &covariance_near,
                                       const py::array_t<double> &covariance_far,
                                       const py::array_t<double> &beacons,
-                                      double beacon_radius, double grid_size)
+                                      double beacon_radius)
         : pomdp_native::StateDependentObservationModelCpp<kLightDarkStateDim>(
               pomdp_native::to_array<kLightDarkStateDim>(next_state_obj, "next_state"),
               py::reinterpret_borrow<py::object>(action_arr),
               pomdp_native::GaussianND<kLightDarkStateDim>::from_covariance(covariance_near),
               pomdp_native::GaussianND<kLightDarkStateDim>::from_covariance(covariance_far)),
           beacons_packed_(flatten_beacons(beacons)),
-          beacon_radius_sq_(beacon_radius * beacon_radius),
-          grid_size_(grid_size) {}
+          beacon_radius_sq_(beacon_radius * beacon_radius) {}
 
     py::array_t<double> next_state_property() const {
         return pomdp_native::array_from_vector(next_state_.data(), next_state_.size());
@@ -147,16 +148,9 @@ class ContinuousLightDarkObservationCpp
         return false;
     }
 
-    void post_sample_transform(double *sample) const override {
-        for (std::size_t i = 0; i < kLightDarkStateDim; ++i) {
-            sample[i] = std::clamp(sample[i], 0.0, grid_size_);
-        }
-    }
-
   private:
     std::vector<double> beacons_packed_;  // [x0, y0, x1, y1, ...]
     double beacon_radius_sq_;
-    double grid_size_;
 };
 
 // ---------------------------------------------------------------------------
@@ -976,10 +970,9 @@ PYBIND11_MODULE(_native, m) {
     py::class_<ContinuousLightDarkObservationCpp>(m, "ContinuousLightDarkObservationCpp")
         .def(py::init<const py::object &, const py::array_t<double> &,
                       const py::array_t<double> &, const py::array_t<double> &,
-                      const py::array_t<double> &, double, double>(),
+                      const py::array_t<double> &, double>(),
              py::arg("next_state"), py::arg("action"), py::arg("covariance_near"),
-             py::arg("covariance_far"), py::arg("beacons"), py::arg("beacon_radius"),
-             py::arg("grid_size"))
+             py::arg("covariance_far"), py::arg("beacons"), py::arg("beacon_radius"))
         .def("sample", &ContinuousLightDarkObservationCpp::sample, py::arg("n_samples") = 1)
         .def("probability", &ContinuousLightDarkObservationCpp::probability, py::arg("values"))
         .def("batch_log_likelihood",

--- a/POMDPPlanners/environments/light_dark_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/light_dark_pomdp/_native.pyi
@@ -162,7 +162,9 @@ class ContinuousLightDarkObservationCpp:
 
     Picks between a near-beacon and a far-from-beacon covariance based on
     whether the next_state falls within ``beacon_radius`` of any beacon.
-    Samples are clipped to ``[0, grid_size]`` after Gaussian draw.
+    Samples are NOT clipped to the grid: ``observation_log_probability``
+    evaluates the unclipped Gaussian density, so clipping the sampler
+    would break importance weights near grid edges.
     """
 
     next_state: NDArray[np.float64]
@@ -177,7 +179,6 @@ class ContinuousLightDarkObservationCpp:
         covariance_far: NDArray[np.floating],
         beacons: NDArray[np.floating],
         beacon_radius: float,
-        grid_size: float,
     ) -> None: ...
     def sample(self, n_samples: int = 1) -> List[NDArray[np.float64]]: ...
     def probability(

--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
@@ -321,7 +321,7 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
     # These replace the deleted Python wrapper classes
     # ContinuousLightDarkNormalNoiseNoObsInDarkObservationModel and
     # ContinuousLightDarkDistanceBasedObservationModel. The math is preserved
-    # bit-for-bit (RNG draw count, near-beacon predicate strictness, clipping).
+    # bit-for-bit (RNG draw count, near-beacon predicate strictness).
 
     def _near_beacon_continuous(self, next_state: np.ndarray) -> bool:
         return bool(
@@ -330,28 +330,25 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
             )
         )
 
-    def _sample_mvn_clipped(
+    def _sample_mvn(
         self,
         next_state: np.ndarray,
         dist: CovarianceParameterizedMultivariateNormal,
         n_samples: int,
     ) -> np.ndarray:
-        # Mirrors the wrapper sample path:
-        #   z = np.random.standard_normal((n_samples, 2))
-        #   obs = next_state + z @ dist._cholesky_L_T
-        #   obs = clip(obs, 0, grid_size)
+        # Sample MVN observations: obs = next_state + z @ chol_L_T.
+        # Samples are NOT clipped to the grid because observation_log_probability
+        # evaluates the unclipped Gaussian density — clipping the sampler while
+        # leaving the PDF unclipped breaks importance weights near grid edges.
         z = np.random.standard_normal((n_samples, 2))
         chol_L_T = dist._cholesky_L_T  # pylint: disable=protected-access
-        observations = mvn_sample_2d_kernel(next_state, z, chol_L_T)
-        return np.clip(observations, 0, self.grid_size)
+        return mvn_sample_2d_kernel(next_state, z, chol_L_T)
 
     def _sample_no_obs_in_dark(self, next_state: np.ndarray, n_samples: int) -> List[Any]:
         # Mirrors ContinuousLightDarkNormalNoiseNoObsInDarkObservationModel.sample():
         # near_beacon (strict <) → MVN samples from near-beacon dist, else "None".
         if self._near_beacon_continuous(next_state):
-            observations = self._sample_mvn_clipped(
-                next_state, self._obs_dist_near_beacon, n_samples
-            )
+            observations = self._sample_mvn(next_state, self._obs_dist_near_beacon, n_samples)
             return list(observations)
         return ["None"] * n_samples
 
@@ -368,7 +365,7 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
             if self._near_beacon_continuous(next_state)
             else self._obs_dist_far_from_beacon
         )
-        observations = self._sample_mvn_clipped(next_state, active_dist, n_samples)
+        observations = self._sample_mvn(next_state, active_dist, n_samples)
         return list(observations)
 
     def _log_prob_no_obs_in_dark(self, next_state: np.ndarray, observations: Any) -> np.ndarray:
@@ -483,7 +480,6 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
                 covariance_far=self._obs_cov_far_view,
                 beacons=self.beacons,
                 beacon_radius=float(self.beacon_radius),
-                grid_size=float(self.grid_size),
             )
             self._obs_kernel_cache[key] = kernel
         return kernel

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_beliefs/continuous_light_dark_vectorized_updater.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_beliefs/continuous_light_dark_vectorized_updater.py
@@ -187,7 +187,6 @@ class ContinuousLightDarkVectorizedUpdater(VectorizedParticleBeliefUpdater):
             covariance_far=self._obs_cov_far,
             beacons=self.beacons,
             beacon_radius=float(self.beacon_radius),
-            grid_size=float(self.grid_size),
         )
         return obs_model.batch_log_likelihood(next_particles, observation_arr)
 

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 from POMDPPlanners.environments.cartpole_pomdp import (
+    CartPoleInitialObservationDistribution,
     CartPoleInitialStateDistribution,
     CartPolePOMDP,
     _native,
@@ -526,8 +527,9 @@ def test_cartpole_pomdp_models():
     Given: A CartPolePOMDP environment and state [0.0, 0.0, 0.0, 0.0] with action 0
     When: env.sample_next_state, env.sample_observation, and env.initial_state_dist /
         env.initial_observation_dist are exercised
-    Then: sample methods return 4D float ndarrays and the initial distributions are
-        CartPoleInitialStateDistribution instances
+    Then: sample methods return 4D float ndarrays, ``initial_state_dist`` is a
+        ``CartPoleInitialStateDistribution`` and ``initial_observation_dist`` is a
+        ``CartPoleInitialObservationDistribution`` (state prior + obs noise)
 
     Test type: unit
     """
@@ -549,7 +551,7 @@ def test_cartpole_pomdp_models():
     assert isinstance(initial_dist, CartPoleInitialStateDistribution)
 
     initial_obs_dist = env.initial_observation_dist()
-    assert isinstance(initial_obs_dist, CartPoleInitialStateDistribution)
+    assert isinstance(initial_obs_dist, CartPoleInitialObservationDistribution)
 
 
 def test_cartpole_observation_model_probability_shape_single_observation():
@@ -1134,3 +1136,65 @@ def test_scalar_obs_log_prob_un_floored_matches_batch_after_fix() -> None:
     # Post symmetric C++ floor: both paths floor at log(1e-300) ~= -690.776
     # for events past the floor, so they agree exactly.
     np.testing.assert_allclose(scalar, batch, atol=1e-6)
+
+
+def test_initial_observation_dist_applies_obs_noise() -> None:
+    """initial_observation_dist marginalises state through the obs noise.
+
+    Purpose: Pins the post-fix contract that ``initial_observation_dist``
+        returns samples drawn from ``∫ p(o|s) p_0(s) ds`` rather than
+        ``p_0(s)`` directly. Pre-fix, the method aliased
+        ``CartPoleInitialStateDistribution`` and produced noise-free
+        states bounded by [-0.05, 0.05] per coordinate, which is
+        impossible under the env's continuous Gaussian obs model.
+
+    Given: A CartPolePOMDP env with diagonal ``noise_cov=diag(0.04)``
+        (std=0.2 per coord), seeded NumPy.
+    When: ``5000`` samples are drawn from ``initial_observation_dist``.
+    Then: At least one coordinate of at least one sample escapes the
+        ``[-0.05, 0.05]`` band of the raw state prior (proves noise was
+        added), the empirical mean is close to zero, and the empirical
+        variance is close to ``0.04`` per coordinate.
+
+    Test type: unit
+    """
+    np.random.seed(0)
+    noise_cov = np.eye(4) * 0.04
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
+
+    samples = np.asarray(env.initial_observation_dist().sample(n_samples=5000))
+
+    assert samples.shape == (5000, 4)
+    # Raw state prior is bounded to [-0.05, 0.05]; with std=0.2 noise the
+    # observation must routinely escape that band.
+    assert (np.abs(samples) > 0.05).any()
+    np.testing.assert_allclose(samples.mean(axis=0), np.zeros(4), atol=0.02)
+    np.testing.assert_allclose(samples.var(axis=0), np.full(4, 0.04), atol=0.01)
+
+
+def test_is_equal_observation_tolerates_float_roundoff() -> None:
+    """is_equal_observation accepts numerically-close continuous obs.
+
+    Purpose: Pins the post-fix contract that two observations differing
+        only by float roundoff (e.g. an obs vs. itself after a no-op
+        arithmetic round-trip) compare equal, while clearly distinct
+        obs and exact copies retain the expected behavior.
+
+    Given: A CartPolePOMDP env and three observations: ``a``, an
+        identical copy ``a_copy``, a roundoff-perturbed ``a_eps``
+        (``a + 1e-12``), and a clearly different ``b``.
+    When: ``is_equal_observation`` is called on each pair.
+    Then: ``a == a_copy`` and ``a == a_eps`` return True; ``a == b``
+        returns False.
+
+    Test type: unit
+    """
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1)
+    a = np.array([0.1, -0.2, 0.03, -0.04])
+    a_copy = a.copy()
+    a_eps = a + 1e-12
+    b = np.array([0.1, -0.2, 0.03, 0.5])
+
+    assert env.is_equal_observation(a, a_copy)
+    assert env.is_equal_observation(a, a_eps)
+    assert not env.is_equal_observation(a, b)

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
@@ -3086,3 +3086,52 @@ def test_scalar_and_batch_obs_log_prob_share_symmetric_floor_in_deep_underflow()
     np.testing.assert_allclose(scalar, expected_floor, atol=1e-6)
     np.testing.assert_allclose(batch, expected_floor, atol=1e-6)
     np.testing.assert_allclose(scalar, batch, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "obs_type",
+    [
+        ObservationModelType.NORMAL_NOISE,
+        ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK,
+        ObservationModelType.DISTANCE_BASED,
+    ],
+)
+def test_observation_sampler_unbiased_near_grid_edge(obs_type: ObservationModelType):
+    """Regression test: obs sampler must not clip while obs_pdf leaves density unclipped.
+
+    Purpose: Validates that observation samples follow the unclipped Gaussian
+    density used by ``observation_log_probability``. Previously the sampler
+    clipped to ``[0, grid_size]`` while the PDF stayed unclipped, biasing
+    importance weights near grid edges (audit: continuous_light_dark_pomdp.py
+    obs sampler clip-vs-pdf mismatch).
+
+    Given: A ContinuousLightDarkPOMDPDiscreteActions env with observation
+        covariance ``I`` (σ=1.0) and a next_state at (0.3, 0.3) — within
+        beacon_radius of beacon (0, 0) so NoObsInDark/DistanceBased return
+        real observations, and close enough to the lower grid edge that a
+        clipped sampler would shift the empirical mean upward by ≈0.27.
+    When: 10_000 observations are drawn and the per-component empirical mean
+        is compared to next_state.
+    Then: Empirical mean is within 0.05 of next_state in every component
+        (pre-fix bias was ≈0.27, ≫ 0.05).
+
+    Test type: unit
+    """
+    next_state = np.array([0.3, 0.3])
+    n_samples = 10_000
+    np.random.seed(0)
+
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95,
+        observation_cov_matrix=np.eye(2),
+        observation_model_type=obs_type,
+    )
+    observations = env.sample_observation(next_state, "up", n_samples=n_samples)
+    observations_arr = np.asarray(observations, dtype=float)
+    empirical_mean = observations_arr.mean(axis=0)
+    bias = np.abs(empirical_mean - next_state)
+    assert bias.max() < 0.05, (
+        f"{obs_type.name}: empirical mean {empirical_mean} differs from "
+        f"next_state {next_state} by {bias} — sampler clipping while PDF "
+        f"is unclipped breaks importance weights near edges."
+    )


### PR DESCRIPTION
## Summary

Two independent observation-model bug fixes in the env layer, each with regression coverage.

### CartPole — `initial_observation_dist` and `is_equal_observation`

- `initial_observation_dist()` was returning the bare state prior (`CartPoleInitialStateDistribution`), so initial observation samples were noise-free and impossible under the env's Gaussian observation model. Replaced with a new `CartPoleInitialObservationDistribution` that draws `s ~ p_0(s)` and adds zero-mean Gaussian noise with the env's `noise_cov`, giving the correct marginal `∫ p(o|s) p_0(s) ds`.
- `is_equal_observation()` compared continuous observation arrays with `np.array_equal` (exact bit-for-bit equality). Two copies of the same observation that survived any float round-trip would compare unequal, breaking `obs_key` lookups in tree planners. Switched to `np.allclose(..., rtol=1e-7, atol=1e-9)`.

### Continuous Light-Dark — sampler clip vs unclipped PDF

The Python and C++ observation samplers clipped draws to `[0, grid_size]`, while `observation_log_probability` evaluated the unclipped Gaussian density. For `next_state`s near a grid edge this clip-vs-PDF mismatch shifted the empirical observation mean away from `next_state`, biasing importance weights in particle-filter belief updates.

- Drop the clip in both code paths (Python `_sample_mvn`, C++ `ContinuousLightDarkObservationCpp::post_sample_transform`).
- Remove the now-unused `grid_size` argument from `ContinuousLightDarkObservationCpp` (and the matching `_native.pyi` / `ContinuousLightDarkVectorizedUpdater` call sites).

## Test plan
- [x] New regression: `test_initial_observation_dist_applies_obs_noise` — empirical mean/variance over 5000 samples matches `noise_cov`, and samples escape the bare prior's `[-0.05, 0.05]` band.
- [x] New regression: `test_is_equal_observation_tolerates_float_roundoff` — equal copy and `+1e-12` perturbation both compare equal; clearly different obs compares not-equal.
- [x] New regression: `test_observation_sampler_unbiased_near_grid_edge` parametrized over all three observation-model variants (`NORMAL_NOISE`, `NORMAL_NOISE_NO_OBS_IN_DARK`, `DISTANCE_BASED`) — empirical mean tracks `next_state` near the lower grid edge (pre-fix bias was ≈0.27, post-fix < 0.05).
- [x] Full test suite for both modules passes locally (124 tests).
- [x] `pyright POMDPPlanners/` clean for PR scope; `pylint` score on touched files improves vs `develop` baseline (9.88 → 9.96, remaining warnings are pre-existing).