### PR TITLE
refactor(environment_utils): extract generic dangerous-area numba kernels

### DIFF
--- a/POMDPPlanners/environments/environment_utils/__init__.py
+++ b/POMDPPlanners/environments/environment_utils/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-environment utilities reusable across POMDP environments."""

--- a/POMDPPlanners/environments/environment_utils/dangerous_areas_kernels.py
+++ b/POMDPPlanners/environments/environment_utils/dangerous_areas_kernels.py
@@ -1,0 +1,223 @@
+"""Generic Numba kernels for dangerous-area reward contributions.
+
+Each kernel maps a 2-D point (and a batch of points) to the *dangerous-
+area* reward contribution under a specific stochastic model. The kernels
+are env-agnostic so they can be reused by light-dark, pacman, laser-tag,
+and any future grid / continuous environment that needs circular hazard
+zones with a reward penalty.
+
+Three reward-model variants are provided, each as a scalar / batch pair:
+
+- **constant_prob**: penalty applied with a fixed probability whenever the
+  point lies inside any zone. Matches the light-dark Standard reward
+  model and the laser-tag / pacman dangerous-area contract (degenerate
+  case ``hit_probability=1.0``).
+- **high_variance**: ``±penalty`` with 50/50 split whenever the point
+  lies inside any zone. Zero expected contribution, high variance.
+  Matches the light-dark HIGH_VARIANCE_STATES reward model.
+- **decaying_prob**: penalty applied with probability
+  ``exp(-min_dist / penalty_decay)`` based on the *closest* zone centre
+  (no radius cutoff). Matches the light-dark Decaying-Hit-Probability
+  model.
+
+Conventions (matching :mod:`POMDPPlanners.utils.numba_kernels`):
+
+- All inputs are plain numeric arrays / scalars; no Python objects.
+- Points are passed as ``np.ndarray`` of shape ``(2,)`` (scalar kernel)
+  or ``(N, 2)`` (batch kernel).
+- Zone centres are passed as a contiguous ``float64`` array of shape
+  ``(2, D)`` — ``x`` coordinates on row 0, ``y`` on row 1. Matches the
+  ``_convert_*_to_array`` helpers already used by light-dark.
+- Radii are passed pre-squared (``radius_sq``) so the kernel never sqrts
+  on the hot path and callers cache the squaring once at construction.
+- RNG stays in Python. The caller draws ``uniform ~ U[0, 1)`` (or
+  ``uniforms`` for the batch path) and passes them in. This preserves
+  seed semantics and keeps outputs bit-identical under fixed seeds.
+- Each kernel returns *only* the dangerous-area contribution. The caller
+  composes this with whatever env-specific geometry (fuel, goal, grid
+  bounds, ...) it needs.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numba import njit
+
+# pylint: disable=no-value-for-parameter,not-an-iterable
+
+
+@njit(cache=True)  # type: ignore[misc]
+def constant_prob_penalty_kernel(
+    point: np.ndarray,
+    centers: np.ndarray,
+    radius_sq: float,
+    penalty: float,
+    hit_probability: float,
+    uniform: float,
+) -> float:
+    """Constant-probability dangerous-area penalty.
+
+    Returns ``penalty`` iff the point lies inside any of the ``D`` zones
+    (squared-distance check against ``radius_sq``) *and*
+    ``uniform < hit_probability``. Otherwise returns ``0.0``.
+    """
+    x = point[0]
+    y = point[1]
+    n_centers = centers.shape[1]
+    for i in range(n_centers):
+        dx = x - centers[0, i]
+        dy = y - centers[1, i]
+        if dx * dx + dy * dy <= radius_sq:
+            if uniform < hit_probability:
+                return penalty
+            return 0.0
+    return 0.0
+
+
+@njit(cache=True)  # type: ignore[misc]
+def constant_prob_penalty_batch_kernel(
+    points: np.ndarray,
+    centers: np.ndarray,
+    radius_sq: float,
+    penalty: float,
+    hit_probability: float,
+    uniforms: np.ndarray,
+) -> np.ndarray:
+    """Batched form of :func:`constant_prob_penalty_kernel`.
+
+    ``points`` is shape ``(N, 2)``, ``uniforms`` is shape ``(N,)``.
+    Returns a length-``N`` array of contributions. ``uniforms[i]`` is
+    consulted only when ``points[i]`` lies inside some zone, so callers
+    can either pre-draw ``N`` uniforms or pre-draw only enough for the
+    in-zone subset and pass that subset's rows.
+    """
+    n_points = points.shape[0]
+    out = np.zeros(n_points, dtype=np.float64)
+    n_centers = centers.shape[1]
+    for s in range(n_points):
+        x = points[s, 0]
+        y = points[s, 1]
+        for i in range(n_centers):
+            dx = x - centers[0, i]
+            dy = y - centers[1, i]
+            if dx * dx + dy * dy <= radius_sq:
+                if uniforms[s] < hit_probability:
+                    out[s] = penalty
+                break
+    return out
+
+
+@njit(cache=True)  # type: ignore[misc]
+def high_variance_penalty_kernel(
+    point: np.ndarray,
+    centers: np.ndarray,
+    radius_sq: float,
+    penalty: float,
+    uniform: float,
+) -> float:
+    """High-variance dangerous-area contribution.
+
+    Returns ``penalty`` (with ``uniform < 0.5``) or ``-penalty``
+    (otherwise) iff the point lies inside any of the ``D`` zones, else
+    ``0.0``. Expected contribution is zero; the variance is
+    ``penalty**2``. Pass the signed ``penalty`` value the caller wants
+    on the ``uniform < 0.5`` branch (e.g. ``obstacle_reward = -10.0``);
+    the kernel emits ``+10.0`` on the other branch.
+    """
+    x = point[0]
+    y = point[1]
+    n_centers = centers.shape[1]
+    for i in range(n_centers):
+        dx = x - centers[0, i]
+        dy = y - centers[1, i]
+        if dx * dx + dy * dy <= radius_sq:
+            if uniform < 0.5:
+                return penalty
+            return -penalty
+    return 0.0
+
+
+@njit(cache=True)  # type: ignore[misc]
+def high_variance_penalty_batch_kernel(
+    points: np.ndarray,
+    centers: np.ndarray,
+    radius_sq: float,
+    penalty: float,
+    uniforms: np.ndarray,
+) -> np.ndarray:
+    """Batched form of :func:`high_variance_penalty_kernel`."""
+    n_points = points.shape[0]
+    out = np.zeros(n_points, dtype=np.float64)
+    n_centers = centers.shape[1]
+    for s in range(n_points):
+        x = points[s, 0]
+        y = points[s, 1]
+        for i in range(n_centers):
+            dx = x - centers[0, i]
+            dy = y - centers[1, i]
+            if dx * dx + dy * dy <= radius_sq:
+                if uniforms[s] < 0.5:
+                    out[s] = penalty
+                else:
+                    out[s] = -penalty
+                break
+    return out
+
+
+@njit(cache=True)  # type: ignore[misc]
+def decaying_prob_penalty_kernel(
+    point: np.ndarray,
+    centers: np.ndarray,
+    penalty: float,
+    penalty_decay: float,
+    uniform: float,
+) -> float:
+    """Distance-decaying dangerous-area penalty.
+
+    Computes the minimum Euclidean distance from the point to any zone
+    centre, then applies ``penalty`` with probability
+    ``exp(-min_dist / penalty_decay)``. No radius cutoff — every point
+    feels the (vanishingly small at large distance) penalty risk.
+    """
+    x = point[0]
+    y = point[1]
+    n_centers = centers.shape[1]
+    min_sq = np.inf
+    for i in range(n_centers):
+        dx = x - centers[0, i]
+        dy = y - centers[1, i]
+        d_sq = dx * dx + dy * dy
+        min_sq = min(min_sq, d_sq)
+    min_dist = min_sq**0.5
+    hit_prob = np.exp(-min_dist / penalty_decay)
+    if uniform < hit_prob:
+        return penalty
+    return 0.0
+
+
+@njit(cache=True)  # type: ignore[misc]
+def decaying_prob_penalty_batch_kernel(
+    points: np.ndarray,
+    centers: np.ndarray,
+    penalty: float,
+    penalty_decay: float,
+    uniforms: np.ndarray,
+) -> np.ndarray:
+    """Batched form of :func:`decaying_prob_penalty_kernel`."""
+    n_points = points.shape[0]
+    out = np.zeros(n_points, dtype=np.float64)
+    n_centers = centers.shape[1]
+    for s in range(n_points):
+        x = points[s, 0]
+        y = points[s, 1]
+        min_sq = np.inf
+        for i in range(n_centers):
+            dx = x - centers[0, i]
+            dy = y - centers[1, i]
+            d_sq = dx * dx + dy * dy
+            min_sq = min(min_sq, d_sq)
+        min_dist = min_sq**0.5
+        hit_prob = np.exp(-min_dist / penalty_decay)
+        if uniforms[s] < hit_prob:
+            out[s] = penalty
+    return out

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
@@ -3,6 +3,9 @@ from typing import Optional
 
 import numpy as np
 
