### PR TITLE
feat(pacman_pomdp): add opt-in circular dangerous areas

### DIFF
--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -67,6 +67,9 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         ghost_aggressiveness: Temperature parameter for ghost movement policy
         observation_noise_factor: Multiplier for observation noise based on distance
         max_observation_noise: Maximum noise standard deviation
+        dangerous_areas: List of (row, col) centers of circular hazard zones
+        dangerous_area_radius: Radius (in grid cells) defining each hazard zone
+        dangerous_area_penalty: Penalty subtracted when PacMan ends a step inside a zone
 
     Example:
         >>> import numpy as np
@@ -86,6 +89,24 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         >>> # Check terminal condition
         >>> env.is_terminal(initial_state)
         False
+
+    Example:
+        Construct an env with a circular hazard zone — PacMan is penalised by
+        ``dangerous_area_penalty`` whenever its realised next position lies
+        inside the zone, but the zone does not block movement or terminate.
+
+        >>> import numpy as np
+        >>> np.random.seed(0)
+        >>> env = PacManPOMDP(
+        ...     maze_size=(7, 7),
+        ...     dangerous_areas={(3, 3)},
+        ...     dangerous_area_radius=1.0,
+        ...     dangerous_area_penalty=5.0,
+        ... )
+        >>> state = env.initial_state_dist().sample()[0]
+        >>> _ = env.sample_next_step(state, env.get_actions()[0])
+        >>> env.dangerous_area_penalty
+        5.0
     """
 
     def __init__(  # pylint: disable=too-many-statements
@@ -106,6 +127,9 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         ghost_strategies: Optional[List[str]] = None,
         observation_noise_factor: float = 0.3,
         max_observation_noise: float = 1.5,
+        dangerous_areas: Optional[Set[Tuple[int, int]]] = None,
+        dangerous_area_radius: float = 1.0,
+        dangerous_area_penalty: float = 5.0,
         discount_factor: float = 0.95,
         name: str = "PacManPOMDP",
         output_dir: Optional[Path] = None,
@@ -130,13 +154,25 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             ghost_strategies: Individual ghost strategies (list of "aggressive", "patrol", "ambush"). Defaults to None.
             observation_noise_factor: Observation noise factor. Defaults to 0.3.
             max_observation_noise: Maximum observation noise. Defaults to 1.5.
+            dangerous_areas: Set of (row, col) centers of circular hazard zones. ``None``
+                or an empty set disables the feature. Defaults to ``None`` (opt-in).
+            dangerous_area_radius: Radius (in grid cells) defining each hazard zone via
+                Euclidean distance. Defaults to 1.0.
+            dangerous_area_penalty: Non-negative penalty subtracted from the reward when
+                PacMan's realised next position lies inside any hazard zone. Defaults to 5.0.
             discount_factor: Discount factor. Defaults to 0.95.
             name: Environment name. Defaults to "PacManPOMDP".
             output_dir: Output directory for logging. Defaults to None.
             debug: Enable debug logging. Defaults to False.
         """
-        # Calculate reward range based on parameters
+        # Calculate reward range based on parameters. The dangerous-area
+        # penalty only contributes to ``min_reward`` when at least one zone
+        # is configured, so disabling the feature preserves the historical
+        # reward range exactly.
+        _has_dangerous_areas = bool(dangerous_areas)
         min_reward = step_penalty + ghost_collision_penalty
