### PR TITLE
feat(run_progress): Slack notifications + SQLite stall detection for long runs

### DIFF
--- a/POMDPPlanners/core/simulation/tasks.py
+++ b/POMDPPlanners/core/simulation/tasks.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 from POMDPPlanners.utils.logger import get_logger
 
@@ -157,6 +157,21 @@ class TaskManager(ABC):
 
         Returns:
             Tuple[List[Any], list]: Results and successful task identifiers
+        """
+
+    def set_progress_callback(self, callback: Optional[Callable[[], None]]) -> None:
+        """Register a callback fired once per completed task.
+
+        Subclasses that support per-task progress reporting (e.g.
+        :class:`JoblibTaskManager`) override this to store the callback and
+        invoke it from inside their parallel execution loop. The default
+        implementation is a no-op so callers may invoke it unconditionally.
+
+        Args:
+            callback: A zero-argument callable invoked in the parent process
+                after each task completes, or ``None`` to clear a previously
+                set callback. Exceptions raised by the callable are caught
+                and ignored by implementing task managers.
         """
 
     def __enter__(self):

--- a/POMDPPlanners/simulations/hyper_parameter_tuning_simulations.py
+++ b/POMDPPlanners/simulations/hyper_parameter_tuning_simulations.py
@@ -119,8 +119,9 @@ Note:
     - Results include optimized policies with their chosen hyperparameters
 """
 
+import uuid
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import mlflow
 
@@ -133,6 +134,12 @@ from POMDPPlanners.core.simulation.hyperparameter_tuning import (
     HyperParameterRunParams,
     OptimizedPolicyResult,
     ParallelizationLevel,
+)
+from POMDPPlanners.simulations.simulations_deployment.run_progress import (
+    NotificationConfig,
+    Notifier,
+    build_notifier,
+    install_signal_handlers,
 )
 from POMDPPlanners.simulations.simulations_deployment.task_manager_configs import (
     JoblibConfig,
@@ -246,6 +253,7 @@ class HyperParameterOptimizer:
         mlflow_tracking_uri: Optional[Path] = None,
         use_queue_logger: bool = False,
         parallelization_level: ParallelizationLevel = ParallelizationLevel.OPTUNA_TRIALS,
+        notification_config: Optional[NotificationConfig] = None,
     ):
         """Initialize the hyperparameter optimizer.
 
@@ -307,6 +315,21 @@ class HyperParameterOptimizer:
             cache_dir=str(self.cache_dir_path / "task_manager_cache")
         )
 
+        self.notification_config: NotificationConfig = (
+            notification_config
+            if notification_config is not None
+            else NotificationConfig.disabled()
+        )
+        self._run_id: str = uuid.uuid4().hex
+        self._notifier: Notifier = build_notifier(
+            experiment_name=self.experiment_name,
+            config=self.notification_config,
+            logger=logger,
+        )
+        self._uninstall_signals: Callable[[], None] = install_signal_handlers(
+            self._notifier, self._run_id
+        )
+
     def __enter__(self):
         """Context manager entry."""
         return self
@@ -314,6 +337,21 @@ class HyperParameterOptimizer:
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Context manager exit with proper cleanup."""
         self.cleanup()
+
+    def __getstate__(self) -> Dict:
+        # The signal-handler uninstall callable is a closure and not
+        # picklable; drop it. The unpickled optimizer is not the live
+        # process that installed the handlers, so the no-op restore is
+        # correct.
+        state = self.__dict__.copy()
+        state["_uninstall_signals"] = None
+        return state
+
+    def __setstate__(self, state: Dict) -> None:
+        for key, value in state.items():
+            setattr(self, key, value)
+        if getattr(self, "_uninstall_signals", None) is None:
+            self._uninstall_signals = lambda: None
 
     def cleanup(self):
         """Clean up resources including loggers and task managers."""
@@ -331,6 +369,14 @@ class HyperParameterOptimizer:
         except Exception:  # pylint: disable=broad-exception-caught
             pass
 
+        # Uninstall SIGTERM/SIGINT handlers installed at __init__ time.
+        try:
+            uninstall = getattr(self, "_uninstall_signals", None)
+            if callable(uninstall):
+                uninstall()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
         # Clean up logger resources to prevent hanging
         try:
             cleanup_all_loggers()
@@ -340,8 +386,10 @@ class HyperParameterOptimizer:
     def _create_tasks(
         self, configs: List[HyperParameterRunParams]
     ) -> Tuple[List[HyperParameterTuningSimulationTask], List[str]]:
+        total_trials = sum(config.n_trials for config in configs)
         tasks = []
         task_identifiers = []
+        running_offset = 0
         for config in configs:
             task = HyperParameterTuningSimulationTask(
                 environment=config.environment,
@@ -360,9 +408,21 @@ class HyperParameterOptimizer:
                 confidence_interval_level=self.confidence_interval_level,
                 alpha=self.alpha,
                 parallelization_level=self.parallelization_level,
+                experiment_name=self.experiment_name,
+                parent_run_id=self._run_id,
+                webhook_url=(
+                    self.notification_config.webhook_url
+                    if self.notification_config.is_active()
+                    else None
+                ),
+                trial_interval=self.notification_config.trial_interval,
+                trial_offset=running_offset,
+                total_trials_globally=total_trials,
+                progress_db_path=self.notification_config.progress_db_path,
             )
             tasks.append(task)
             task_identifiers.append(task.get_config_id())
+            running_offset += config.n_trials
 
         return tasks, task_identifiers
 
@@ -434,25 +494,52 @@ class HyperParameterOptimizer:
             len(configs),
         )
 
-        # Prepare MLflow session and execute optimization tasks
-        self._prepare_mlflow_session()
-
-        with mlflow.start_run(run_name=f"optimize_batch_{len(configs)}_configs"):
-            # Log batch-level information
-            self._log_batch_level_parameters(configs)
-
-            # Execute optimization tasks
-            task_results, tasks = self._execute_optimization_tasks(configs)
-
-            # Process results and log to MLflow
-            results = self._process_task_results_with_mlflow_logging(configs, task_results, tasks)
-
-            # Log batch-level summary
-            self._log_batch_level_summary(configs, results)
-
-        logger.info(
-            "All %s configurations optimized successfully with MLflow tracking", len(configs)
+        total_trials = sum(config.n_trials for config in configs)
+        self._notifier.run_started(
+            self._run_id,
+            metadata={
+                "num_configs": len(configs),
+                "total_trials": total_trials,
+                "trial_notification_interval": self.notification_config.trial_interval,
+                "n_jobs": self.n_jobs,
+            },
         )
+
+        try:
+            # Prepare MLflow session and execute optimization tasks
+            self._prepare_mlflow_session()
+
+            with mlflow.start_run(run_name=f"optimize_batch_{len(configs)}_configs"):
+                # Log batch-level information
+                self._log_batch_level_parameters(configs)
+
+                # Execute optimization tasks
+                task_results, tasks = self._execute_optimization_tasks(configs)
+
+                # Process results and log to MLflow
+                results = self._process_task_results_with_mlflow_logging(
+                    configs, task_results, tasks
+                )
+
+                # Log batch-level summary
+                self._log_batch_level_summary(configs, results)
+
+            logger.info(
+                "All %s configurations optimized successfully with MLflow tracking",
+                len(configs),
+            )
+        except Exception as exc:
+            try:
+                self._notifier.run_failed(self._run_id, f"{type(exc).__name__}: {exc}")
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+            raise
+
+        try:
+            self._notifier.run_finished(self._run_id)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
         return results
 
     def _prepare_mlflow_session(self) -> None:

--- a/POMDPPlanners/simulations/simulation_apis/dask_simulations_api.py
+++ b/POMDPPlanners/simulations/simulation_apis/dask_simulations_api.py
@@ -18,6 +18,9 @@ from POMDPPlanners.simulations.workflows.hyperparameter_tuning_evaluation_workfl
 from POMDPPlanners.simulations.hyper_parameter_tuning_simulations import (
     HyperParameterOptimizer,
 )
+from POMDPPlanners.simulations.simulations_deployment.run_progress import (
+    NotificationConfig,
+)
 from POMDPPlanners.simulations.simulations_deployment.task_manager_configs import (
     DaskConfig,
 )
@@ -93,15 +96,23 @@ class DaskSimulationsAPI(SimulationsAPIInterface):
         debug: bool = False,
         scheduler_address: Optional[str] = None,
         cache_size: int = int(2e9),
+        notification_config: Optional[NotificationConfig] = None,
     ):
         """Initialize the DaskSimulationsAPI.
 
         Args:
             cache_dir_path: Optional path for storing simulation results and logs
             debug: Whether to enable debug-level logging output
+            notification_config: Optional :class:`NotificationConfig`. When
+                ``None``, defaults to :meth:`NotificationConfig.from_env`.
         """
         self.logger = get_logger(
             name="dask_simulations_api", output_dir=cache_dir_path, debug=debug
+        )
+        self.notification_config: NotificationConfig = (
+            notification_config
+            if notification_config is not None
+            else NotificationConfig.from_env()
         )
         self.logger.info("Initialized DaskSimulationsAPI")
 
@@ -229,6 +240,7 @@ class DaskSimulationsAPI(SimulationsAPIInterface):
             debug=debug,
             enable_profiling=enable_profiling,
             profiling_output_limit=profiling_output_limit,
+            notification_config=self.notification_config,
         ) as simulator:
             self.logger.info("Running simulation comparison")
             results = simulator.compare_multiple_environments_policies(
@@ -397,6 +409,7 @@ class DaskSimulationsAPI(SimulationsAPIInterface):
             alpha=alpha,
             use_queue_logger=use_queue_logger,
             parallelization_level=parallelization_level,
+            notification_config=self.notification_config,
         )
 
         try:

--- a/POMDPPlanners/simulations/simulation_apis/local_simulations_api.py
+++ b/POMDPPlanners/simulations/simulation_apis/local_simulations_api.py
@@ -22,6 +22,9 @@ from POMDPPlanners.simulations.workflows.hyperparameter_tuning_evaluation_workfl
 from POMDPPlanners.simulations.hyper_parameter_tuning_simulations import (
     HyperParameterOptimizer,
 )
+from POMDPPlanners.simulations.simulations_deployment.run_progress import (
+    NotificationConfig,
+)
 from POMDPPlanners.simulations.simulations_deployment.task_manager_configs import (
     JoblibConfig,
 )
@@ -91,15 +94,31 @@ class LocalSimulationsAPI(SimulationsAPIInterface):
         2
     """
 
-    def __init__(self, cache_dir_path: Optional[Path] = None, debug: bool = False):
+    def __init__(
+        self,
+        cache_dir_path: Optional[Path] = None,
+        debug: bool = False,
+        notification_config: Optional[NotificationConfig] = None,
+    ):
         """Initialize the LocalSimulationsAPI.
 
         Args:
             cache_dir_path: Optional path for storing simulation results and logs
             debug: Whether to enable debug-level logging output
+            notification_config: Optional :class:`NotificationConfig` controlling
+                Slack + progress-DB notifications threaded into every
+                :class:`POMDPSimulator` / :class:`HyperParameterOptimizer`
+                constructed by this API. When ``None``, defaults to
+                :meth:`NotificationConfig.from_env`, preserving the
+                zero-config env-var workflow.
         """
         self.logger = get_logger(
             name="local_simulations_api", output_dir=cache_dir_path, debug=debug
+        )
+        self.notification_config: NotificationConfig = (
+            notification_config
+            if notification_config is not None
+            else NotificationConfig.from_env()
         )
         self.logger.info("Initialized LocalSimulationsAPI")
 
@@ -219,6 +238,7 @@ class LocalSimulationsAPI(SimulationsAPIInterface):
             debug=debug,
             enable_profiling=enable_profiling,
             profiling_output_limit=profiling_output_limit,
+            notification_config=self.notification_config,
         ) as simulator:
             self.logger.info("Running simulation comparison")
             results = simulator.compare_multiple_environments_policies(
@@ -365,6 +385,7 @@ class LocalSimulationsAPI(SimulationsAPIInterface):
             debug=True,
             enable_profiling=enable_profiling,
             profiling_output_limit=profiling_output_limit,
+            notification_config=self.notification_config,
         ) as simulator_debug:
             simulator_debug.compare_multiple_environments_policies(
                 environment_run_params=environment_run_params_debug,
@@ -388,6 +409,7 @@ class LocalSimulationsAPI(SimulationsAPIInterface):
             debug=False,
             enable_profiling=enable_profiling,
             profiling_output_limit=profiling_output_limit,
+            notification_config=self.notification_config,
         ) as simulator:
             results = simulator.compare_multiple_environments_policies(
                 environment_run_params=environment_run_params,
@@ -612,6 +634,7 @@ class LocalSimulationsAPI(SimulationsAPIInterface):
             alpha=alpha,
             parallelization_level=parallelization_level,
             use_queue_logger=use_queue_logger,
+            notification_config=self.notification_config,
         )
 
         try:

--- a/POMDPPlanners/simulations/simulation_apis/pbs_simulations_api.py
+++ b/POMDPPlanners/simulations/simulation_apis/pbs_simulations_api.py
@@ -18,6 +18,9 @@ from POMDPPlanners.simulations.workflows.hyperparameter_tuning_evaluation_workfl
 from POMDPPlanners.simulations.hyper_parameter_tuning_simulations import (
     HyperParameterOptimizer,
 )
+from POMDPPlanners.simulations.simulations_deployment.run_progress import (
+    NotificationConfig,
+)
 from POMDPPlanners.simulations.simulations_deployment.task_manager_configs import PBSConfig
 from POMDPPlanners.simulations.simulator import POMDPSimulator
 from POMDPPlanners.simulations.simulation_apis.simulations_api_interface import (
@@ -101,6 +104,7 @@ class PBSSimulationsAPI(SimulationsAPIInterface):
         dashboard_prefix: Optional[str] = None,
         cache_dir_path: Optional[Path] = None,
         debug: bool = False,
+        notification_config: Optional[NotificationConfig] = None,
     ):
         """Initialize the PBSSimulationsAPI.
 
@@ -118,6 +122,8 @@ class PBSSimulationsAPI(SimulationsAPIInterface):
             dashboard_prefix: URL prefix for dashboard (useful with reverse proxies)
             cache_dir_path: Optional path for storing simulation results and logs
             debug: Whether to enable debug-level logging output
+            notification_config: Optional :class:`NotificationConfig`. When
+                ``None``, defaults to :meth:`NotificationConfig.from_env`.
         """
         # Store PBS-specific configuration
         self.queue = queue
@@ -133,6 +139,11 @@ class PBSSimulationsAPI(SimulationsAPIInterface):
         self.dashboard_prefix = dashboard_prefix
         self.cache_dir_path = cache_dir_path
         self.debug = debug
+        self.notification_config: NotificationConfig = (
+            notification_config
+            if notification_config is not None
+            else NotificationConfig.from_env()
+        )
 
         self.logger = get_logger(name="pbs_simulations_api", output_dir=cache_dir_path, debug=debug)
         self.logger.info("Initialized PBSSimulationsAPI")
@@ -266,6 +277,7 @@ class PBSSimulationsAPI(SimulationsAPIInterface):
             enable_profiling=enable_profiling,
             profiling_output_limit=profiling_output_limit,
             use_queue_logger=True,
+            notification_config=self.notification_config,
         ) as simulator:
             self.logger.info("Running PBS cluster simulation comparison")
             results = simulator.compare_multiple_environments_policies(
@@ -429,6 +441,7 @@ class PBSSimulationsAPI(SimulationsAPIInterface):
             alpha=alpha,
             use_queue_logger=use_queue_logger,
             parallelization_level=parallelization_level,
+            notification_config=self.notification_config,
         )
 
         self.logger.info("Running PBS cluster hyperparameter optimization")

--- a/POMDPPlanners/simulations/simulation_apis/simulations_api_interface.py
+++ b/POMDPPlanners/simulations/simulation_apis/simulations_api_interface.py
@@ -20,6 +20,9 @@ from POMDPPlanners.core.simulation.hyperparameter_tuning import (
     OptimizedPolicyResult,
     ParallelizationLevel,
 )
+from POMDPPlanners.simulations.simulations_deployment.run_progress import (
+    NotificationConfig,
+)
 
 
 class SimulationsAPIInterface(ABC):
@@ -43,12 +46,21 @@ class SimulationsAPIInterface(ABC):
     """
 
     @abstractmethod
-    def __init__(self, cache_dir_path: Optional[Path] = None, debug: bool = False):
+    def __init__(
+        self,
+        cache_dir_path: Optional[Path] = None,
+        debug: bool = False,
+        notification_config: Optional[NotificationConfig] = None,
+    ):
         """Initialize the SimulationsAPI.
 
         Args:
             cache_dir_path: Optional path for storing simulation results and logs
             debug: Whether to enable debug-level logging output
+            notification_config: Optional :class:`NotificationConfig` controlling
+                Slack + progress-DB notifications. Implementations default to
+                :meth:`NotificationConfig.from_env` when ``None`` is passed,
+                preserving the env-var-driven zero-config UX.
         """
 
     @abstractmethod

--- a/POMDPPlanners/simulations/simulations_deployment/run_progress/__init__.py
+++ b/POMDPPlanners/simulations/simulations_deployment/run_progress/__init__.py
@@ -1,0 +1,49 @@
+"""Progress tracking + notification module for long experiment runs.
+
+Two layers:
+
+- **Layer 1 (in-process)**: a :class:`Notifier` constructed automatically by
+  :class:`~POMDPPlanners.simulations.simulator.base_simulator.BaseSimulator`.
+  Emits ``run_started`` / ``episode_completed`` (heartbeat) / ``run_finished``
+  / ``run_failed`` events to a local SQLite DB and (if a Slack webhook is
+  configured) to Slack.
+
+- **Layer 2 (external watcher)**: a CLI module
+  (:mod:`POMDPPlanners.simulations.simulations_deployment.run_progress.watcher`)
+  that reads the same DB and emits ``run_stalled`` Slack notifications for
+  runs whose last heartbeat is older than a configurable threshold. Run from
+  cron to catch hard process death (SIGKILL / OOM / reboot).
+
+Whether notifications are sent is controlled by the deployment environment:
+:func:`build_notifier` inspects ``SLACK_WEBHOOK_URL`` and a few opt-out env
+vars. User-facing code constructs ``SimulationsAPI`` as usual; no
+configuration is threaded through the public API.
+"""
+
+from POMDPPlanners.simulations.simulations_deployment.run_progress.config import (
+    NotificationConfig,
+)
+from POMDPPlanners.simulations.simulations_deployment.run_progress.db import (
+    ProgressDB,
+    RunRow,
+)
+from POMDPPlanners.simulations.simulations_deployment.run_progress.notify import (
+    NullNotifier,
+    Notifier,
+    SlackNotifier,
+    build_notifier,
+    install_signal_handlers,
+    post_trial_milestone,
+)
+
+__all__ = [
+    "Notifier",
+    "NotificationConfig",
+    "NullNotifier",
+    "ProgressDB",
+    "RunRow",
+    "SlackNotifier",
+    "build_notifier",
+    "install_signal_handlers",
+    "post_trial_milestone",
+]

