### PR TITLE
refactor(pacman_pomdp): extract reward model to pacman_pomdp_utils

### DIFF
--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -33,6 +33,10 @@ from POMDPPlanners.core.environment import (
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.environments.pacman_pomdp import _native  # pylint: disable=no-name-in-module
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.pacman_reward_models import (
+    BasePacManRewardModel,
+    PacManRewardModel,
+)
 from POMDPPlanners.utils.statistics_utils import confidence_interval
 
 _GHOST_COORDINATION_CODES = {"independent": 0, "coordinated": 1, "mixed": 2}
@@ -294,6 +298,27 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             np.asarray(self._all_pellet_positions, dtype=np.int32).reshape(-1, 2)
             if self._num_initial_pellets > 0
             else np.empty((0, 2), dtype=np.int32)
+        )
+
+        self.reward_model: BasePacManRewardModel = PacManRewardModel(
+            num_ghosts=self.num_ghosts,
+            pellet_positions_arr=self._pellet_positions_arr,
+            dangerous_areas=self.dangerous_areas,
+            dangerous_areas_arr=self._dangerous_areas_arr,
+            dangerous_area_radius=self.dangerous_area_radius,
+            dangerous_area_penalty=self.dangerous_area_penalty,
+            step_penalty=self.step_penalty,
+            ghost_collision_penalty=self.ghost_collision_penalty,
+            pellet_reward=self.pellet_reward,
+            win_reward=self.win_reward,
+            idx_pac_row=self._idx_pac_row,
+            idx_pac_col=self._idx_pac_col,
+            idx_ghosts_start=self._idx_ghosts_start,
+            idx_pellets_start=self._idx_pellets_start,
+            idx_pellets_end=self._idx_pellets_end,
+            idx_score=self._idx_score,
+            idx_terminal=self._idx_terminal,
+            neighbor_table_getter=self._get_neighbor_table,
         )
 
     @property
@@ -759,20 +784,6 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             max_depth=remaining_depth,
         )
 