+        if _has_dangerous_areas:
+            min_reward -= float(dangerous_area_penalty)
         max_reward = step_penalty + pellet_reward + win_reward
 
         space_info = SpaceInfo(
@@ -167,6 +203,19 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         self.ghost_strategies = ghost_strategies or ["aggressive"] * num_ghosts
         self.observation_noise_factor = observation_noise_factor
         self.max_observation_noise = max_observation_noise
+        self.dangerous_areas: List[Tuple[int, int]] = (
+            list(dangerous_areas) if dangerous_areas else []
+        )
+        self.dangerous_area_radius = float(dangerous_area_radius)
+        self.dangerous_area_penalty = float(dangerous_area_penalty)
+        # Pre-built (D, 2) float64 array reused by the vectorised batch-reward
+        # path. Kept C-contiguous so future native callers can consume it
+        # without an extra copy.
+        self._dangerous_areas_arr: np.ndarray = (
+            np.ascontiguousarray(np.asarray(self.dangerous_areas, dtype=np.float64))
+            if self.dangerous_areas
+            else np.empty((0, 2), dtype=np.float64)
+        )
 
         # Handle ghost positions (backward compatibility)
         if initial_ghost_positions is not None:
@@ -495,6 +544,24 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             if strategy not in valid_strategies:
                 raise ValueError(f"ghost_strategies[{i}] must be one of {valid_strategies}")
 
+        # Validate dangerous-area configuration. Overlap with walls, pellets,
+        # or agent positions is intentionally permitted (matches laser_tag).
+        if self.dangerous_area_radius < 0:
+            raise ValueError(
+                f"dangerous_area_radius must be non-negative, got {self.dangerous_area_radius}"
+            )
+        if self.dangerous_area_penalty < 0:
+            raise ValueError(
+                f"dangerous_area_penalty must be non-negative, got {self.dangerous_area_penalty}"
+            )
+        for i, danger_pos in enumerate(self.dangerous_areas):
+            if not (
+                0 <= danger_pos[0] < self.maze_size[0] and 0 <= danger_pos[1] < self.maze_size[1]
+            ):
+                raise ValueError(
+                    f"Dangerous area {i} position {danger_pos} is outside maze bounds {self.maze_size}"
+                )
+
     def get_actions(self) -> List[int]:
         """Get all available actions."""
         return list(range(len(self.action_names)))
@@ -692,6 +759,20 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             max_depth=remaining_depth,
         )
 