--- a/POMDPPlanners/simulations/simulations_deployment/run_progress/config.py
+++ b/POMDPPlanners/simulations/simulations_deployment/run_progress/config.py
@@ -1,0 +1,131 @@
+"""Notification configuration dataclass for the run_progress module.
+
+`NotificationConfig` bundles every parameter the run-progress
+infrastructure needs into a single explicit object. Simulation classes
+(`BaseSimulator`, `HyperParameterOptimizer`) accept one as a constructor
+argument; the `SimulationsAPI` layer is the only thing that reads env
+vars (via :meth:`NotificationConfig.from_env`).
+
+This split keeps simulation classes pure DI — they no longer touch
+:data:`os.environ` at construction time — while preserving the existing
+zero-config UX through the API layer.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+_SLACK_WEBHOOK_ENV_VAR = "SLACK_WEBHOOK_URL"
+_DISABLE_ENV_VAR = "POMDPPLANNERS_DISABLE_NOTIFY"
+_PYTEST_ENV_VAR = "PYTEST_CURRENT_TEST"
+_TRIAL_INTERVAL_ENV_VAR = "HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL"
+_PROGRESS_DB_ENV_VAR = "POMDP_PROGRESS_DB"
+_DEFAULT_TRIAL_INTERVAL = 50
+
+
+@dataclass
+class NotificationConfig:
+    """Configuration for Slack + progress-DB notifications.
+
+    Construct directly for programmatic per-instance control, or via
+    :meth:`from_env` to mirror the legacy env-var-driven behaviour at the
+    API layer.
+
+    Attributes:
+        webhook_url: Slack incoming-webhook URL. ``None`` means "no Slack
+            posts" (events still write to the progress DB if a notifier
+            is constructed, but the SlackNotifier is replaced with a
+            NullNotifier).
+        trial_interval: Number of completed Optuna trials between
+            milestone Slack messages during hyperparameter tuning. ``0``
+            disables milestone messages. Only the
+            :class:`HyperParameterOptimizer` reads this; the simulator
+            ignores it.
+        progress_db_path: Optional override for the SQLite progress DB
+            path. ``None`` falls back to the path resolved by
+            :class:`ProgressDB` (``POMDP_PROGRESS_DB`` env var, then
+            ``~/.cache/POMDPPlanners/progress.db``).
+        disable: Hard kill switch. When ``True``, the notifier built
+            from this config is always a :class:`NullNotifier`, even if
+            ``webhook_url`` is set. Equivalent to the legacy
+            ``POMDPPLANNERS_DISABLE_NOTIFY=1`` env var.
+
+    Example:
+        Explicit construction (e.g. routing two simulations in one process
+        to different Slack channels)::
+
+            cfg_a = NotificationConfig(webhook_url="https://hooks.slack.com/A")
+            cfg_b = NotificationConfig(webhook_url="https://hooks.slack.com/B")
+
+        Environment-driven construction (used by ``LocalSimulationsAPI``)::
+
+            cfg = NotificationConfig.from_env()
+    """
+
+    webhook_url: Optional[str] = None
+    trial_interval: int = 0
+    progress_db_path: Optional[Path] = None
+    disable: bool = False
+
+    @classmethod
+    def from_env(cls) -> "NotificationConfig":
+        """Build a config from the run-progress environment variables.
+
+        Reads ``SLACK_WEBHOOK_URL``, ``POMDPPLANNERS_DISABLE_NOTIFY``,
+        ``PYTEST_CURRENT_TEST``, ``HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL``,
+        and ``POMDP_PROGRESS_DB``. Returns a config that is functionally
+        disabled (``disable=True``) when running under pytest or when
+        ``POMDPPLANNERS_DISABLE_NOTIFY=1`` is set; otherwise reflects the
+        webhook URL (or ``None`` if unset) and the milestone interval
+        (default 50).
+
+        Returns:
+            A new :class:`NotificationConfig` instance.
+        """
+        disable = bool(os.environ.get(_PYTEST_ENV_VAR)) or os.environ.get(_DISABLE_ENV_VAR) == "1"
+        webhook_url = os.environ.get(_SLACK_WEBHOOK_ENV_VAR, "") or None
+        trial_interval = _resolve_int_env(_TRIAL_INTERVAL_ENV_VAR, default=_DEFAULT_TRIAL_INTERVAL)
+        progress_db_path_raw = os.environ.get(_PROGRESS_DB_ENV_VAR, "")
+        progress_db_path = Path(progress_db_path_raw) if progress_db_path_raw else None
+        return cls(
+            webhook_url=webhook_url,
+            trial_interval=trial_interval,
+            progress_db_path=progress_db_path,
+            disable=disable,
+        )
+
+    @classmethod
+    def disabled(cls) -> "NotificationConfig":
+        """Return a config with notifications hard-disabled.
+
+        Used as the default for simulation classes constructed without an
+        explicit config (e.g. unit tests, workflows called outside a
+        :class:`SimulationsAPI`).
+
+        Returns:
+            A :class:`NotificationConfig` with ``disable=True``.
+        """
+        return cls(disable=True)
+
+    def is_active(self) -> bool:
+        """Return ``True`` iff this config should produce a real Slack notifier.
+
+        A config is active when it is not hard-disabled and has a non-empty
+        webhook URL. When ``False``, :func:`build_notifier` returns a
+        :class:`NullNotifier`.
+        """
+        return (not self.disable) and bool(self.webhook_url)
+
+
+def _resolve_int_env(name: str, *, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else 0

--- a/POMDPPlanners/simulations/simulations_deployment/run_progress/db.py
+++ b/POMDPPlanners/simulations/simulations_deployment/run_progress/db.py
@@ -1,0 +1,269 @@
+"""SQLite-backed progress storage for long experiment runs.
+
+Stores per-run metadata, status transitions, and a heartbeat timestamp that
+gets bumped once per completed episode. The DB is written to **only by the
+parent process** of a run (joblib workers fork, and SQLite connections do not
+survive fork). Reads from a separate watcher process are safe thanks to WAL
+mode plus a 5-second busy timeout.
+
+Classes:
+    ProgressDB: SQLite progress writer / reader.
+    RunRow: Frozen dataclass mirroring one row of the ``runs`` table.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sqlite3
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+_DEFAULT_DB_REL_PATH = Path(".cache") / "POMDPPlanners" / "progress.db"
+_PROGRESS_DB_ENV_VAR = "POMDP_PROGRESS_DB"
+
+RunStatus = Literal["running", "finished", "failed"]
+
+
+@dataclass(frozen=True)
+class RunRow:
+    """A snapshot of one row in the ``runs`` table.
+
+    Attributes:
+        run_id: Unique id for the run (typically ``uuid4().hex``).
+        experiment_name: Human-readable label for the run (e.g. the simulator
+            experiment name).
+        host: Host the run started on, as returned by :func:`socket.gethostname`.
+        pid: Process id of the parent simulator process.
+        status: One of ``"running"``, ``"finished"``, or ``"failed"``.
+        started_at: ISO-8601 UTC timestamp of run start.
+        finished_at: ISO-8601 UTC timestamp of run finish, or ``None`` while
+            running.
+        last_heartbeat_at: ISO-8601 UTC timestamp of the most recent heartbeat.
+        error_msg: Stringified exception if the run failed, else ``None``.
+        metadata: JSON-decoded metadata dict supplied at run start.
+        stall_notified_at: ISO-8601 UTC timestamp at which a watcher sent a
+            stall notification for this run, or ``None`` if no stall
+            notification has been sent.
+    """
+
+    run_id: str
+    experiment_name: str
+    host: str
+    pid: int
+    status: str
+    started_at: str
+    finished_at: str | None
+    last_heartbeat_at: str
+    error_msg: str | None
+    metadata: dict[str, Any]
+    stall_notified_at: str | None
+
+
+class ProgressDB:
+    """SQLite-backed progress writer / reader for experiment runs.
+
+    Opens a fresh connection per call (no shared connection state), so each
+    method is safe to call from any thread inside the parent process. WAL
+    journaling is enabled on first connect so that a separate watcher process
+    can read concurrently. The path can be supplied explicitly or resolved
+    from the ``POMDP_PROGRESS_DB`` environment variable; if neither is set,
+    the default is ``~/.cache/POMDPPlanners/progress.db``.
+
+    Example:
+        Basic usage::
+
+            db = ProgressDB()
+            db.start_run("abc123", "tiger_experiment", {"episodes": 100})
+            db.heartbeat("abc123")
+            db.finish_run("abc123", status="finished", error=None)
+    """
+
+    def __init__(self, path: Path | None = None):
+        """Initialize the progress DB.
+
+        Args:
+            path: Optional explicit path to the SQLite file. If ``None``,
+                the path is read from the ``POMDP_PROGRESS_DB`` env var, or
+                defaults to ``~/.cache/POMDPPlanners/progress.db``. The
+                parent directory is created if it does not already exist.
+        """
+        self.path = _resolve_path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_schema()
+
+    def start_run(
+        self,
+        run_id: str,
+        experiment_name: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Record the start of a new run.
+
+        Args:
+            run_id: Unique id for the run.
+            experiment_name: Human-readable label for the run.
+            metadata: Optional metadata dict, JSON-serialized into storage.
+        """
+        now = _now_iso()
+        row = (
+            run_id,
+            experiment_name,
+            socket.gethostname(),
+            os.getpid(),
+            "running",
+            now,
+            None,
+            now,
+            None,
+            json.dumps(metadata or {}),
+            None,
+        )
+        self._execute(
+            "INSERT INTO runs (run_id, experiment_name, host, pid, status, "
+            "started_at, finished_at, last_heartbeat_at, error_msg, "
+            "metadata_json, stall_notified_at) VALUES "
+            "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            row,
+        )
+
+    def heartbeat(self, run_id: str) -> None:
+        """Bump the heartbeat timestamp for a run.
+
+        Args:
+            run_id: The run to update.
+        """
+        self._execute(
+            "UPDATE runs SET last_heartbeat_at = ? WHERE run_id = ?",
+            (_now_iso(), run_id),
+        )
+
+    def finish_run(
+        self,
+        run_id: str,
+        status: RunStatus,
+        error: str | None = None,
+    ) -> None:
+        """Mark a run finished or failed.
+
+        Args:
+            run_id: The run to update.
+            status: Either ``"finished"`` or ``"failed"``.
+            error: Optional error message; stored verbatim.
+        """
+        self._execute(
+            "UPDATE runs SET status = ?, finished_at = ?, error_msg = ? " "WHERE run_id = ?",
+            (status, _now_iso(), error, run_id),
+        )
+
+    def list_stalled(self, threshold_seconds: int) -> list[RunRow]:
+        """Return runs whose last heartbeat is older than ``threshold_seconds``.
+
+        Only ``status='running'`` rows that have not yet been stall-notified
+        are returned, so the watcher can use this list directly without
+        additional filtering.
+
+        Args:
+            threshold_seconds: Heartbeat-age threshold in seconds. A run is
+                considered stalled if ``now - last_heartbeat_at`` exceeds this.
+
+        Returns:
+            List of :class:`RunRow` entries, oldest heartbeat first.
+        """
+        cutoff = (datetime.now(timezone.utc) - timedelta(seconds=threshold_seconds)).isoformat()
+        with closing(self._connect()) as conn:
+            rows = conn.execute(
+                "SELECT * FROM runs WHERE status = 'running' "
+                "AND last_heartbeat_at < ? AND stall_notified_at IS NULL "
+                "ORDER BY last_heartbeat_at ASC",
+                (cutoff,),
+            ).fetchall()
+        return [_row_to_runrow(row) for row in rows]
+
+    def mark_stall_notified(self, run_id: str) -> None:
+        """Record that a stall notification has been emitted for a run.
+
+        Args:
+            run_id: The run to mark.
+        """
+        self._execute(
+            "UPDATE runs SET stall_notified_at = ? WHERE run_id = ?",
+            (_now_iso(), run_id),
+        )
+
+    def get_run(self, run_id: str) -> RunRow | None:
+        """Fetch a single run by id.
+
+        Args:
+            run_id: The run to look up.
+
+        Returns:
+            The matching :class:`RunRow`, or ``None`` if no such run exists.
+        """
+        with closing(self._connect()) as conn:
+            row = conn.execute("SELECT * FROM runs WHERE run_id = ?", (run_id,)).fetchone()
+        return _row_to_runrow(row) if row is not None else None
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        with closing(self._connect()) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS runs ("
+                "run_id TEXT PRIMARY KEY, "
+                "experiment_name TEXT NOT NULL, "
+                "host TEXT NOT NULL, "
+                "pid INTEGER NOT NULL, "
+                "status TEXT NOT NULL, "
+                "started_at TEXT NOT NULL, "
+                "finished_at TEXT, "
+                "last_heartbeat_at TEXT NOT NULL, "
+                "error_msg TEXT, "
+                "metadata_json TEXT NOT NULL, "
+                "stall_notified_at TEXT"
+                ")"
+            )
+            conn.commit()
+
+    def _execute(self, sql: str, params: tuple) -> None:
+        with closing(self._connect()) as conn:
+            conn.execute(sql, params)
+            conn.commit()
+
+
+def _resolve_path(path: Path | None) -> Path:
+    if path is not None:
+        return Path(path)
+    env_path = os.environ.get(_PROGRESS_DB_ENV_VAR)
+    if env_path:
+        return Path(env_path)
+    return Path.home() / _DEFAULT_DB_REL_PATH
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _row_to_runrow(row: sqlite3.Row) -> RunRow:
+    return RunRow(
+        run_id=row["run_id"],
+        experiment_name=row["experiment_name"],
+        host=row["host"],
+        pid=row["pid"],
+        status=row["status"],
+        started_at=row["started_at"],
+        finished_at=row["finished_at"],
+        last_heartbeat_at=row["last_heartbeat_at"],
+        error_msg=row["error_msg"],
+        metadata=json.loads(row["metadata_json"]),
+        stall_notified_at=row["stall_notified_at"],
+    )

--- a/POMDPPlanners/simulations/simulations_deployment/run_progress/notify.py
+++ b/POMDPPlanners/simulations/simulations_deployment/run_progress/notify.py
@@ -1,0 +1,380 @@
+"""Notifier interface, implementations, and signal-handler installer.
+
+The :class:`Notifier` Protocol defines four events that the simulator emits
+during a run:
+
+- ``run_started`` — fired at the entry point of the experiment loop.
+- ``episode_completed`` — fired once per completed episode (heartbeat).
+- ``run_finished`` — fired on a clean exit.
+- ``run_failed`` — fired when an exception or signal aborts the run.
+
+Two concrete implementations are provided:
+
+- :class:`NullNotifier` — no-op; used when notifications are disabled.
+- :class:`SlackNotifier` — writes events to the local progress DB and posts
+  to a Slack incoming webhook (via stdlib ``urllib.request``).
+
+The :func:`build_notifier` factory consumes a :class:`NotificationConfig`
+and returns the appropriate implementation; it does **not** read any
+environment variables itself — env-var resolution is the responsibility of
+the caller (typically :meth:`NotificationConfig.from_env` invoked by the
+``SimulationsAPI`` layer). The :func:`install_signal_handlers` helper
+attaches SIGTERM/SIGINT handlers that emit ``run_failed`` before re-raising.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import types
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Protocol, runtime_checkable
+
+from POMDPPlanners.simulations.simulations_deployment.run_progress.config import (
+    NotificationConfig,
+)
+from POMDPPlanners.simulations.simulations_deployment.run_progress.db import ProgressDB
+
+_SLACK_POST_TIMEOUT_SECONDS = 5
+
+_SignalFrame = types.FrameType | None
+_SignalHandler = Callable[[int, _SignalFrame], Any] | int | signal.Handlers | None
+
+
+@runtime_checkable
+class Notifier(Protocol):
+    """Protocol describing the four run-lifecycle events a simulator emits.
+
+    Implementations may write to a database, post to a chat tool, both, or
+    neither. The Protocol is :func:`runtime_checkable` so tests can assert
+    structural conformance without inheritance.
+    """
+
+    def run_started(self, run_id: str, *, metadata: dict[str, Any] | None = None) -> None:
+        """Record that a run has begun.
+
+        Args:
+            run_id: Unique id for the run.
+            metadata: Optional metadata dict describing the run.
+        """
+
+    def episode_completed(self, run_id: str) -> None:
+        """Record that a single episode finished (heartbeat).
+
+        Args:
+            run_id: The run to which the episode belongs.
+        """
+
+    def run_finished(self, run_id: str) -> None:
+        """Record that a run finished cleanly.
+
+        Args:
+            run_id: The run to mark as finished.
+        """
+
+    def run_failed(self, run_id: str, error: str) -> None:
+        """Record that a run aborted with an error.
+
+        Args:
+            run_id: The run that failed.
+            error: Stringified exception or signal-name describing the cause.
+        """
+
+
+class NullNotifier:
+    """No-op :class:`Notifier`. All methods discard their arguments.
+
+    Used when notifications are disabled (``SLACK_WEBHOOK_URL`` unset,
+    ``POMDPPLANNERS_DISABLE_NOTIFY=1`` set, or running under pytest).
+
+    Example:
+        Basic usage::
+
+            notifier = NullNotifier()
+            notifier.run_started("rid", metadata={"k": "v"})
+            notifier.episode_completed("rid")
+            notifier.run_finished("rid")
+    """
+
+    def run_started(self, run_id: str, *, metadata: dict[str, Any] | None = None) -> None:
+        """No-op."""
+        del run_id, metadata
+
+    def episode_completed(self, run_id: str) -> None:
+        """No-op."""
+        del run_id
+
+    def run_finished(self, run_id: str) -> None:
+        """No-op."""
+        del run_id
+
+    def run_failed(self, run_id: str, error: str) -> None:
+        """No-op."""
+        del run_id, error
+
+
+class SlackNotifier:
+    """:class:`Notifier` that writes to :class:`ProgressDB` and Slack.
+
+    ``run_started`` / ``run_finished`` / ``run_failed`` write to the DB
+    **and** POST a short message to the Slack webhook. ``episode_completed``
+    only writes a heartbeat to the DB — it does not post to Slack, to avoid
+    spamming the channel during long runs.
+
+    Slack-side failures are caught and logged at WARNING level via the
+    supplied logger; they do not propagate to the caller.
+
+    Example:
+        Basic usage::
+
+            notifier = SlackNotifier(
+                webhook_url="https://hooks.slack.com/services/T/B/X",
+                experiment_name="tiger_experiment",
+            )
+            notifier.run_started("rid-1", metadata={"episodes": 100})
+            notifier.episode_completed("rid-1")
+            notifier.run_finished("rid-1")
+    """
+
+    def __init__(
+        self,
+        webhook_url: str,
+        experiment_name: str,
+        *,
+        db: ProgressDB | None = None,
+        logger: logging.Logger | None = None,
+    ):
+        """Initialize the Slack notifier.
+
+        Args:
+            webhook_url: A Slack incoming-webhook URL.
+            experiment_name: Human-readable label recorded for each run
+                started via this notifier.
+            db: Optional :class:`ProgressDB` instance to write to. If
+                ``None``, a default ``ProgressDB()`` is constructed.
+            logger: Optional logger used to emit warnings when Slack posts
+                fail. If ``None``, a logger named ``run_progress.notify``
+                is used.
+        """
+        self.webhook_url = webhook_url
+        self.experiment_name = experiment_name
+        self.db = db if db is not None else ProgressDB()
+        self.logger = logger if logger is not None else logging.getLogger("run_progress.notify")
+
+    def run_started(self, run_id: str, *, metadata: dict[str, Any] | None = None) -> None:
+        """Record start in DB and POST a start message to Slack.
+
+        Args:
+            run_id: Unique id for the run.
+            metadata: Optional metadata dict written to the DB.
+        """
+        self.db.start_run(run_id, self.experiment_name, metadata or {})
+        self._post(f":rocket: Run *started*: `{self.experiment_name}` (id=`{run_id}`)")
+
+    def episode_completed(self, run_id: str) -> None:
+        """Update the heartbeat in the DB. Does not post to Slack.
+
+        Args:
+            run_id: The run to which the episode belongs.
+        """
+        self.db.heartbeat(run_id)
+
+    def run_finished(self, run_id: str) -> None:
+        """Mark the run finished in the DB and POST a success message.
+
+        Args:
+            run_id: The run to mark as finished.
+        """
+        self.db.finish_run(run_id, status="finished", error=None)
+        self._post(f":white_check_mark: Run *finished*: `{self.experiment_name}` (id=`{run_id}`)")
+
+    def run_failed(self, run_id: str, error: str) -> None:
+        """Mark the run failed in the DB and POST a failure message.
+
+        Args:
+            run_id: The run that failed.
+            error: Stringified exception or signal-name describing the cause.
+        """
+        self.db.finish_run(run_id, status="failed", error=error)
+        self._post(f":x: Run *failed*: `{self.experiment_name}` (id=`{run_id}`): {error}")
+
+    def _post(self, text: str) -> None:
+        _post_slack_text(
+            webhook_url=self.webhook_url,
+            text=text,
+            logger=self.logger,
+        )
+
+
+def post_trial_milestone(
+    webhook_url: str,
+    *,
+    experiment_name: str,
+    run_id: str,
+    completed_trials: int,
+    total_trials: int,
+    config_name: str,
+    best_score: float | None,
+    logger: logging.Logger | None = None,
+) -> None:
+    """POST a Slack message reporting hyperparameter-tuning progress.
+
+    Stateless helper called once per ``HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL``
+    Optuna trials. ``webhook_url`` must be a non-empty Slack incoming-webhook
+    URL — callers (typically the in-task Optuna callback) are responsible
+    for skipping the call when notifications are disabled. Network errors
+    are caught and logged at WARNING level; nothing propagates to the
+    caller.
+
+    Args:
+        webhook_url: Slack incoming-webhook URL.
+        experiment_name: Human-readable label for the tuning run, included
+            in the message body.
+        run_id: Unique id of the parent tuning run (same id used by
+            ``run_started``/``run_finished``).
+        completed_trials: Number of trials completed globally so far.
+        total_trials: Total trials scheduled across all configs.
+        config_name: Name of the config whose trial just completed; lets the
+            reader see which leg of the sweep is currently running.
+        best_score: Best objective value seen so far in the current config
+            (e.g. ``study.best_value``). Pass ``None`` if no trial has
+            produced a usable score yet — the message will note this.
+        logger: Optional logger for swallowed-error WARNING. Defaults to
+            a logger named ``run_progress.notify``.
+    """
+    progress_logger = logger if logger is not None else logging.getLogger("run_progress.notify")
+    best_score_text = f"{best_score:.4f}" if best_score is not None else "n/a"
+    text = (
+        f":ladder: Tuning *milestone*: `{experiment_name}` (id=`{run_id}`) "
+        f"— {completed_trials}/{total_trials} trials done, "
+        f"current config `{config_name}`, best so far {best_score_text}"
+    )
+    _post_slack_text(webhook_url=webhook_url, text=text, logger=progress_logger)
+
+
+def _post_slack_text(
+    webhook_url: str,
+    text: str,
+    logger: logging.Logger,
+) -> None:
+    body = json.dumps({"text": text}).encode("utf-8")
+    request = urllib.request.Request(
+        webhook_url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=_SLACK_POST_TIMEOUT_SECONDS) as resp:
+            resp.read()
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        logger.warning("Slack notification failed: %s", exc)
+
+
+def build_notifier(
+    experiment_name: str,
+    *,
+    config: NotificationConfig,
+    logger: logging.Logger | None = None,
+) -> Notifier:
+    """Construct the appropriate :class:`Notifier` from a config.
+
+    This function performs **no environment reads**. The caller passes an
+    explicit :class:`NotificationConfig`; if that config is active
+    (non-empty webhook URL AND ``disable=False``), a :class:`SlackNotifier`
+    is returned. Otherwise a :class:`NullNotifier` is returned. Env-var
+    resolution belongs in :meth:`NotificationConfig.from_env` — typically
+    invoked by the ``SimulationsAPI`` layer.
+
+    Args:
+        experiment_name: Human-readable label used for run records and
+            Slack messages.
+        config: The :class:`NotificationConfig` controlling whether and
+            where Slack messages are sent.
+        logger: Optional logger forwarded to :class:`SlackNotifier`.
+
+    Returns:
+        A :class:`Notifier` instance — either :class:`NullNotifier` or
+        :class:`SlackNotifier` depending on whether ``config.is_active()``.
+    """
+    if not config.is_active() or config.webhook_url is None:
+        return NullNotifier()
+    return SlackNotifier(
+        webhook_url=config.webhook_url,
+        experiment_name=experiment_name,
+        logger=logger,
+    )
+
+
+def install_signal_handlers(
+    notifier: Notifier,
+    run_id: str,
+) -> Callable[[], None]:
+    """Install SIGTERM/SIGINT handlers that emit :meth:`Notifier.run_failed`.
+
+    The installed handlers:
+
+    1. Call ``notifier.run_failed(run_id, error="signal:<NAME>")``.
+       Exceptions inside the notifier are swallowed.
+    2. Chain to the previous handler if it is callable. Non-callable
+       handlers (``signal.SIG_DFL`` / ``signal.SIG_IGN``, both integer
+       sentinels) are skipped, and the signal is re-delivered to the
+       process with default handling restored.
+
+    Returns a callable that uninstalls both handlers (restoring whatever
+    was previously installed). Calling the uninstall function multiple
+    times is safe.
+
+    Args:
+        notifier: The :class:`Notifier` to emit ``run_failed`` on signal.
+        run_id: The run identifier to pass to ``run_failed``.
+
+    Returns:
+        An idempotent uninstall callable. The caller should invoke it
+        during normal teardown (e.g. ``BaseSimulator.__exit__``) so signal
+        handling reverts to the prior configuration.
+    """
+    prev_handlers: dict[int, _SignalHandler] = {}
+    handler = _make_signal_handler(notifier, run_id, prev_handlers)
+    installed_signals: list[int] = []
+    for signum in (signal.SIGTERM, signal.SIGINT):
+        prev_handlers[signum] = signal.getsignal(signum)
+        try:
+            signal.signal(signum, handler)
+        except ValueError:
+            # signal.signal raises ValueError if not on the main thread.
+            del prev_handlers[signum]
+            continue
+        installed_signals.append(signum)
+
+    def uninstall() -> None:
+        while installed_signals:
+            signum = installed_signals.pop()
+            try:
+                signal.signal(signum, prev_handlers[signum])
+            except (ValueError, KeyError):
+                pass
+
+    return uninstall
+
+
+def _make_signal_handler(
+    notifier: Notifier,
+    run_id: str,
+    prev_handlers: dict[int, _SignalHandler],
+) -> Callable[[int, _SignalFrame], None]:
+    def handler(signum: int, frame: _SignalFrame) -> None:
+        try:
+            notifier.run_failed(run_id, f"signal:{signal.Signals(signum).name}")
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass  # never let notifier errors mask the signal
+        prev = prev_handlers.get(signum)
+        if callable(prev):
+            prev(signum, frame)
+        else:
+            signal.signal(signum, signal.SIG_DFL)
+            os.kill(os.getpid(), signum)
+
+    return handler

--- a/POMDPPlanners/simulations/simulations_deployment/run_progress/watcher.py
+++ b/POMDPPlanners/simulations/simulations_deployment/run_progress/watcher.py
@@ -1,0 +1,138 @@
+"""CLI watcher that posts Slack alerts for stalled experiment runs.
+
+Intended to be invoked from cron (typically once per minute):
+
+.. code-block:: text
+
+    * * * * * /path/to/.venv/bin/python -m \
+        POMDPPlanners.simulations.simulations_deployment.run_progress.watcher \
+        --threshold-seconds 3600
+
+For every run in the progress DB whose status is ``running`` AND whose
+``last_heartbeat_at`` is older than ``--threshold-seconds`` AND which has
+not previously been stall-notified, the watcher POSTs a short Slack
+message and marks the row notified so subsequent ticks do not duplicate.
+
+The watcher is **stateless** — it makes one pass through the DB and exits.
+Cron handles "the watcher died" semantics so no separate daemon is needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Sequence
+
+from POMDPPlanners.simulations.simulations_deployment.run_progress.db import (
+    ProgressDB,
+    RunRow,
+)
+
+_SLACK_WEBHOOK_ENV_VAR = "SLACK_WEBHOOK_URL"
+_SLACK_POST_TIMEOUT_SECONDS = 5
+_DEFAULT_THRESHOLD_SECONDS = 3600
+
+_logger = logging.getLogger("run_progress.watcher")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one watcher pass.
+
+    Args:
+        argv: Optional argv override (for tests). When ``None``, falls
+            back to :data:`sys.argv` after the program name.
+
+    Returns:
+        Exit status. ``0`` on success (including the "no stalled runs"
+        case). Non-zero is reserved for hard configuration errors.
+    """
+    args = _parse_args(argv)
+    webhook_url = args.webhook_url or os.environ.get(_SLACK_WEBHOOK_ENV_VAR, "")
+
+    db = ProgressDB(path=args.db)
+    stalled = db.list_stalled(threshold_seconds=args.threshold_seconds)
+    if not stalled:
+        _logger.info("No stalled runs found.")
+        return 0
+
+    if not webhook_url:
+        _logger.warning(
+            "Found %d stalled run(s) but SLACK_WEBHOOK_URL is unset; " "skipping notifications.",
+            len(stalled),
+        )
+        return 0
+
+    _logger.info("Notifying about %d stalled run(s).", len(stalled))
+    for run in stalled:
+        _post_to_slack(webhook_url, _format_stall_message(run))
+        db.mark_stall_notified(run.run_id)
+    return 0
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="run_progress.watcher",
+        description="Post Slack alerts for stalled POMDPPlanners experiment runs.",
+    )
+    parser.add_argument(
+        "--threshold-seconds",
+        type=int,
+        default=_DEFAULT_THRESHOLD_SECONDS,
+        help=(
+            "Heartbeat age (in seconds) above which a still-running entry is "
+            "considered stalled. Default: %(default)s."
+        ),
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the SQLite progress DB. Defaults to "
+            "$POMDP_PROGRESS_DB if set, else "
+            "~/.cache/POMDPPlanners/progress.db."
+        ),
+    )
+    parser.add_argument(
+        "--webhook-url",
+        type=str,
+        default=None,
+        help=(
+            "Slack incoming-webhook URL. Defaults to $SLACK_WEBHOOK_URL. "
+            "If neither is set, stalled runs are logged but not posted."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _format_stall_message(run: RunRow) -> str:
+    return (
+        f":hourglass_flowing_sand: Run *stalled*: `{run.experiment_name}` "
+        f"(id=`{run.run_id}`, host=`{run.host}`, pid=`{run.pid}`, "
+        f"last heartbeat at `{run.last_heartbeat_at}`)"
+    )
+
+
+def _post_to_slack(webhook_url: str, text: str) -> None:
+    body = json.dumps({"text": text}).encode("utf-8")
+    request = urllib.request.Request(
+        webhook_url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=_SLACK_POST_TIMEOUT_SECONDS) as resp:
+            resp.read()
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        _logger.warning("Slack notification failed: %s", exc)
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via tests
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    sys.exit(main())

--- a/POMDPPlanners/simulations/simulations_deployment/task_managers.py
+++ b/POMDPPlanners/simulations/simulations_deployment/task_managers.py
@@ -3,7 +3,7 @@ import os
 import time
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import psutil
 from dask.cache import Cache
@@ -238,6 +238,41 @@ class JoblibTaskManager(TaskManagerExternalDB):
         # Create a cached version of the task runner
         self._cached_run = self.memory.cache(self._run_single_task)
 
+        self._on_progress: Optional[Callable[[], None]] = None
+
+    def set_progress_callback(self, callback: Optional[Callable[[], None]]) -> None:
+        """Register a callback invoked once per completed task.
+
+        The callback runs in the parent process inside the joblib generator
+        loop, so it is safe to touch parent-only resources (e.g. SQLite
+        connections). Exceptions raised by the callback are caught and
+        logged at DEBUG level so a flaky callback cannot break the run.
+
+        The callback is intentionally excluded from this object's pickled
+        state (via :meth:`__getstate__`) so that joblib's :class:`Memory`
+        cache, which hashes function arguments (including ``self``), can
+        still serialize the task manager even when the callback closes
+        over non-picklable parent objects such as a live notifier or
+        simulator.
+
+        Args:
+            callback: A zero-argument callable, or ``None`` to clear an
+                existing callback.
+        """
+        self._on_progress = callback
+
+    def __getstate__(self) -> Dict[str, Any]:
+        # Drop the progress callback from the pickled state so joblib's
+        # Memory cache hashing does not have to serialize whatever the
+        # caller closed over (typically the live simulator + notifier).
+        state = self.__dict__.copy()
+        state["_on_progress"] = None
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        for key, value in state.items():
+            setattr(self, key, value)
+
     def _run_single_task(self, task: SimulationTask) -> Any:
         """Run a single task and return its result.
 
@@ -306,18 +341,35 @@ class JoblibTaskManager(TaskManagerExternalDB):
         return tqdm_logger_callback
 
     def _execute_tasks_parallel(
-        self, tasks: List[SimulationTask], start_time: float
-    ) -> list:  # pylint: disable=unused-argument
-        """Execute tasks in parallel using joblib with progress tracking."""
+        self,
+        tasks: List[SimulationTask],
+        start_time: float,  # pylint: disable=unused-argument
+    ) -> list:
+        """Execute tasks in parallel using joblib with progress tracking.
 
-        # Use tqdm with conditional disabling based on no_logs
-        with tqdm(tasks, desc="Running tasks", disable=self.no_logs) as pbar:
-            results = list(
-                Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
-                    delayed(self._cached_run)(task) for task in pbar
-                )
-            )
+        Uses ``return_as="generator"`` so results are yielded as they
+        complete in the parent process. After each completion, the
+        registered :meth:`set_progress_callback` callable (if any) is
+        invoked — this is the hook the simulator uses to write per-episode
+        heartbeats.
+        """
+        parallel = Parallel(n_jobs=self.n_jobs, verbose=self.verbose, return_as="generator")
+        results: list = []
+        with tqdm(total=len(tasks), desc="Running tasks", disable=self.no_logs) as pbar:
+            for result in parallel(delayed(self._cached_run)(task) for task in tasks):
+                results.append(result)
+                pbar.update(1)
+                self._fire_progress_callback()
         return results
+
+    def _fire_progress_callback(self) -> None:
+        callback = self._on_progress
+        if callback is None:
+            return
+        try:
+            callback()
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            self.logger.debug("Progress callback raised: %s", exc)
 
     def _log_completion_statistics(self, results: list, start_time: float) -> None:
         """Log completion statistics and cache information."""

--- a/POMDPPlanners/simulations/simulations_deployment/tasks/hyper_parameter_tuning_simulation_task.py
+++ b/POMDPPlanners/simulations/simulations_deployment/tasks/hyper_parameter_tuning_simulation_task.py
@@ -4,7 +4,7 @@ import random
 import time
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
 import optuna
@@ -30,6 +30,11 @@ from POMDPPlanners.simulations.simulation_statistics import (
     compute_statistics_environment_policy_pair,
 )
 from POMDPPlanners.simulations.simulations_deployment.cache_dbs import DiskCacheDB
+from POMDPPlanners.simulations.simulations_deployment.run_progress import (
+    NotificationConfig,
+    ProgressDB,
+    post_trial_milestone,
+)
 from POMDPPlanners.simulations.simulations_deployment.task_manager_configs import (
     JoblibConfig,
 )
@@ -38,6 +43,23 @@ from POMDPPlanners.utils.config_to_id import config_to_id
 from POMDPPlanners.utils.logger import get_logger
 
 HyperParameterFeature = Union[CategoricalHyperParameter, NumericalHyperParameter]
+
+
+def _best_value_or_none(study: optuna.study.Study) -> Optional[float]:
+    """Return ``study.best_value`` for single-objective studies, else None.
+
+    Multi-objective Optuna studies do not expose a single ``best_value`` —
+    they have a Pareto front instead. For milestone messages we just want
+    a representative scalar, so we return ``None`` in that case and let the
+    caller render ``"n/a"``.
+    """
+    if len(study.directions) != 1:
+        return None
+    try:
+        return float(study.best_value)
+    except ValueError:
+        # No completed trials yet.
+        return None
 
 
 class HyperParameterTuningSimulationTask(SimulationTask):
@@ -64,6 +86,12 @@ class HyperParameterTuningSimulationTask(SimulationTask):
         use_queue_logger: bool = False,
         training_hyper_parameters: Optional[Sequence[HyperParameterFeature]] = None,
         training_constant_parameters: Optional[Dict[str, Any]] = None,
+        parent_run_id: Optional[str] = None,
+        webhook_url: Optional[str] = None,
+        trial_interval: int = 0,
+        trial_offset: int = 0,
+        total_trials_globally: int = 0,
+        progress_db_path: Optional[Path] = None,
     ):
         """Initialize a hyperparameter tuning simulation task.
 
@@ -149,6 +177,16 @@ class HyperParameterTuningSimulationTask(SimulationTask):
         self.use_queue_logger = use_queue_logger
         self.training_hyper_parameters = training_hyper_parameters or ()
         self.training_constant_parameters = training_constant_parameters or {}
+        self.experiment_name = experiment_name
+
+        # Notification / heartbeat plumbing used by the in-task Optuna callback.
+        self.parent_run_id = parent_run_id
+        self.webhook_url = webhook_url
+        self.trial_interval = trial_interval
+        self.trial_offset = trial_offset
+        self.total_trials_globally = total_trials_globally
+        self.progress_db_path = progress_db_path
+
         # Create task manager config for joblib
         task_manager_config = JoblibConfig(n_jobs=n_jobs, console_output=False, no_logs=True)
 
@@ -160,6 +198,7 @@ class HyperParameterTuningSimulationTask(SimulationTask):
             use_queue_logger=use_queue_logger,
             console_output=False,
             no_logs=True,
+            notification_config=NotificationConfig.disabled(),
         )
 
         if self.cache_dir is not None:
@@ -741,14 +780,79 @@ class HyperParameterTuningSimulationTask(SimulationTask):
 
         study = optuna.create_study(directions=directions)
 
+        callbacks = [self._build_progress_callback()]
+
         self.logger.info("Starting optimization trials...")
-        study.optimize(objective_function, n_trials=n_trials, n_jobs=n_jobs)
+        study.optimize(
+            objective_function,
+            n_trials=n_trials,
+            n_jobs=n_jobs,
+            callbacks=callbacks,
+        )
 
         # Log optimization completion
         self.logger.info("Optimization completed successfully!")
         self.logger.info("Found %d Pareto-optimal trials", len(study.best_trials))
 
         return study
+
+    def _build_progress_callback(
+        self,
+    ) -> Callable[[optuna.study.Study, FrozenTrial], None]:
+        """Build an Optuna callback that heartbeats the DB and fires milestones.
+
+        The returned callable is intended to be passed in
+        ``study.optimize(callbacks=[...])``. Per trial it:
+
+        - Calls ``ProgressDB.heartbeat(parent_run_id)`` so the external
+          watcher sees forward progress (silent — no Slack).
+        - If a non-zero ``trial_interval`` is configured and the global
+          completed-trial counter (``trial_offset + trial.number + 1``)
+          crosses a multiple of it, calls :func:`post_trial_milestone` to
+          send a Slack progress update.
+
+        Both side effects are best-effort: any exception inside the callback
+        is logged and swallowed so a flaky network or DB cannot abort the
+        Optuna run.
+        """
+
+        def _on_trial(study: optuna.study.Study, trial: FrozenTrial) -> None:
+            try:
+                self._heartbeat_progress_db()
+                self._maybe_post_milestone(study, trial)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                self.logger.debug("Trial progress callback raised: %s", exc)
+
+        return _on_trial
+
+    def _heartbeat_progress_db(self) -> None:
+        if not self.parent_run_id:
+            return
+        ProgressDB(path=self.progress_db_path).heartbeat(self.parent_run_id)
+
+    def _maybe_post_milestone(
+        self,
+        study: optuna.study.Study,
+        trial: FrozenTrial,
+    ) -> None:
+        if not self.webhook_url or self.trial_interval <= 0:
+            return
+        if not self.parent_run_id:
+            return
+        global_completed = self.trial_offset + trial.number + 1
+        if global_completed % self.trial_interval != 0:
+            return
+        best_score = _best_value_or_none(study)
+        post_trial_milestone(
+            self.webhook_url,
+            experiment_name=self.experiment_name,
+            run_id=self.parent_run_id,
+            completed_trials=global_completed,
+            total_trials=self.total_trials_globally or global_completed,
+            config_name=self.get_config_id(),
+            best_score=best_score,
+            logger=self.logger,
+        )
 
     def _build_optimization_results(self, study, optimization_time: float) -> OptimizedPolicyResult:
         """Build OptimizedPolicyResult using Pareto-optimal policy selection.
@@ -1077,6 +1181,7 @@ class HyperParameterTuningSimulationTask(SimulationTask):
             use_queue_logger=self.use_queue_logger,
             console_output=False,
             no_logs=True,
+            notification_config=NotificationConfig.disabled(),
         )
 
     def _reconstruct_study_storage(self):

--- a/POMDPPlanners/simulations/simulator/base_simulator.py
+++ b/POMDPPlanners/simulations/simulator/base_simulator.py
@@ -5,9 +5,10 @@ import io
 import pstats
 import shutil
 import tempfile
+import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 import mlflow
 import pandas as pd
@@ -23,6 +24,12 @@ from POMDPPlanners.core.simulation import (
 )
 from POMDPPlanners.simulations.simulation_statistics import (
     metrics_dict_to_dataframe,
+)
+from POMDPPlanners.simulations.simulations_deployment.run_progress import (
+    NotificationConfig,
+    Notifier,
+    build_notifier,
+    install_signal_handlers,
 )
 from POMDPPlanners.simulations.simulations_deployment.task_manager_configs import (
     TaskManagerConfig,
@@ -130,6 +137,7 @@ class BaseSimulator(ABC):
         console_output: bool = True,
         no_logs: bool = False,
         visualizer: Optional[ExperimentVisualizer] = None,
+        notification_config: Optional[NotificationConfig] = None,
     ):
         """Initialize the simulator.
 
