### PR TITLE
chore(core): replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/POMDPPlanners/core/policy.py
+++ b/POMDPPlanners/core/policy.py
@@ -12,6 +12,7 @@ Classes:
 """
 
 import importlib
+import importlib.metadata
 import inspect
 import json
 import logging
@@ -24,7 +25,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import numpy as np
-import pkg_resources
 
 from POMDPPlanners.utils.config_to_id import config_to_id, NumpyEncoder
 from POMDPPlanners.utils.logger import get_logger
@@ -250,9 +250,8 @@ def _get_package_version() -> str:
         Package version string or "unknown"
     """
     try:
-        return pkg_resources.get_distribution("POMDPPlanners").version
-    except Exception:  # pylint: disable=broad-exception-caught
-        # Catch all exceptions to ensure function always returns a version string
+        return importlib.metadata.version("POMDPPlanners")
+    except importlib.metadata.PackageNotFoundError:
         return "unknown"
 
 


### PR DESCRIPTION
## Summary
- `pkg_resources` emits a `UserWarning` on import and is slated for removal by setuptools.
- Switches `_get_package_version()` to stdlib `importlib.metadata.version()` (available since Python 3.8) and narrows the except to `PackageNotFoundError` instead of a bare `Exception`.

## Test plan
- [x] `python -W error::UserWarning -c "from POMDPPlanners.core.policy import _get_package_version; print(_get_package_version())"` → resolves to installed version with no warnings raised
- [x] `python -m pyright POMDPPlanners/core/policy.py` → 0 errors, 0 warnings
- [x] pre-commit (black, pylint, pyright) passed on commit and push