+    def _is_in_dangerous_area(self, position: Tuple[int, int]) -> bool:
+        # Squared-distance check matches laser_tag's discrete implementation
+        # and avoids a sqrt per call on a hot path.
+        if not self.dangerous_areas:
+            return False
+        pos_row, pos_col = position
+        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
+        for danger_row, danger_col in self.dangerous_areas:
+            dr = pos_row - danger_row
+            dc = pos_col - danger_col
+            if dr * dr + dc * dc <= radius_sq:
+                return True
+        return False
+
     def reward(self, state: np.ndarray, action: int, next_state: Any = None) -> float:
         """Calculate immediate reward.
 
@@ -723,6 +804,9 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
 
         if next_state[self._idx_score] > state[self._idx_score]:
             total_reward += self.pellet_reward
+
+        if self._is_in_dangerous_area((next_pac_row, next_pac_col)):
+            total_reward -= self.dangerous_area_penalty
 
         if next_state[self._idx_terminal] > 0.5:
             pellet_mask = next_state[self._idx_pellets_start : self._idx_pellets_end]
@@ -801,6 +885,10 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             rewards, terminal, new_pac_rows, new_pac_cols, next_states_arr
         )
 
+        rewards = self._add_dangerous_area_penalty_batch(
+            rewards, terminal, new_pac_rows, new_pac_cols
+        )
+
         if self._pellet_positions_arr.shape[0] == 0:
             # Degenerate config (env constructed with no pellets): there is
             # nothing to collect and therefore nothing to "win". Returning
@@ -846,6 +934,25 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             g_cols = next_states_arr[:, self._idx_ghosts_start + 2 * g + 1].astype(np.int32)
             collision |= (g_rows == new_pac_rows) & (g_cols == new_pac_cols)
         return rewards + np.where(~terminal & collision, self.ghost_collision_penalty, 0.0)
+
+    def _add_dangerous_area_penalty_batch(
+        self,
+        rewards: np.ndarray,
+        terminal: np.ndarray,
+        new_pac_rows: np.ndarray,
+        new_pac_cols: np.ndarray,
+    ) -> np.ndarray:
+        if self._dangerous_areas_arr.shape[0] == 0:
+            return rewards
+        # Vectorised squared-distance check across all configured zones;
+        # ``any`` collapses the (N, D) matrix to a per-particle mask. Uses
+        # squared distance to stay consistent with ``_is_in_dangerous_area``.
+        centers = self._dangerous_areas_arr  # (D, 2) float64
+        dr = new_pac_rows[:, None] - centers[:, 0]
+        dc = new_pac_cols[:, None] - centers[:, 1]
+        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
+        in_danger = (dr * dr + dc * dc <= radius_sq).any(axis=1)
+        return rewards + np.where(~terminal & in_danger, -self.dangerous_area_penalty, 0.0)
 
     def _get_neighbor_table(self) -> np.ndarray:
         if self._cached_neighbor_table is None:

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_visualizer.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_visualizer.py
@@ -132,6 +132,29 @@ class PacManVisualizer:
                 else:
                     draw.rectangle([x, y, x + tile_size, y + tile_size], fill=(0, 0, 0, 255))
 
+    def _draw_dangerous_areas(self, canvas: Image.Image, tile_size: int) -> None:
+        """Overlay dangerous areas as translucent red circles.
+
+        Painted into a separate RGBA overlay so the configured alpha blends
+        with the maze background without clobbering pellets, ghosts, or
+        PacMan, which are composited on top in :meth:`_render_frame`.
+        """
+        areas = getattr(self.env, "dangerous_areas", None)
+        if not areas:
+            return
+        radius = float(getattr(self.env, "dangerous_area_radius", 1.0))
+        overlay = Image.new("RGBA", canvas.size, (0, 0, 0, 0))  # type: ignore[arg-type]
+        draw_overlay = ImageDraw.Draw(overlay)
+        px_radius = max(1, int(round(radius * tile_size)))
+        for danger_row, danger_col in areas:
+            cx = int(danger_col * tile_size + tile_size / 2)
+            cy = int(danger_row * tile_size + tile_size / 2)
+            draw_overlay.ellipse(
+                [cx - px_radius, cy - px_radius, cx + px_radius, cy + px_radius],
+                fill=(255, 0, 0, 90),
+            )
+        canvas.alpha_composite(overlay)
+
     def _draw_pellets(self, state: np.ndarray, draw: ImageDraw.ImageDraw, tile_size: int) -> None:
         """Draw pellets on the maze."""
         rows, cols = self.env.maze_size
@@ -297,11 +320,30 @@ class PacManVisualizer:
             font=self.font_regular,
         )
 
+        # Second swatch + caption — only rendered when dangerous areas are
+        # configured so the legend stays compact for vanilla PacMan runs.
+        has_danger = bool(getattr(self.env, "dangerous_areas", None))
+        if has_danger:
+            danger_x = legend_x + 130
+            draw.rectangle(
+                [danger_x, legend_y + 2, danger_x + 14, legend_y + 14],
+                fill=(255, 0, 0, 110),
+            )
+            draw.text(
+                (danger_x + 20, legend_y),
+                "= danger zone",
+                fill=(255, 255, 255),
+                font=self.font_regular,
+            )
+
         if self.env.get_terminal(state):
             banner = "YOU WIN!" if len(pellets) == 0 else "GAME OVER"
             color = (0, 255, 0) if len(pellets) == 0 else (255, 80, 80)
+            # Push the banner right of the danger-zone caption when present,
+            # otherwise keep the historical x-offset.
+            banner_x = legend_x + (260 if has_danger else 130)
             draw.text(
-                (legend_x + 130, legend_y),
+                (banner_x, legend_y),
                 banner,
                 fill=color,
                 font=self.font_bold,
@@ -324,6 +366,9 @@ class PacManVisualizer:
         draw = ImageDraw.Draw(canvas)
 
         self._draw_maze_background(draw, tile_size)
+        # Dangerous areas sit just above the maze background so the belief
+        # heatmap, pellets, ghosts, and PacMan all remain readable on top.
+        self._draw_dangerous_areas(canvas, tile_size)
         # Belief overlay sits beneath pellets/ghosts/pacman so it doesn't
         # obscure them; pellets remain visible on top of the heatmap.
         self._draw_ghost_belief(belief, canvas, tile_size)

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
@@ -2423,3 +2423,267 @@ def _python_reference_rollout(
         current = next_state
 
     return total
+
+
+class TestPacManDangerousAreas:
+    """Test cases for PacMan dangerous-area hazard zones."""
+
+    def setup_method(self):
+        """Set up a PacMan env with a single configured danger cell."""
+        # Maze placed so the danger center (3, 3) is reachable from (3, 2)
+        # by moving east, and (3, 4) sits exactly at distance 1.0 from the
+        # center to exercise the squared-distance boundary check.
+        self.pomdp = PacManPOMDP(
+            maze_size=(7, 7),
+            walls=set(),
+            initial_pellets=[(0, 6)],
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(6, 6)],
+            dangerous_areas={(3, 3)},
+            dangerous_area_radius=1.0,
+            dangerous_area_penalty=5.0,
+        )
+
+    def _state_with_pac(self, pos: Tuple[int, int], score: float = 0.0) -> np.ndarray:
+        return self.pomdp.make_state(
+            pacman_pos=pos,
+            ghost_positions=((6, 6),),
+            pellets=((0, 6),),
+            score=score,
+        )
+
+    def test_dangerous_areas_default_empty_keeps_existing_reward_contract(self):
+        """Default constructor opts out so the historical reward contract holds.
+
+        Purpose: Validates that omitting ``dangerous_areas`` leaves the env's
+            reward path unchanged — a regression guard for existing PacMan
+            configs that should not start picking up a danger penalty.
+
+        Given: A PacManPOMDP constructed without the ``dangerous_areas`` kwarg.
+        When: ``reward()`` is invoked for a step that lands PacMan on a cell
+            that would have been hazardous in another env.
+        Then: The returned reward equals only the step penalty (no danger
+            term), and ``reward_range`` matches the legacy ``step_penalty +
+            ghost_collision_penalty`` lower bound.
+
+        Test type: unit
+        """
+        plain = PacManPOMDP(
+            maze_size=(7, 7),
+            walls=set(),
+            initial_pellets=[(0, 6)],
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(6, 6)],
+        )
+        state = plain.make_state(pacman_pos=(3, 2), ghost_positions=((6, 6),), pellets=((0, 6),))
+        next_state = plain.make_state(
+            pacman_pos=(3, 3), ghost_positions=((6, 6),), pellets=((0, 6),)
+        )
+
+        assert not plain.dangerous_areas
+        assert plain.reward(state, action=1, next_state=next_state) == plain.step_penalty
+        assert plain.reward_range == (
+            plain.step_penalty + plain.ghost_collision_penalty,
+            plain.step_penalty + plain.pellet_reward + plain.win_reward,
+        )
+
+    def test_dangerous_area_penalty_applied_when_pacman_enters_zone(self):
+        """Penalty fires when the realised next position falls inside a zone.
+
+        Purpose: Validates that ``reward()`` subtracts
+            ``dangerous_area_penalty`` when PacMan's realised next position
+            lies inside any configured hazard zone.
+
+        Given: An env with one zone centered at (3, 3) radius 1.0, a state
+            at (3, 2), and an explicit next_state that places PacMan at (3, 3).
+        When: ``reward(state, action=East, next_state=next_state)`` is called.
+        Then: Reward equals ``step_penalty - dangerous_area_penalty`` (no
+            pellet collection, no ghost collision, no win bonus).
+
+        Test type: unit
+        """
+        state = self._state_with_pac((3, 2))
+        next_state = self._state_with_pac((3, 3))
+
+        reward = self.pomdp.reward(state, action=1, next_state=next_state)
+
+        assert reward == self.pomdp.step_penalty - self.pomdp.dangerous_area_penalty
+
+    def test_dangerous_area_penalty_skipped_when_pacman_outside_zone(self):
+        """No penalty when PacMan's realised next position sits outside all zones.
+
+        Purpose: Validates the symmetric negative case of penalty application.
+
+        Given: The same env as above and a transition that ends outside the
+            single zone (distance > radius).
+        When: ``reward(state, action, next_state)`` is called.
+        Then: Reward equals only ``step_penalty``.
+
+        Test type: unit
+        """
+        state = self._state_with_pac((0, 0))
+        next_state = self._state_with_pac((0, 1))
+
+        reward = self.pomdp.reward(state, action=1, next_state=next_state)
+
+        assert reward == self.pomdp.step_penalty
+
+    def test_dangerous_area_radius_uses_squared_distance_boundary(self):
+        """Threshold is inclusive: distance == radius counts as inside.
+
+        Purpose: Pins the squared-distance boundary semantics so future
+            changes to the helper cannot silently flip the inequality.
+
+        Given: A zone at (3, 3) radius 1.0.
+        When: PacMan ends a step at (3, 4) (distance == 1.0, inside) and
+            separately at (3, 5) (distance == 2.0, outside).
+        Then: Only the (3, 4) transition incurs the penalty.
+
+        Test type: unit
+        """
+        state_inside = self._state_with_pac((3, 3))
+        next_inside = self._state_with_pac((3, 4))
+        reward_inside = self.pomdp.reward(state_inside, action=1, next_state=next_inside)
+        assert reward_inside == (self.pomdp.step_penalty - self.pomdp.dangerous_area_penalty)
+
+        state_outside = self._state_with_pac((3, 4))
+        next_outside = self._state_with_pac((3, 5))
+        reward_outside = self.pomdp.reward(state_outside, action=1, next_state=next_outside)
+        assert reward_outside == self.pomdp.step_penalty
+
+    def test_reward_batch_applies_dangerous_area_penalty(self):
+        """Vectorised batch reward agrees with the scalar path on the same inputs.
+
+        Purpose: Validates that ``_compute_reward_batch`` mirrors
+            ``reward()`` so per-particle rollouts and trajectory rollouts
+            stay consistent under dangerous-area configuration.
+
+        Given: A batch of two (state, next_state) pairs — one entering the
+            zone, one outside.
+        When: ``reward_batch(states, action, next_states)`` is called.
+        Then: The returned array matches the scalar ``reward()`` outputs
+            element-wise.
+
+        Test type: unit
+        """
+        s0 = self._state_with_pac((3, 2))
+        ns0 = self._state_with_pac((3, 3))  # inside zone
+        s1 = self._state_with_pac((0, 0))
+        ns1 = self._state_with_pac((0, 1))  # outside zone
+
+        states = np.stack([s0, s1], axis=0)
+        next_states = np.stack([ns0, ns1], axis=0)
+
+        batch = self.pomdp.reward_batch(states, action=1, next_states=next_states)
+        scalar = np.array(
+            [
+                self.pomdp.reward(s0, action=1, next_state=ns0),
+                self.pomdp.reward(s1, action=1, next_state=ns1),
+            ]
+        )
+
+        np.testing.assert_allclose(batch, scalar)
+
+    def test_dangerous_area_position_out_of_bounds_raises(self):
+        """Out-of-bounds dangerous-area centers are rejected at construction.
+
+        Purpose: Validates the new validation branch in
+            ``_validate_parameters`` so users discover misconfigured zones
+            up front instead of silently mis-rendering them or hitting a
+            zero-penalty edge case.
+
+        Given: A request to build a PacManPOMDP with a danger center outside
+            the configured maze bounds.
+        When: ``PacManPOMDP(...)`` is invoked.
+        Then: ``ValueError`` is raised with a message naming the offending
+            position and the maze bounds.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match=r"Dangerous area .* is outside maze bounds"):
+            PacManPOMDP(
+                maze_size=(5, 5),
+                walls=set(),
+                initial_pellets=[(1, 1)],
+                initial_pacman_pos=(0, 0),
+                num_ghosts=1,
+                initial_ghost_positions=[(4, 4)],
+                dangerous_areas={(5, 0)},
+            )
+
+    def test_dangerous_area_negative_radius_or_penalty_raises(self):
+        """Negative radius or penalty values are rejected.
+
+        Purpose: Pins the non-negative invariants on the two scalar danger
+            parameters so silently-accepted negatives can never flip the
+            sign of the penalty term.
+
+        Given: A request to build an env with either negative radius or
+            negative penalty.
+        When: ``PacManPOMDP(...)`` is invoked.
+        Then: ``ValueError`` is raised in each case.
+
+        Test type: unit
+        """
+        common = {
+            "maze_size": (5, 5),
+            "walls": set(),
+            "initial_pellets": [(1, 1)],
+            "initial_pacman_pos": (0, 0),
+            "num_ghosts": 1,
+            "initial_ghost_positions": [(4, 4)],
+            "dangerous_areas": {(2, 2)},
+        }
+        with pytest.raises(ValueError, match=r"dangerous_area_radius must be non-negative"):
+            PacManPOMDP(dangerous_area_radius=-0.1, **common)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match=r"dangerous_area_penalty must be non-negative"):
+            PacManPOMDP(dangerous_area_penalty=-1.0, **common)  # type: ignore[arg-type]
+
+    def test_dangerous_areas_do_not_block_movement_or_terminate(self):
+        """Walking through a zone is allowed and non-terminal.
+
+        Purpose: Pins the laser_tag-equivalent contract that dangerous areas
+            are reward-only — they do not block the transition kernel and
+            do not flip the terminal flag.
+
+        Given: A state with PacMan adjacent to a danger zone.
+        When: ``sample_next_step(state, action_east)`` is called repeatedly
+            from inside / outside the zone.
+        Then: The next state is reachable (no exception), and the terminal
+            flag stays ``False`` (no ghost in this scenario).
+
+        Test type: integration
+        """
+        state = self._state_with_pac((3, 2))
+
+        for _ in range(5):
+            next_state, obs, reward = self.pomdp.sample_next_step(state, action=1)
+            assert isinstance(obs, tuple)
+            assert isinstance(reward, (int, float))
+            assert not self.pomdp.is_terminal(next_state)
+            state = next_state
+
+    def test_dangerous_area_reward_range_includes_penalty_when_configured(self):
+        """``reward_range`` lower bound shifts down when a zone is configured.
+
+        Purpose: Validates that the constructor accounts for the danger
+            penalty in ``min_reward`` so downstream consumers reading the
+            range (e.g. planners normalising returns) see a faithful bound.
+
+        Given: An env with ``dangerous_areas={(3, 3)}`` and
+            ``dangerous_area_penalty=5.0``.
+        When: ``reward_range`` is read.
+        Then: Lower bound equals ``step_penalty + ghost_collision_penalty -
+            dangerous_area_penalty``.
+
+        Test type: unit
+        """
+        expected_min = (
+            self.pomdp.step_penalty
+            + self.pomdp.ghost_collision_penalty
+            - self.pomdp.dangerous_area_penalty
+        )
+        expected_max = self.pomdp.step_penalty + self.pomdp.pellet_reward + self.pomdp.win_reward
+        assert self.pomdp.reward_range == (expected_min, expected_max)

