### PR TITLE
refactor(light_dark): rename DANGEROUS_STATES reward model to HIGH_VARIANCE_STATES

### DIFF
--- a/POMDPPlanners/configs/environment_configs.py
+++ b/POMDPPlanners/configs/environment_configs.py
@@ -372,7 +372,7 @@ class RiskAverseEnvironmentConfigsAPI:
         GOAL_STATE_RADIUS = 1.5  # Radius around goal to consider as reached
         BEACON_RADIUS = 1.0  # Radius around beacons for observations
         OBSTACLE_RADIUS = 1.2  # Radius around obstacles for collision
-        REWARD_MODEL_TYPE = RewardModelType.DANGEROUS_STATES  # Standard reward model
+        REWARD_MODEL_TYPE = RewardModelType.HIGH_VARIANCE_STATES  # Standard reward model
         PENALTY_DECAY = 1.0  # No decay in penalty
 
         pomdp = ContinuousLightDarkPOMDPDiscreteActions(
@@ -423,7 +423,7 @@ class RiskAverseEnvironmentConfigsAPI:
         GOAL_STATE_RADIUS = 1.5  # Radius around goal to consider as reached
         BEACON_RADIUS = 1.0  # Radius around beacons for observations
         OBSTACLE_RADIUS = 1.2  # Radius around obstacles for collision
-        REWARD_MODEL_TYPE = RewardModelType.DANGEROUS_STATES  # Standard reward model
+        REWARD_MODEL_TYPE = RewardModelType.HIGH_VARIANCE_STATES  # Standard reward model
         PENALTY_DECAY = 1.0  # No decay in penalty
 
         pomdp = ContinuousLightDarkPOMDP(

--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
@@ -51,7 +51,7 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.numba_ke
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models import (
     BaseLightDarkRewardModel,
-    ContinuousLDDangerousStatesRewardModel,
+    ContinuousLDHighVarianceStatesRewardModel,
     ContinuousLightDarkDecayingHitProbabilityRewardModel,
     ContinuousLightDarkRewardModel,
 )
@@ -71,13 +71,13 @@ class ContinuousLightDarkPOMDPMetrics(Enum):
     OBSTACLE_HIT_RATE = "obstacle_hit_rate"
     AVG_OBSTACLE_HIT_COUNTER = "avg_obstacle_hit_counter"
     OUT_OF_GRID_RATE = "out_of_grid_rate"
-    AVG_DANGEROUS_STATES_COUNTER = "avg_dangerous_states_counter"
+    AVG_HIGH_VARIANCE_STATES_COUNTER = "avg_high_variance_states_counter"
 
 
 class RewardModelType(Enum):
     STANDARD = "standard"
     DECAYING_HIT_PROBABILITY = "decaying_hit_probability"
-    DANGEROUS_STATES = "dangerous_states"
+    HIGH_VARIANCE_STATES = "high_variance_states"
 
 
 class ObservationModelType(Enum):
@@ -97,7 +97,7 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
     - Continuous 2D state and action spaces
     - Light beacons reduce observation noise when nearby
     - Multiple observation models available (normal noise, normal noise with no observation in dark)
-    - Multiple reward models available (standard, decaying hit probability, dangerous states)
+    - Multiple reward models available (standard, decaying hit probability, high-variance states)
     - Optional obstacles with configurable hit penalties
     - Terminal conditions for goal reaching, obstacle hits, and boundary violations
 
@@ -176,7 +176,7 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
             # Max: -fuel_cost - 0 + goal_reward (at goal, no penalty)
             min_reward = -fuel_cost - max_distance_to_goal + obstacle_reward
             max_reward = -fuel_cost + goal_reward
-        elif reward_model_type == RewardModelType.DANGEROUS_STATES:
+        elif reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
             # Min: -fuel_cost - max_distance + obstacle_reward (negative)
             # Max: -fuel_cost - 0 + goal_reward OR -fuel_cost - distance - obstacle_reward (if obstacle_reward is negative)
             min_reward = -fuel_cost - max_distance_to_goal + obstacle_reward
@@ -283,8 +283,8 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
                 fuel_cost=self.fuel_cost,
                 penalty_decay=self.penalty_decay,
             )
-        elif reward_model_type == RewardModelType.DANGEROUS_STATES:
-            self.reward_model = ContinuousLDDangerousStatesRewardModel(
+        elif reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+            self.reward_model = ContinuousLDHighVarianceStatesRewardModel(
                 goal_state=self.goal_state,
                 obstacles=self.obstacles,
                 goal_state_radius=self.goal_state_radius,
@@ -670,7 +670,7 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
 
         Returns:
             List containing metric names: goal_reaching_rate, obstacle_hit_rate,
-            avg_obstacle_hit_counter, out_of_grid_rate, and avg_dangerous_states_counter
+            avg_obstacle_hit_counter, out_of_grid_rate, and avg_high_variance_states_counter
         """
         return [metric.value for metric in ContinuousLightDarkPOMDPMetrics]
 
@@ -679,7 +679,7 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
         obstacle_hits = []
         obstacle_hit_counter = []
         out_of_grid = []
-        dangerous_states_counter = []
+        high_variance_states_counter = []
         for history in histories:
             goal_reached_in_history = False
             obstacle_hit_in_history = False
@@ -708,8 +708,8 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
             obstacle_hits.append(1 if obstacle_hit_in_history else 0)
             obstacle_hit_counter.append(obstacle_hit_counter_in_history)
             out_of_grid.append(1 if out_of_grid_in_history else 0)
-            # Sum obstacle hits and out-of-grid occurrences as dangerous states
-            dangerous_states_counter.append(
+            # Sum obstacle hits and out-of-grid occurrences as high-variance states
+            high_variance_states_counter.append(
                 obstacle_hit_counter_in_history + out_of_grid_counter_in_history
             )
 
@@ -717,13 +717,13 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
         avg_obstacle_hits = float(np.mean(obstacle_hits))
         avg_obstacle_hit_counter = float(np.mean(obstacle_hit_counter))
         avg_out_of_grid = float(np.mean(out_of_grid))
-        avg_dangerous_states_counter = float(np.mean(dangerous_states_counter))
+        avg_high_variance_states_counter = float(np.mean(high_variance_states_counter))
         goal_reached_ci = confidence_interval(data=goal_reached, confidence=0.95)
         obstacle_hits_ci = confidence_interval(data=obstacle_hits, confidence=0.95)
         obstacle_hit_counter_ci = confidence_interval(data=obstacle_hit_counter, confidence=0.95)
         out_of_grid_ci = confidence_interval(data=out_of_grid, confidence=0.95)
-        dangerous_states_counter_ci = confidence_interval(
-            data=dangerous_states_counter, confidence=0.95
+        high_variance_states_counter_ci = confidence_interval(
+            data=high_variance_states_counter, confidence=0.95
         )
 
         return [
@@ -752,10 +752,10 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
                 upper_confidence_bound=out_of_grid_ci[1],
             ),
             MetricValue(
-                name=ContinuousLightDarkPOMDPMetrics.AVG_DANGEROUS_STATES_COUNTER.value,
-                value=avg_dangerous_states_counter,
-                lower_confidence_bound=dangerous_states_counter_ci[0],
-                upper_confidence_bound=dangerous_states_counter_ci[1],
+                name=ContinuousLightDarkPOMDPMetrics.AVG_HIGH_VARIANCE_STATES_COUNTER.value,
+                value=avg_high_variance_states_counter,
+                lower_confidence_bound=high_variance_states_counter_ci[0],
+                upper_confidence_bound=high_variance_states_counter_ci[1],
             ),
         ]
 
@@ -974,7 +974,7 @@ class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, Discrete
         """Random rollout via native C++ for the STANDARD reward model.
 
         Falls back to the base-class Python loop for non-STANDARD reward
-        models (DECAYING_HIT_PROBABILITY, DANGEROUS_STATES) which have
+        models (DECAYING_HIT_PROBABILITY, HIGH_VARIANCE_STATES) which have
         different stochastic semantics not yet ported to C++.
 
         Args:
@@ -1001,7 +1001,7 @@ class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, Discrete
         bypass_native_for_realised_pos = cov_diag_max > 0.0 and self._obstacles_flat.shape[0] > 0
         if (
             not isinstance(self.reward_model, ContinuousLightDarkRewardModel)
-            or isinstance(self.reward_model, (ContinuousLDDangerousStatesRewardModel,))
+            or isinstance(self.reward_model, (ContinuousLDHighVarianceStatesRewardModel,))
             or bypass_native_for_realised_pos
         ):
             return python_random_rollout(

--- a/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
@@ -25,7 +25,7 @@ class DiscreteLightDarkPOMDPMetrics(Enum):
     OBSTACLE_HIT_RATE = "obstacle_hit_rate"
     AVG_OBSTACLE_HIT_COUNTER = "avg_obstacle_hit_counter"
     OUT_OF_GRID_RATE = "out_of_grid_rate"
-    AVG_DANGEROUS_STATES_COUNTER = "avg_dangerous_states_counter"
+    AVG_HIGH_VARIANCE_STATES_COUNTER = "avg_high_variance_states_counter"
 
 
 class ObservationModelType(Enum):
@@ -828,7 +828,7 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
 
         Returns:
             List containing metric names: goal_reaching_rate, obstacle_hit_rate,
-            avg_obstacle_hit_counter, out_of_grid_rate, and avg_dangerous_states_counter
+            avg_obstacle_hit_counter, out_of_grid_rate, and avg_high_variance_states_counter
         """
         return [metric.value for metric in DiscreteLightDarkPOMDPMetrics]
 
@@ -837,7 +837,7 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
         obstacle_hits = []
         obstacle_hit_counter = []
         out_of_grid = []
-        dangerous_states_counter = []
+        high_variance_states_counter = []
         for history in histories:
             goal_reached_in_history = False
             obstacle_hit_in_history = False
@@ -865,8 +865,8 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
             obstacle_hits.append(1 if obstacle_hit_in_history else 0)
             obstacle_hit_counter.append(obstacle_hit_counter_in_history)
             out_of_grid.append(1 if out_of_grid_in_history else 0)
-            # Sum obstacle hits and out-of-grid occurrences as dangerous states
-            dangerous_states_counter.append(
+            # Sum obstacle hits and out-of-grid occurrences as high-variance states
+            high_variance_states_counter.append(
                 obstacle_hit_counter_in_history + out_of_grid_counter_in_history
             )
 
@@ -874,13 +874,13 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
         avg_obstacle_hits = float(np.mean(obstacle_hits))
         avg_obstacle_hit_counter = float(np.mean(obstacle_hit_counter))
         avg_out_of_grid = float(np.mean(out_of_grid))
-        avg_dangerous_states_counter = float(np.mean(dangerous_states_counter))
+        avg_high_variance_states_counter = float(np.mean(high_variance_states_counter))
         goal_reached_ci = confidence_interval(data=goal_reached, confidence=0.95)
         obstacle_hits_ci = confidence_interval(data=obstacle_hits, confidence=0.95)
         obstacle_hit_counter_ci = confidence_interval(data=obstacle_hit_counter, confidence=0.95)
         out_of_grid_ci = confidence_interval(data=out_of_grid, confidence=0.95)
-        dangerous_states_counter_ci = confidence_interval(
-            data=dangerous_states_counter, confidence=0.95
+        high_variance_states_counter_ci = confidence_interval(
+            data=high_variance_states_counter, confidence=0.95
         )
 
         return [
@@ -909,10 +909,10 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
                 upper_confidence_bound=out_of_grid_ci[1],
             ),
             MetricValue(
-                name=DiscreteLightDarkPOMDPMetrics.AVG_DANGEROUS_STATES_COUNTER.value,
-                value=avg_dangerous_states_counter,
-                lower_confidence_bound=dangerous_states_counter_ci[0],
-                upper_confidence_bound=dangerous_states_counter_ci[1],
+                name=DiscreteLightDarkPOMDPMetrics.AVG_HIGH_VARIANCE_STATES_COUNTER.value,
+                value=avg_high_variance_states_counter,
+                lower_confidence_bound=high_variance_states_counter_ci[0],
+                upper_confidence_bound=high_variance_states_counter_ci[1],
             ),
         ]
 

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
@@ -162,7 +162,7 @@ class ContinuousLightDarkRewardModel(BaseLightDarkRewardModel):
         return np.where(hits, self.obstacle_reward, 0.0)
 
 
-class ContinuousLDDangerousStatesRewardModel(ContinuousLightDarkRewardModel):
+class ContinuousLDHighVarianceStatesRewardModel(ContinuousLightDarkRewardModel):
     def _obstacle_reward_scalar(self) -> float:
         """The expected reward is 0.0, but the variance is high."""
         return self.obstacle_reward if np.random.rand() < 0.5 else -self.obstacle_reward

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py
@@ -1,7 +1,7 @@
 """Light-Dark-specific Numba-JIT kernels.
 
 Holds kernels whose signatures or logic hardcode light-dark concepts
-(goal+obstacles+out-of-grid shape, standard / dangerous-states / decaying-
+(goal+obstacles+out-of-grid shape, standard / high-variance-states / decaying-
 hit-probability reward formulas). Generic geometric / numerical primitives
 used here also by other envs live in
 ``POMDPPlanners.utils.numba_kernels`` instead.
@@ -14,7 +14,7 @@ Public kernels
 --------------
 - :func:`is_terminal_kernel` — replaces ``ContinuousLightDarkPOMDP.is_terminal``.
 - :func:`compute_reward_base_kernel` — deterministic part of the Standard /
-  DangerousStates reward model plus an ``is_obstacle_hit_region`` flag so the
+  HighVarianceStates reward model plus an ``is_obstacle_hit_region`` flag so the
   Python caller can decide whether to draw a uniform.
 - :func:`compute_reward_base_batch_kernel` — batched version of
   :func:`compute_reward_base_kernel`. Returns ``(rewards, obstacle_mask)`` so
@@ -77,7 +77,7 @@ def compute_reward_base_kernel(
     out-of-grid penalty. The caller (Python) must add the stochastic
     obstacle-hit contribution when ``is_obstacle_hit_region`` is ``True``,
     using its own ``np.random.rand()`` draw so seeded tests stay bit-identical.
-    Used by Standard and DangerousStates reward models.
+    Used by Standard and HighVarianceStates reward models.
 
     ``next_state`` is the realised post-transition position. The Python
     caller threads either the draw from

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_models.py
@@ -3,7 +3,7 @@
 This module tests the reward models from light_dark_reward_models.py, focusing on:
 - Base reward model functionality
 - Continuous light dark reward model with obstacles
-- Dangerous states reward model with high variance
+- High-variance states reward model
 - Decaying hit probability reward model
 """
 
@@ -16,7 +16,7 @@ import pytest
 
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models import (
     BaseLightDarkRewardModel,
-    ContinuousLDDangerousStatesRewardModel,
+    ContinuousLDHighVarianceStatesRewardModel,
     ContinuousLightDarkDecayingHitProbabilityRewardModel,
     ContinuousLightDarkRewardModel,
 )
@@ -411,8 +411,8 @@ class TestContinuousLightDarkRewardModel:
             assert reward < -model_boundary.fuel_cost - np.linalg.norm(next_state - self.goal_state)
 
 
-class TestContinuousLDDangerousStatesRewardModel:
-    """Test cases for dangerous states reward model."""
+class TestContinuousLDHighVarianceStatesRewardModel:
+    """Test cases for high-variance states reward model."""
 
     def setup_method(self):
         """Set up test environment before each test method."""
@@ -426,7 +426,7 @@ class TestContinuousLDDangerousStatesRewardModel:
         self.goal_reward = 100.0
         self.fuel_cost = 1.0
 
-        self.model = ContinuousLDDangerousStatesRewardModel(
+        self.model = ContinuousLDHighVarianceStatesRewardModel(
             goal_state=self.goal_state,
             obstacles=self.obstacles,
             goal_state_radius=self.goal_state_radius,
@@ -488,7 +488,7 @@ class TestContinuousLDDangerousStatesRewardModel:
         assert 0.4 < bonus_ratio < 0.6, f"Bonus ratio {bonus_ratio} not close to 0.5"
 
     def test_inheritance_from_base(self):
-        """Test that dangerous states model inherits correctly from base."""
+        """Test that high-variance states model inherits correctly from base."""
         # Should have all the same methods as base class
         assert hasattr(self.model, "compute_reward")
         assert hasattr(self.model, "_compute_reward")
@@ -754,7 +754,7 @@ class TestRewardModelBatch:
             fuel_cost=self.fuel_cost,
         )
 
-        self.dangerous_model = ContinuousLDDangerousStatesRewardModel(
+        self.high_variance_model = ContinuousLDHighVarianceStatesRewardModel(
             goal_state=self.goal_state,
             obstacles=self.obstacles,
             goal_state_radius=self.goal_state_radius,
@@ -801,12 +801,12 @@ class TestRewardModelBatch:
         expected = np.array([self.model.compute_reward(states[i], action) for i in range(100)])
         np.testing.assert_allclose(batch_rewards, expected)
 
-    def test_dangerous_model_batch_matches_scalar(self):
-        """Test ContinuousLDDangerousStatesRewardModel batch matches scalar with same seed.
+    def test_high_variance_model_batch_matches_scalar(self):
+        """Test ContinuousLDHighVarianceStatesRewardModel batch matches scalar with same seed.
 
         Purpose: Validates vectorized compute_reward_batch matches per-element compute_reward
 
-        Given: A ContinuousLDDangerousStatesRewardModel and 100 random states
+        Given: A ContinuousLDHighVarianceStatesRewardModel and 100 random states
         When: compute_reward_batch and scalar calls are made with same seed
         Then: Both produce identical reward arrays
 
@@ -816,12 +816,12 @@ class TestRewardModelBatch:
         action = np.array([0.5, 0.5])
 
         np.random.seed(99)
-        batch_rewards = self.dangerous_model.compute_reward_batch(states, action)
+        batch_rewards = self.high_variance_model.compute_reward_batch(states, action)
         assert batch_rewards.shape == (100,)
 
         np.random.seed(99)
         expected = np.array(
-            [self.dangerous_model.compute_reward(states[i], action) for i in range(100)]
+            [self.high_variance_model.compute_reward(states[i], action) for i in range(100)]
         )
         np.testing.assert_allclose(batch_rewards, expected)
 

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
@@ -41,7 +41,7 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
 )
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models import (
     ContinuousLightDarkDecayingHitProbabilityRewardModel,
-    ContinuousLDDangerousStatesRewardModel,
+    ContinuousLDHighVarianceStatesRewardModel,
 )
 
 
@@ -826,8 +826,8 @@ def test_decaying_hit_probability_reward_model():
     assert isinstance(env.reward_model, ContinuousLightDarkDecayingHitProbabilityRewardModel)
 
 
-def test_dangerous_states_reward_model():
-    """Test that the environment uses the dangerous states reward model when specified."""
+def test_high_variance_states_reward_model():
+    """Test that the environment uses the high-variance states reward model when specified."""
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
         state_transition_cov_matrix=np.eye(2),
@@ -840,11 +840,11 @@ def test_dangerous_states_reward_model():
         goal_state_radius=1.5,
         beacon_radius=1.0,
         obstacle_radius=1.5,
-        reward_model_type=RewardModelType.DANGEROUS_STATES,
+        reward_model_type=RewardModelType.HIGH_VARIANCE_STATES,
     )
 
     # Test that the correct reward model is initialized
-    assert isinstance(env.reward_model, ContinuousLDDangerousStatesRewardModel)
+    assert isinstance(env.reward_model, ContinuousLDHighVarianceStatesRewardModel)
 
     # Test that the reward model produces both positive and negative rewards near obstacles
     state = np.array([4, 5])  # Near obstacle at (5, 5) - distance 1.0
@@ -2500,9 +2500,9 @@ def test_continuous_reward_in_obstacle_zone_drifts_by_p_hit_times_obstacle_rewar
     [
         (RewardModelType.STANDARD, -2.0),
         (RewardModelType.DECAYING_HIT_PROBABILITY, -10.0),
-        (RewardModelType.DANGEROUS_STATES, 0.0),
+        (RewardModelType.HIGH_VARIANCE_STATES, 0.0),
     ],
-    ids=["STANDARD", "DECAYING_HIT_PROBABILITY", "DANGEROUS_STATES"],
+    ids=["STANDARD", "DECAYING_HIT_PROBABILITY", "HIGH_VARIANCE_STATES"],
 )
 def test_continuous_reward_in_obstacle_depends_on_reward_model_type(
     reward_model_type: RewardModelType, expected_drift: float
@@ -2512,7 +2512,7 @@ def test_continuous_reward_in_obstacle_depends_on_reward_model_type(
     Purpose: Validates that reward_model_type switches the obstacle-zone
         contribution between ``obstacle_reward * p_hit`` (STANDARD),
         ``obstacle_reward`` (DECAYING_HIT_PROBABILITY at d=0 since
-        hit_prob=exp(0)=1), and ``0`` (DANGEROUS_STATES, +/- obstacle_reward
+        hit_prob=exp(0)=1), and ``0`` (HIGH_VARIANCE_STATES, +/- obstacle_reward
         with p=0.5 averaging to zero).
 
     Given: state=[5,5] (default obstacle position) so min_dist_to_obstacle=0,
@@ -2544,7 +2544,7 @@ def test_continuous_reward_in_obstacle_depends_on_reward_model_type(
     elif reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
         # At d=0 the Bernoulli is degenerate (hit_prob=1) — zero variance.
         sigma = 0.0
-    else:  # DANGEROUS_STATES
+    else:  # HIGH_VARIANCE_STATES
         sigma = abs(env.obstacle_reward)
     sigma_mean = sigma / np.sqrt(n_samples)
     tolerance = max(3.0 * sigma_mean, 1e-9)


### PR DESCRIPTION
## Summary

- The Light-Dark reward variant previously named ``DANGEROUS_STATES`` samples ``±obstacle_reward`` with ``p=0.5`` — i.e. ``E[r]=0`` with high variance. The old name suggested a loss-skewed hazard; the new name describes the actual semantics (a neutral-EV gamble whose risk lives in the variance).
- Renames the enum value, reward-model class, metric enum/string, local variables, test names, and surrounding docstring/comment references.
- No logic changes — the rename is mechanical and the existing 184 light-dark tests pass unchanged.

## Renames

| Before | After |
| --- | --- |
| ``RewardModelType.DANGEROUS_STATES`` (``"dangerous_states"``) | ``RewardModelType.HIGH_VARIANCE_STATES`` (``"high_variance_states"``) |
| ``ContinuousLDDangerousStatesRewardModel`` | ``ContinuousLDHighVarianceStatesRewardModel`` |
| ``AVG_DANGEROUS_STATES_COUNTER`` / ``"avg_dangerous_states_counter"`` | ``AVG_HIGH_VARIANCE_STATES_COUNTER`` / ``"avg_high_variance_states_counter"`` |

## Note on historical artifacts

Pre-existing mlruns JSON under ``docs/examples/planners_comparison_results/`` keeps the old column name. Those are frozen experiment outputs and renaming them would falsify the historical record, so they were intentionally left alone.

## Test plan

- [x] ``pytest POMDPPlanners/tests/test_environments/test_light_dark_pomdp/`` — 184 passed
- [x] ``pyright POMDPPlanners/`` — 0 errors (pre-existing 1 unrelated warning in core/environment/environment.py)
- [x] Pre-commit hooks (black + pylint + pyright) pass on commit and push