@@ -145,6 +153,12 @@ class BaseSimulator(ABC):
             no_logs: Whether to disable all logging (default: False)
             visualizer: Strategy for rendering aggregated experiment artifacts after
                 each comparison run. Defaults to :class:`EpisodeReturnsVisualizer`.
+            notification_config: Optional :class:`NotificationConfig` controlling
+                Slack + progress-DB notifications. When ``None``, defaults to
+                :meth:`NotificationConfig.disabled`, meaning no notifications
+                will fire. The ``SimulationsAPI`` layer is responsible for
+                building a config from env vars and threading it in; direct
+                callers (tests, workflows) get silent behaviour by default.
         """
         self.cache_dir_path = cache_dir_path
         self.experiment_name = experiment_name
@@ -168,6 +182,40 @@ class BaseSimulator(ABC):
 
         if cache_dir_path is not None:
             self._setup_mlflow_tracking()
+
+        self.notification_config: NotificationConfig = (
+            notification_config
+            if notification_config is not None
+            else NotificationConfig.disabled()
+        )
+        self._run_id: str = uuid.uuid4().hex
+        self._notifier: Notifier = build_notifier(
+            experiment_name=self.experiment_name,
+            config=self.notification_config,
+            logger=self.logger,
+        )
+        self._uninstall_signals: Callable[[], None] = install_signal_handlers(
+            self._notifier, self._run_id
+        )
+        self.task_manager.set_progress_callback(
+            lambda: self._notifier.episode_completed(self._run_id)
+        )
+
+    def __getstate__(self) -> Dict:
+        # The signal-handler uninstall callable is a closure created by
+        # :func:`install_signal_handlers` and is therefore not picklable.
+        # Drop it on pickle; restore as a no-op on unpickle. Unpickled
+        # simulators are not the live process that installed the handlers,
+        # so they have nothing to uninstall.
+        state = self.__dict__.copy()
+        state["_uninstall_signals"] = None
+        return state
+
+    def __setstate__(self, state: Dict) -> None:
+        for key, value in state.items():
+            setattr(self, key, value)
+        if getattr(self, "_uninstall_signals", None) is None:
+            self._uninstall_signals = lambda: None
 
     def _setup_mlflow_tracking(self) -> None:
         """Configure MLFlow tracking."""
@@ -201,6 +249,19 @@ class BaseSimulator(ABC):
         self.task_manager.__exit__(exc_type, exc_val, exc_tb)
 
         try:
+            if exc_type is None:
+                self._notifier.run_finished(self._run_id)
+            else:
+                self._notifier.run_failed(self._run_id, f"{exc_type.__name__}: {exc_val}")
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
+        try:
+            self._uninstall_signals()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
+        try:
             cleanup_all_loggers()
         except Exception:  # pylint: disable=broad-exception-caught
             pass
@@ -225,6 +286,15 @@ class BaseSimulator(ABC):
         Returns:
             Tuple of results dictionary and statistics DataFrame
         """
+        self._notifier.run_started(
+            self._run_id,
+            metadata={
+                "num_environments": len(environment_run_params),
+                "environment_names": [params.environment.name for params in environment_run_params],
+                "n_jobs": n_jobs,
+            },
+        )
+
         if self.enable_profiling:
             self.profiler = cProfile.Profile()
             self.profiler.enable()

--- a/POMDPPlanners/simulations/simulator/pomdp_simulator.py
+++ b/POMDPPlanners/simulations/simulator/pomdp_simulator.py
@@ -17,6 +17,9 @@ from POMDPPlanners.simulations.simulation_statistics import (
     compute_statistics_environment_policy_pair,
     get_metric_names_from_environment_policy_pair,
 )
+from POMDPPlanners.simulations.simulations_deployment.run_progress import (
+    NotificationConfig,
+)
 from POMDPPlanners.simulations.simulations_deployment.task_manager_configs import (
     TaskManagerConfig,
 )
@@ -118,6 +121,7 @@ class POMDPSimulator(BaseSimulator):
         console_output: bool = True,
         no_logs: bool = False,
         visualizer: Optional[ExperimentVisualizer] = None,
+        notification_config: Optional[NotificationConfig] = None,
     ):
         """Initialize the POMDP simulator.
 
@@ -136,6 +140,10 @@ class POMDPSimulator(BaseSimulator):
             no_logs: Whether to disable all logging (default: False)
             visualizer: Strategy for rendering aggregated experiment artifacts.
                 Defaults to :class:`EpisodeReturnsVisualizer`.
+            notification_config: Optional :class:`NotificationConfig` controlling
+                Slack + progress-DB notifications. Forwarded to
+                :class:`BaseSimulator`. When ``None``, the parent defaults to
+                :meth:`NotificationConfig.disabled`.
         """
         super().__init__(
             task_manager_config=task_manager_config,
@@ -148,6 +156,7 @@ class POMDPSimulator(BaseSimulator):
             console_output=console_output,
             no_logs=no_logs,
             visualizer=visualizer,
+            notification_config=notification_config,
         )
         self.task_console_output = task_console_output
 

--- a/POMDPPlanners/tests/test_simulations/test_hyper_parameter_tuning_simulations.py
+++ b/POMDPPlanners/tests/test_simulations/test_hyper_parameter_tuning_simulations.py
@@ -2889,3 +2889,165 @@ class TestHyperParameterOptimizerParallelizationLevel:
 
         for task in tasks:
             assert task.parallelization_level == ParallelizationLevel.OPTUNA_TRIALS
