### PR TITLE
release: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "POMDPPlanners"
-version = "0.2.0"
+version = "0.3.0"
 description = "A Python package for POMDP planning algorithms and environments"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps \`pyproject.toml\` from 0.2.0 to 0.3.0.

CHANGELOG entry for 0.3.0 landed earlier via #164. After this merges, the v0.3.0 tag will be created on the resulting master commit and a GitHub Release published to trigger \`release.yml\` (PyPI publish).