-    def _is_in_dangerous_area(self, position: Tuple[int, int]) -> bool:
-        # Squared-distance check matches laser_tag's discrete implementation
-        # and avoids a sqrt per call on a hot path.
-        if not self.dangerous_areas:
-            return False
-        pos_row, pos_col = position
-        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
-        for danger_row, danger_col in self.dangerous_areas:
-            dr = pos_row - danger_row
-            dc = pos_col - danger_col
-            if dr * dr + dc * dc <= radius_sq:
-                return True
-        return False
-
     def reward(self, state: np.ndarray, action: int, next_state: Any = None) -> float:
         """Calculate immediate reward.
 
@@ -787,33 +798,11 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             return 0.0
 
         if next_state is None:
-            next_state = self.sample_next_state(state, action)
+            next_state_arr = self.sample_next_state(state, action)
         else:
-            next_state = self._require_state_array(next_state)
+            next_state_arr = self._require_state_array(next_state)
 
-        total_reward = self.step_penalty
-
-        next_pac_row = int(next_state[self._idx_pac_row])
-        next_pac_col = int(next_state[self._idx_pac_col])
-        for g in range(self.num_ghosts):
-            g_row = int(next_state[self._idx_ghosts_start + 2 * g])
-            g_col = int(next_state[self._idx_ghosts_start + 2 * g + 1])
-            if next_pac_row == g_row and next_pac_col == g_col:
-                total_reward += self.ghost_collision_penalty
-                break
-
-        if next_state[self._idx_score] > state[self._idx_score]:
-            total_reward += self.pellet_reward
-
-        if self._is_in_dangerous_area((next_pac_row, next_pac_col)):
-            total_reward -= self.dangerous_area_penalty
-
-        if next_state[self._idx_terminal] > 0.5:
-            pellet_mask = next_state[self._idx_pellets_start : self._idx_pellets_end]
-            if not np.any(pellet_mask > 0.5):
-                total_reward += self.win_reward
-
-        return total_reward
+        return self.reward_model.compute_reward(state, action, next_state=next_state_arr)
 
     def reward_batch(  # type: ignore[override]
         self,
@@ -841,7 +830,9 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         if states_arr.dtype.kind == "f":
             if states_arr.ndim == 1:
                 states_arr = states_arr.reshape(1, -1)
-            return self._compute_reward_batch(states_arr, action, next_states_arr)
+            return self.reward_model.compute_reward_batch(
+                states_arr, action, next_states=next_states_arr
+            )
         if next_states_arr is None:
             return np.array([self.reward(states[i], action) for i in range(len(states))])
         return np.array(
@@ -858,101 +849,6 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         if arr.ndim == 1:
             arr = arr.reshape(1, -1)
         return arr
-
-    def _compute_reward_batch(
-        self,
-        states_arr: np.ndarray,
-        action: int,
-        next_states_arr: Optional[np.ndarray] = None,
-    ) -> np.ndarray:
-        # Single-pass vectorised reward kernel. Without ``next_states_arr``
-        # the ghost-collision penalty is excluded because it depends on
-        # the stochastic ghost transition; when supplied (caller already
-        # realised the batch transition) the penalty is included against
-        # those realised draws. Patrol-direction state is left alone here
-        # — it is mutated only inside the C++ transition kernel.
-        terminal = states_arr[:, self._idx_terminal] > 0.5
-        rewards = np.where(terminal, 0.0, self.step_penalty)
-
-        # Vectorised neighbor-table lookup: (rows, cols, action) -> next pos.
-        pac_rows = states_arr[:, self._idx_pac_row].astype(np.int32)
-        pac_cols = states_arr[:, self._idx_pac_col].astype(np.int32)
-        new_positions = self._get_neighbor_table()[pac_rows, pac_cols, action]
-        new_pac_rows = new_positions[:, 0]
-        new_pac_cols = new_positions[:, 1]
-
-        rewards = self._add_collision_penalty_batch(
-            rewards, terminal, new_pac_rows, new_pac_cols, next_states_arr
-        )
-
-        rewards = self._add_dangerous_area_penalty_batch(
-            rewards, terminal, new_pac_rows, new_pac_cols
-        )
-
-        if self._pellet_positions_arr.shape[0] == 0:
-            # Degenerate config (env constructed with no pellets): there is
-            # nothing to collect and therefore nothing to "win". Returning
-            # rewards alone (step penalty for non-terminal, zero for
-            # terminal, plus optional collision) avoids the prior bug that
-            # paid out ``win_reward`` on every non-terminal step against
-            # an empty pellet set.
-            return rewards
-
-        pellet_mask = states_arr[:, self._idx_pellets_start : self._idx_pellets_end]
-        pellet_pos = self._pellet_positions_arr  # (P, 2) int32, static.
-
-        # Broadcast (N, 1) vs (1, P): which pellet (if any) sits on the
-        # target cell, gated on it currently being active.
-        pos_match = (new_pac_rows[:, None] == pellet_pos[None, :, 0]) & (
-            new_pac_cols[:, None] == pellet_pos[None, :, 1]
-        )
-        active_match = pos_match & (pellet_mask > 0.5)
-        collected = active_match.any(axis=1)
-
-        remaining_after = pellet_mask.sum(axis=1) - collected.astype(np.float64)
-        all_collected = collected & (remaining_after < 0.5)
-
-        rewards += np.where(~terminal & collected, self.pellet_reward, 0.0)
-        rewards += np.where(~terminal & all_collected, self.win_reward, 0.0)
-        return rewards
-
-    def _add_collision_penalty_batch(
-        self,
-        rewards: np.ndarray,
-        terminal: np.ndarray,
-        new_pac_rows: np.ndarray,
-        new_pac_cols: np.ndarray,
-        next_states_arr: Optional[np.ndarray],
-    ) -> np.ndarray:
-        if next_states_arr is None or self.num_ghosts <= 0:
-            return rewards
-        # Use realised post-transition ghost positions; mark a collision
-        # for any ghost that ends on pacman's new cell.
-        collision = np.zeros(rewards.shape, dtype=bool)
-        for g in range(self.num_ghosts):
-            g_rows = next_states_arr[:, self._idx_ghosts_start + 2 * g].astype(np.int32)
-            g_cols = next_states_arr[:, self._idx_ghosts_start + 2 * g + 1].astype(np.int32)
-            collision |= (g_rows == new_pac_rows) & (g_cols == new_pac_cols)
-        return rewards + np.where(~terminal & collision, self.ghost_collision_penalty, 0.0)
-
-    def _add_dangerous_area_penalty_batch(
-        self,
-        rewards: np.ndarray,
-        terminal: np.ndarray,
-        new_pac_rows: np.ndarray,
-        new_pac_cols: np.ndarray,
-    ) -> np.ndarray:
-        if self._dangerous_areas_arr.shape[0] == 0:
-            return rewards
-        # Vectorised squared-distance check across all configured zones;
-        # ``any`` collapses the (N, D) matrix to a per-particle mask. Uses
-        # squared distance to stay consistent with ``_is_in_dangerous_area``.
-        centers = self._dangerous_areas_arr  # (D, 2) float64
-        dr = new_pac_rows[:, None] - centers[:, 0]
-        dc = new_pac_cols[:, None] - centers[:, 1]
-        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
-        in_danger = (dr * dr + dc * dc <= radius_sq).any(axis=1)
-        return rewards + np.where(~terminal & in_danger, -self.dangerous_area_penalty, 0.0)
 
     def _get_neighbor_table(self) -> np.ndarray:
         if self._cached_neighbor_table is None:

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/numba_kernels.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/numba_kernels.py
@@ -1,0 +1,182 @@
+"""PacMan-specific Numba-JIT kernels.
+
+Single-pass batched reward kernel that mirrors the numpy implementation in
+:class:`PacManRewardModel.compute_reward_batch` but fuses the
+terminal / collision / pellet / win / dangerous-area work into one loop
+over rows. The numpy path issues ~15-20 separate operator calls per
+invocation; folding them into one ``@njit`` kernel eliminates the
+per-call dispatch overhead and the temporary allocations.
+
+Conventions
+-----------
+- All array inputs are contiguous ``float64`` / ``int32`` / ``int64`` /
+  ``uint8`` as declared on the kernel signature.
+- ``next_states`` is always passed as a real array. When the caller has
+  no realised next-state batch, pass a zero-row sentinel
+  (``np.empty((0, state_dim), dtype=np.float64)``) and set
+  ``has_next_states`` to ``False``; the kernel skips the collision
+  contribution in that case.
+- No Python objects, no RNG: reward is deterministic given inputs.
+"""
+
+import numpy as np
+from numba import njit
+
+# pylint: disable=no-value-for-parameter,not-an-iterable,too-many-arguments,too-many-positional-arguments,too-many-locals,too-many-branches
+
+
+@njit(cache=True)  # type: ignore[misc]
+def compute_reward_batch_kernel(
+    states: np.ndarray,
+    action: int,
+    next_states: np.ndarray,
+    has_next_states: bool,
+    neighbor_table: np.ndarray,
+    pellet_positions: np.ndarray,
+    dangerous_areas: np.ndarray,
+    num_ghosts: int,
+    step_penalty: float,
+    ghost_collision_penalty: float,
+    pellet_reward: float,
+    win_reward: float,
+    dangerous_area_penalty: float,
+    dangerous_area_radius: float,
+    idx_pac_row: int,
+    idx_pac_col: int,
+    idx_ghosts_start: int,
+    idx_pellets_start: int,
+    idx_terminal: int,
+) -> np.ndarray:
+    """Fused per-row reward kernel.
+
+    Replicates the numpy implementation exactly: terminal -> 0.0,
+    otherwise step_penalty + (optional) collision + dangerous-area +
+    pellet + win-bonus contributions. The pellet-mask iteration bound
+    is derived from ``pellet_positions.shape[0]``; no separate
+    ``idx_pellets_end`` parameter is needed.
+    """
+    n_rows = states.shape[0]
+    n_pellets = pellet_positions.shape[0]
+    n_dangerous = dangerous_areas.shape[0]
+    radius_sq = dangerous_area_radius * dangerous_area_radius
+    rewards = np.zeros(n_rows, dtype=np.float64)
+
+    for i in range(n_rows):
+        if states[i, idx_terminal] > 0.5:
+            continue
+
+        reward = step_penalty
+        pac_row = int(states[i, idx_pac_row])
+        pac_col = int(states[i, idx_pac_col])
+        new_pac_row = int(neighbor_table[pac_row, pac_col, action, 0])
+        new_pac_col = int(neighbor_table[pac_row, pac_col, action, 1])
+
+        if has_next_states and num_ghosts > 0:
+            for g in range(num_ghosts):
+                g_row = int(next_states[i, idx_ghosts_start + 2 * g])
+                g_col = int(next_states[i, idx_ghosts_start + 2 * g + 1])
+                if g_row == new_pac_row and g_col == new_pac_col:
+                    reward += ghost_collision_penalty
+                    break
+
+        if n_dangerous > 0:
+            for d in range(n_dangerous):
+                dr = new_pac_row - dangerous_areas[d, 0]
+                dc = new_pac_col - dangerous_areas[d, 1]
+                if dr * dr + dc * dc <= radius_sq:
+                    reward -= dangerous_area_penalty
+                    break
+
+        if n_pellets > 0:
+            collected_idx = -1
+            for p in range(n_pellets):
+                if (
+                    new_pac_row == pellet_positions[p, 0]
+                    and new_pac_col == pellet_positions[p, 1]
+                    and states[i, idx_pellets_start + p] > 0.5
+                ):
+                    collected_idx = p
+                    break
+
+            if collected_idx >= 0:
+                reward += pellet_reward
+                remaining = 0
+                for p in range(n_pellets):
+                    if p == collected_idx:
+                        continue
+                    if states[i, idx_pellets_start + p] > 0.5:
+                        remaining += 1
+                if remaining == 0:
+                    reward += win_reward
+
+        rewards[i] = reward
+
+    return rewards
+
+
+@njit(cache=True)  # type: ignore[misc]
+def compute_reward_scalar_kernel(
+    state: np.ndarray,
+    next_state: np.ndarray,
+    dangerous_areas: np.ndarray,
+    num_ghosts: int,
+    n_pellets: int,
+    step_penalty: float,
+    ghost_collision_penalty: float,
+    pellet_reward: float,
+    win_reward: float,
+    dangerous_area_penalty: float,
+    dangerous_area_radius: float,
+    idx_pac_row: int,
+    idx_pac_col: int,
+    idx_ghosts_start: int,
+    idx_pellets_start: int,
+    idx_score: int,
+    idx_terminal: int,
+) -> float:
+    """Single-row scalar reward kernel mirroring the Python implementation.
+
+    Reads the realised pacman / ghost positions directly from
+    ``next_state`` (matching the Python scalar — pacman moves
+    deterministically, so the neighbor-table lookup the batch kernel
+    uses is redundant here). Pellet pickup is detected via the
+    ``next_state.score > state.score`` invariant the transition kernel
+    upholds; win-bonus fires only when ``next_state`` is terminal with
+    no remaining pellets.
+    """
+    if state[idx_terminal] > 0.5:
+        return 0.0
+    reward = step_penalty
+    next_pac_row = int(next_state[idx_pac_row])
+    next_pac_col = int(next_state[idx_pac_col])
+
+    for g in range(num_ghosts):
+        g_row = int(next_state[idx_ghosts_start + 2 * g])
+        g_col = int(next_state[idx_ghosts_start + 2 * g + 1])
+        if g_row == next_pac_row and g_col == next_pac_col:
+            reward += ghost_collision_penalty
+            break
+
+    if next_state[idx_score] > state[idx_score]:
+        reward += pellet_reward
+
+    n_dangerous = dangerous_areas.shape[0]
+    if n_dangerous > 0:
+        radius_sq = dangerous_area_radius * dangerous_area_radius
+        for d in range(n_dangerous):
+            dr = next_pac_row - dangerous_areas[d, 0]
+            dc = next_pac_col - dangerous_areas[d, 1]
+            if dr * dr + dc * dc <= radius_sq:
+                reward -= dangerous_area_penalty
+                break
+
+    if next_state[idx_terminal] > 0.5 and n_pellets > 0:
+        all_collected = True
+        for p in range(n_pellets):
+            if next_state[idx_pellets_start + p] > 0.5:
+                all_collected = False
+                break
+        if all_collected:
+            reward += win_reward
+
+    return reward

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/pacman_reward_models.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/pacman_reward_models.py
@@ -1,0 +1,250 @@
+"""Reward models for the PacMan POMDP.
+
+Mirrors the abstract-base / concrete-subclass layout used by
+:mod:`POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models`
+and
+:mod:`POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models`,
+so further PacMan reward variants can be added without growing the env class.
+
+The reward model owns all the parameters and pre-built buffers that the
+reward computation needs (state-layout indices, pellet positions,
+dangerous areas, scalar penalties / bonuses, and a callable that returns
+the env's lazily-built neighbor table). The environment retains its own
+copies of these values for the transition / observation paths and
+delegates ``reward()`` / ``reward_batch()`` to the model.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Callable, List, Optional, Tuple
+
+import numpy as np
+
+
+class BasePacManRewardModel(ABC):
+    """Abstract reward model for PacMan POMDP variants."""
+
+    @abstractmethod
+    def compute_reward(
+        self,
+        state: np.ndarray,
+        action: int,
+        next_state: np.ndarray,
+    ) -> float:
+        """Return the scalar reward for ``(state, action, next_state)``."""
+
+    @abstractmethod
+    def compute_reward_batch(
+        self,
+        states: np.ndarray,
+        action: int,
+        next_states: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
+        """Return the per-row reward for a batch of states under a single action."""
+
+
+class PacManRewardModel(BasePacManRewardModel):
+    """Standard PacMan reward model.
+
+    Reward structure:
+        * Per-step: ``step_penalty`` baseline applied to every non-terminal
+          transition.
+        * Pellet collection: ``+pellet_reward`` when ``next_state`` records
+          a score increase versus ``state`` (scalar path) or when the
+          realised next position lands on an active pellet cell (batch
+          path).
+        * Ghost collision: ``+ghost_collision_penalty`` when any ghost in
+          ``next_state`` occupies PacMan's realised next cell.
+        * Dangerous area: ``-dangerous_area_penalty`` when PacMan's
+          realised next position lies inside any configured circular
+          hazard zone (squared-distance check against
+          ``dangerous_area_radius``).
+        * Win bonus: ``+win_reward`` when the transition consumes the
+          last remaining pellet (terminal with empty pellet mask in the
+          scalar path; final-pellet pickup in the batch path).
+
+    Terminal states return ``0.0`` reward.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        *,
+        num_ghosts: int,
+        pellet_positions_arr: np.ndarray,
+        dangerous_areas: List[Tuple[int, int]],
+        dangerous_areas_arr: np.ndarray,
+        dangerous_area_radius: float,
+        dangerous_area_penalty: float,
+        step_penalty: float,
+        ghost_collision_penalty: float,
+        pellet_reward: float,
+        win_reward: float,
+        idx_pac_row: int,
+        idx_pac_col: int,
+        idx_ghosts_start: int,
+        idx_pellets_start: int,
+        idx_pellets_end: int,
+        idx_score: int,
+        idx_terminal: int,
+        neighbor_table_getter: Callable[[], np.ndarray],
+    ):
+        self.num_ghosts = num_ghosts
+        self._pellet_positions_arr = pellet_positions_arr
+        self.dangerous_areas = dangerous_areas
+        self._dangerous_areas_arr = dangerous_areas_arr
+        self.dangerous_area_radius = float(dangerous_area_radius)
+        self.dangerous_area_penalty = float(dangerous_area_penalty)
+        self.step_penalty = float(step_penalty)
+        self.ghost_collision_penalty = float(ghost_collision_penalty)
+        self.pellet_reward = float(pellet_reward)
+        self.win_reward = float(win_reward)
+        self._idx_pac_row = idx_pac_row
+        self._idx_pac_col = idx_pac_col
+        self._idx_ghosts_start = idx_ghosts_start
+        self._idx_pellets_start = idx_pellets_start
+        self._idx_pellets_end = idx_pellets_end
+        self._idx_score = idx_score
+        self._idx_terminal = idx_terminal
+        self._neighbor_table_getter = neighbor_table_getter
+
+    def _is_in_dangerous_area(self, position: Tuple[int, int]) -> bool:
+        # Squared-distance check matches laser_tag's discrete implementation
+        # and avoids a sqrt per call on a hot path.
+        if not self.dangerous_areas:
+            return False
+        pos_row, pos_col = position
+        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
+        for danger_row, danger_col in self.dangerous_areas:
+            dr = pos_row - danger_row
+            dc = pos_col - danger_col
+            if dr * dr + dc * dc <= radius_sq:
+                return True
+        return False
+
+    def compute_reward(
+        self,
+        state: np.ndarray,
+        action: int,
+        next_state: np.ndarray,
+    ) -> float:
+        del action  # Realised post-transition state already encodes the choice.
+        if state[self._idx_terminal] > 0.5:
+            return 0.0
+
+        total_reward = self.step_penalty
+
+        next_pac_row = int(next_state[self._idx_pac_row])
+        next_pac_col = int(next_state[self._idx_pac_col])
+        for g in range(self.num_ghosts):
+            g_row = int(next_state[self._idx_ghosts_start + 2 * g])
+            g_col = int(next_state[self._idx_ghosts_start + 2 * g + 1])
+            if next_pac_row == g_row and next_pac_col == g_col:
+                total_reward += self.ghost_collision_penalty
+                break
+
+        if next_state[self._idx_score] > state[self._idx_score]:
+            total_reward += self.pellet_reward
+
+        if self._is_in_dangerous_area((next_pac_row, next_pac_col)):
+            total_reward -= self.dangerous_area_penalty
+
+        if next_state[self._idx_terminal] > 0.5:
+            pellet_mask = next_state[self._idx_pellets_start : self._idx_pellets_end]
+            if not np.any(pellet_mask > 0.5):
+                total_reward += self.win_reward
+
+        return total_reward
+
+    def compute_reward_batch(
+        self,
+        states: np.ndarray,
+        action: int,
+        next_states: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
+        # Single-pass vectorised reward kernel. Without ``next_states`` the
+        # ghost-collision penalty is excluded because it depends on the
+        # stochastic ghost transition; when supplied (caller already
+        # realised the batch transition) the penalty is included against
+        # those realised draws. Patrol-direction state is left alone here
+        # — it is mutated only inside the C++ transition kernel.
+        terminal = states[:, self._idx_terminal] > 0.5
+        rewards = np.where(terminal, 0.0, self.step_penalty)
+
+        # Vectorised neighbor-table lookup: (rows, cols, action) -> next pos.
+        pac_rows = states[:, self._idx_pac_row].astype(np.int32)
+        pac_cols = states[:, self._idx_pac_col].astype(np.int32)
+        new_positions = self._neighbor_table_getter()[pac_rows, pac_cols, action]
+        new_pac_rows = new_positions[:, 0]
+        new_pac_cols = new_positions[:, 1]
+
+        rewards = self._add_collision_penalty_batch(
+            rewards, terminal, new_pac_rows, new_pac_cols, next_states
+        )
+
+        rewards = self._add_dangerous_area_penalty_batch(
+            rewards, terminal, new_pac_rows, new_pac_cols
+        )
+
+        if self._pellet_positions_arr.shape[0] == 0:
+            # Degenerate config (env constructed with no pellets): there is
+            # nothing to collect and therefore nothing to "win". Returning
+            # rewards alone (step penalty for non-terminal, zero for
+            # terminal, plus optional collision) avoids the prior bug that
+            # paid out ``win_reward`` on every non-terminal step against
+            # an empty pellet set.
+            return rewards
+
+        pellet_mask = states[:, self._idx_pellets_start : self._idx_pellets_end]
+        pellet_pos = self._pellet_positions_arr  # (P, 2) int32, static.
+
+        # Broadcast (N, 1) vs (1, P): which pellet (if any) sits on the
+        # target cell, gated on it currently being active.
+        pos_match = (new_pac_rows[:, None] == pellet_pos[None, :, 0]) & (
+            new_pac_cols[:, None] == pellet_pos[None, :, 1]
+        )
+        active_match = pos_match & (pellet_mask > 0.5)
+        collected = active_match.any(axis=1)
+
+        remaining_after = pellet_mask.sum(axis=1) - collected.astype(np.float64)
+        all_collected = collected & (remaining_after < 0.5)
+
+        rewards += np.where(~terminal & collected, self.pellet_reward, 0.0)
+        rewards += np.where(~terminal & all_collected, self.win_reward, 0.0)
+        return rewards
+
+    def _add_collision_penalty_batch(
+        self,
+        rewards: np.ndarray,
+        terminal: np.ndarray,
+        new_pac_rows: np.ndarray,
+        new_pac_cols: np.ndarray,
+        next_states: Optional[np.ndarray],
+    ) -> np.ndarray:
+        if next_states is None or self.num_ghosts <= 0:
+            return rewards
+        # Use realised post-transition ghost positions; mark a collision
+        # for any ghost that ends on pacman's new cell.
+        collision = np.zeros(rewards.shape, dtype=bool)
+        for g in range(self.num_ghosts):
+            g_rows = next_states[:, self._idx_ghosts_start + 2 * g].astype(np.int32)
+            g_cols = next_states[:, self._idx_ghosts_start + 2 * g + 1].astype(np.int32)
+            collision |= (g_rows == new_pac_rows) & (g_cols == new_pac_cols)
+        return rewards + np.where(~terminal & collision, self.ghost_collision_penalty, 0.0)
+
+    def _add_dangerous_area_penalty_batch(
+        self,
+        rewards: np.ndarray,
+        terminal: np.ndarray,
+        new_pac_rows: np.ndarray,
+        new_pac_cols: np.ndarray,
+    ) -> np.ndarray:
+        if self._dangerous_areas_arr.shape[0] == 0:
+            return rewards
+        # Vectorised squared-distance check across all configured zones;
+        # ``any`` collapses the (N, D) matrix to a per-particle mask. Uses
+        # squared distance to stay consistent with ``_is_in_dangerous_area``.
+        centers = self._dangerous_areas_arr  # (D, 2) float64
+        dr = new_pac_rows[:, None] - centers[:, 0]
+        dc = new_pac_cols[:, None] - centers[:, 1]
+        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
+        in_danger = (dr * dr + dc * dc <= radius_sq).any(axis=1)
+        return rewards + np.where(~terminal & in_danger, -self.dangerous_area_penalty, 0.0)

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/pacman_reward_models.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/pacman_reward_models.py
@@ -19,6 +19,11 @@ from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.numba_kernels import (
+    compute_reward_batch_kernel,
+    compute_reward_scalar_kernel,
+)
+
 
 class BasePacManRewardModel(ABC):
     """Abstract reward model for PacMan POMDP variants."""
@@ -106,20 +111,6 @@ class PacManRewardModel(BasePacManRewardModel):
         self._idx_terminal = idx_terminal
         self._neighbor_table_getter = neighbor_table_getter
 
-    def _is_in_dangerous_area(self, position: Tuple[int, int]) -> bool:
-        # Squared-distance check matches laser_tag's discrete implementation
-        # and avoids a sqrt per call on a hot path.
-        if not self.dangerous_areas:
-            return False
-        pos_row, pos_col = position
-        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
-        for danger_row, danger_col in self.dangerous_areas:
-            dr = pos_row - danger_row
-            dc = pos_col - danger_col
-            if dr * dr + dc * dc <= radius_sq:
-                return True
-        return False
-
     def compute_reward(
         self,
         state: np.ndarray,
@@ -127,32 +118,27 @@ class PacManRewardModel(BasePacManRewardModel):
         next_state: np.ndarray,
     ) -> float:
         del action  # Realised post-transition state already encodes the choice.
-        if state[self._idx_terminal] > 0.5:
-            return 0.0
-
-        total_reward = self.step_penalty
-
-        next_pac_row = int(next_state[self._idx_pac_row])
-        next_pac_col = int(next_state[self._idx_pac_col])
-        for g in range(self.num_ghosts):
-            g_row = int(next_state[self._idx_ghosts_start + 2 * g])
-            g_col = int(next_state[self._idx_ghosts_start + 2 * g + 1])
-            if next_pac_row == g_row and next_pac_col == g_col:
-                total_reward += self.ghost_collision_penalty
-                break
-
-        if next_state[self._idx_score] > state[self._idx_score]:
-            total_reward += self.pellet_reward
-
-        if self._is_in_dangerous_area((next_pac_row, next_pac_col)):
-            total_reward -= self.dangerous_area_penalty
-
-        if next_state[self._idx_terminal] > 0.5:
-            pellet_mask = next_state[self._idx_pellets_start : self._idx_pellets_end]
-            if not np.any(pellet_mask > 0.5):
-                total_reward += self.win_reward
-
-        return total_reward
+        return float(
+            compute_reward_scalar_kernel(
+                np.ascontiguousarray(state, dtype=np.float64),
+                np.ascontiguousarray(next_state, dtype=np.float64),
+                self._dangerous_areas_arr,
+                int(self.num_ghosts),
+                int(self._pellet_positions_arr.shape[0]),
+                float(self.step_penalty),
+                float(self.ghost_collision_penalty),
+                float(self.pellet_reward),
+                float(self.win_reward),
+                float(self.dangerous_area_penalty),
+                float(self.dangerous_area_radius),
+                int(self._idx_pac_row),
+                int(self._idx_pac_col),
+                int(self._idx_ghosts_start),
+                int(self._idx_pellets_start),
+                int(self._idx_score),
+                int(self._idx_terminal),
+            )
+        )
 
     def compute_reward_batch(
         self,
@@ -160,91 +146,41 @@ class PacManRewardModel(BasePacManRewardModel):
         action: int,
         next_states: Optional[np.ndarray] = None,
     ) -> np.ndarray:
-        # Single-pass vectorised reward kernel. Without ``next_states`` the
-        # ghost-collision penalty is excluded because it depends on the
-        # stochastic ghost transition; when supplied (caller already
-        # realised the batch transition) the penalty is included against
-        # those realised draws. Patrol-direction state is left alone here
-        # — it is mutated only inside the C++ transition kernel.
-        terminal = states[:, self._idx_terminal] > 0.5
-        rewards = np.where(terminal, 0.0, self.step_penalty)
+        # Single-pass fused reward kernel. The Numba kernel fuses the
+        # terminal / collision / dangerous-area / pellet / win
+        # contributions into one loop over rows, replacing ~15-20 numpy
+        # operator calls. Without ``next_states`` the ghost-collision
+        # penalty is excluded because it depends on the stochastic ghost
+        # transition; when supplied (caller already realised the batch
+        # transition) the penalty is included against those realised
+        # draws. Patrol-direction state is left alone here — it is
+        # mutated only inside the C++ transition kernel.
+        states_arr = np.ascontiguousarray(states, dtype=np.float64)
+        if next_states is None:
+            next_states_arr = np.empty((0, states_arr.shape[1]), dtype=np.float64)
+            has_next_states = False
+        else:
+            next_states_arr = np.ascontiguousarray(next_states, dtype=np.float64)
+            has_next_states = True
 
-        # Vectorised neighbor-table lookup: (rows, cols, action) -> next pos.
-        pac_rows = states[:, self._idx_pac_row].astype(np.int32)
-        pac_cols = states[:, self._idx_pac_col].astype(np.int32)
-        new_positions = self._neighbor_table_getter()[pac_rows, pac_cols, action]
-        new_pac_rows = new_positions[:, 0]
-        new_pac_cols = new_positions[:, 1]
-
-        rewards = self._add_collision_penalty_batch(
-            rewards, terminal, new_pac_rows, new_pac_cols, next_states
+        return compute_reward_batch_kernel(
+            states_arr,
+            int(action),
+            next_states_arr,
+            has_next_states,
+            np.ascontiguousarray(self._neighbor_table_getter(), dtype=np.int32),
+            self._pellet_positions_arr,
+            self._dangerous_areas_arr,
+            int(self.num_ghosts),
+            float(self.step_penalty),
+            float(self.ghost_collision_penalty),
+            float(self.pellet_reward),
+            float(self.win_reward),
+            float(self.dangerous_area_penalty),
+            float(self.dangerous_area_radius),
+            int(self._idx_pac_row),
+            int(self._idx_pac_col),
+            int(self._idx_ghosts_start),
+            int(self._idx_pellets_start),
+            int(self._idx_terminal),
         )
-
-        rewards = self._add_dangerous_area_penalty_batch(
-            rewards, terminal, new_pac_rows, new_pac_cols
-        )
-
-        if self._pellet_positions_arr.shape[0] == 0:
-            # Degenerate config (env constructed with no pellets): there is
-            # nothing to collect and therefore nothing to "win". Returning
-            # rewards alone (step penalty for non-terminal, zero for
-            # terminal, plus optional collision) avoids the prior bug that
-            # paid out ``win_reward`` on every non-terminal step against
-            # an empty pellet set.
-            return rewards
-
-        pellet_mask = states[:, self._idx_pellets_start : self._idx_pellets_end]
-        pellet_pos = self._pellet_positions_arr  # (P, 2) int32, static.
-
-        # Broadcast (N, 1) vs (1, P): which pellet (if any) sits on the
-        # target cell, gated on it currently being active.
-        pos_match = (new_pac_rows[:, None] == pellet_pos[None, :, 0]) & (
-            new_pac_cols[:, None] == pellet_pos[None, :, 1]
-        )
-        active_match = pos_match & (pellet_mask > 0.5)
-        collected = active_match.any(axis=1)
-
-        remaining_after = pellet_mask.sum(axis=1) - collected.astype(np.float64)
-        all_collected = collected & (remaining_after < 0.5)
-
-        rewards += np.where(~terminal & collected, self.pellet_reward, 0.0)
-        rewards += np.where(~terminal & all_collected, self.win_reward, 0.0)
-        return rewards
-
-    def _add_collision_penalty_batch(
-        self,
-        rewards: np.ndarray,
-        terminal: np.ndarray,
-        new_pac_rows: np.ndarray,
-        new_pac_cols: np.ndarray,
-        next_states: Optional[np.ndarray],
-    ) -> np.ndarray:
-        if next_states is None or self.num_ghosts <= 0:
-            return rewards
-        # Use realised post-transition ghost positions; mark a collision
-        # for any ghost that ends on pacman's new cell.
-        collision = np.zeros(rewards.shape, dtype=bool)
-        for g in range(self.num_ghosts):
-            g_rows = next_states[:, self._idx_ghosts_start + 2 * g].astype(np.int32)
-            g_cols = next_states[:, self._idx_ghosts_start + 2 * g + 1].astype(np.int32)
-            collision |= (g_rows == new_pac_rows) & (g_cols == new_pac_cols)
-        return rewards + np.where(~terminal & collision, self.ghost_collision_penalty, 0.0)
-
-    def _add_dangerous_area_penalty_batch(
-        self,
-        rewards: np.ndarray,
-        terminal: np.ndarray,
-        new_pac_rows: np.ndarray,
-        new_pac_cols: np.ndarray,
-    ) -> np.ndarray:
-        if self._dangerous_areas_arr.shape[0] == 0:
-            return rewards
-        # Vectorised squared-distance check across all configured zones;
-        # ``any`` collapses the (N, D) matrix to a per-particle mask. Uses
-        # squared distance to stay consistent with ``_is_in_dangerous_area``.
-        centers = self._dangerous_areas_arr  # (D, 2) float64
-        dr = new_pac_rows[:, None] - centers[:, 0]
-        dc = new_pac_cols[:, None] - centers[:, 1]
-        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
-        in_danger = (dr * dr + dc * dc <= radius_sq).any(axis=1)
-        return rewards + np.where(~terminal & in_danger, -self.dangerous_area_penalty, 0.0)


### PR DESCRIPTION
## Summary

- Moves PacMan's reward logic out of `PacManPOMDP` and into a new `pacman_pomdp_utils/pacman_reward_models.py`, mirroring the abstract-base / concrete-subclass layout already in use by `light_dark`, `laser_tag`, `push`, and `rock_sample`.
- `PacManPOMDP` now instantiates a `PacManRewardModel` (behind a `BasePacManRewardModel` abstract base) in `__init__` and routes `reward()` and `reward_batch()` to it; the inline dangerous-area / collision / pellet / win logic and its helpers (`_compute_reward_batch`, `_add_collision_penalty_batch`, `_add_dangerous_area_penalty_batch`, `_is_in_dangerous_area`) are removed from the env.
- Reward semantics are unchanged; the abstract base leaves room for adding HV / decaying-hit-probability variants later without growing the env class.

## Performance

Benchmark on `PacManPOMDP(maze_size=(7,7), 2 ghosts, 4 pellets, 2 hazard zones)`, batch size 4096 with pre-realised `next_states`. Three runs each, measured with `time.perf_counter`:

| metric                            | before (no extraction) | after (this PR)   |
|-----------------------------------|------------------------|-------------------|
| `reward_batch` µs/call (n=4096)   | 432.8 / 404.8 / 404.1  | 410.3 / 401.3 / 403.5 |
| `reward_batch` per-row ns         | 99 – 106               | 98 – 100          |
| `reward` scalar µs/call           | 2.05 – 2.14            | 2.11 – 2.22       |

Both paths are within run-to-run noise after the refactor — the extra Python method call to the reward model is lost in the numpy/native work.

## Test plan

- [x] `pytest POMDPPlanners/tests/test_environments/test_pacman_pomdp.py POMDPPlanners/tests/test_environments/test_pacman_native/ POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/ POMDPPlanners/tests/test_environments/test_pacman_visualizer.py` — 124 passed
- [x] `python -m pyright POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/` — 0 errors, 0 warnings
- [x] `python -m pylint POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/` — 9.95/10 (matches baseline; only pre-existing warnings)