### PR TITLE
release: v0.3.1 — fix broken sdist (missing C++ headers)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,16 @@
-include CHANGELOG.md
+include LICENSE.md
+include README.md
+include pyproject.toml
+include setup.py
+
+# C++ sources and headers for pybind11 extensions. Without these in the
+# sdist, `pip install` from PyPI fails to compile because setup.py's
+# `include_dirs=[...]` points at paths that don't exist in the tarball.
+recursive-include POMDPPlanners *.cpp *.hpp *.h
+recursive-include POMDPPlanners *.pyi
+
+# Drop build/test artifacts that sometimes get picked up.
+global-exclude __pycache__
+global-exclude *.py[cod]
+global-exclude *.so
+prune **/__pycache__

--- a/POMDPPlanners/__init__.py
+++ b/POMDPPlanners/__init__.py
@@ -1,3 +1,3 @@
 """POMDPPlanners - A Python package for POMDP planning algorithms and environments."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.1"

--- a/POMDPPlanners/tests/test_packaging/test_sdist_contents.py
+++ b/POMDPPlanners/tests/test_packaging/test_sdist_contents.py
@@ -1,0 +1,134 @@
+"""Static sdist content checks.
+
+These run without compiling anything (~1s). They guard against the class of
+packaging bug that produced a broken 0.3.0 on PyPI: ``MANIFEST.in`` failed
+to bundle the C++ headers referenced by ``setup.py``'s ``include_dirs``,
+so every ``pip install`` from PyPI hit a missing-header compile error.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import sys
+import tarfile
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PACKAGE_ROOT = REPO_ROOT / "POMDPPlanners"
+NATIVE_SUFFIXES = {".cpp", ".hpp", ".h", ".pyi"}
+
+
+@pytest.fixture(scope="module")
+def built_sdist(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
+    """Build the project sdist once per module run, return its path.
+
+    A stale ``POMDPPlanners.egg-info/SOURCES.txt`` from a previous build
+    will silently override ``MANIFEST.in``, so this fixture deletes it
+    first to mirror the state of a fresh CI checkout.
+    """
+    egg_info = REPO_ROOT / "POMDPPlanners.egg-info"
+    if egg_info.exists():
+        shutil.rmtree(egg_info)
+    out_dir = tmp_path_factory.mktemp("sdist")
+    subprocess.check_call(
+        [sys.executable, "-m", "build", "--sdist", "--outdir", str(out_dir)],
+        cwd=REPO_ROOT,
+    )
+    matches = list(out_dir.glob("*.tar.gz"))
+    assert len(matches) == 1, f"expected one sdist, got {matches}"
+    return matches[0]
+
+
+def _sdist_members(sdist: pathlib.Path) -> set[str]:
+    with tarfile.open(sdist) as tar:
+        members: set[str] = set()
+        for member in tar.getmembers():
+            if "/" not in member.name:
+                continue
+            members.add(member.name.split("/", 1)[1])
+        return members
+
+
+def test_sdist_bundles_all_native_sources_and_stubs(built_sdist: pathlib.Path) -> None:
+    """sdist must bundle every C++ source/header/stub the build needs.
+
+    Purpose: Validates that ``MANIFEST.in`` keeps every native source, header,
+        and ``.pyi`` stub on disk inside the sdist tarball.
+
+    Given: The project sdist freshly built from the working tree.
+    When: The tarball is inspected for entries matching expected native files.
+    Then: Every ``.cpp``, ``.hpp``, ``.h``, and ``.pyi`` under
+        ``POMDPPlanners/`` on disk appears in the sdist.
+
+    Test type: integration
+    """
+    on_disk = {
+        str(path.relative_to(REPO_ROOT))
+        for path in PACKAGE_ROOT.rglob("*")
+        if path.is_file() and path.suffix in NATIVE_SUFFIXES
+    }
+    in_sdist = _sdist_members(built_sdist)
+    missing = sorted(on_disk - in_sdist)
+    assert not missing, (
+        "Native sources/headers/stubs present on disk but missing from sdist. "
+        f"Update MANIFEST.in. Missing: {missing}"
+    )
+
+
+def test_sdist_includes_packaging_metadata(built_sdist: pathlib.Path) -> None:
+    """sdist must include the metadata files PyPI / pip rely on.
+
+    Purpose: Validates that core project metadata files are bundled in the sdist.
+
+    Given: The project sdist freshly built from the working tree.
+    When: The tarball is inspected for top-level metadata entries.
+    Then: ``README.md``, ``LICENSE.md``, ``CHANGELOG.md``, ``pyproject.toml``,
+        and ``setup.py`` are all present.
+
+    Test type: integration
+    """
+    in_sdist = _sdist_members(built_sdist)
+    candidates = (
+        "README.md",
+        "LICENSE.md",
+        "CHANGELOG.md",
+        "pyproject.toml",
+        "setup.py",
+        "MANIFEST.in",
+    )
+    required = {name for name in candidates if (REPO_ROOT / name).exists()}
+    missing = sorted(required - in_sdist)
+    assert not missing, f"sdist missing required metadata files: {missing}"
+
+
+def test_version_matches_pyproject() -> None:
+    """``POMDPPlanners.__version__`` must match ``pyproject.toml`` version.
+
+    Purpose: Validates a single source of truth for the package version so a
+        release cannot ship while ``__init__.py`` lags ``pyproject.toml``.
+
+    Given: The current package source tree.
+    When: ``__version__`` from ``POMDPPlanners`` and the ``version =`` line
+        in ``pyproject.toml`` are read.
+    Then: The two strings are equal.
+
+    Test type: unit
+    """
+    pyproject_text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    pyproject_version: str | None = None
+    for line in pyproject_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("version") and "=" in stripped:
+            pyproject_version = stripped.split("=", 1)[1].strip().strip('"').strip("'")
+            break
+    assert pyproject_version is not None, "no version= line in pyproject.toml"
+
+    import POMDPPlanners as pkg  # pylint: disable=import-outside-toplevel
+
+    assert pkg.__version__ == pyproject_version, (
+        f"version mismatch: POMDPPlanners.__version__={pkg.__version__!r}, "
+        f"pyproject.toml version={pyproject_version!r}"
+    )

--- a/POMDPPlanners/tests/test_packaging/test_sdist_contents.py
+++ b/POMDPPlanners/tests/test_packaging/test_sdist_contents.py
@@ -21,6 +21,23 @@ PACKAGE_ROOT = REPO_ROOT / "POMDPPlanners"
 NATIVE_SUFFIXES = {".cpp", ".hpp", ".h", ".pyi"}
 
 
+def _ensure_build_frontend_installed() -> None:
+    """Install the PyPA ``build`` frontend if the current interpreter lacks it.
+
+    The Docker CI image does not preinstall ``build``, and ``python -m build``
+    fails with "No module named build.__main__" when only an unrelated
+    ``build`` package shadows it. Self-heal so this test is self-contained.
+    """
+    probe = subprocess.run(
+        [sys.executable, "-m", "build", "--version"],
+        capture_output=True,
+        check=False,
+    )
+    if probe.returncode == 0:
+        return
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "--quiet", "build"])
+
+
 @pytest.fixture(scope="module")
 def built_sdist(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
     """Build the project sdist once per module run, return its path.
@@ -29,6 +46,7 @@ def built_sdist(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
     will silently override ``MANIFEST.in``, so this fixture deletes it
     first to mirror the state of a fresh CI checkout.
     """
+    _ensure_build_frontend_installed()
     egg_info = REPO_ROOT / "POMDPPlanners.egg-info"
     if egg_info.exists():
         shutil.rmtree(egg_info)

--- a/POMDPPlanners/tests/test_packaging/test_sdist_installs.py
+++ b/POMDPPlanners/tests/test_packaging/test_sdist_installs.py
@@ -1,0 +1,65 @@
+"""End-to-end sdist install check.
+
+Slow: this builds the sdist, creates a fresh venv, installs the tarball
+(compiling pybind11 extensions), and imports the package. Marked ``slow``
+so it stays out of the default ``pytest`` run; intended for release CI.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import venv
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.slow
+def test_sdist_installs_and_imports_in_clean_venv(tmp_path: pathlib.Path) -> None:
+    """Sdist must install cleanly and expose its native extension.
+
+    Purpose: Validates that the published artifact is actually installable end
+        to end: the sdist compiles, the wheel imports, and the pybind11
+        ``_native`` extension loads. Catches MANIFEST.in gaps that would
+        otherwise only surface on PyPI.
+
+    Given: The project working tree.
+    When: ``python -m build --sdist`` runs, then the resulting tarball is
+        installed into a brand-new venv with ``pip install``.
+    Then: ``import POMDPPlanners`` and ``from POMDPPlanners.core import
+        _native`` both succeed from a working directory outside the repo.
+
+    Test type: integration
+    """
+    subprocess.check_call(
+        [sys.executable, "-m", "build", "--sdist", "--outdir", str(tmp_path)],
+        cwd=REPO_ROOT,
+    )
+    sdists = list(tmp_path.glob("*.tar.gz"))
+    assert len(sdists) == 1, f"expected one sdist, got {sdists}"
+    sdist = sdists[0]
+
+    venv_dir = tmp_path / "venv"
+    venv.create(venv_dir, with_pip=True)
+    venv_python = venv_dir / "bin" / "python"
+    if not venv_python.exists():
+        venv_python = venv_dir / "Scripts" / "python.exe"
+    assert venv_python.exists(), f"venv python not found under {venv_dir}"
+
+    subprocess.check_call([str(venv_python), "-m", "pip", "install", str(sdist)])
+
+    # `cwd` must NOT be the repo root: Python prepends `sys.path[0]` from the
+    # script's directory, and from the repo root that would import the source
+    # tree instead of the installed package, masking a broken sdist.
+    subprocess.check_call(
+        [
+            str(venv_python),
+            "-c",
+            "import POMDPPlanners; from POMDPPlanners.core import _native; "
+            "print('ok', POMDPPlanners.__version__, _native.__file__)",
+        ],
+        cwd=tmp_path,
+    )

--- a/POMDPPlanners/tests/test_packaging/test_sdist_installs.py
+++ b/POMDPPlanners/tests/test_packaging/test_sdist_installs.py
@@ -34,6 +34,13 @@ def test_sdist_installs_and_imports_in_clean_venv(tmp_path: pathlib.Path) -> Non
 
     Test type: integration
     """
+    probe = subprocess.run(
+        [sys.executable, "-m", "build", "--version"],
+        capture_output=True,
+        check=False,
+    )
+    if probe.returncode != 0:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "--quiet", "build"])
     subprocess.check_call(
         [sys.executable, "-m", "build", "--sdist", "--outdir", str(tmp_path)],
         cwd=REPO_ROOT,

--- a/POMDPPlanners/tests/test_setup.py
+++ b/POMDPPlanners/tests/test_setup.py
@@ -18,14 +18,14 @@ def test_package_installed():
 
     Purpose: Validates that POMDPPlanners package is properly installed and accessible with correct version
 
-    Given: POMDPPlanners package should be installed in the Python environment with version 0.2.0
+    Given: POMDPPlanners package should be installed in the Python environment with version 0.3.1
     When: Package is imported and version is checked
-    Then: Import succeeds without error and version matches expected 0.2.0
+    Then: Import succeeds without error and version matches expected 0.3.1
 
     Test type: unit
     """
     try:
-        assert POMDPPlanners.__version__ == "0.2.0"
+        assert POMDPPlanners.__version__ == "0.3.1"
     except ImportError as e:
         raise AssertionError(f"Failed to import POMDPPlanners: {e}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "POMDPPlanners"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Python package for POMDP planning algorithms and environments"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dev = [
     "nbformat>=5.0.0",
     "pytest-benchmark>=4.0.0",
     "pybind11>=2.12",
+    "build>=1.0.0",
 ]
 docs = [
     "sphinx>=5.0.0",


### PR DESCRIPTION
## Summary
- **Hotfix release for 0.3.0**, which is broken on PyPI: `pip install POMDPPlanners==0.3.0` fails with `fatal error: pomdp_native/rng.hpp: No such file or directory` because `MANIFEST.in` did not bundle the pybind11 headers.
- `MANIFEST.in` now ships every `.cpp`/`.hpp`/`.h`/`.pyi` under `POMDPPlanners/` plus `LICENSE.md` / `README.md` / `pyproject.toml` / `setup.py` (`d1530402`, `c336dd01`).
- `__version__` and `pyproject.toml` bumped to **0.3.1**; new test `test_version_matches_pyproject` prevents this single-source-of-truth drift going forward.
- New `POMDPPlanners/tests/test_packaging/` suite catches the class of bug:
  - `test_sdist_contents.py` (~2s, default): builds the sdist after scrubbing stale `egg-info`, asserts every native source/stub on disk lives in the tarball, asserts version sync.
  - `test_sdist_installs.py` (`@pytest.mark.slow`, release CI): full `pip install` of freshly-built sdist into clean venv, imports POMDPPlanners + loads `_native`. Runs from `tmp_path` to dodge `sys.path[0]` source-tree shadowing.
- Both packaging tests self-install the PyPA `build` frontend if the base image lacks it.

End-to-end install verified against TestPyPI 0.3.1 in a clean venv. Cheap test demonstrably catches the bug (revert `MANIFEST.in` to broken 1-liner → fails with the 4 missing `.hpp` listed; restore → 3/3 pass).

## Test plan
- [ ] `pytest POMDPPlanners/tests/test_packaging/test_sdist_contents.py POMDPPlanners/tests/test_setup.py -v` (already green on develop, CI run 25686436795)
- [ ] `pytest POMDPPlanners/tests/test_packaging/test_sdist_installs.py -m slow -v` (full end-to-end, ~5–10 min)
- [ ] After merge: tag `v0.3.1`, build sdist, `twine upload dist/pomdpplanners-0.3.1.tar.gz` to real PyPI
- [ ] Yank 0.3.0 on PyPI (https://pypi.org/manage/project/pomdpplanners/release/0.3.0/)