--- a/POMDPPlanners/tests/test_environments/test_pacman_visualizer.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_visualizer.py
@@ -235,5 +235,67 @@ def test_cache_visualization_vectorized_belief_renders_red_overlay() -> None:
         ), "Expected at least one red-dominant pixel inside the belief-concentrated tile"
 
 
+def test_draw_dangerous_areas_renders_red_overlay_on_configured_cell() -> None:
+    """Dangerous-area overlay tints the configured center cell red.
+
+    Purpose: Smoke-tests :meth:`PacManVisualizer._draw_dangerous_areas` so
+        that future refactors of the visualizer cannot silently drop the
+        hazard rendering — without it, planners and reviewers reading a
+        cached GIF would have no visual cue that the danger penalty was
+        active.
+
+    Given: A PacManPOMDP with one configured zone at (2, 2) radius 1.0 and
+        a fresh blank RGBA canvas matching the visualizer dimensions.
+    When: ``_draw_dangerous_areas`` is invoked on the canvas.
+    Then: The center pixel of tile (2, 2) has alpha > 0 (red overlay
+        present), and a clearly distant tile (0, 0) still has alpha == 0.
+
+    Test type: unit
+    """
+    env = PacManPOMDP(
+        maze_size=(5, 5),
+        walls=set(),
+        initial_pacman_pos=(0, 0),
+        num_ghosts=1,
+        initial_ghost_positions=[(4, 4)],
+        initial_pellets=[(2, 2)],
+        dangerous_areas={(2, 2)},
+        dangerous_area_radius=1.0,
+        dangerous_area_penalty=5.0,
+    )
+    visualizer = PacManVisualizer(env, tile_size=16)
+    canvas = _blank_canvas(env, visualizer.tile_size)
+
+    visualizer._draw_dangerous_areas(canvas, visualizer.tile_size)
+
+    assert _tile_center_alpha(canvas, 2, 2, visualizer.tile_size) > 0
+    assert _tile_center_alpha(canvas, 0, 0, visualizer.tile_size) == 0
+
+
+def test_draw_dangerous_areas_noop_when_feature_disabled() -> None:
+    """No danger zones configured ⇒ no overlay touches the canvas.
+
+    Purpose: Guards the opt-in contract — vanilla PacMan envs (default
+        ``dangerous_areas``) should produce pixel-identical canvases before
+        and after the new hook fires.
+
+    Given: A PacManPOMDP constructed without ``dangerous_areas``.
+    When: ``_draw_dangerous_areas`` is invoked on a fresh canvas.
+    Then: Every tile center still has alpha == 0.
+
+    Test type: unit
+    """
+    env = _make_env()
+    visualizer = PacManVisualizer(env, tile_size=16)
+    canvas = _blank_canvas(env, visualizer.tile_size)
+
+    visualizer._draw_dangerous_areas(canvas, visualizer.tile_size)
+
+    rows, cols = env.maze_size
+    for r in range(rows):
+        for c in range(cols):
+            assert _tile_center_alpha(canvas, r, c, visualizer.tile_size) == 0
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Adds `dangerous_areas`, `dangerous_area_radius`, `dangerous_area_penalty` to `PacManPOMDP` — circular hazard zones that subtract a penalty whenever PacMan's realised next position falls inside any zone. Mirrors the discrete `laser_tag_pomdp` contract: penalty only, no movement block, no termination, ghosts unaffected.
- Fully opt-in (`dangerous_areas` defaults to `None`). Existing PacMan configs are unchanged, and the C++ transition kernel is untouched — penalty is computed in Python on both the scalar `reward()` path and the vectorised `_compute_reward_batch` helper.
- Visualizer overlays each zone as a translucent red circle between the maze background and the ghost belief heatmap, with a conditional "= danger zone" legend swatch that only appears when the feature is configured.

## Test plan

- [x] `pytest POMDPPlanners/tests/test_environments/test_pacman_pomdp.py POMDPPlanners/tests/test_environments/test_pacman_visualizer.py -v` — 82 tests pass, including 9 new dangerous-area tests + 2 new visualizer overlay tests
- [x] `pytest POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs POMDPPlanners/tests/test_environments/test_pacman_native` — 42 adjacent pacman tests pass (no regression in beliefs / native kernel)
- [x] `pytest --doctest-modules POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py` — both docstring examples pass (the new one demonstrates configuring a zone)
- [x] `pyright POMDPPlanners/environments/pacman_pomdp/ POMDPPlanners/tests/test_environments/test_pacman_pomdp.py POMDPPlanners/tests/test_environments/test_pacman_visualizer.py` — 0 errors / 0 warnings
- [x] Whole-tree `pyright POMDPPlanners/` — 0 errors (the one pre-existing warning in `core/environment/environment.py:345` is unrelated)
- [x] `pylint` on source: 9.96/10 (only pre-existing warnings in untouched code); `pylint` on tests: 9.70/10, +0.03 above baseline (no new warning categories introduced)