+
+
+class TestHyperParameterOptimizerNotifications:
+    """Tests for the Slack/DB notification surface added to the optimizer."""
+
+    def test_optimizer_emits_run_started_and_run_finished_on_success(
+        self, temp_cache_dir, sample_configs
+    ):
+        """Verify run_started and run_finished fire when optimize() succeeds.
+
+        Purpose: Validates the parent-side notifier integration in the
+        happy-path of :meth:`HyperParameterOptimizer.optimize`.
+
+        Given: An optimizer with sample_configs (two configs, 2 trials each).
+        When: optimize() is called and completes without raising; the
+            internal notifier is swapped for a Mock just before the call.
+        Then: notifier.run_started is called exactly once with metadata
+            containing num_configs=2 and total_trials=4; notifier.run_finished
+            is called exactly once; notifier.run_failed is never called.
+
+        Test type: integration
+        """
+        optimizer = HyperParameterOptimizer(cache_dir_path=temp_cache_dir)
+        mock_notifier = Mock()
+        optimizer._notifier = mock_notifier
+
+        optimizer.optimize(sample_configs)
+
+        mock_notifier.run_started.assert_called_once()
+        started_args, started_kwargs = mock_notifier.run_started.call_args
+        assert started_args[0] == optimizer._run_id
+        assert started_kwargs["metadata"]["num_configs"] == len(sample_configs)
+        assert started_kwargs["metadata"]["total_trials"] == sum(c.n_trials for c in sample_configs)
+        mock_notifier.run_finished.assert_called_once_with(optimizer._run_id)
+        mock_notifier.run_failed.assert_not_called()
+
+    def test_optimizer_emits_run_failed_on_exception(self, temp_cache_dir, sample_configs):
+        """Verify run_failed fires when optimize() raises.
+
+        Purpose: Validates the crash-path notifier integration so a 2-week
+        tuning run that dies mid-flight surfaces in Slack.
+
+        Given: An optimizer with sample_configs and the internal task
+            execution monkeypatched to raise.
+        When: optimize() is called.
+        Then: The exception propagates; notifier.run_failed is called
+            exactly once with an error string containing the exception
+            type and message; notifier.run_finished is never called.
+
+        Test type: integration
+        """
+        optimizer = HyperParameterOptimizer(cache_dir_path=temp_cache_dir)
+        mock_notifier = Mock()
+        optimizer._notifier = mock_notifier
+
+        def _explode(_configs):
+            raise RuntimeError("synthetic failure")
+
+        optimizer._execute_optimization_tasks = _explode  # type: ignore[assignment]
+
+        with pytest.raises(RuntimeError, match="synthetic failure"):
+            optimizer.optimize(sample_configs)
+
+        mock_notifier.run_failed.assert_called_once()
+        failed_args, _ = mock_notifier.run_failed.call_args
+        assert failed_args[0] == optimizer._run_id
+        assert "RuntimeError" in failed_args[1]
+        assert "synthetic failure" in failed_args[1]
+        mock_notifier.run_finished.assert_not_called()
+
+    def test_optimizer_is_picklable(self, temp_cache_dir):
+        """Verify the optimizer survives pickle.dumps despite the signal closure.
+
+        Purpose: Locks in the regression we caught for BaseSimulator. The
+        signal-handler uninstall is a closure; without __getstate__ it
+        would crash pickle.
+
+        Given: An optimizer with default settings.
+        When: pickle.dumps(optimizer) is called.
+        Then: No AttributeError / PicklingError is raised, and the
+            unpickled optimizer has a callable _uninstall_signals attribute.
+
+        Test type: unit
+        """
+        import pickle  # pylint: disable=import-outside-toplevel
+
+        optimizer = HyperParameterOptimizer(cache_dir_path=temp_cache_dir)
+        payload = pickle.dumps(optimizer)
+        revived = pickle.loads(payload)
+        assert callable(revived._uninstall_signals)
+        # The no-op uninstall on the revived instance must not raise.
+        revived._uninstall_signals()
+
+    def test_trial_milestone_fires_every_n_trials(self, temp_cache_dir):
+        """Verify post_trial_milestone is called once per interval.
+
+        Purpose: Validates that the in-task Optuna callback emits at
+        exactly the configured cadence with no double-firing.
+
+        Given: A HyperParameterTuningSimulationTask configured with
+            trial_interval=2, total_trials_globally=4, a fake webhook URL,
+            and a parent_run_id; an Optuna study run with 4 trials.
+        When: The task's progress callback is registered with the study
+            and the study completes.
+        Then: post_trial_milestone is called exactly 2 times (at the
+            completions of trial.number=1 and trial.number=3 — global
+            counts 2 and 4).
+
+        Test type: integration
+        """
+        import optuna  # pylint: disable=import-outside-toplevel
+
+        from POMDPPlanners.simulations.simulations_deployment.run_progress import (  # pylint: disable=import-outside-toplevel
+            ProgressDB,
+        )
+
+        # Minimal real Task instance so the bound `_build_progress_callback`
+        # has the wiring it needs without standing up a full simulator.
+        env = TigerPOMDP(discount_factor=0.95)
+        belief = get_initial_belief(env, n_particles=4)
+        task = HyperParameterTuningSimulationTask(
+            environment=env,
+            belief=belief,
+            policy_cls=SparseSamplingDiscreteActionsPlanner,
+            hyper_parameters=[NumericalHyperParameter(1, 2, "branching_factor")],
+            constant_parameters={"depth": 1},
+            num_episodes=1,
+            num_steps=1,
+            parameters_to_optimize=[
+                ("average_return", HyperParameterOptimizationDirection.MAXIMIZE)
+            ],
+            n_trials=4,
+            cache_dir=temp_cache_dir,
+            parent_run_id="rid-test",
+            webhook_url="https://hooks.slack.com/test",
+            trial_interval=2,
+            trial_offset=0,
+            total_trials_globally=4,
+            progress_db_path=temp_cache_dir / "progress.db",
+        )
+
+        # Pre-create the run row so heartbeats during the callback have a
+        # row to update (otherwise the UPDATE is a silent no-op, which is
+        # also fine but creates noise in tests).
+        ProgressDB(path=temp_cache_dir / "progress.db").start_run("rid-test", "exp-test", {})
+
+        callback = task._build_progress_callback()
+        study = optuna.create_study(direction="maximize")
+
+        with patch(
+            "POMDPPlanners.simulations.simulations_deployment.tasks."
+            "hyper_parameter_tuning_simulation_task.post_trial_milestone"
+        ) as mock_milestone:
+            study.optimize(
+                lambda trial: trial.suggest_float("x", 0.0, 1.0), n_trials=4, callbacks=[callback]
+            )
+
+        assert mock_milestone.call_count == 2
+        first_call_kwargs = mock_milestone.call_args_list[0].kwargs
+        assert first_call_kwargs["completed_trials"] == 2
+        assert first_call_kwargs["run_id"] == "rid-test"
+        assert first_call_kwargs["total_trials"] == 4

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/test_config.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/test_config.py
@@ -1,0 +1,296 @@
+"""Tests for :mod:`POMDPPlanners.simulations.simulations_deployment.run_progress.config`."""
+
+from pathlib import Path
+
+from POMDPPlanners.simulations.simulations_deployment.run_progress.config import (
+    NotificationConfig,
+)
+
+
+def test_default_construction_is_inactive():
+    """Verify the bare-default config is silent.
+
+    Purpose: Validates the safe-by-default contract — constructing
+    NotificationConfig() with no arguments produces a config that
+    :func:`build_notifier` will turn into a NullNotifier.
+
+    Given: No arguments.
+    When: NotificationConfig() is constructed.
+    Then: All fields hold their safe defaults; is_active() returns False.
+
+    Test type: unit
+    """
+    cfg = NotificationConfig()
+
+    assert cfg.webhook_url is None
+    assert cfg.trial_interval == 0
+    assert cfg.progress_db_path is None
+    assert cfg.disable is False
+    assert cfg.is_active() is False
+
+
+def test_disabled_factory_returns_inactive_config():
+    """Verify :meth:`NotificationConfig.disabled` is hard-disabled.
+
+    Purpose: Validates the factory used as the default by simulation
+    classes constructed without an explicit config (tests, workflows).
+
+    Given: NotificationConfig.disabled().
+    When: is_active() is checked.
+    Then: disable is True and is_active() returns False — even if a
+        webhook were also set (verified by manually constructing).
+
+    Test type: unit
+    """
+    cfg = NotificationConfig.disabled()
+
+    assert cfg.disable is True
+    assert cfg.is_active() is False
+
+    cfg_with_webhook_and_disabled = NotificationConfig(
+        webhook_url="https://hooks.slack.com/test", disable=True
+    )
+    assert cfg_with_webhook_and_disabled.is_active() is False
+
+
+def test_is_active_requires_webhook_and_not_disabled():
+    """Verify is_active() returns True only when webhook is set and not disabled.
+
+    Purpose: Documents the exact gate :func:`build_notifier` uses.
+
+    Given: Various combinations of webhook_url and disable.
+    When: is_active() is checked.
+    Then: True iff webhook_url is non-empty AND disable is False.
+
+    Test type: unit
+    """
+    assert NotificationConfig(webhook_url="https://x").is_active() is True
+    assert NotificationConfig(webhook_url="https://x", disable=True).is_active() is False
+    assert NotificationConfig(webhook_url=None).is_active() is False
+    assert NotificationConfig(webhook_url="").is_active() is False
+
+
+def test_from_env_returns_disabled_under_pytest(monkeypatch):
+    """Verify from_env() returns disabled when PYTEST_CURRENT_TEST is set.
+
+    Purpose: Validates the test-safety gate so test suites never page
+    Slack even when SLACK_WEBHOOK_URL is set in the environment.
+
+    Given: PYTEST_CURRENT_TEST is set, SLACK_WEBHOOK_URL is also set.
+    When: NotificationConfig.from_env() is called.
+    Then: disable is True; the webhook still appears in the config (so
+        callers can introspect it), but is_active() returns False.
+
+    Test type: unit
+    """
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "fake")
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/test")
+
+    cfg = NotificationConfig.from_env()
+
+    assert cfg.disable is True
+    assert cfg.is_active() is False
+
+
+def test_from_env_returns_disabled_when_kill_switch_set(monkeypatch):
+    """Verify POMDPPLANNERS_DISABLE_NOTIFY=1 produces a disabled config.
+
+    Purpose: Validates the explicit per-run opt-out env var.
+
+    Given: PYTEST_CURRENT_TEST is unset, SLACK_WEBHOOK_URL is set, and
+        POMDPPLANNERS_DISABLE_NOTIFY=1 is set.
+    When: NotificationConfig.from_env() is called.
+    Then: disable is True; is_active() returns False.
+
+    Test type: unit
+    """
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("POMDPPLANNERS_DISABLE_NOTIFY", "1")
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/test")
+
+    cfg = NotificationConfig.from_env()
+
+    assert cfg.disable is True
+    assert cfg.is_active() is False
+
+
+def test_from_env_returns_inactive_when_webhook_unset(monkeypatch):
+    """Verify the no-webhook path yields an inactive (but not disabled) config.
+
+    Purpose: Validates that absent SLACK_WEBHOOK_URL silently disables
+    Slack posting without flipping the hard `disable` flag.
+
+    Given: PYTEST_CURRENT_TEST and POMDPPLANNERS_DISABLE_NOTIFY are unset,
+        SLACK_WEBHOOK_URL is unset.
+    When: NotificationConfig.from_env() is called.
+    Then: disable is False, webhook_url is None, is_active() is False.
+
+    Test type: unit
+    """
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("POMDPPLANNERS_DISABLE_NOTIFY", raising=False)
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+
+    cfg = NotificationConfig.from_env()
+
+    assert cfg.disable is False
+    assert cfg.webhook_url is None
+    assert cfg.is_active() is False
+
+
+def test_from_env_returns_active_config_when_webhook_set(monkeypatch):
+    """Verify the happy-path env reading produces an active config.
+
+    Purpose: Validates the zero-config UX through SimulationsAPI: just
+    export SLACK_WEBHOOK_URL and notifications work.
+
+    Given: PYTEST_CURRENT_TEST and POMDPPLANNERS_DISABLE_NOTIFY are unset,
+        SLACK_WEBHOOK_URL is set.
+    When: NotificationConfig.from_env() is called.
+    Then: webhook_url matches; disable is False; is_active() is True.
+
+    Test type: unit
+    """
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("POMDPPLANNERS_DISABLE_NOTIFY", raising=False)
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/abc")
+
+    cfg = NotificationConfig.from_env()
+
+    assert cfg.webhook_url == "https://hooks.slack.com/abc"
+    assert cfg.disable is False
+    assert cfg.is_active() is True
+
+
+def test_from_env_reads_trial_interval(monkeypatch):
+    """Verify HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL flows into the config.
+
+    Purpose: Validates the milestone-cadence env var path.
+
+    Given: HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL=10 in the env.
+    When: NotificationConfig.from_env() is called.
+    Then: trial_interval is 10.
+
+    Test type: unit
+    """
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("POMDPPLANNERS_DISABLE_NOTIFY", raising=False)
+    monkeypatch.setenv("HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL", "10")
+
+    cfg = NotificationConfig.from_env()
+
+    assert cfg.trial_interval == 10
+
+
+def test_from_env_default_trial_interval_is_50(monkeypatch):
+    """Verify the milestone-interval default when the env var is unset.
+
+    Purpose: Locks in the documented default cadence.
+
+    Given: HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL is unset.
+    When: NotificationConfig.from_env() is called.
+    Then: trial_interval is 50.
+
+    Test type: unit
+    """
+    monkeypatch.delenv("HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL", raising=False)
+
+    cfg = NotificationConfig.from_env()
+
+    assert cfg.trial_interval == 50
+
+
+def test_from_env_trial_interval_zero_when_non_positive(monkeypatch):
+    """Verify a non-positive interval is normalised to 0 (disabled).
+
+    Purpose: Defensive against bad env values; 0 means "no milestone
+    posts" in the optimizer.
+
+    Given: HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL is set to "0" or a
+        negative number.
+    When: NotificationConfig.from_env() is called.
+    Then: trial_interval is 0.
+
+    Test type: unit
+    """
+    monkeypatch.setenv("HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL", "0")
+    assert NotificationConfig.from_env().trial_interval == 0
+
+    monkeypatch.setenv("HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL", "-5")
+    assert NotificationConfig.from_env().trial_interval == 0
+
+
+def test_from_env_trial_interval_falls_back_on_malformed(monkeypatch):
+    """Verify a non-integer env value falls back to the default of 50.
+
+    Purpose: Avoid crashes if the env var is fat-fingered.
+
+    Given: HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL is set to a non-integer
+        string.
+    When: NotificationConfig.from_env() is called.
+    Then: trial_interval is the documented default of 50.
+
+    Test type: unit
+    """
+    monkeypatch.setenv("HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL", "not-a-number")
+
+    cfg = NotificationConfig.from_env()
+
+    assert cfg.trial_interval == 50
+
+
+def test_from_env_reads_progress_db_path(monkeypatch, tmp_path):
+    """Verify POMDP_PROGRESS_DB is threaded into progress_db_path.
+
+    Purpose: Validates the per-user DB-path override used for multi-tenant
+    setups and explicit watcher targeting.
+
+    Given: POMDP_PROGRESS_DB points to a path under tmp_path.
+    When: NotificationConfig.from_env() is called.
+    Then: progress_db_path equals that Path.
+
+    Test type: unit
+    """
+    target = tmp_path / "my_progress.db"
+    monkeypatch.setenv("POMDP_PROGRESS_DB", str(target))
+
+    cfg = NotificationConfig.from_env()
+
+    assert cfg.progress_db_path == target
+
+
+def test_from_env_progress_db_path_is_none_when_unset(monkeypatch):
+    """Verify progress_db_path is None when POMDP_PROGRESS_DB is unset.
+
+    Purpose: Validates the "let ProgressDB pick the default" path.
+
+    Given: POMDP_PROGRESS_DB is unset.
+    When: NotificationConfig.from_env() is called.
+    Then: progress_db_path is None.
+
+    Test type: unit
+    """
+    monkeypatch.delenv("POMDP_PROGRESS_DB", raising=False)
+
+    cfg = NotificationConfig.from_env()
+
+    assert cfg.progress_db_path is None
+
+
+def test_path_field_accepts_explicit_construction(tmp_path):
+    """Verify NotificationConfig stores a Path object as-given.
+
+    Purpose: Validates programmatic construction with a custom DB path.
+
+    Given: An explicit progress_db_path argument.
+    When: NotificationConfig is constructed.
+    Then: The field stores the exact Path object.
+
+    Test type: unit
+    """
+    target = tmp_path / "custom.db"
+
+    cfg = NotificationConfig(progress_db_path=target)
+
+    assert cfg.progress_db_path == target
+    assert isinstance(cfg.progress_db_path, Path)

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/test_db.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/test_db.py
@@ -1,0 +1,411 @@
+# pylint: disable=protected-access  # Tests need to inspect internal state
+"""Tests for :mod:`POMDPPlanners.simulations.simulations_deployment.run_progress.db`."""
+
+import json
+import sqlite3
+import time
+from contextlib import closing
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from POMDPPlanners.simulations.simulations_deployment.run_progress.db import (
+    ProgressDB,
+    RunRow,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    """Fixture returning a fresh SQLite path inside the pytest tmp dir."""
+    return tmp_path / "progress.db"
+
+
+@pytest.fixture
+def progress_db(db_path):
+    """Fixture constructing a :class:`ProgressDB` on a fresh file."""
+    return ProgressDB(path=db_path)
+
+
+def test_initialization_creates_parent_directory(tmp_path):
+    """Verify that ProgressDB auto-creates a missing parent directory.
+
+    Purpose: Validates first-time setup on a host with no prior progress DB.
+
+    Given: A path under a directory tree that does not yet exist on disk.
+    When: ProgressDB is instantiated with that path.
+    Then: The parent directory exists and the SQLite file is created.
+
+    Test type: unit
+    """
+    nested_path = tmp_path / "a" / "b" / "c" / "progress.db"
+    assert not nested_path.parent.exists()
+
+    db = ProgressDB(path=nested_path)
+
+    assert nested_path.parent.exists()
+    assert db.path == nested_path
+
+
+def test_initialization_uses_env_var_when_no_path_given(monkeypatch, tmp_path):
+    """Verify that ProgressDB reads POMDP_PROGRESS_DB when no path is given.
+
+    Purpose: Validates the env-var override path used by the watcher CLI.
+
+    Given: POMDP_PROGRESS_DB is set to a path under tmp_path.
+    When: ProgressDB is instantiated with no explicit path.
+    Then: The DB is created at the env-var location.
+
+    Test type: unit
+    """
+    env_path = tmp_path / "from_env.db"
+    monkeypatch.setenv("POMDP_PROGRESS_DB", str(env_path))
+
+    db = ProgressDB()
+
+    assert db.path == env_path
+
+
+def test_initialization_falls_back_to_default_path(monkeypatch, tmp_path):
+    """Verify default path resolves under the user's cache directory.
+
+    Purpose: Validates the no-config default for new installations.
+
+    Given: POMDP_PROGRESS_DB is unset and Path.home() is monkeypatched.
+    When: ProgressDB is instantiated with no path argument.
+    Then: The path resolves to ``<home>/.cache/POMDPPlanners/progress.db``.
+
+    Test type: unit
+    """
+    monkeypatch.delenv("POMDP_PROGRESS_DB", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    db = ProgressDB()
+
+    assert db.path == tmp_path / ".cache" / "POMDPPlanners" / "progress.db"
+    assert db.path.parent.exists()
+
+
+def test_schema_is_idempotent(db_path):
+    """Verify that constructing ProgressDB twice on the same file is safe.
+
+    Purpose: Validates the CREATE TABLE IF NOT EXISTS contract.
+
+    Given: A ProgressDB has already been instantiated on a path.
+    When: A second ProgressDB is instantiated on the same path.
+    Then: No exception is raised, and existing data is preserved.
+
+    Test type: unit
+    """
+    first = ProgressDB(path=db_path)
+    first.start_run("rid-1", "exp-A", {"k": "v"})
+
+    ProgressDB(path=db_path)  # second open should not raise or wipe rows
+
+    fetched = first.get_run("rid-1")
+    assert fetched is not None
+    assert fetched.experiment_name == "exp-A"
+
+
+def test_wal_mode_is_enabled(progress_db):
+    """Verify that journal_mode=WAL is set on the SQLite file.
+
+    Purpose: Validates the parent/watcher concurrency invariant.
+
+    Given: A freshly initialized ProgressDB.
+    When: PRAGMA journal_mode is queried on the file.
+    Then: The reported mode is ``wal``.
+
+    Test type: unit
+    """
+    with closing(sqlite3.connect(progress_db.path)) as conn:
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+    assert mode.lower() == "wal"
+
+
+def test_start_run_records_status_and_metadata(progress_db):
+    """Verify that start_run inserts a row with the expected fields.
+
+    Purpose: Validates the run-start hook writes correct initial state.
+
+    Given: A fresh ProgressDB and a metadata dict.
+    When: start_run is called with a run_id, experiment_name, and metadata.
+    Then: get_run returns a RunRow with status='running', the metadata
+        JSON-round-tripped, no error_msg, no finished_at, and a
+        last_heartbeat_at equal to started_at.
+
+    Test type: unit
+    """
+    progress_db.start_run("rid-2", "tiger_exp", {"episodes": 100, "seed": 42})
+
+    row = progress_db.get_run("rid-2")
+    assert isinstance(row, RunRow)
+    assert row.run_id == "rid-2"
+    assert row.experiment_name == "tiger_exp"
+    assert row.status == "running"
+    assert row.metadata == {"episodes": 100, "seed": 42}
+    assert row.error_msg is None
+    assert row.finished_at is None
+    assert row.stall_notified_at is None
+    assert row.last_heartbeat_at == row.started_at
+
+
+def test_start_run_with_no_metadata_stores_empty_dict(progress_db):
+    """Verify that omitting metadata results in an empty dict, not NULL.
+
+    Purpose: Validates the metadata-default contract for callers that have
+    nothing meaningful to record.
+
+    Given: A fresh ProgressDB.
+    When: start_run is called without a metadata argument.
+    Then: get_run returns a row whose metadata is an empty dict.
+
+    Test type: unit
+    """
+    progress_db.start_run("rid-3", "tiger_exp")
+
+    row = progress_db.get_run("rid-3")
+    assert row is not None
+    assert row.metadata == {}
+
+
+def test_heartbeat_updates_only_heartbeat_field(progress_db):
+    """Verify that heartbeat advances last_heartbeat_at and leaves the rest.
+
+    Purpose: Validates the per-episode update path is minimal and correct.
+
+    Given: A running row whose last_heartbeat_at equals started_at.
+    When: A short delay is awaited and then heartbeat is called.
+    Then: last_heartbeat_at is strictly greater than the original; status,
+        started_at, finished_at, and error_msg are unchanged.
+
+    Test type: unit
+    """
+    progress_db.start_run("rid-4", "exp")
+    before = progress_db.get_run("rid-4")
+    assert before is not None
+    time.sleep(0.01)  # ensure ISO timestamps differ
+
+    progress_db.heartbeat("rid-4")
+
+    after = progress_db.get_run("rid-4")
+    assert after is not None
+    assert after.last_heartbeat_at > before.last_heartbeat_at
+    assert after.started_at == before.started_at
+    assert after.status == "running"
+    assert after.finished_at is None
+    assert after.error_msg is None
+
+
+def test_finish_run_marks_finished_with_timestamp(progress_db):
+    """Verify the clean-finish update path.
+
+    Purpose: Validates the run-finished hook writes the correct status.
+
+    Given: A running row.
+    When: finish_run is called with status='finished' and no error.
+    Then: status becomes 'finished', finished_at is populated, error_msg
+        remains None.
+
+    Test type: unit
+    """
+    progress_db.start_run("rid-5", "exp")
+
+    progress_db.finish_run("rid-5", status="finished", error=None)
+
+    row = progress_db.get_run("rid-5")
+    assert row is not None
+    assert row.status == "finished"
+    assert row.finished_at is not None
+    assert row.error_msg is None
+
+
+def test_finish_run_marks_failed_with_error_message(progress_db):
+    """Verify the crash update path captures the error message.
+
+    Purpose: Validates the run-failed hook records the cause.
+
+    Given: A running row.
+    When: finish_run is called with status='failed' and an error string.
+    Then: status becomes 'failed', finished_at is populated, error_msg
+        contains the supplied string.
+
+    Test type: unit
+    """
+    progress_db.start_run("rid-6", "exp")
+
+    progress_db.finish_run("rid-6", status="failed", error="RuntimeError: boom")
+
+    row = progress_db.get_run("rid-6")
+    assert row is not None
+    assert row.status == "failed"
+    assert row.finished_at is not None
+    assert row.error_msg == "RuntimeError: boom"
+
+
+def test_get_run_returns_none_for_unknown_id(progress_db):
+    """Verify get_run does not raise when the id is absent.
+
+    Purpose: Validates lookup safety so callers can use a simple None check.
+
+    Given: A ProgressDB containing no rows.
+    When: get_run is called with an unknown id.
+    Then: ``None`` is returned (no exception raised).
+
+    Test type: unit
+    """
+    assert progress_db.get_run("does-not-exist") is None
+
+
+def test_list_stalled_returns_only_old_running_rows(progress_db, db_path):
+    """Verify the stall query filters by status, age, and notification state.
+
+    Purpose: Validates the watcher's primary query.
+
+    Given: Four rows — running+old, running+fresh, finished+old, and
+        running+old-but-already-notified.
+    When: list_stalled is called with a threshold that classifies "old"
+        heartbeats as stalled.
+    Then: Only the first row is returned (and ordered oldest-first when
+        multiple stalled rows are present).
+
+    Test type: unit
+    """
+    progress_db.start_run("running_old", "exp")
+    progress_db.start_run("running_fresh", "exp")
+    progress_db.start_run("finished_old", "exp")
+    progress_db.finish_run("finished_old", status="finished", error=None)
+    progress_db.start_run("running_old_notified", "exp")
+    progress_db.mark_stall_notified("running_old_notified")
+
+    # Rewind two rows' heartbeats far into the past to make them "old".
+    _backdate_heartbeat(db_path, "running_old", seconds=3600)
+    _backdate_heartbeat(db_path, "running_old_notified", seconds=3600)
+
+    stalled = progress_db.list_stalled(threshold_seconds=60)
+
+    stalled_ids = [r.run_id for r in stalled]
+    assert stalled_ids == ["running_old"]
+
+
+def test_list_stalled_ordered_oldest_first(progress_db, db_path):
+    """Verify ordering when multiple stalled runs exist.
+
+    Purpose: Validates the watcher always notifies oldest stalls first.
+
+    Given: Two stalled running rows with backdated heartbeats — one older
+        than the other.
+    When: list_stalled is called.
+    Then: The returned list is ordered with the oldest heartbeat first.
+
+    Test type: unit
+    """
+    progress_db.start_run("older", "exp")
+    progress_db.start_run("newer", "exp")
+    _backdate_heartbeat(db_path, "older", seconds=7200)
+    _backdate_heartbeat(db_path, "newer", seconds=3600)
+
+    stalled = progress_db.list_stalled(threshold_seconds=60)
+
+    assert [r.run_id for r in stalled] == ["older", "newer"]
+
+
+def test_mark_stall_notified_sets_timestamp(progress_db):
+    """Verify mark_stall_notified records when the notification was sent.
+
+    Purpose: Validates the watcher's dedupe-update path.
+
+    Given: A running row with stall_notified_at IS NULL.
+    When: mark_stall_notified is called.
+    Then: The row's stall_notified_at becomes a non-empty ISO timestamp.
+
+    Test type: unit
+    """
+    progress_db.start_run("rid-7", "exp")
+
+    progress_db.mark_stall_notified("rid-7")
+
+    row = progress_db.get_run("rid-7")
+    assert row is not None
+    assert row.stall_notified_at is not None
+    assert "T" in row.stall_notified_at  # ISO-8601 format sanity
+
+
+def test_metadata_round_trips_nested_structures(progress_db):
+    """Verify that nested JSON metadata survives a write/read cycle.
+
+    Purpose: Validates that arbitrary JSON-serializable structures are
+    preserved end-to-end without flattening.
+
+    Given: A metadata dict containing nested dicts and lists.
+    When: start_run is called and the row is read back.
+    Then: The metadata equals the original (no truncation, no type drift).
+
+    Test type: unit
+    """
+    metadata = {
+        "envs": ["tiger", "rocksample"],
+        "planner": {"name": "POMCP", "params": {"c": 1.0, "iters": 500}},
+    }
+    progress_db.start_run("rid-8", "exp", metadata)
+
+    row = progress_db.get_run("rid-8")
+    assert row is not None
+    assert row.metadata == metadata
+
+
+def _backdate_heartbeat(db_path: Path, run_id: str, seconds: int) -> None:
+    """Helper: rewind a row's last_heartbeat_at by ``seconds`` for stall tests."""
+    new_ts = (datetime.now(timezone.utc) - timedelta(seconds=seconds)).isoformat()
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.execute(
+            "UPDATE runs SET last_heartbeat_at = ? WHERE run_id = ?",
+            (new_ts, run_id),
+        )
+        conn.commit()
+
+
+def test_helper_backdate_heartbeat_works(progress_db, db_path):
+    """Smoke test for the backdate helper used by other tests.
+
+    Purpose: Validates the test helper does what its callers depend on.
+
+    Given: A running row.
+    When: _backdate_heartbeat is called with a large delta.
+    Then: The stored last_heartbeat_at is older than the original by at
+        least that many seconds.
+
+    Test type: unit
+    """
+    progress_db.start_run("rid-9", "exp")
+    original = progress_db.get_run("rid-9")
+    assert original is not None
+
+    _backdate_heartbeat(db_path, "rid-9", seconds=3600)
+
+    updated = progress_db.get_run("rid-9")
+    assert updated is not None
+    assert updated.last_heartbeat_at < original.last_heartbeat_at
+
+
+def test_runrow_metadata_is_dict_not_string(progress_db):
+    """Verify the metadata field is decoded JSON, not the raw JSON string.
+
+    Purpose: Validates the row-to-RunRow conversion deserializes metadata.
+
+    Given: A row stored with a non-empty metadata dict.
+    When: get_run returns a RunRow.
+    Then: row.metadata is a dict (not a string) and indexes work.
+
+    Test type: unit
+    """
+    progress_db.start_run("rid-10", "exp", {"k": 1})
+
+    row = progress_db.get_run("rid-10")
+    assert row is not None
+    assert isinstance(row.metadata, dict)
+    assert row.metadata["k"] == 1
+    assert not isinstance(row.metadata, str)
+    # confirm it's not "just happen to" be JSON bytes
+    json.dumps(row.metadata)  # raises if non-serializable

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/test_notify.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/test_notify.py
@@ -1,0 +1,447 @@
+# pylint: disable=protected-access  # Tests need to inspect internal state
+"""Tests for :mod:`POMDPPlanners.simulations.simulations_deployment.run_progress.notify`."""
+
+import json
+import logging
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from POMDPPlanners.simulations.simulations_deployment.run_progress.config import (
+    NotificationConfig,
+)
+from POMDPPlanners.simulations.simulations_deployment.run_progress.db import ProgressDB
+from POMDPPlanners.simulations.simulations_deployment.run_progress.notify import (
+    NullNotifier,
+    Notifier,
+    SlackNotifier,
+    build_notifier,
+    post_trial_milestone,
+)
+
+
+@pytest.fixture
+def progress_db(tmp_path):
+    """Fresh ProgressDB rooted in pytest's tmp_path."""
+    return ProgressDB(path=tmp_path / "progress.db")
+
+
+@pytest.fixture
+def slack_notifier(progress_db):
+    """SlackNotifier wired to the tmp ProgressDB with a recording logger."""
+    logger = logging.getLogger("test.run_progress.notify")
+    logger.handlers.clear()
+    return SlackNotifier(
+        webhook_url="https://hooks.slack.com/test/abc",
+        experiment_name="my_exp",
+        db=progress_db,
+        logger=logger,
+    )
+
+
+def test_null_notifier_satisfies_protocol():
+    """Verify NullNotifier structurally matches the Notifier Protocol.
+
+    Purpose: Validates the no-op type substitutes anywhere a Notifier is
+    expected.
+
+    Given: A fresh NullNotifier instance.
+    When: isinstance() is checked against the runtime-checkable Protocol.
+    Then: The instance is reported as a Notifier and all four methods can be
+        called without raising.
+
+    Test type: unit
+    """
+    notifier = NullNotifier()
+
+    assert isinstance(notifier, Notifier)
+    notifier.run_started("rid", metadata={"k": "v"})
+    notifier.episode_completed("rid")
+    notifier.run_finished("rid")
+    notifier.run_failed("rid", "boom")
+
+
+def test_slack_notifier_satisfies_protocol(slack_notifier):
+    """Verify SlackNotifier structurally matches the Notifier Protocol.
+
+    Purpose: Validates the concrete impl conforms to the structural contract.
+
+    Given: A fresh SlackNotifier.
+    When: isinstance() is checked against Notifier.
+    Then: The instance is reported as a Notifier.
+
+    Test type: unit
+    """
+    assert isinstance(slack_notifier, Notifier)
+
+
+def test_run_started_writes_to_db_and_posts_to_slack(slack_notifier, progress_db):
+    """Verify run_started persists a row AND POSTs to Slack.
+
+    Purpose: Validates the start-of-run event side-effects.
+
+    Given: A SlackNotifier with mocked urlopen.
+    When: run_started is called with a run_id and metadata.
+    Then: The DB contains a 'running' row with that metadata, and exactly
+        one HTTP POST was issued to the webhook with a JSON body containing
+        a 'text' field that mentions the experiment name.
+
+    Test type: unit
+    """
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"ok"
+
+        slack_notifier.run_started("rid-A", metadata={"episodes": 7})
+
+        assert mock_urlopen.call_count == 1
+        request = mock_urlopen.call_args[0][0]
+        assert request.full_url == "https://hooks.slack.com/test/abc"
+        body = json.loads(request.data.decode("utf-8"))
+        assert "my_exp" in body["text"]
+
+    row = progress_db.get_run("rid-A")
+    assert row is not None
+    assert row.status == "running"
+    assert row.metadata == {"episodes": 7}
+
+
+def test_episode_completed_writes_heartbeat_only(slack_notifier, progress_db):
+    """Verify episode_completed updates the DB heartbeat without posting.
+
+    Purpose: Validates the per-episode hook does not spam Slack.
+
+    Given: A SlackNotifier and a running run.
+    When: episode_completed is called.
+    Then: The DB heartbeat advances, and urlopen is never called.
+
+    Test type: unit
+    """
+    slack_notifier.db.start_run("rid-B", "my_exp", {})
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        slack_notifier.episode_completed("rid-B")
+        assert mock_urlopen.call_count == 0
+
+    row = progress_db.get_run("rid-B")
+    assert row is not None
+    assert row.status == "running"  # heartbeat does not change status
+
+
+def test_run_finished_writes_to_db_and_posts_to_slack(slack_notifier, progress_db):
+    """Verify run_finished marks the row 'finished' AND POSTs to Slack.
+
+    Purpose: Validates the clean-finish event side-effects.
+
+    Given: A SlackNotifier and a previously-started run.
+    When: run_finished is called.
+    Then: The DB row has status='finished', and one HTTP POST was sent
+        containing the experiment name in the message body.
+
+    Test type: unit
+    """
+    slack_notifier.db.start_run("rid-C", "my_exp", {})
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"ok"
+
+        slack_notifier.run_finished("rid-C")
+
+        assert mock_urlopen.call_count == 1
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode("utf-8"))
+        assert "my_exp" in body["text"]
+
+    row = progress_db.get_run("rid-C")
+    assert row is not None
+    assert row.status == "finished"
+    assert row.error_msg is None
+
+
+def test_run_failed_writes_error_and_posts_to_slack(slack_notifier, progress_db):
+    """Verify run_failed records the error AND POSTs a failure message.
+
+    Purpose: Validates the crash-path event side-effects.
+
+    Given: A SlackNotifier and a previously-started run.
+    When: run_failed is called with an error message.
+    Then: The DB row has status='failed' and error_msg is the supplied
+        string. The Slack POST body mentions the error string.
+
+    Test type: unit
+    """
+    slack_notifier.db.start_run("rid-D", "my_exp", {})
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"ok"
+
+        slack_notifier.run_failed("rid-D", "RuntimeError: division by zero")
+
+        assert mock_urlopen.call_count == 1
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode("utf-8"))
+        assert "RuntimeError" in body["text"]
+
+    row = progress_db.get_run("rid-D")
+    assert row is not None
+    assert row.status == "failed"
+    assert row.error_msg == "RuntimeError: division by zero"
+
+
+def test_slack_post_failure_is_logged_not_raised(slack_notifier, caplog):
+    """Verify Slack-side failures do not propagate to the caller.
+
+    Purpose: Validates that the simulator is not derailed by a Slack outage.
+
+    Given: A SlackNotifier whose urlopen raises a URLError.
+    When: run_started is called.
+    Then: No exception propagates; a WARNING is logged; the DB row is
+        still written.
+
+    Test type: unit
+    """
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("no DNS")):
+        with caplog.at_level(logging.WARNING, logger="test.run_progress.notify"):
+            slack_notifier.run_started("rid-E", metadata={})
+
+    assert any("Slack notification failed" in r.message for r in caplog.records)
+    row = slack_notifier.db.get_run("rid-E")
+    assert row is not None  # DB write still happened despite Slack failure
+
+
+def test_build_notifier_returns_null_for_disabled_config():
+    """Verify build_notifier returns NullNotifier when the config is disabled.
+
+    Purpose: Validates the kill-switch path. A config with disable=True
+    must produce a no-op notifier even if a webhook URL is set.
+
+    Given: A NotificationConfig with disable=True and a webhook URL.
+    When: build_notifier is called with that config.
+    Then: A NullNotifier is returned.
+
+    Test type: unit
+    """
+    config = NotificationConfig(webhook_url="https://hooks.slack.com/x", disable=True)
+
+    notifier = build_notifier("exp", config=config)
+
+    assert isinstance(notifier, NullNotifier)
+
+
+def test_build_notifier_returns_null_when_webhook_missing():
+    """Verify build_notifier returns NullNotifier when webhook is unset.
+
+    Purpose: Validates the default-off path: no webhook → silent.
+
+    Given: A NotificationConfig with webhook_url=None.
+    When: build_notifier is called with that config.
+    Then: A NullNotifier is returned.
+
+    Test type: unit
+    """
+    config = NotificationConfig(webhook_url=None)
+
+    notifier = build_notifier("exp", config=config)
+
+    assert isinstance(notifier, NullNotifier)
+
+
+def test_build_notifier_returns_null_for_disabled_factory():
+    """Verify the NotificationConfig.disabled() factory yields a NullNotifier.
+
+    Purpose: Validates the default-arg path for simulation classes
+    constructed without an explicit config.
+
+    Given: NotificationConfig.disabled().
+    When: build_notifier is called with it.
+    Then: A NullNotifier is returned.
+
+    Test type: unit
+    """
+    notifier = build_notifier("exp", config=NotificationConfig.disabled())
+
+    assert isinstance(notifier, NullNotifier)
+
+
+def test_build_notifier_returns_slack_when_config_is_active():
+    """Verify build_notifier returns SlackNotifier for an active config.
+
+    Purpose: Validates the happy-path of the factory.
+
+    Given: A NotificationConfig with a non-empty webhook_url and
+        disable=False.
+    When: build_notifier is called with that config and an experiment name.
+    Then: A SlackNotifier is returned, configured with the webhook URL
+        and experiment_name from the call.
+
+    Test type: unit
+    """
+    config = NotificationConfig(webhook_url="https://hooks.slack.com/abc")
+
+    notifier = build_notifier("tiger_experiment", config=config)
+
+    assert isinstance(notifier, SlackNotifier)
+    assert notifier.webhook_url == "https://hooks.slack.com/abc"
+    assert notifier.experiment_name == "tiger_experiment"
+
+
+def test_slack_notifier_uses_supplied_db(slack_notifier, progress_db):
+    """Verify SlackNotifier writes to the injected ProgressDB, not a default one.
+
+    Purpose: Validates the DI surface used by the watcher's DB-path override.
+
+    Given: A SlackNotifier constructed with an explicit ProgressDB pointing
+        at a tmp path.
+    When: run_started is called.
+    Then: The row appears in the supplied ProgressDB.
+
+    Test type: unit
+    """
+    with patch("urllib.request.urlopen"):
+        slack_notifier.run_started("rid-F", metadata={})
+
+    assert progress_db.get_run("rid-F") is not None
+
+
+def test_slack_notifier_post_uses_json_content_type(slack_notifier):
+    """Verify the Slack POST body is JSON with the right Content-Type header.
+
+    Purpose: Validates the wire format matches Slack's incoming-webhook spec.
+
+    Given: A SlackNotifier with mocked urlopen.
+    When: A Slack-posting event (run_started) is fired.
+    Then: The Request has Content-Type 'application/json' and a JSON body
+        with a 'text' key.
+
+    Test type: unit
+    """
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"ok"
+        slack_notifier.run_started("rid-G", metadata={})
+
+    request = mock_urlopen.call_args[0][0]
+    assert request.headers.get("Content-type") == "application/json"
+    body = json.loads(request.data.decode("utf-8"))
+    assert "text" in body
+
+
+def test_run_failed_swallows_db_error_in_signal_path(slack_notifier):
+    """Verify run_failed itself does not raise even if the DB write would.
+
+    Purpose: Documents/locks in that callers (signal handlers) can rely on
+    notifier methods to never raise. (DB writes via this notifier are
+    expected to be reliable; this test guards against a future change that
+    might make them throw.)
+
+    Given: A SlackNotifier whose db.finish_run is monkeypatched to raise.
+    When: run_failed is called from regular code.
+    Then: The exception propagates (this test documents the *current*
+        contract — the notifier does NOT swallow internal errors; the
+        signal-handler in install_signal_handlers does that wrapping).
+
+    Test type: unit
+    """
+    slack_notifier.db.finish_run = MagicMock(side_effect=RuntimeError("db down"))
+
+    with pytest.raises(RuntimeError):
+        slack_notifier.run_failed("rid-H", "boom")
+
+
+def test_post_trial_milestone_posts_to_slack():
+    """Verify post_trial_milestone POSTs a Slack message with progress info.
+
+    Purpose: Validates the in-task helper used for trial-milestone events
+    in hyperparameter tuning.
+
+    Given: A mocked urlopen and a populated set of milestone arguments.
+    When: post_trial_milestone is called with completed/total trial counts,
+        a config name, and a best score.
+    Then: Exactly one HTTP POST is sent to the supplied webhook URL with
+        a JSON body whose 'text' field contains the experiment name, run
+        id, completed/total counts, config name, and the score formatted.
+
+    Test type: unit
+    """
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"ok"
+
+        post_trial_milestone(
+            "https://hooks.slack.com/test/abc",
+            experiment_name="tune_exp",
+            run_id="rid-M",
+            completed_trials=50,
+            total_trials=200,
+            config_name="config_a",
+            best_score=-12.345,
+        )
+
+    assert mock_urlopen.call_count == 1
+    request = mock_urlopen.call_args[0][0]
+    assert request.full_url == "https://hooks.slack.com/test/abc"
+    body = json.loads(request.data.decode("utf-8"))
+    text = body["text"]
+    assert "tune_exp" in text
+    assert "rid-M" in text
+    assert "50/200" in text
+    assert "config_a" in text
+    assert "-12.3450" in text  # 4 decimal places per the helper
+
+
+def test_post_trial_milestone_handles_none_best_score():
+    """Verify the helper renders a sensible string when best_score is None.
+
+    Purpose: Validates the early-tuning case where no trial has yet
+    produced a usable score.
+
+    Given: A mocked urlopen.
+    When: post_trial_milestone is called with best_score=None.
+    Then: The message body includes 'n/a' (or equivalent) in place of a
+        score number.
+
+    Test type: unit
+    """
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"ok"
+
+        post_trial_milestone(
+            "https://hooks.slack.com/test/abc",
+            experiment_name="exp",
+            run_id="rid-N",
+            completed_trials=10,
+            total_trials=200,
+            config_name="cfg",
+            best_score=None,
+        )
+
+    body = json.loads(mock_urlopen.call_args[0][0].data.decode("utf-8"))
+    assert "n/a" in body["text"]
+
+
+def test_post_trial_milestone_swallows_network_errors(caplog):
+    """Verify the helper does not propagate Slack-side failures.
+
+    Purpose: Validates resilience — Slack outages must not derail a
+    multi-day tuning run.
+
+    Given: urlopen raises URLError.
+    When: post_trial_milestone is called.
+    Then: No exception propagates; a WARNING is logged via the supplied
+        logger.
+
+    Test type: unit
+    """
+    logger = logging.getLogger("test.run_progress.notify.trial_milestone")
+    logger.handlers.clear()
+
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("no net")):
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            post_trial_milestone(
+                "https://hooks.slack.com/test/abc",
+                experiment_name="exp",
+                run_id="rid-O",
+                completed_trials=50,
+                total_trials=200,
+                config_name="cfg",
+                best_score=0.5,
+                logger=logger,
+            )
+
+    assert any("Slack notification failed" in r.message for r in caplog.records)

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/test_signal_handlers.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/test_signal_handlers.py
@@ -1,0 +1,238 @@
+# pylint: disable=protected-access  # Tests need to inspect internal state
+"""Tests for :func:`install_signal_handlers`.
+
+The handler is installed via :func:`signal.signal` which has process-wide
+state. To keep tests hermetic, an autouse fixture saves and restores the
+SIGTERM / SIGINT handlers around every test in this file.
+"""
+
+import os
+import signal
+import threading
+from typing import Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+from POMDPPlanners.simulations.simulations_deployment.run_progress.notify import (
+    NullNotifier,
+    install_signal_handlers,
+)
+
+
+@pytest.fixture(autouse=True)
+def _save_restore_signal_handlers():
+    """Save SIGTERM/SIGINT before every test, restore after."""
+    saved = {
+        signal.SIGTERM: signal.getsignal(signal.SIGTERM),
+        signal.SIGINT: signal.getsignal(signal.SIGINT),
+    }
+    yield
+    for signum, handler in saved.items():
+        signal.signal(signum, handler)
+
+
+def test_install_handlers_returns_uninstall_callable():
+    """Verify install_signal_handlers returns a callable for cleanup.
+
+    Purpose: Validates the lifecycle contract: install returns uninstall.
+
+    Given: A NullNotifier on the main thread.
+    When: install_signal_handlers is called.
+    Then: The return value is callable, and after calling it, the original
+        SIGTERM/SIGINT handlers are restored.
+
+    Test type: unit
+    """
+    original_term = signal.getsignal(signal.SIGTERM)
+    original_int = signal.getsignal(signal.SIGINT)
+
+    uninstall = install_signal_handlers(NullNotifier(), run_id="rid-1")
+
+    assert callable(uninstall)
+    assert signal.getsignal(signal.SIGTERM) is not original_term
+    assert signal.getsignal(signal.SIGINT) is not original_int
+
+    uninstall()
+
+    assert signal.getsignal(signal.SIGTERM) is original_term
+    assert signal.getsignal(signal.SIGINT) is original_int
+
+
+def test_uninstall_is_idempotent():
+    """Verify calling the returned uninstall callable twice does not raise.
+
+    Purpose: Validates that double-cleanup (e.g. atexit + __exit__) is safe.
+
+    Given: An installed pair of signal handlers.
+    When: The uninstall callable is invoked twice.
+    Then: Neither invocation raises.
+
+    Test type: unit
+    """
+    uninstall = install_signal_handlers(NullNotifier(), run_id="rid-2")
+
+    uninstall()
+    uninstall()
+
+
+def test_handler_invokes_notifier_run_failed(monkeypatch):
+    """Verify the installed handler emits run_failed with the run_id.
+
+    Purpose: Validates the core "notify on signal" contract.
+
+    Given: A MagicMock Notifier with handlers installed for run_id 'rid-x'.
+    When: The SIGTERM handler is fetched and invoked manually with a dummy
+        frame, os.kill mocked out so the test process is not killed.
+    Then: notifier.run_failed was called once, with 'rid-x' as first arg
+        and an error string starting with 'signal:SIGTERM'.
+
+    Test type: unit
+    """
+    notifier = MagicMock()
+    install_signal_handlers(notifier, run_id="rid-x")
+
+    handler = signal.getsignal(signal.SIGTERM)
+    assert callable(handler)
+    monkeypatch.setattr(os, "kill", lambda *_args, **_kwargs: None)
+
+    handler(signal.SIGTERM, None)
+
+    notifier.run_failed.assert_called_once()
+    args, _ = notifier.run_failed.call_args
+    assert args[0] == "rid-x"
+    assert args[1].startswith("signal:SIGTERM")
+
+
+def test_handler_chains_to_previous_callable():
+    """Verify the installed handler invokes the prior handler when callable.
+
+    Purpose: Validates chaining so existing handlers (e.g. QueueLoggerManager
+    cleanup at logger.py:256-260) still run on signal.
+
+    Given: A prior SIGTERM handler that records invocation, then
+        install_signal_handlers wrapping a NullNotifier on top of it.
+    When: The new SIGTERM handler is invoked with a dummy frame.
+    Then: The prior handler is invoked exactly once.
+
+    Test type: unit
+    """
+    prior_calls: list[tuple[int, object]] = []
+
+    def prior_handler(signum: int, frame: object) -> None:
+        prior_calls.append((signum, frame))
+
+    signal.signal(signal.SIGTERM, prior_handler)
+    install_signal_handlers(NullNotifier(), run_id="rid-3")
+
+    handler = signal.getsignal(signal.SIGTERM)
+    assert callable(handler)
+    handler(signal.SIGTERM, None)
+
+    assert prior_calls == [(signal.SIGTERM, None)]
+
+
+def test_handler_with_sig_dfl_redelivers_signal(monkeypatch):
+    """Verify SIG_DFL fallback re-delivers the signal via os.kill.
+
+    Purpose: Validates the non-callable-prev path: when there is no prior
+    handler chain, default OS handling is restored and the signal is
+    re-delivered so the process exits as it normally would.
+
+    Given: Default handlers (SIG_DFL) on SIGTERM, then install_signal_handlers.
+    When: The new SIGTERM handler runs.
+    Then: os.kill(getpid(), SIGTERM) is invoked exactly once.
+
+    Test type: unit
+    """
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    install_signal_handlers(NullNotifier(), run_id="rid-4")
+
+    handler = signal.getsignal(signal.SIGTERM)
+    assert callable(handler)
+
+    kill_calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(os, "kill", lambda pid, sig: kill_calls.append((pid, sig)))
+
+    handler(signal.SIGTERM, None)
+
+    assert kill_calls == [(os.getpid(), signal.SIGTERM)]
+
+
+def test_handler_with_sig_ign_redelivers_signal(monkeypatch):
+    """Verify SIG_IGN prev-handler also goes through the re-deliver path.
+
+    Purpose: Validates that ``signal.SIG_IGN`` (int, not callable) is treated
+    like SIG_DFL — re-delivered. The OS then ignores the re-delivered signal.
+
+    Given: SIG_IGN as the prior SIGINT handler.
+    When: The new SIGINT handler runs.
+    Then: os.kill is called with the current pid and SIGINT.
+
+    Test type: unit
+    """
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    install_signal_handlers(NullNotifier(), run_id="rid-5")
+
+    handler = signal.getsignal(signal.SIGINT)
+    assert callable(handler)
+
+    kill_calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(os, "kill", lambda pid, sig: kill_calls.append((pid, sig)))
+
+    handler(signal.SIGINT, None)
+
+    assert kill_calls == [(os.getpid(), signal.SIGINT)]
+
+
+def test_handler_swallows_notifier_exception(monkeypatch):
+    """Verify a raising notifier does not break the signal-handler path.
+
+    Purpose: Validates the signal handler's own try/except around notifier.
+
+    Given: A Notifier whose run_failed raises.
+    When: The signal handler is invoked.
+    Then: The exception is swallowed; the re-deliver path still runs.
+
+    Test type: unit
+    """
+    notifier = MagicMock()
+    notifier.run_failed.side_effect = RuntimeError("notifier broken")
+    install_signal_handlers(notifier, run_id="rid-6")
+
+    handler = signal.getsignal(signal.SIGTERM)
+    assert callable(handler)
+
+    kill_calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(os, "kill", lambda pid, sig: kill_calls.append((pid, sig)))
+
+    handler(signal.SIGTERM, None)  # must not raise
+
+    notifier.run_failed.assert_called_once()
+    assert kill_calls == [(os.getpid(), signal.SIGTERM)]
+
+
+def test_install_on_non_main_thread_does_not_raise():
+    """Verify install_signal_handlers is a no-op when off the main thread.
+
+    Purpose: Validates the ValueError-swallow path so Dask/PBS workers
+    instantiating BaseSimulator off-thread do not crash.
+
+    Given: A thread that is not the main thread.
+    When: install_signal_handlers is called inside that thread.
+    Then: It returns a callable without raising, and the returned uninstall
+        is also safe to call.
+
+    Test type: unit
+    """
+    uninstall_holder: list[Callable[[], None]] = []
+
+    def worker() -> None:
+        uninstall_holder.append(install_signal_handlers(NullNotifier(), run_id="rid-7"))
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert len(uninstall_holder) == 1
+    uninstall_holder[0]()  # idempotent + safe

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/test_watcher.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/test_watcher.py
@@ -1,0 +1,278 @@
+# pylint: disable=protected-access  # Tests need to inspect internal helpers
+"""Tests for :mod:`POMDPPlanners.simulations.simulations_deployment.run_progress.watcher`."""
+
+import json
+import sqlite3
+from contextlib import closing
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from POMDPPlanners.simulations.simulations_deployment.run_progress import watcher
+from POMDPPlanners.simulations.simulations_deployment.run_progress.db import ProgressDB
+
+
+@pytest.fixture
+def db_path(tmp_path) -> Path:
+    """A fresh SQLite path inside the pytest tmp dir."""
+    return tmp_path / "progress.db"
+
+
+@pytest.fixture
+def populated_db(db_path):
+    """ProgressDB with a healthy run, a stalled run, and a finished old run."""
+    db = ProgressDB(path=db_path)
+    db.start_run("healthy", "exp_healthy", {})
+    db.start_run("stalled", "exp_stalled", {"episodes": 100})
+    db.start_run("done_old", "exp_done")
+    db.finish_run("done_old", status="finished", error=None)
+    _backdate_heartbeat(db_path, "stalled", seconds=7200)
+    _backdate_heartbeat(db_path, "done_old", seconds=7200)
+    return db
+
+
+def test_main_no_stalled_runs_returns_zero(db_path):
+    """Verify exit 0 when the DB has no stalled rows.
+
+    Purpose: Validates the happy "everything is fine" tick.
+
+    Given: A fresh DB with one fresh running row.
+    When: main() is invoked with a short threshold and a webhook URL.
+    Then: Exit status is 0 and urlopen is never called.
+
+    Test type: integration
+    """
+    db = ProgressDB(path=db_path)
+    db.start_run("fresh", "exp_fresh", {})
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        exit_code = watcher.main(
+            [
+                "--db",
+                str(db_path),
+                "--threshold-seconds",
+                "3600",
+                "--webhook-url",
+                "https://hooks.slack.com/test",
+            ]
+        )
+
+    assert exit_code == 0
+    assert mock_urlopen.call_count == 0
+
+
+def test_main_posts_one_message_per_stalled_run(populated_db, db_path):
+    """Verify exactly one Slack POST is sent per stalled run.
+
+    Purpose: Validates the watcher's core notification path.
+
+    Given: A populated DB with one stalled run and one finished old run.
+    When: main() runs with a webhook URL and a 60-second threshold.
+    Then: urlopen is called exactly once with the stalled run's
+        experiment name in the JSON body.
+
+    Test type: integration
+    """
+    del populated_db
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"ok"
+        exit_code = watcher.main(
+            [
+                "--db",
+                str(db_path),
+                "--threshold-seconds",
+                "60",
+                "--webhook-url",
+                "https://hooks.slack.com/test",
+            ]
+        )
+
+    assert exit_code == 0
+    assert mock_urlopen.call_count == 1
+    request = mock_urlopen.call_args[0][0]
+    body = json.loads(request.data.decode("utf-8"))
+    assert "exp_stalled" in body["text"]
+
+
+def test_main_is_idempotent_across_calls(populated_db, db_path):
+    """Verify the watcher does not double-notify on a second tick.
+
+    Purpose: Validates the stall_notified_at dedupe column. Cron may fire
+    the watcher every minute; only the *first* tick after a stall should
+    post.
+
+    Given: A populated DB with one stalled run.
+    When: main() runs twice in succession with the same threshold.
+    Then: urlopen is called exactly once total (the second tick is silent).
+
+    Test type: integration
+    """
+    del populated_db
+
+    args = [
+        "--db",
+        str(db_path),
+        "--threshold-seconds",
+        "60",
+        "--webhook-url",
+        "https://hooks.slack.com/test",
+    ]
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"ok"
+        watcher.main(args)
+        watcher.main(args)
+
+    assert mock_urlopen.call_count == 1
+
+
+def test_main_no_webhook_logs_and_returns_zero(populated_db, db_path, caplog):
+    """Verify the watcher logs (does not crash) when no webhook is configured.
+
+    Purpose: Validates the "configured for stall detection but no webhook"
+    fallback path so the watcher is safe to install before Slack is set up.
+
+    Given: A populated DB with one stalled run and *no* webhook configured.
+    When: main() runs.
+    Then: Exit status is 0, urlopen is never called, and a WARNING is
+        logged that mentions the stalled count.
+
+    Test type: integration
+    """
+    del populated_db
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        with caplog.at_level("WARNING", logger="run_progress.watcher"):
+            exit_code = watcher.main(["--db", str(db_path), "--threshold-seconds", "60"])
+
+    assert exit_code == 0
+    assert mock_urlopen.call_count == 0
+    assert any("stalled" in r.message.lower() for r in caplog.records)
+
+
+def test_main_db_arg_overrides_env(populated_db, db_path, monkeypatch):
+    """Verify --db arg takes precedence over POMDP_PROGRESS_DB.
+
+    Purpose: Validates CLI override semantics (testability for cron).
+
+    Given: POMDP_PROGRESS_DB points to a *different* empty DB while a
+        populated DB exists at a separate path.
+    When: main() is invoked with --db pointing at the populated DB.
+    Then: The populated DB is used (one Slack post for the stalled run).
+
+    Test type: integration
+    """
+    del populated_db
+    other_db = db_path.parent / "other.db"
+    ProgressDB(path=other_db)  # empty
+    monkeypatch.setenv("POMDP_PROGRESS_DB", str(other_db))
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"ok"
+        watcher.main(
+            [
+                "--db",
+                str(db_path),
+                "--threshold-seconds",
+                "60",
+                "--webhook-url",
+                "https://hooks.slack.com/test",
+            ]
+        )
+
+    assert mock_urlopen.call_count == 1
+
+
+def test_main_webhook_env_var_used_when_arg_absent(populated_db, db_path, monkeypatch):
+    """Verify SLACK_WEBHOOK_URL env var is read when --webhook-url is absent.
+
+    Purpose: Validates the cron-friendly env-only invocation path.
+
+    Given: A populated DB and SLACK_WEBHOOK_URL set in the env, no CLI flag.
+    When: main() runs.
+    Then: Exactly one Slack POST is sent to the env-supplied URL.
+
+    Test type: integration
+    """
+    del populated_db
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/env-url")
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"ok"
+        watcher.main(["--db", str(db_path), "--threshold-seconds", "60"])
+
+    assert mock_urlopen.call_count == 1
+    posted_url = mock_urlopen.call_args[0][0].full_url
+    assert posted_url == "https://hooks.slack.com/env-url"
+
+
+def test_main_slack_failure_does_not_propagate(populated_db, db_path):
+    """Verify Slack outages do not cause the watcher to exit non-zero.
+
+    Purpose: Validates resilience — cron should never see a flaky exit due
+    to a transient Slack hiccup.
+
+    Given: A populated DB with one stalled run and urlopen raising URLError.
+    When: main() runs.
+    Then: Exit code is 0 (no propagation), and the row is still marked as
+        notified so the watcher does not retry on the next tick.
+
+    Test type: integration
+    """
+    del populated_db
+    import urllib.error  # pylint: disable=import-outside-toplevel
+
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("no net")):
+        exit_code = watcher.main(
+            [
+                "--db",
+                str(db_path),
+                "--threshold-seconds",
+                "60",
+                "--webhook-url",
+                "https://hooks.slack.com/test",
+            ]
+        )
+
+    assert exit_code == 0
+    db = ProgressDB(path=db_path)
+    row = db.get_run("stalled")
+    assert row is not None
+    assert row.stall_notified_at is not None
+
+
+def test_format_stall_message_mentions_key_fields(populated_db):
+    """Verify the formatted message includes ids the user needs to act on.
+
+    Purpose: Validates the human-readable contract of stall messages.
+
+    Given: A stalled RunRow fetched from the populated DB.
+    When: _format_stall_message renders it.
+    Then: The message includes experiment_name, run_id, host, pid, and
+        the last_heartbeat_at timestamp.
+
+    Test type: unit
+    """
+    stalled = populated_db.list_stalled(threshold_seconds=60)
+    assert stalled, "test setup invariant violated"
+    message = watcher._format_stall_message(stalled[0])
+
+    assert stalled[0].experiment_name in message
+    assert stalled[0].run_id in message
+    assert stalled[0].host in message
+    assert str(stalled[0].pid) in message
+    assert stalled[0].last_heartbeat_at in message
+
+
+def _backdate_heartbeat(db_path: Path, run_id: str, seconds: int) -> None:
+    """Test helper: rewind a run's last_heartbeat_at by ``seconds``."""
+    new_ts = (datetime.now(timezone.utc) - timedelta(seconds=seconds)).isoformat()
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.execute(
+            "UPDATE runs SET last_heartbeat_at = ? WHERE run_id = ?",
+            (new_ts, run_id),
+        )
+        conn.commit()

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_task_managers.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_task_managers.py
@@ -221,6 +221,89 @@ def test_joblib_task_manager_with_cache_clear(cache_db):
         assert len(list(items)) == 0
 
 