+from POMDPPlanners.environments.environment_utils.dangerous_areas_kernels import (
+    decaying_prob_penalty_batch_kernel,
+)
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.numba_kernels import (
     compute_reward_base_batch_kernel,
     compute_reward_base_kernel,
@@ -118,7 +121,11 @@ class ContinuousLightDarkRewardModel(BaseLightDarkRewardModel):
 
         Called by ``_compute_reward`` only when the Numba kernel reports the
         next state landed in an obstacle region but was not at goal / out-of-grid,
-        preserving the pre-refactor RNG call pattern.
+        preserving the pre-refactor RNG call pattern. The contribution is a
+        single ``penalty if uniform < hit_probability else 0`` check — too
+        trivial to amortise the Python→njit boundary cost of dispatching to
+        :mod:`environment_utils.dangerous_areas_kernels`, so the model keeps
+        the inline form here for hot-path efficiency.
         """
         return self.obstacle_reward if np.random.rand() < self.obstacle_hit_probability else 0.0
 
@@ -158,6 +165,15 @@ class ContinuousLightDarkRewardModel(BaseLightDarkRewardModel):
         return rewards
 
     def _obstacle_reward_batch(self, n: int) -> np.ndarray:
+        """Stochastic obstacle-hit contribution applied to the in-zone subset.
+
+        Kept as inline NumPy rather than dispatched to
+        :mod:`environment_utils.dangerous_areas_kernels` for the same reason
+        as :meth:`_obstacle_reward_scalar`: the per-row work is a single
+        threshold compare, and ``np.where`` over a length-``n_obs`` array
+        beats the Python→njit boundary plus the kernel's redundant zone-scan
+        pass (which the geometry kernel already performed).
+        """
         hits = np.random.rand(n) < self.obstacle_hit_probability
         return np.where(hits, self.obstacle_reward, 0.0)
 
@@ -167,7 +183,7 @@ class ContinuousLDHighVarianceStatesRewardModel(ContinuousLightDarkRewardModel):
         """The expected reward is 0.0, but the variance is high."""
         return self.obstacle_reward if np.random.rand() < 0.5 else -self.obstacle_reward
 
-    def _obstacle_reward(self, state: np.ndarray) -> float:
+    def _obstacle_reward(self, state: np.ndarray) -> float:  # pylint: disable=unused-argument
         """The expected reward is 0.0, but the variance is high."""
         return self.obstacle_reward if np.random.rand() < 0.5 else -self.obstacle_reward
 
@@ -244,9 +260,11 @@ class ContinuousLightDarkDecayingHitProbabilityRewardModel(BaseLightDarkRewardMo
         # to the deterministic ``states + action`` only when no realised
         # batch was supplied.
         if next_states is None:
-            next_states_arr = np.asarray(states) + np.asarray(action)
+            next_states_arr = np.ascontiguousarray(
+                np.asarray(states, dtype=np.float64) + np.asarray(action, dtype=np.float64)
+            )
         else:
-            next_states_arr = np.asarray(next_states)
+            next_states_arr = np.ascontiguousarray(np.asarray(next_states, dtype=np.float64))
         dists_to_goal = np.linalg.norm(next_states_arr - self.goal_state, axis=1)
         rewards = -self.fuel_cost - dists_to_goal
 
@@ -256,8 +274,16 @@ class ContinuousLightDarkDecayingHitProbabilityRewardModel(BaseLightDarkRewardMo
         oob = np.any(next_states_arr < 0, axis=1) | np.any(next_states_arr > self.grid_size, axis=1)
         rewards[oob & ~goal_mask] += self.obstacle_reward
 
-        diffs = next_states_arr[:, :, np.newaxis] - self.obstacles[np.newaxis, :, :]
-        min_dists = np.min(np.linalg.norm(diffs, axis=1), axis=1)
-        probs = np.exp(-min_dists / self.penalty_decay)
-        rewards[np.random.rand(len(next_states_arr)) < probs] += self.obstacle_reward
+        # Danger contribution via the generic decaying-prob batch kernel.
+        # Draws one uniform per row to preserve the pre-refactor RNG call
+        # pattern, then delegates min-distance + probability gating to the
+        # njit kernel (replaces the prior (N, D, 2) NumPy broadcast).
+        uniforms = np.random.rand(next_states_arr.shape[0])
+        rewards += decaying_prob_penalty_batch_kernel(
+            next_states_arr,
+            self.obstacles,
+            self.obstacle_reward,
+            self.penalty_decay,
+            uniforms,
+        )
         return rewards

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py
@@ -29,6 +29,10 @@ from typing import Tuple
 import numpy as np
 from numba import njit
 
+from POMDPPlanners.environments.environment_utils.dangerous_areas_kernels import (
+    decaying_prob_penalty_kernel,  # called from compute_reward_decaying_hit_prob_kernel
+)
+
 # pylint: disable=no-value-for-parameter,not-an-iterable
 
 
@@ -212,15 +216,11 @@ def compute_reward_decaying_hit_prob_kernel(
     elif is_out_of_grid:
         reward += obstacle_reward
 
-    n_obs = obstacles.shape[1]
-    min_obs_sq = np.inf
-    for i in range(n_obs):
-        ox = next_x - obstacles[0, i]
-        oy = next_y - obstacles[1, i]
-        d_sq = ox * ox + oy * oy
-        min_obs_sq = min(min_obs_sq, d_sq)
-    min_obs_dist = min_obs_sq**0.5
-    hit_prob = np.exp(-min_obs_dist / penalty_decay)
-    if uniform < hit_prob:
-        reward += obstacle_reward
+    # Delegate the decaying-hit-probability contribution to the generic
+    # kernel (njit-to-njit, free at call time). Keeps this kernel's outer
+    # signature unchanged for back-compat with the Python caller while
+    # routing the danger logic through the shared environment_utils path.
+    reward += decaying_prob_penalty_kernel(
+        next_state, obstacles, obstacle_reward, penalty_decay, uniform
+    )
     return reward

--- a/POMDPPlanners/tests/test_environments/test_environment_utils/test_dangerous_areas_kernels.py
+++ b/POMDPPlanners/tests/test_environments/test_environment_utils/test_dangerous_areas_kernels.py
@@ -1,0 +1,388 @@
+"""Unit tests for generic dangerous-area Numba kernels.
+
+Each test pairs a kernel against a pure-NumPy reference implementation
+and asserts results agree, plus exercises edge cases (zero zones, point
+exactly on the boundary, scalar/batch parity, empty batch).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.environment_utils.dangerous_areas_kernels import (
+    constant_prob_penalty_batch_kernel,
+    constant_prob_penalty_kernel,
+    decaying_prob_penalty_batch_kernel,
+    decaying_prob_penalty_kernel,
+    high_variance_penalty_batch_kernel,
+    high_variance_penalty_kernel,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def centers_2d() -> np.ndarray:
+    """Two zone centres at (3, 7) and (5, 5), shape (2, 2)."""
+    return np.array([[3.0, 5.0], [7.0, 5.0]])
+
+
+@pytest.fixture
+def empty_centers() -> np.ndarray:
+    return np.empty((2, 0), dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# constant_prob_penalty_kernel — scalar
+# ---------------------------------------------------------------------------
+
+
+def test_constant_prob_returns_zero_outside_zones(centers_2d):
+    """Validates constant_prob_penalty_kernel returns 0 when point outside zones.
+
+    Purpose: Confirms the zone check correctly identifies a point well clear of all centres
+    Given: A point at (0, 0) with two zones at (3, 7) and (5, 5), radius_sq=1.0
+    When: The constant_prob kernel is called with uniform=0.0 (always-hit)
+    Then: Returns 0.0 despite uniform satisfying the probability check
+
+    Test type: unit
+    """
+    point = np.array([0.0, 0.0])
+    result = constant_prob_penalty_kernel(point, centers_2d, 1.0, -10.0, 1.0, 0.0)
+    assert result == 0.0
+
+
+def test_constant_prob_returns_penalty_inside_zone_and_lucky_draw(centers_2d):
+    """Validates constant_prob_penalty_kernel returns penalty on in-zone + low uniform.
+
+    Purpose: Confirms the kernel applies penalty when both zone and probability checks pass
+    Given: A point at (3.0, 7.0) (exactly on a centre) and hit_probability=0.5
+    When: The kernel is called with uniform=0.1 (< 0.5)
+    Then: Returns the negative penalty value -10.0
+
+    Test type: unit
+    """
+    point = np.array([3.0, 7.0])
+    result = constant_prob_penalty_kernel(point, centers_2d, 1.0, -10.0, 0.5, 0.1)
+    assert result == -10.0
+
+
+def test_constant_prob_returns_zero_inside_zone_but_unlucky(centers_2d):
+    """Validates constant_prob_penalty_kernel returns 0 when uniform exceeds hit prob.
+
+    Purpose: Confirms the probability gate correctly suppresses the penalty
+    Given: A point at zone centre and hit_probability=0.5
+    When: The kernel is called with uniform=0.7 (> 0.5)
+    Then: Returns 0.0
+
+    Test type: unit
+    """
+    point = np.array([3.0, 7.0])
+    result = constant_prob_penalty_kernel(point, centers_2d, 1.0, -10.0, 0.5, 0.7)
+    assert result == 0.0
+
+
+def test_constant_prob_boundary_inclusive(centers_2d):
+    """Validates that points exactly on the zone boundary count as inside.
+
+    Purpose: Confirms <= semantics for the squared-distance check
+    Given: A point at distance exactly = radius from a centre
+    When: The kernel is called with uniform=0.0 and hit_probability=1.0
+    Then: Returns the penalty value (boundary point is inside)
+
+    Test type: unit
+    """
+    radius = 0.5
+    point = np.array([3.5, 7.0])  # distance = 0.5 from (3, 7)
+    result = constant_prob_penalty_kernel(point, centers_2d, radius * radius, -10.0, 1.0, 0.0)
+    assert result == -10.0
+
+
+def test_constant_prob_zero_zones_returns_zero(empty_centers):
+    """Validates kernel returns 0 when there are no zones at all.
+
+    Purpose: Confirms degenerate empty-centers configuration is safe
+    Given: An empty (2, 0) centers array
+    When: The kernel is called with always-hit uniform
+    Then: Returns 0.0
+
+    Test type: unit
+    """
+    point = np.array([3.0, 7.0])
+    result = constant_prob_penalty_kernel(point, empty_centers, 1.0, -10.0, 1.0, 0.0)
+    assert result == 0.0
+
+
+# ---------------------------------------------------------------------------
+# constant_prob_penalty_batch_kernel
+# ---------------------------------------------------------------------------
+
+
+def test_constant_prob_batch_matches_scalar_row_by_row(centers_2d):
+    """Validates batch kernel agrees with scalar kernel applied row-by-row.
+
+    Purpose: Confirms scalar/batch parity for the constant-prob model
+    Given: A batch of 6 points mixing inside/outside zones, fixed uniforms
+    When: Both kernels are invoked on the same inputs
+    Then: Per-row scalar results equal the batch array bit-for-bit
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(seed=0)
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [3.0, 7.0],
+            [3.2, 7.1],
+            [5.5, 5.0],
+            [10.0, 10.0],
+            [3.0, 7.0],
+        ]
+    )
+    uniforms = rng.uniform(size=points.shape[0])
+    radius_sq = 0.36
+    penalty = -10.0
+    hit_prob = 0.4
+    batch_result = constant_prob_penalty_batch_kernel(
+        points, centers_2d, radius_sq, penalty, hit_prob, uniforms
+    )
+    scalar_results = np.array(
+        [
+            constant_prob_penalty_kernel(
+                points[i], centers_2d, radius_sq, penalty, hit_prob, uniforms[i]
+            )
+            for i in range(points.shape[0])
+        ]
+    )
+    np.testing.assert_array_equal(batch_result, scalar_results)
+
+
+def test_constant_prob_batch_empty_returns_empty():
+    """Validates batch kernel handles N=0 without error.
+
+    Purpose: Confirms empty-batch corner case returns shape (0,)
+    Given: A (0, 2) points array and (0,) uniforms array
+    When: The batch kernel is called
+    Then: Returns a length-0 float64 array
+
+    Test type: unit
+    """
+    points = np.empty((0, 2), dtype=np.float64)
+    centers = np.array([[3.0], [7.0]])
+    uniforms = np.empty(0, dtype=np.float64)
+    result = constant_prob_penalty_batch_kernel(points, centers, 1.0, -10.0, 0.5, uniforms)
+    assert result.shape == (0,)
+
+
+# ---------------------------------------------------------------------------
+# high_variance_penalty_kernel
+# ---------------------------------------------------------------------------
+
+
+def test_high_variance_outside_zone_returns_zero(centers_2d):
+    """Validates high_variance_penalty_kernel returns 0 when outside zones.
+
+    Purpose: Confirms no spurious contribution when point is clear of all zones
+    Given: A point at (0, 0), well clear of zones at (3, 7) and (5, 5)
+    When: The kernel is called with uniform=0.1
+    Then: Returns 0.0
+
+    Test type: unit
+    """
+    point = np.array([0.0, 0.0])
+    result = high_variance_penalty_kernel(point, centers_2d, 1.0, -10.0, 0.1)
+    assert result == 0.0
+
+
+def test_high_variance_returns_penalty_on_low_uniform(centers_2d):
+    """Validates high_variance returns ``penalty`` for uniform < 0.5.
+
+    Purpose: Confirms the ``uniform < 0.5`` branch returns the signed penalty
+    Given: A point inside a zone, penalty=-10.0
+    When: The kernel is called with uniform=0.3
+    Then: Returns -10.0
+
+    Test type: unit
+    """
+    point = np.array([3.0, 7.0])
+    result = high_variance_penalty_kernel(point, centers_2d, 1.0, -10.0, 0.3)
+    assert result == -10.0
+
+
+def test_high_variance_returns_negated_penalty_on_high_uniform(centers_2d):
+    """Validates high_variance returns ``-penalty`` for uniform >= 0.5.
+
+    Purpose: Confirms the ``uniform >= 0.5`` branch flips the sign
+    Given: A point inside a zone, penalty=-10.0
+    When: The kernel is called with uniform=0.7
+    Then: Returns +10.0
+
+    Test type: unit
+    """
+    point = np.array([3.0, 7.0])
+    result = high_variance_penalty_kernel(point, centers_2d, 1.0, -10.0, 0.7)
+    assert result == 10.0
+
+
+def test_high_variance_zero_expected_contribution(centers_2d):
+    """Validates expected contribution is zero over many uniform draws.
+
+    Purpose: Statistical sanity check — mean across 5000 uniform draws should be ~0
+    Given: A point inside a zone, penalty=-10.0, fixed seed
+    When: The kernel is called 5000 times with random uniforms in [0, 1)
+    Then: Mean contribution is within 0.5 of 0.0
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(seed=42)
+    point = np.array([3.0, 7.0])
+    uniforms = rng.uniform(size=5000)
+    contributions = np.array(
+        [high_variance_penalty_kernel(point, centers_2d, 1.0, -10.0, u) for u in uniforms]
+    )
+    assert abs(contributions.mean()) < 0.5
+
+
+def test_high_variance_batch_matches_scalar(centers_2d):
+    """Validates batch kernel agrees with scalar kernel applied row-by-row.
+
+    Purpose: Confirms scalar/batch parity for the high-variance model
+    Given: A batch of 5 points mixing inside/outside, fixed uniforms
+    When: Both kernels are invoked on the same inputs
+    Then: Per-row scalar results equal the batch array
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(seed=1)
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [3.0, 7.0],
+            [5.0, 5.0],
+            [3.0, 7.0],
+            [10.0, 10.0],
+        ]
+    )
+    uniforms = rng.uniform(size=points.shape[0])
+    batch_result = high_variance_penalty_batch_kernel(points, centers_2d, 1.0, -10.0, uniforms)
+    scalar_results = np.array(
+        [
+            high_variance_penalty_kernel(points[i], centers_2d, 1.0, -10.0, uniforms[i])
+            for i in range(points.shape[0])
+        ]
+    )
+    np.testing.assert_array_equal(batch_result, scalar_results)
+
+
+# ---------------------------------------------------------------------------
+# decaying_prob_penalty_kernel
+# ---------------------------------------------------------------------------
+
+
+def _ref_decaying_prob(
+    point: np.ndarray,
+    centers: np.ndarray,
+    penalty: float,
+    penalty_decay: float,
+    uniform: float,
+) -> float:
+    distances = np.linalg.norm(point.reshape(-1, 1) - centers, axis=0)
+    d = float(np.min(distances))
+    p = float(np.exp(-d / penalty_decay))
+    return float(penalty) if uniform < p else 0.0
+
+
+def test_decaying_prob_close_to_zone_almost_always_hits(centers_2d):
+    """Validates decaying_prob hits with high probability near a zone.
+
+    Purpose: Confirms the probability is close to 1 at zero distance
+    Given: A point exactly on a zone centre, penalty_decay=2.0
+    When: The kernel is called with uniform=0.5
+    Then: Returns the penalty (hit_prob = exp(0) = 1.0 > 0.5)
+
+    Test type: unit
+    """
+    point = np.array([3.0, 7.0])
+    result = decaying_prob_penalty_kernel(point, centers_2d, -10.0, 2.0, 0.5)
+    assert result == -10.0
+
+
+def test_decaying_prob_far_from_zones_almost_never_hits(centers_2d):
+    """Validates decaying_prob suppresses the penalty far from any zone.
+
+    Purpose: Confirms the probability decays toward 0 at large distance
+    Given: A point at (100, 100), penalty_decay=1.0 (so hit_prob = exp(-d) ~ 0)
+    When: The kernel is called with uniform=0.0001
+    Then: Returns 0.0 (uniform exceeds the very small hit probability)
+
+    Test type: unit
+    """
+    point = np.array([100.0, 100.0])
+    result = decaying_prob_penalty_kernel(point, centers_2d, -10.0, 1.0, 0.0001)
+    assert result == 0.0
+
+
+def test_decaying_prob_matches_reference(centers_2d):
+    """Validates decaying_prob kernel matches pure-NumPy reference across many inputs.
+
+    Purpose: Confirms numerical equivalence against an independent implementation
+    Given: A grid of 20 points across [0, 10] x [0, 10] with varied uniforms
+    When: Both kernel and NumPy reference are evaluated
+    Then: Outputs agree to within float64 tolerance
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(seed=2)
+    points = rng.uniform(0.0, 10.0, size=(20, 2))
+    uniforms = rng.uniform(size=20)
+    penalty_decay = 1.5
+    penalty = -7.5
+    for i in range(points.shape[0]):
+        got = decaying_prob_penalty_kernel(
+            points[i], centers_2d, penalty, penalty_decay, uniforms[i]
+        )
+        expected = _ref_decaying_prob(points[i], centers_2d, penalty, penalty_decay, uniforms[i])
+        assert got == pytest.approx(expected)
+
+
+def test_decaying_prob_batch_matches_scalar(centers_2d):
+    """Validates batch kernel agrees with scalar kernel applied row-by-row.
+
+    Purpose: Confirms scalar/batch parity for the decaying-prob model
+    Given: A batch of 8 points and matching uniforms, fixed seed
+    When: Both kernels are invoked on the same inputs
+    Then: Per-row scalar results equal the batch array
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(seed=3)
+    points = rng.uniform(0.0, 10.0, size=(8, 2))
+    uniforms = rng.uniform(size=8)
+    batch_result = decaying_prob_penalty_batch_kernel(points, centers_2d, -7.5, 1.5, uniforms)
+    scalar_results = np.array(
+        [
+            decaying_prob_penalty_kernel(points[i], centers_2d, -7.5, 1.5, uniforms[i])
+            for i in range(points.shape[0])
+        ]
+    )
+    np.testing.assert_array_equal(batch_result, scalar_results)
+
+
+def test_decaying_prob_batch_empty_returns_empty():
+    """Validates batch kernel handles N=0 without error.
+
+    Purpose: Confirms empty-batch corner case returns shape (0,)
+    Given: A (0, 2) points array and (0,) uniforms array
+    When: The decaying batch kernel is called
+    Then: Returns a length-0 float64 array
+
+    Test type: unit
+    """
+    points = np.empty((0, 2), dtype=np.float64)
+    centers = np.array([[3.0], [7.0]])
+    uniforms = np.empty(0, dtype=np.float64)
+    result = decaying_prob_penalty_batch_kernel(points, centers, -10.0, 1.0, uniforms)
+    assert result.shape == (0,)

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/benchmark_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/benchmark_reward_models.py
@@ -1,0 +1,149 @@
+"""Performance benchmark: light_dark env-level ``reward`` / ``reward_batch``.
+
+Times the public Environment-API reward methods
+(:meth:`ContinuousLightDarkPOMDP.reward` and
+:meth:`ContinuousLightDarkPOMDP.reward_batch`) end-to-end so the numbers
+include the thin Python wrapper at ``continuous_light_dark_pomdp.py:637``
+on top of the reward model's ``compute_reward`` / ``compute_reward_batch``.
+Covers all three reward-model variants (Standard, HIGH_VARIANCE_STATES,
+DECAYING_HIT_PROBABILITY) on a fixed workload. Used to compare BEFORE vs
+AFTER the dangerous-area generic-kernel refactor.
+
+Note: the C++ ``_native.simulate_rollout`` path is a separate hot path
+with its own embedded reward logic and is *not* exercised here — to
+benchmark that, time ``env._rollout`` or a full MCTS rollout instead.
+
+Run manually:
+    python -m POMDPPlanners.tests.test_environments.test_light_dark_pomdp.light_dark_pomdp_utils.benchmark_reward_models
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, List, Tuple
+
+import numpy as np
+
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ContinuousLightDarkPOMDP,
+    RewardModelType,
+)
+
+# Fixed workload: 4 obstacles on a 10x10 grid, goal at (8, 8).
+GOAL_STATE = np.array([8.0, 8.0])
+OBSTACLES_LIST: List[Tuple[float, float]] = [(2.0, 2.0), (4.0, 6.0), (6.0, 3.0), (5.0, 7.0)]
+GOAL_RADIUS = 0.5
+OBSTACLE_RADIUS = 0.8
+GRID_SIZE = 10
+OBSTACLE_HIT_PROB = 0.5
+OBSTACLE_REWARD = -10.0
+GOAL_REWARD = 100.0
+FUEL_COST = 1.0
+PENALTY_DECAY = 1.5
+
+BATCH_SIZES: List[int] = [100, 1000, 10000]
+SCALAR_REPS = 5000
+N_RUNS_SCALAR = 5
+N_RUNS_BATCH = 20
+
+
+def _time_fn(fn: Callable[[], Any], n_runs: int) -> Tuple[float, float]:
+    times: List[float] = []
+    for _ in range(n_runs):
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    arr = np.array(times) * 1000.0  # ms
+    return float(arr.mean()), float(arr.std())
+
+
+def _build_envs() -> List[Tuple[str, ContinuousLightDarkPOMDP]]:
+    common = {
+        "discount_factor": 0.95,
+        "goal_state": GOAL_STATE,
+        "obstacles": OBSTACLES_LIST,
+        "goal_state_radius": GOAL_RADIUS,
+        "obstacle_radius": OBSTACLE_RADIUS,
+        "grid_size": GRID_SIZE,
+        "obstacle_hit_probability": OBSTACLE_HIT_PROB,
+        "obstacle_reward": OBSTACLE_REWARD,
+        "goal_reward": GOAL_REWARD,
+        "fuel_cost": FUEL_COST,
+        "penalty_decay": PENALTY_DECAY,
+    }
+    return [
+        (
+            "Standard",
+            ContinuousLightDarkPOMDP(reward_model_type=RewardModelType.STANDARD, **common),
+        ),
+        (
+            "HighVariance",
+            ContinuousLightDarkPOMDP(
+                reward_model_type=RewardModelType.HIGH_VARIANCE_STATES, **common
+            ),
+        ),
+        (
+            "Decaying",
+            ContinuousLightDarkPOMDP(
+                reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY, **common
+            ),
+        ),
+    ]
+
+
+def _scalar_workload(env: ContinuousLightDarkPOMDP, states: np.ndarray, action: np.ndarray) -> None:
+    for i in range(states.shape[0]):
+        env.reward(states[i], action, next_state=states[i])
+
+
+def _benchmark_scalar(envs: List[Tuple[str, ContinuousLightDarkPOMDP]]) -> None:
+    action = np.array([0.5, 0.5])
+    np.random.seed(42)
+    states = np.random.rand(SCALAR_REPS, 2) * GRID_SIZE
+
+    print(f"\n--- env.reward (reps={SCALAR_REPS}) ---")
+    print(f"{'model':>14} | {'mean (ms)':>12} | {'std (ms)':>10} | {'per-call (us)':>14}")
+    print("-" * 60)
+    for name, env in envs:
+        mean, std = _time_fn(
+            lambda e=env: _scalar_workload(e, states, action),
+            n_runs=N_RUNS_SCALAR,
+        )
+        per_call_us = (mean / SCALAR_REPS) * 1000.0
+        print(f"{name:>14} | {mean:>12.3f} | {std:>10.3f} | {per_call_us:>14.3f}")
+
+
+def _benchmark_batch(envs: List[Tuple[str, ContinuousLightDarkPOMDP]]) -> None:
+    action = np.array([0.5, 0.5])
+
+    for n in BATCH_SIZES:
+        np.random.seed(42)
+        states = np.random.rand(n, 2) * GRID_SIZE
+
+        print(f"\n--- env.reward_batch (N={n}) ---")
+        print(f"{'model':>14} | {'mean (ms)':>12} | {'std (ms)':>10}")
+        print("-" * 45)
+        for name, env in envs:
+            mean, std = _time_fn(
+                lambda e=env, s=states: e.reward_batch(s, action, next_states=s),
+                n_runs=N_RUNS_BATCH,
+            )
+            print(f"{name:>14} | {mean:>12.3f} | {std:>10.3f}")
+
+
+def main() -> None:
+    envs = _build_envs()
+    # Warm up the numba kernels so the first call's JIT cost is not charged
+    # to the first model in each table.
+    warmup_states = np.random.rand(8, 2) * GRID_SIZE
+    warmup_action = np.array([0.5, 0.5])
+    for _, env in envs:
+        env.reward(warmup_states[0], warmup_action, next_state=warmup_states[0])
+        env.reward_batch(warmup_states, warmup_action, next_states=warmup_states)
+
+    _benchmark_scalar(envs)
+    _benchmark_batch(envs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds six reusable Numba kernels under `POMDPPlanners/environments/environment_utils/dangerous_areas_kernels.py` — scalar + batch variants for three reward shapes (constant-probability, high-variance, distance-decaying). Env-agnostic API: takes a 2-D point or batch, zone centres of shape `(2, D)`, a pre-squared radius, and pre-drawn uniforms. RNG stays in the Python caller for seed-stable reproducibility.
- Wires the light-dark `DECAYING_HIT_PROBABILITY` model through the new kernels — scalar via njit-to-njit delegation inside `compute_reward_decaying_hit_prob_kernel` (single Python→njit boundary preserved), batch directly (replaces the `(N, D, 2)` NumPy broadcast).
- Standard / HighVariance reward models keep their original inline-NumPy `np.where(rand < p, penalty, 0)` path — per-row work is a single threshold compare, too trivial to amortise the Python→njit boundary cost. Rationale documented at `light_dark_reward_models.py:119,167`.

## Performance — `env.reward` / `env.reward_batch`

Benchmarked end-to-end via the public env API (`continuous_light_dark_pomdp.py:637-654`), 4 runs per config, mean reported. Harness at `POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/benchmark_reward_models.py`.

| Path                           | BEFORE (ms) | AFTER (ms) | Δ           |
|--------------------------------|------------:|-----------:|------------:|
| **scalar `env.reward`** (5000 reps)              |             |            |             |
| Standard                                         | 4.59 | 4.41 | **−4%**       |
| HighVariance                                     | 4.49 | 4.48 | neutral       |
| Decaying                                         | 5.90 | 5.81 | neutral       |
| **`env.reward_batch` N=100**                     |             |            |             |
| Standard                                         | 0.007 | 0.007 | neutral      |
| HighVariance                                     | 0.007 | 0.006 | within noise |
| Decaying                                         | 0.045 | 0.025 | **−44%**     |
| **`env.reward_batch` N=1000**                    |             |            |             |
| Standard                                         | 0.013 | 0.013 | neutral      |
| HighVariance                                     | 0.013 | 0.012 | within noise |
| Decaying                                         | 0.188 | 0.071 | **−62%**     |
| **`env.reward_batch` N=10000**                   |             |            |             |
| Standard                                         | 0.072 | 0.072 | neutral      |
| HighVariance                                     | 0.073 | 0.070 | within noise |
| Decaying                                         | 1.483 | 0.562 | **−62%**     |

Every path is neutral or improved. Decaying batch is ~2.6× faster across all sizes.

**Note**: the C++ `_native.simulate_rollout` rollout path has its own embedded reward logic and is **not** touched — it never calls back into the Python `compute_reward_batch` surface.

## Why this is staged

Stage 1: light-dark only. Future stages can route pacman / laser_tag dangerous-area handling through the same kernels (their `_is_in_dangerous_area` + batch helpers in `pacman_pomdp.py:762,938` and `laser_tag_pomdp.py:737,890` mirror the same circular-zone contract). The kernel signature was chosen to drop in once those envs transpose their `(D, 2)` centre arrays to `(2, D)` at construction.

## Test plan

- [x] 17 new unit tests for the generic kernels — zero zones, single zone (inside/boundary/outside), multi-zone, deterministic behaviour under fixed uniforms, scalar↔batch parity, empty batch.
- [x] 306 existing light-dark tests pass.
- [x] Broader 3130-test sweep passes (one pre-existing pacman-visualizer golden-file failure is unrelated and present on `origin/develop`).
- [x] `python -m pyright POMDPPlanners/` → 0 errors (1 pre-existing warning at `environment.py:345` unrelated to this PR).
- [x] `python -m pylint` on touched files → 10.00/10.