+def test_joblib_task_manager_progress_callback_fires_per_task(cache_db, environment, policy):
+    """Test that set_progress_callback fires once per completed task.
+
+    Purpose: Validates the per-episode heartbeat hook used by the simulator
+    to write heartbeats into the run-progress DB.
+
+    Given: A JoblibTaskManager with a counting callback registered via
+        set_progress_callback, and 3 real EpisodeSimulationTask instances.
+    When: run_tasks is called with the three tasks.
+    Then: The counter equals the number of tasks (3) — one callback fire
+        per completed task, all in the parent process.
+
+    Test type: integration
+    """
+    with JoblibTaskManager(cache_db=cache_db, n_jobs=1) as task_manager:
+        call_count = [0]
+
+        def on_progress() -> None:
+            call_count[0] += 1
+
+        task_manager.set_progress_callback(on_progress)
+
+        tasks = []
+        identifiers = []
+        for i in range(3):
+            tasks.append(
+                EpisodeSimulationTask(
+                    environment=environment,
+                    policy=policy,
+                    initial_belief=create_test_belief(),
+                    num_steps=2,
+                    episode_id=i,
+                    seed=42 + i,
+                    console_output=False,
+                )
+            )
+            identifiers.append(f"episode_{i}")
+
+        task_manager.run_tasks(tasks, identifiers)
+
+        assert call_count[0] == 3
+
+
+def test_joblib_task_manager_progress_callback_exception_is_swallowed(
+    cache_db, environment, policy
+):
+    """Test that a raising progress callback does not break task execution.
+
+    Purpose: Validates the robustness clause documented on
+        :meth:`JoblibTaskManager.set_progress_callback` — a flaky callback
+        cannot derail a 2-week run.
+
+    Given: A JoblibTaskManager with a callback that always raises, and
+        one real EpisodeSimulationTask.
+    When: run_tasks is called.
+    Then: The task completes successfully (one History returned) and no
+        exception propagates from the callback.
+
+    Test type: integration
+    """
+    with JoblibTaskManager(cache_db=cache_db, n_jobs=1) as task_manager:
+
+        def on_progress() -> None:
+            raise RuntimeError("callback broken")
+
+        task_manager.set_progress_callback(on_progress)
+
+        task = EpisodeSimulationTask(
+            environment=environment,
+            policy=policy,
+            initial_belief=create_test_belief(),
+            num_steps=2,
+            episode_id=0,
+            seed=42,
+            console_output=False,
+        )
+
+        results, ids = task_manager.run_tasks([task], ["episode_0"])
+
+        assert len(results) == 1
+        assert ids == ["episode_0"]
+
+
 def test_joblib_task_manager_run_tasks(cache_db, environment, policy):
     """Test running tasks with JoblibTaskManager.
 

--- a/scripts/tune_and_evaluate_pomcp_tiger.py
+++ b/scripts/tune_and_evaluate_pomcp_tiger.py
@@ -1,0 +1,167 @@
+"""Simple parameter-tuning + evaluation demo for POMCP on TigerPOMDP.
+
+Two phases, each a separate :class:`POMDPSimulator` instance — and therefore
+two distinct runs in the progress DB / Slack channel:
+
+1. **Tuning phase**: compare POMCP with several values of ``n_simulations``
+   side-by-side on a modest number of episodes; pick the best by mean
+   discounted return.
+2. **Evaluation phase**: re-run only the winning configuration on a larger
+   number of episodes to get a tighter estimate of its performance.
+
+Run with::
+
+    source .venv/bin/activate
+    export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."  # optional
+    python scripts/tune_and_evaluate_pomcp_tiger.py
+
+If ``SLACK_WEBHOOK_URL`` is set, you will see four messages in the channel
+(two ``run_started`` / ``run_finished`` pairs). If it is unset, the script
+runs silently w.r.t. Slack but still writes the run history into the
+progress DB at ``~/.cache/POMDPPlanners/progress.db``.
+"""
+
+from __future__ import annotations
+
+import statistics
+from pathlib import Path
+
+from POMDPPlanners.core.belief import get_initial_belief
+from POMDPPlanners.core.simulation import EnvironmentRunParams
+from POMDPPlanners.core.simulation.history import history_to_discounted_return_value
+from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.planners.mcts_planners.pomcp import POMCP
+from POMDPPlanners.simulations.simulation_apis.local_simulations_api import (
+    LocalSimulationsAPI,
+)
+
+CACHE_DIR = Path("./cache/pomcp_tiger_demo")
+TUNING_EPISODES = 30
+EVALUATION_EPISODES = 100
+NUM_STEPS = 5
+N_PARTICLES = 50
+DISCOUNT_FACTOR = 0.95
+EXPLORATION_CONSTANT = 1.0
+ROLLOUT_DEPTH = 5
+CANDIDATE_N_SIMULATIONS = [5, 20, 50, 100]
+
+
+def main() -> None:
+    """Run the two-phase tuning + evaluation experiment."""
+    tiger = TigerPOMDP(discount_factor=DISCOUNT_FACTOR)
+    initial_belief = get_initial_belief(tiger, n_particles=N_PARTICLES)
+    api = LocalSimulationsAPI(cache_dir_path=CACHE_DIR)
+
+    best_n_sims = _run_tuning_phase(api, tiger, initial_belief)
+    _run_evaluation_phase(api, tiger, initial_belief, best_n_sims)
+
+
+def _run_tuning_phase(
+    api: LocalSimulationsAPI,
+    tiger: TigerPOMDP,
+    initial_belief,
+) -> int:
+    print(
+        f"[tuning] Comparing POMCP with n_simulations in "
+        f"{CANDIDATE_N_SIMULATIONS} over {TUNING_EPISODES} episodes each"
+    )
+    candidate_policies = [
+        POMCP(
+            environment=tiger,
+            discount_factor=DISCOUNT_FACTOR,
+            depth=ROLLOUT_DEPTH,
+            exploration_constant=EXPLORATION_CONSTANT,
+            n_simulations=n_sims,
+            name=f"POMCP_n{n_sims}",
+        )
+        for n_sims in CANDIDATE_N_SIMULATIONS
+    ]
+    env_params = [
+        EnvironmentRunParams(
+            environment=tiger,
+            belief=initial_belief,
+            policies=candidate_policies,
+            num_episodes=TUNING_EPISODES,
+            num_steps=NUM_STEPS,
+        )
+    ]
+
+    results, _ = api.run_multiple_environments_and_policies(
+        environment_run_params=env_params,
+        alpha=0.1,
+        confidence_interval_level=0.95,
+        experiment_name="tune_pomcp_tiger",
+        n_jobs=1,
+        cache_dir_path=CACHE_DIR / "tuning",
+    )
+
+    return _pick_best_n_simulations(results, tiger.name)
+
+
+def _pick_best_n_simulations(results: dict, environment_name: str) -> int:
+    print("[tuning] Mean discounted returns:")
+    mean_returns: dict[int, float] = {}
+    for policy_name, histories in results[environment_name].items():
+        returns = [history_to_discounted_return_value(h) for h in histories]
+        mean_returns[_parse_n_sims_from_name(policy_name)] = statistics.fmean(returns)
+        print(f"  {policy_name}: {statistics.fmean(returns):.3f}")
+
+    best_n_sims = max(mean_returns, key=lambda k: mean_returns[k])
+    print(f"[tuning] Winner: n_simulations={best_n_sims}")
+    return best_n_sims
+
+
+def _parse_n_sims_from_name(policy_name: str) -> int:
+    # Policy names are constructed as f"POMCP_n{n_sims}".
+    return int(policy_name.rsplit("_n", 1)[-1])
+
+
+def _run_evaluation_phase(
+    api: LocalSimulationsAPI,
+    tiger: TigerPOMDP,
+    initial_belief,
+    best_n_sims: int,
+) -> None:
+    print(
+        f"[eval] Re-running winner (n_simulations={best_n_sims}) "
+        f"on {EVALUATION_EPISODES} episodes"
+    )
+    winning_policy = POMCP(
+        environment=tiger,
+        discount_factor=DISCOUNT_FACTOR,
+        depth=ROLLOUT_DEPTH,
+        exploration_constant=EXPLORATION_CONSTANT,
+        n_simulations=best_n_sims,
+        name=f"POMCP_n{best_n_sims}_eval",
+    )
+    env_params = [
+        EnvironmentRunParams(
+            environment=tiger,
+            belief=initial_belief,
+            policies=[winning_policy],
+            num_episodes=EVALUATION_EPISODES,
+            num_steps=NUM_STEPS,
+        )
+    ]
+
+    results, _ = api.run_multiple_environments_and_policies(
+        environment_run_params=env_params,
+        alpha=0.1,
+        confidence_interval_level=0.95,
+        experiment_name="evaluate_pomcp_tiger",
+        n_jobs=1,
+        cache_dir_path=CACHE_DIR / "evaluation",
+    )
+
+    histories = results[tiger.name][winning_policy.name]
+    returns = [history_to_discounted_return_value(h) for h in histories]
+    print(
+        f"[eval] n_simulations={best_n_sims}: "
+        f"mean={statistics.fmean(returns):.3f}, "
+        f"stdev={statistics.stdev(returns):.3f} "
+        f"over {len(returns)} episodes"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tune_and_evaluate_pomcp_tiger_optuna.py
+++ b/scripts/tune_and_evaluate_pomcp_tiger_optuna.py
@@ -1,0 +1,145 @@
+"""Optuna tuning + evaluation demo for POMCP on TigerPOMDP via ``LocalSimulationsAPI``.
+
+Two phases, two separate API calls (each triggers its own parent-side run on
+Slack):
+
+1. **Tuning** via :meth:`LocalSimulationsAPI.run_hyperparameter_optimization`.
+   Optuna tunes POMCP's ``exploration_constant`` over ``N_TRIALS`` trials.
+   Milestone Slack messages fire every
+   ``HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL`` completed trials.
+2. **Evaluation** via :meth:`LocalSimulationsAPI.run_multiple_environments_and_policies`.
+   The winning policy returned by the optimizer is re-run on a larger
+   episode budget for a tighter point estimate.
+
+Run with::
+
+    source .venv/bin/activate
+    export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
+    export HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL=3   # for demo visibility
+    python scripts/tune_and_evaluate_pomcp_tiger_optuna.py
+"""
+
+from __future__ import annotations
+
+import statistics
+from pathlib import Path
+
+from POMDPPlanners.core.belief import get_initial_belief
+from POMDPPlanners.core.simulation import (
+    EnvironmentRunParams,
+    NumericalHyperParameter,
+)
+from POMDPPlanners.core.simulation.history import history_to_discounted_return_value
+from POMDPPlanners.core.simulation.hyperparameter_tuning import (
+    HyperParamPlannerConfig,
+    HyperParameterOptimizationDirection,
+    HyperParameterRunParams,
+    OptimizedPolicyResult,
+)
+from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.planners.mcts_planners.pomcp import POMCP
+from POMDPPlanners.simulations.simulation_apis.local_simulations_api import (
+    LocalSimulationsAPI,
+)
+
+CACHE_DIR = Path("./cache/pomcp_tiger_optuna_demo")
+NUM_PARTICLES = 50
+DISCOUNT_FACTOR = 0.95
+NUM_STEPS = 10
+TUNING_EPISODES = 10
+N_TRIALS = 10
+EVALUATION_EPISODES = 100
+ROLLOUT_DEPTH = 5
+N_SIMULATIONS = 50
+
+
+def main() -> None:
+    """Run the two-phase Optuna tuning + evaluation experiment."""
+    tiger = TigerPOMDP(discount_factor=DISCOUNT_FACTOR)
+    initial_belief = get_initial_belief(tiger, n_particles=NUM_PARTICLES)
+    api = LocalSimulationsAPI(cache_dir_path=CACHE_DIR)
+
+    optimized = _run_tuning_phase(api, tiger, initial_belief)
+    _run_evaluation_phase(api, tiger, initial_belief, optimized)
+
+
+def _run_tuning_phase(
+    api: LocalSimulationsAPI,
+    tiger: TigerPOMDP,
+    initial_belief,
+) -> OptimizedPolicyResult:
+    print(
+        f"[tuning] Optuna over POMCP exploration_constant: "
+        f"{N_TRIALS} trials, {TUNING_EPISODES} episodes/trial, {NUM_STEPS} steps"
+    )
+    planner_config = HyperParamPlannerConfig(
+        policy_cls=POMCP,
+        hyper_parameters=[
+            NumericalHyperParameter(0.1, 10.0, "exploration_constant"),
+        ],
+        constant_parameters={
+            "discount_factor": DISCOUNT_FACTOR,
+            "depth": ROLLOUT_DEPTH,
+            "n_simulations": N_SIMULATIONS,
+            "name": "POMCP_tuning",
+        },
+    )
+    optimization_config = HyperParameterRunParams(
+        environment=tiger,
+        belief=initial_belief,
+        hyper_param_planner_config=planner_config,
+        num_episodes=TUNING_EPISODES,
+        num_steps=NUM_STEPS,
+        n_trials=N_TRIALS,
+        parameters_to_optimize=[("average_return", HyperParameterOptimizationDirection.MAXIMIZE)],
+    )
+
+    results = api.run_hyperparameter_optimization(
+        environment_run_params=[optimization_config],
+        experiment_name="optuna_tune_pomcp_tiger",
+        n_jobs=1,
+        cache_dir_path=CACHE_DIR / "tuning",
+    )
+    best = results[0]
+    print(f"[tuning] Best hyperparameters: {best.chosen_hyper_parameters}")
+    print(f"[tuning] Optimized metric values: {best.optimized_metric_values}")
+    return best
+
+
+def _run_evaluation_phase(
+    api: LocalSimulationsAPI,
+    tiger: TigerPOMDP,
+    initial_belief,
+    optimized: OptimizedPolicyResult,
+) -> None:
+    print(
+        f"[eval] Re-running winner on {EVALUATION_EPISODES} episodes "
+        f"({optimized.chosen_hyper_parameters})"
+    )
+    env_params = [
+        EnvironmentRunParams(
+            environment=tiger,
+            belief=initial_belief,
+            policies=[optimized.policy],
+            num_episodes=EVALUATION_EPISODES,
+            num_steps=NUM_STEPS,
+        )
+    ]
+    results, _ = api.run_multiple_environments_and_policies(
+        environment_run_params=env_params,
+        alpha=0.1,
+        confidence_interval_level=0.95,
+        experiment_name="optuna_evaluate_pomcp_tiger",
+        n_jobs=1,
+        cache_dir_path=CACHE_DIR / "evaluation",
+    )
+    histories = results[tiger.name][optimized.policy.name]
+    returns = [history_to_discounted_return_value(h) for h in histories]
+    print(
+        f"[eval] mean={statistics.fmean(returns):.3f}, "
+        f"stdev={statistics.stdev(returns):.3f} over {len(returns)} episodes"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a run-progress subsystem that surfaces lifecycle events from the simulator and the hyperparameter optimizer to Slack and a local SQLite progress DB. Designed for multi-day / multi-week experiment runs where stdout tailing is impractical and SIGKILL / OOM must not result in silent disappearance.

Zero user-facing API change: set `SLACK_WEBHOOK_URL` and notifications fire automatically through `LocalSimulationsAPI` / `DaskSimulationsAPI` / `PBSSimulationsAPI`. Programmatic users can also inject a `NotificationConfig` directly for per-instance Slack channel routing.

## Architecture

```
shell env ──► NotificationConfig.from_env()
                     │ (only the SimulationsAPI layer reads env)
                     ▼
   LocalSimulationsAPI(notification_config=cfg or None)
                     │
                     ▼
   POMDPSimulator(notification_config=cfg) / HyperParameterOptimizer(notification_config=cfg)
                     │
                     ▼
   build_notifier(experiment_name, config=cfg) → Notifier (Slack or null)
```

Two layers of detection:
- **In-process notifier** — fires `run_started` / `run_finished` / `run_failed` for clean lifecycle + caught exceptions + SIGTERM/SIGINT.
- **External cron watcher** — `python -m ...run_progress.watcher` reads the same DB and emits `run_stalled` if the parent process died hard. This is what makes the system robust to SIGKILL / OOM / kernel panic.

## New files

```
POMDPPlanners/simulations/simulations_deployment/run_progress/
├── __init__.py
├── config.py     # NotificationConfig dataclass
├── db.py         # ProgressDB (SQLite, WAL, parent-process-only writer)
├── notify.py     # Notifier Protocol, NullNotifier, SlackNotifier, signal handlers
└── watcher.py    # cron-driven stall-detection CLI
```

## Env vars (read only inside `NotificationConfig.from_env`)

| Var | Default | Effect |
|---|---|---|
| `SLACK_WEBHOOK_URL` | unset | Slack incoming-webhook URL (unset → NullNotifier) |
| `POMDPPLANNERS_DISABLE_NOTIFY` | unset | `"1"` hard-disables notifications |
| `PYTEST_CURRENT_TEST` | set by pytest | auto-disables under pytest |
| `HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL` | `50` | Optuna milestone cadence |
| `POMDP_PROGRESS_DB` | unset | override DB path |

## Pickle safety

`BaseSimulator` / `HyperParameterOptimizer` add `__getstate__` / `__setstate__` that drop the unpicklable signal-handler closure. `JoblibTaskManager.__getstate__` blanks the progress callback so the joblib `Memory`-cache hash doesn't pickle parent-side closures.

## Tests

~50 new tests:

| File | Count |
|---|---|
| `test_db.py` | 17 |
| `test_notify.py` | 17 |
| `test_signal_handlers.py` | 8 |
| `test_watcher.py` | 8 |
| `test_config.py` | 14 |
| `test_hyper_parameter_tuning_simulations.py` (additions) | 4 |
| `test_task_managers.py` (additions) | 2 |

## Demo scripts (`scripts/`)

- `tune_and_evaluate_pomcp_tiger.py` — 4-point grid sweep via the comparison path
- `tune_and_evaluate_pomcp_tiger_optuna.py` — Optuna tuning via the hyperparameter-optimization path; demonstrates milestone messages

Both have been run end-to-end against a real Slack channel; both produced the expected Slack events and progress-DB rows.

## Verification

- `pyright POMDPPlanners/` — 0 errors, 0 warnings on the modified surface (1 pre-existing warning in `core/environment/environment.py` unrelated)
- `pylint` — 10.00/10 on the new module
- `pytest POMDPPlanners/tests/test_simulations/ -m ""` — **500 passed, 1 skipped, 0 regressions** (run from a worktree based on the latest `origin/develop`)

## Test plan

- [ ] Reviewer pulls the branch, sets `export SLACK_WEBHOOK_URL=...` to a personal test webhook
- [ ] `python scripts/tune_and_evaluate_pomcp_tiger.py` → 4 Slack messages (start/finish × 2 phases) + rows in `~/.cache/POMDPPlanners/progress.db`
- [ ] `HYPERPARAM_TRIAL_NOTIFICATION_INTERVAL=3 python scripts/tune_and_evaluate_pomcp_tiger_optuna.py` → 7 Slack messages (start + 3 milestones + finish for tuning, then start + finish for eval)
- [ ] Verify tests: `pytest POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/ -v`
- [ ] Optional: install the cron watcher line documented in the PR description, kill -9 a running simulation, confirm a `run_stalled` Slack message after the threshold elapses