### PR TITLE
feat(rock_sample_pomdp): HV/decaying reward variants + batch acceleration

### DIFF
--- a/POMDPPlanners/environments/environment_utils/dangerous_areas_kernels.py
+++ b/POMDPPlanners/environments/environment_utils/dangerous_areas_kernels.py
@@ -47,6 +47,40 @@ from numba import njit
 
 
 @njit(cache=True)  # type: ignore[misc]
+def membership_within_radius_batch_kernel(
+    points: np.ndarray,
+    centers: np.ndarray,
+    radius_sq: float,
+) -> np.ndarray:
+    """Batched dangerous-area membership test.
+
+    Returns a length-``N`` boolean array; entry ``i`` is ``True`` iff
+    ``points[i]`` lies within ``sqrt(radius_sq)`` of *any* centre in
+    ``centers``. ``points`` is shape ``(N, 2)``, ``centers`` is shape
+    ``(2, D)`` (x on row 0, y on row 1, matching the convention of the
+    other kernels in this module).
+
+    Use this when the caller wants the in-zone mask separately from the
+    reward contribution (e.g. so it can keep RNG handling in Python and
+    preserve bit-identical seeded behaviour with a non-batched reference
+    implementation).
+    """
+    n_points = points.shape[0]
+    out = np.zeros(n_points, dtype=np.bool_)
+    n_centers = centers.shape[1]
+    for s in range(n_points):
+        x = points[s, 0]
+        y = points[s, 1]
+        for i in range(n_centers):
+            dx = x - centers[0, i]
+            dy = y - centers[1, i]
+            if dx * dx + dy * dy <= radius_sq:
+                out[s] = True
+                break
+    return out
+
+
+@njit(cache=True)  # type: ignore[misc]
 def constant_prob_penalty_kernel(
     point: np.ndarray,
     centers: np.ndarray,

--- a/POMDPPlanners/environments/rock_sample_pomdp/__init__.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/__init__.py
@@ -10,6 +10,7 @@ Classes:
 """
 
 from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import (
+    RewardModelType,
     RockSamplePOMDP,
     RockSampleState,
     create_random_rock_sample,
@@ -27,6 +28,7 @@ from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_visualizer import 
 )
 
 __all__ = [
+    "RewardModelType",
     "RockSamplePOMDP",
     "RockSampleState",
     "RockSampleVisualizer",

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -31,6 +31,8 @@ from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.environments.rock_sample_pomdp import _native
 from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_utils.rock_sample_reward_models import (
     BaseRockSampleRewardModel,
+    RockSampleDecayingHitProbabilityRewardModel,
+    RockSampleHighVarianceRewardModel,
     RockSampleRewardModel,
 )
 from POMDPPlanners.utils.statistics_utils import confidence_interval
@@ -42,6 +44,21 @@ class RockSamplePOMDPMetrics(Enum):
     AVG_ROCKS_SAMPLED = "avg_rocks_sampled"
     EXIT_SUCCESS_RATE = "exit_success_rate"
     AVERAGE_DANGEROUS_AREA_STEPS = "average_dangerous_area_steps"
+
+
+class RewardModelType(Enum):
+    """Reward-model variants for :class:`RockSamplePOMDP`.
+
+    Variants differ only in how the dangerous-area penalty is applied —
+    base scoring (exit / sample / sense / step) is identical across all
+    three. See
+    :mod:`POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_utils.rock_sample_reward_models`
+    for the per-variant semantics.
+    """
+
+    STANDARD = "standard"
+    DECAYING_HIT_PROBABILITY = "decaying_hit_probability"
+    HIGH_VARIANCE_STATES = "high_variance_states"
 
 
 # Type alias for RockSampleState
@@ -178,6 +195,8 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         dangerous_area_radius: float = 1.0,
         dangerous_area_penalty: float = -5.0,
         dangerous_area_hit_probability: float = 1.0,
+        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        penalty_decay: float = 1.0,
         discount_factor: float = 0.95,
         name: str = "RockSample",
         output_dir: Optional[Path] = None,
@@ -211,7 +230,23 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
                 reward stochastic (per-call Bernoulli draw), useful for
                 risk-sensitive planning benchmarks. Note that this makes
                 ``reward(state, action)`` non-deterministic given a
-                state-action pair.
+                state-action pair. Ignored by ``HIGH_VARIANCE_STATES``
+                and ``DECAYING_HIT_PROBABILITY`` reward models.
+            reward_model_type: Which dangerous-area penalty model to use.
+                Defaults to ``RewardModelType.STANDARD`` (legacy
+                constant-probability behaviour). ``HIGH_VARIANCE_STATES``
+                applies ``±dangerous_area_penalty`` 50/50 in-zone (zero
+                expected contribution, high variance — useful for
+                risk-sensitive planner benchmarks).
+                ``DECAYING_HIT_PROBABILITY`` applies the penalty with
+                probability ``exp(-min_dist / penalty_decay)`` based on
+                distance to the closest dangerous-area centre (no radius
+                cutoff). See
+                :class:`~POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp.RewardModelType`.
+            penalty_decay: Distance-decay constant for the
+                ``DECAYING_HIT_PROBABILITY`` reward model. Must be
+                positive. Ignored by other reward models. Defaults to
+                ``1.0``.
             discount_factor: Discount factor. Defaults to 0.95.
             name: Environment name. Defaults to "RockSample".
             output_dir: Output directory for logging. Defaults to None.
@@ -229,10 +264,21 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
                 stacklevel=2,
             )
 
-        # Calculate reward range based on parameters
-        danger_term = dangerous_area_penalty if dangerous_areas else 0.0
-        min_reward = step_penalty + bad_rock_penalty + sensor_use_penalty + min(0.0, danger_term)
-        max_reward = step_penalty + exit_reward + max(0.0, danger_term)
+        # Calculate reward range based on parameters. HIGH_VARIANCE_STATES
+        # can flip the sign of the dangerous-area contribution, so its
+        # effective danger term spans ``[-|penalty|, +|penalty|]``.
+        if dangerous_areas:
+            if reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+                danger_term_min = -abs(dangerous_area_penalty)
+                danger_term_max = abs(dangerous_area_penalty)
+            else:
+                danger_term_min = min(0.0, dangerous_area_penalty)
+                danger_term_max = max(0.0, dangerous_area_penalty)
+        else:
+            danger_term_min = 0.0
+            danger_term_max = 0.0
+        min_reward = step_penalty + bad_rock_penalty + sensor_use_penalty + danger_term_min
+        max_reward = step_penalty + exit_reward + danger_term_max
 
         space_info = SpaceInfo(
             action_space=SpaceType.DISCRETE, observation_space=SpaceType.DISCRETE
@@ -265,20 +311,10 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         self.dangerous_area_radius = dangerous_area_radius
         self.dangerous_area_penalty = dangerous_area_penalty
         self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
+        self.reward_model_type = reward_model_type
+        self.penalty_decay = float(penalty_decay)
 
-        self.reward_model: BaseRockSampleRewardModel = RockSampleRewardModel(
-            map_size=self.map_size,
-            rock_positions=self.rock_positions,
-            step_penalty=self.step_penalty,
-            bad_rock_penalty=self.bad_rock_penalty,
-            good_rock_reward=self.good_rock_reward,
-            sensor_use_penalty=self.sensor_use_penalty,
-            exit_reward=self.exit_reward,
-            dangerous_areas=self.dangerous_areas,
-            dangerous_area_radius=self.dangerous_area_radius,
-            dangerous_area_penalty=self.dangerous_area_penalty,
-            dangerous_area_hit_probability=self.dangerous_area_hit_probability,
-        )
+        self.reward_model: BaseRockSampleRewardModel = self._build_reward_model()
 
         # Validate parameters
         self._validate_parameters()
@@ -315,6 +351,30 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         # / ``_get_obs_kernel`` and reset on unpickle.
         self._trans_kernel_cache: Dict[int, Any] = {}
         self._obs_kernel_cache: Dict[int, Any] = {}
+
+    def _build_reward_model(self) -> BaseRockSampleRewardModel:
+        common_kwargs = {
+            "map_size": self.map_size,
+            "rock_positions": self.rock_positions,
+            "step_penalty": self.step_penalty,
+            "bad_rock_penalty": self.bad_rock_penalty,
+            "good_rock_reward": self.good_rock_reward,
+            "sensor_use_penalty": self.sensor_use_penalty,
+            "exit_reward": self.exit_reward,
+            "dangerous_areas": self.dangerous_areas,
+            "dangerous_area_radius": self.dangerous_area_radius,
+            "dangerous_area_penalty": self.dangerous_area_penalty,
+            "dangerous_area_hit_probability": self.dangerous_area_hit_probability,
+        }
+        if self.reward_model_type == RewardModelType.STANDARD:
+            return RockSampleRewardModel(**common_kwargs)
+        if self.reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+            return RockSampleHighVarianceRewardModel(**common_kwargs)
+        if self.reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+            return RockSampleDecayingHitProbabilityRewardModel(
+                **common_kwargs, penalty_decay=self.penalty_decay
+            )
+        raise ValueError(f"Unknown reward model type: {self.reward_model_type}")
 
     def _validate_parameters(self):
         """Validate environment parameters."""

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_utils/rock_sample_reward_models.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_utils/rock_sample_reward_models.py
@@ -7,10 +7,20 @@ and
 so that further RockSample reward variants can be added without growing
 the env class.
 
-The reward model owns the parameters that the reward computation needs
-(rock positions, dangerous areas, per-action rewards). The environment
-retains its own parameter copies for the transition / observation paths
-and delegates ``reward()`` / ``reward_batch()`` to the model.
+Three concrete variants are provided. They share all of the
+non-dangerous-area scoring (exit, sample, sense, step-penalty) via the
+``RockSampleRewardModel`` base; each variant only customises the
+dangerous-area contribution:
+
+* :class:`RockSampleRewardModel` (STANDARD): constant-probability
+  penalty when the realised next position is in any dangerous area.
+* :class:`RockSampleHighVarianceRewardModel` (HIGH_VARIANCE_STATES):
+  ``±dangerous_area_penalty`` 50/50 in-zone — zero expected
+  contribution, high variance.
+* :class:`RockSampleDecayingHitProbabilityRewardModel`
+  (DECAYING_HIT_PROBABILITY): penalty applied with probability
+  ``exp(-min_dist / penalty_decay)`` based on the *closest* zone
+  centre — no radius cutoff.
 """
 
 import math
@@ -18,6 +28,12 @@ from abc import ABC, abstractmethod
 from typing import List, Optional, Tuple
 
 import numpy as np
+
+from POMDPPlanners.environments.environment_utils.dangerous_areas_kernels import (
+    decaying_prob_penalty_batch_kernel,
+    decaying_prob_penalty_kernel,
+    membership_within_radius_batch_kernel,
+)
 
 
 class BaseRockSampleRewardModel(ABC):
@@ -58,6 +74,10 @@ class RockSampleRewardModel(BaseRockSampleRewardModel):
 
     Note that this model uses the additive convention: pass a *negative*
     ``dangerous_area_penalty`` to penalise danger entry.
+
+    Subclasses override :meth:`_dangerous_area_contribution_scalar` and
+    :meth:`_apply_dangerous_area_contribution_batch` to express different
+    stochastic penalty models; the rest of the scoring is identical.
     """
 
     def __init__(
@@ -85,6 +105,20 @@ class RockSampleRewardModel(BaseRockSampleRewardModel):
         self.dangerous_area_radius = dangerous_area_radius
         self.dangerous_area_penalty = dangerous_area_penalty
         self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
+
+        # Pre-built (2, D) C-contiguous float64 array of dangerous-area centres
+        # consumed by the njit kernels so the hot path avoids per-call array
+        # construction. Squared radius cached so the membership kernel takes
+        # ``radius_sq`` directly.
+        if self.dangerous_areas:
+            self._dangerous_areas_xy: np.ndarray = np.ascontiguousarray(
+                np.asarray(self.dangerous_areas, dtype=np.float64).T
+            )
+        else:
+            self._dangerous_areas_xy = np.empty((2, 0), dtype=np.float64)
+        self._dangerous_area_radius_sq: float = float(
+            self.dangerous_area_radius * self.dangerous_area_radius
+        )
 
     def _is_in_dangerous_area(self, position: Tuple[int, int]) -> bool:
         """Check if a position is within any dangerous area."""
@@ -125,12 +159,7 @@ class RockSampleRewardModel(BaseRockSampleRewardModel):
             total_reward += self.sensor_use_penalty
 
         next_robot_pos = (int(next_state[0]), int(next_state[1]))
-        if self._is_in_dangerous_area(next_robot_pos):
-            if (
-                self.dangerous_area_hit_probability >= 1.0
-                or np.random.random() < self.dangerous_area_hit_probability
-            ):
-                total_reward += self.dangerous_area_penalty
+        total_reward += self._dangerous_area_contribution_scalar(next_robot_pos)
 
         return total_reward
 
@@ -173,14 +202,61 @@ class RockSampleRewardModel(BaseRockSampleRewardModel):
             next_robot_cols = next_states[:, 1].astype(int)
         else:
             next_robot_rows, next_robot_cols = self._closed_form_next_robot_pos(states, action)
-        deterministic = self.dangerous_area_hit_probability >= 1.0
-        for j in range(n):
-            if not self._is_in_dangerous_area((next_robot_rows[j], next_robot_cols[j])):
-                continue
-            if deterministic or np.random.random() < self.dangerous_area_hit_probability:
-                rewards[j] += self.dangerous_area_penalty
+
+        self._apply_dangerous_area_contribution_batch(rewards, next_robot_rows, next_robot_cols)
 
         return rewards
+
+    def _dangerous_area_contribution_scalar(self, next_robot_pos: Tuple[int, int]) -> float:
+        """Constant-probability penalty: ``+dangerous_area_penalty`` in-zone
+        with probability ``dangerous_area_hit_probability`` (deterministic
+        when ``== 1.0``), otherwise ``0.0``.
+        """
+        if not self._is_in_dangerous_area(next_robot_pos):
+            return 0.0
+        if (
+            self.dangerous_area_hit_probability >= 1.0
+            or np.random.random() < self.dangerous_area_hit_probability
+        ):
+            return self.dangerous_area_penalty
+        return 0.0
+
+    def _apply_dangerous_area_contribution_batch(
+        self,
+        rewards: np.ndarray,
+        next_robot_rows: np.ndarray,
+        next_robot_cols: np.ndarray,
+    ) -> None:
+        """Vectorised constant-probability dangerous-area contribution.
+
+        RNG stays in Python so seeded behaviour matches the per-row scalar
+        loop bit-for-bit: deterministic case draws zero uniforms;
+        stochastic case draws exactly ``in_zone.sum()`` uniforms, in
+        ascending row index order.
+        """
+        in_zone = self._compute_in_zone_mask(next_robot_rows, next_robot_cols)
+        if self.dangerous_area_hit_probability >= 1.0:
+            rewards[in_zone] += self.dangerous_area_penalty
+        else:
+            in_zone_indices = np.flatnonzero(in_zone)
+            coins = np.random.random(in_zone_indices.size)
+            hits = coins < self.dangerous_area_hit_probability
+            rewards[in_zone_indices[hits]] += self.dangerous_area_penalty
+
+    def _compute_in_zone_mask(
+        self, next_robot_rows: np.ndarray, next_robot_cols: np.ndarray
+    ) -> np.ndarray:
+        # Single allocation + cast-on-assign beats column_stack(astype, astype),
+        # which materialises two extra intermediate float64 arrays before
+        # concatenating them.
+        points = np.empty((next_robot_rows.shape[0], 2), dtype=np.float64)
+        points[:, 0] = next_robot_rows
+        points[:, 1] = next_robot_cols
+        return membership_within_radius_batch_kernel(
+            points,
+            self._dangerous_areas_xy,
+            self._dangerous_area_radius_sq,
+        )
 
     def _closed_form_next_robot_pos(
         self, states: np.ndarray, action: int
@@ -209,3 +285,120 @@ class RockSampleRewardModel(BaseRockSampleRewardModel):
         new_rows[terminal] = robot_rows[terminal]
         new_cols[terminal] = robot_cols[terminal]
         return new_rows, new_cols
+
+
+class RockSampleHighVarianceRewardModel(RockSampleRewardModel):
+    """HIGH_VARIANCE_STATES variant.
+
+    Replaces the constant-probability penalty with a 50/50 split between
+    ``+dangerous_area_penalty`` and ``-dangerous_area_penalty`` whenever
+    the realised next position is in any dangerous area. Expected
+    contribution is ``0``; variance is ``dangerous_area_penalty**2``.
+    Suitable for benchmarking risk-sensitive planners against
+    expected-value planners on identical means.
+
+    ``dangerous_area_hit_probability`` is **ignored** in this model.
+    """
+
+    def _dangerous_area_contribution_scalar(self, next_robot_pos: Tuple[int, int]) -> float:
+        if not self._is_in_dangerous_area(next_robot_pos):
+            return 0.0
+        if np.random.random() < 0.5:
+            return self.dangerous_area_penalty
+        return -self.dangerous_area_penalty
+
+    def _apply_dangerous_area_contribution_batch(
+        self,
+        rewards: np.ndarray,
+        next_robot_rows: np.ndarray,
+        next_robot_cols: np.ndarray,
+    ) -> None:
+        in_zone = self._compute_in_zone_mask(next_robot_rows, next_robot_cols)
+        in_zone_indices = np.flatnonzero(in_zone)
+        coins = np.random.random(in_zone_indices.size)
+        signs = np.where(coins < 0.5, 1.0, -1.0)
+        rewards[in_zone_indices] += signs * self.dangerous_area_penalty
+
+
+class RockSampleDecayingHitProbabilityRewardModel(RockSampleRewardModel):
+    """DECAYING_HIT_PROBABILITY variant.
+
+    Penalty is applied with probability
+    ``exp(-min_dist / penalty_decay)`` where ``min_dist`` is the
+    Euclidean distance from the realised next position to the *closest*
+    dangerous-area centre. No radius cutoff — every step risks some
+    (vanishingly small at large distance) penalty. Each call draws one
+    uniform regardless of distance, matching the existing decaying-prob
+    kernel and light-dark's analogous reward model.
+
+    ``dangerous_area_radius`` and ``dangerous_area_hit_probability`` are
+    **ignored** in this model.
+    """
+
+    def __init__(
+        self,
+        map_size: Tuple[int, int],
+        rock_positions: List[Tuple[int, int]],
+        step_penalty: float,
+        bad_rock_penalty: float,
+        good_rock_reward: float,
+        sensor_use_penalty: float,
+        exit_reward: float,
+        dangerous_areas: List[Tuple[int, int]],
+        dangerous_area_radius: float,
+        dangerous_area_penalty: float,
+        dangerous_area_hit_probability: float,
+        penalty_decay: float,
+    ):
+        super().__init__(
+            map_size=map_size,
+            rock_positions=rock_positions,
+            step_penalty=step_penalty,
+            bad_rock_penalty=bad_rock_penalty,
+            good_rock_reward=good_rock_reward,
+            sensor_use_penalty=sensor_use_penalty,
+            exit_reward=exit_reward,
+            dangerous_areas=dangerous_areas,
+            dangerous_area_radius=dangerous_area_radius,
+            dangerous_area_penalty=dangerous_area_penalty,
+            dangerous_area_hit_probability=dangerous_area_hit_probability,
+        )
+        if penalty_decay <= 0.0:
+            raise ValueError("penalty_decay must be positive")
+        self.penalty_decay = float(penalty_decay)
+
+    def _dangerous_area_contribution_scalar(self, next_robot_pos: Tuple[int, int]) -> float:
+        if not self.dangerous_areas:
+            return 0.0
+        point = np.asarray(next_robot_pos, dtype=np.float64)
+        uniform = float(np.random.random())
+        return float(
+            decaying_prob_penalty_kernel(
+                point,
+                self._dangerous_areas_xy,
+                self.dangerous_area_penalty,
+                self.penalty_decay,
+                uniform,
+            )
+        )
+
+    def _apply_dangerous_area_contribution_batch(
+        self,
+        rewards: np.ndarray,
+        next_robot_rows: np.ndarray,
+        next_robot_cols: np.ndarray,
+    ) -> None:
+        # Single allocation + cast-on-assign beats column_stack(astype, astype),
+        # which materialises two extra intermediate float64 arrays before
+        # concatenating them.
+        points = np.empty((next_robot_rows.shape[0], 2), dtype=np.float64)
+        points[:, 0] = next_robot_rows
+        points[:, 1] = next_robot_cols
+        uniforms = np.random.random(points.shape[0])
+        rewards += decaying_prob_penalty_batch_kernel(
+            points,
+            self._dangerous_areas_xy,
+            self.dangerous_area_penalty,
+            self.penalty_decay,
+            uniforms,
+        )

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/rock_sample_pomdp_utils/test_rock_sample_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/rock_sample_pomdp_utils/test_rock_sample_reward_models.py
@@ -1,0 +1,368 @@
+"""Tests for the RockSample HIGH_VARIANCE_STATES and DECAYING_HIT_PROBABILITY
+reward-model variants.
+
+The STANDARD model is exercised by the env-level parity tests in
+``test_rock_sample_pomdp.py`` / ``test_rock_sample_kernel_cache.py`` and
+is not re-tested here. These tests target only the new variants and
+their integration with :class:`RockSamplePOMDP` via the
+``reward_model_type`` enum.
+"""
+
+# pylint: disable=protected-access  # Tests reach into internal hooks for parity checks.
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.rock_sample_pomdp import (
+    RewardModelType,
+    RockSamplePOMDP,
+    create_rock_sample_state,
+)
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_utils.rock_sample_reward_models import (
+    RockSampleDecayingHitProbabilityRewardModel,
+    RockSampleHighVarianceRewardModel,
+    RockSampleRewardModel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Env-level dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_env_builds_standard_reward_model_by_default():
+    """Default ``reward_model_type`` produces a STANDARD ``RockSampleRewardModel``.
+
+    Purpose: Validates the default dispatch path through ``_build_reward_model``.
+
+    Given: A ``RockSamplePOMDP`` constructed with no explicit reward_model_type.
+    When: The env is built.
+    Then: ``env.reward_model`` is exactly a ``RockSampleRewardModel`` and not
+        one of the two new subclasses.
+
+    Test type: unit
+    """
+    env = RockSamplePOMDP(dangerous_areas=[(2, 2)])
+    assert type(env.reward_model) is RockSampleRewardModel  # pylint: disable=unidiomatic-typecheck
+
+
+def test_env_builds_high_variance_reward_model_on_request():
+    """HIGH_VARIANCE_STATES dispatch path constructs the right subclass.
+
+    Purpose: Validates that the env's reward-model factory picks the
+        high-variance subclass when asked.
+
+    Given: A ``RockSamplePOMDP`` with ``reward_model_type=HIGH_VARIANCE_STATES``.
+    When: The env is built.
+    Then: ``env.reward_model`` is a ``RockSampleHighVarianceRewardModel``
+        and the env-level reward_range spans both signs of the penalty.
+
+    Test type: unit
+    """
+    env = RockSamplePOMDP(
+        dangerous_areas=[(2, 2)],
+        dangerous_area_penalty=-5.0,
+        reward_model_type=RewardModelType.HIGH_VARIANCE_STATES,
+    )
+    assert isinstance(env.reward_model, RockSampleHighVarianceRewardModel)
+    # HIGH_VARIANCE flips the penalty sign with probability 0.5, so the
+    # reward_range must include the positive sign too.
+    assert env.reward_range is not None
+    min_r, max_r = env.reward_range
+    assert min_r <= -5.0
+    assert max_r >= 5.0
+
+
+def test_env_builds_decaying_reward_model_on_request():
+    """DECAYING_HIT_PROBABILITY dispatch path constructs the right subclass.
+
+    Purpose: Validates the env's reward-model factory picks the
+        decaying-probability subclass and threads ``penalty_decay`` through.
+
+    Given: A ``RockSamplePOMDP`` with reward_model_type=DECAYING_HIT_PROBABILITY
+        and penalty_decay=2.5.
+    When: The env is built.
+    Then: ``env.reward_model`` is a ``RockSampleDecayingHitProbabilityRewardModel``
+        with ``penalty_decay`` 2.5.
+
+    Test type: unit
+    """
+    env = RockSamplePOMDP(
+        dangerous_areas=[(2, 2)],
+        reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY,
+        penalty_decay=2.5,
+    )
+    assert isinstance(env.reward_model, RockSampleDecayingHitProbabilityRewardModel)
+    assert env.reward_model.penalty_decay == 2.5
+
+
+def test_decaying_model_rejects_non_positive_penalty_decay():
+    """Validation: ``penalty_decay`` must be > 0 for the decaying model.
+
+    Purpose: Validates the decaying-model constructor refuses zero / negative decay.
+
+    Given: A direct ``RockSampleDecayingHitProbabilityRewardModel`` build with
+        ``penalty_decay=0.0`` (and again with a negative value).
+    When: The constructor is called.
+    Then: ``ValueError`` is raised in both cases.
+
+    Test type: unit
+    """
+    with pytest.raises(ValueError, match="penalty_decay must be positive"):
+        RockSampleDecayingHitProbabilityRewardModel(
+            map_size=(5, 5),
+            rock_positions=[(0, 0)],
+            step_penalty=0.0,
+            bad_rock_penalty=-1.0,
+            good_rock_reward=10.0,
+            sensor_use_penalty=0.0,
+            exit_reward=10.0,
+            dangerous_areas=[(2, 2)],
+            dangerous_area_radius=1.0,
+            dangerous_area_penalty=-5.0,
+            dangerous_area_hit_probability=1.0,
+            penalty_decay=0.0,
+        )
+    with pytest.raises(ValueError, match="penalty_decay must be positive"):
+        RockSampleDecayingHitProbabilityRewardModel(
+            map_size=(5, 5),
+            rock_positions=[(0, 0)],
+            step_penalty=0.0,
+            bad_rock_penalty=-1.0,
+            good_rock_reward=10.0,
+            sensor_use_penalty=0.0,
+            exit_reward=10.0,
+            dangerous_areas=[(2, 2)],
+            dangerous_area_radius=1.0,
+            dangerous_area_penalty=-5.0,
+            dangerous_area_hit_probability=1.0,
+            penalty_decay=-1.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# HIGH_VARIANCE_STATES semantics
+# ---------------------------------------------------------------------------
+
+
+def _make_high_variance_env() -> RockSamplePOMDP:
+    return RockSamplePOMDP(
+        map_size=(7, 7),
+        rock_positions=[(0, 0), (2, 2), (3, 3), (5, 5)],
+        dangerous_areas=[(2, 2), (4, 4)],
+        dangerous_area_penalty=-5.0,
+        reward_model_type=RewardModelType.HIGH_VARIANCE_STATES,
+    )
+
+
+def test_high_variance_scalar_returns_zero_outside_zone():
+    """High-variance contribution is exactly zero outside any dangerous zone.
+
+    Purpose: Validates the high-variance model never adds noise when the
+        realised position is outside all dangerous areas.
+
+    Given: A high-variance env with dangerous areas at (2,2) and (4,4),
+        radius 1.0. A scalar reward call with a next_state at (0,0)
+        (which lies outside both zones).
+    When: ``compute_reward`` is invoked many times under a fixed seed.
+    Then: Every call returns the deterministic base reward (no penalty
+        sign flip) — i.e. the same value across all repetitions.
+
+    Test type: unit
+    """
+    env = _make_high_variance_env()
+    state = create_rock_sample_state((0, 0), (False, False, False, False))
+    next_state = create_rock_sample_state((0, 0), (False, False, False, False))
+
+    rewards = []
+    np.random.seed(42)
+    for _ in range(50):
+        rewards.append(env.reward_model.compute_reward(state, action=1, next_state=next_state))
+
+    assert all(r == rewards[0] for r in rewards)
+
+
+def test_high_variance_scalar_has_zero_expected_contribution_in_zone():
+    """In-zone high-variance contribution averages to ~0 over many trials.
+
+    Purpose: Validates the ±penalty 50/50 split has zero expected value.
+
+    Given: A high-variance env. A state and next_state placing the robot
+        inside a dangerous zone. Action = 1 (north, no rock/exit term).
+    When: ``compute_reward`` is invoked 2000 times under a fixed seed.
+    Then: The mean reward is within 0.5 of the (deterministic) base
+        reward, confirming the ±penalty noise averages out. The std is
+        close to ``|dangerous_area_penalty|``.
+
+    Test type: unit
+    """
+    env = _make_high_variance_env()
+    state = create_rock_sample_state((2, 2), (False, False, False, False))
+    next_state = create_rock_sample_state((2, 2), (False, False, False, False))
+
+    np.random.seed(0)
+    rewards = np.array(
+        [
+            env.reward_model.compute_reward(state, action=1, next_state=next_state)
+            for _ in range(2000)
+        ]
+    )
+
+    base_reward = env.step_penalty  # action=1 contributes only step_penalty
+    assert abs(rewards.mean() - base_reward) < 0.5
+    assert abs(rewards.std() - abs(env.dangerous_area_penalty)) < 0.5
+
+
+def test_high_variance_batch_seeded_parity_with_scalar_loop():
+    """Batch high-variance path is bit-identical to a row-by-row scalar replay.
+
+    Purpose: Validates that the vectorised batch implementation produces
+        exactly the same per-row rewards as repeatedly calling the
+        scalar ``compute_reward`` under the same seed.
+
+    Given: A high-variance env, 64 identical states all inside a
+        dangerous zone, ``next_states`` matching, action = 1.
+    When: ``compute_reward_batch`` is called once with seed=99, then the
+        same env is reseeded and each row is computed via scalar
+        ``compute_reward`` in ascending index order.
+    Then: The two reward arrays are exactly equal — confirming
+        ``np.random.random(n_in_zone)`` consumes the same uniform
+        sequence the scalar loop would.
+
+    Test type: unit
+    """
+    env = _make_high_variance_env()
+    state = create_rock_sample_state((2, 2), (False, False, False, False))
+    n = 64
+    states = np.tile(state, (n, 1)).astype(np.float64)
+    next_states = np.tile(state, (n, 1)).astype(np.float64)
+
+    np.random.seed(99)
+    batch_rewards = env.reward_model.compute_reward_batch(states, action=1, next_states=next_states)
+
+    np.random.seed(99)
+    scalar_rewards = np.array(
+        [
+            env.reward_model.compute_reward(states[i], action=1, next_state=next_states[i])
+            for i in range(n)
+        ]
+    )
+
+    np.testing.assert_array_equal(batch_rewards, scalar_rewards)
+
+
+# ---------------------------------------------------------------------------
+# DECAYING_HIT_PROBABILITY semantics
+# ---------------------------------------------------------------------------
+
+
+def _make_decaying_env(penalty_decay: float = 1.0) -> RockSamplePOMDP:
+    return RockSamplePOMDP(
+        map_size=(7, 7),
+        rock_positions=[(0, 0), (2, 2), (3, 3), (5, 5)],
+        dangerous_areas=[(3, 3)],
+        dangerous_area_penalty=-5.0,
+        reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY,
+        penalty_decay=penalty_decay,
+    )
+
+
+def test_decaying_scalar_hit_rate_decreases_with_distance():
+    """Decaying-model hit rate falls off with distance to the closest centre.
+
+    Purpose: Validates the ``exp(-dist / penalty_decay)`` gating: states
+        near a dangerous-area centre get the penalty often; far states
+        get it rarely.
+
+    Given: A decaying env with one centre at (3, 3) and penalty_decay=1.0.
+        Two next-states: one at (3, 3) (distance 0, prob 1.0) and one
+        at (6, 6) (distance ~4.24, prob ~exp(-4.24) ≈ 0.014).
+    When: 2000 scalar reward draws are taken at each next-state under a
+        fixed seed.
+    Then: Near-state hit rate > 0.9; far-state hit rate < 0.1.
+
+    Test type: unit
+    """
+    env = _make_decaying_env(penalty_decay=1.0)
+    state = create_rock_sample_state((3, 3), (False, False, False, False))
+    near = create_rock_sample_state((3, 3), (False, False, False, False))
+    far = create_rock_sample_state((6, 6), (False, False, False, False))
+
+    base_reward = env.step_penalty  # action=1 contributes only step_penalty
+    np.random.seed(7)
+    near_hits = sum(
+        env.reward_model.compute_reward(state, action=1, next_state=near) != base_reward
+        for _ in range(2000)
+    )
+    np.random.seed(7)
+    far_hits = sum(
+        env.reward_model.compute_reward(state, action=1, next_state=far) != base_reward
+        for _ in range(2000)
+    )
+
+    assert near_hits / 2000 > 0.9
+    assert far_hits / 2000 < 0.1
+
+
+def test_decaying_batch_seeded_parity_with_scalar_loop():
+    """Batch decaying-prob path matches a row-by-row scalar replay bit-identically.
+
+    Purpose: Validates that the vectorised njit-backed batch implementation
+        produces exactly the same per-row rewards as repeatedly calling the
+        scalar ``compute_reward`` under the same seed. Confirms
+        ``np.random.random(n)`` in the batch path consumes the same
+        uniform sequence the scalar loop would.
+
+    Given: A decaying env, 32 next-states at a mix of distances from the
+        centre, action = 1.
+    When: ``compute_reward_batch`` runs once with seed=11, then the same
+        env is reseeded and each row is computed via scalar
+        ``compute_reward`` in ascending index order.
+    Then: The two reward arrays are exactly equal.
+
+    Test type: unit
+    """
+    env = _make_decaying_env(penalty_decay=1.5)
+    rng_states = []
+    for r in range(7):
+        for c in range(7):
+            rng_states.append(create_rock_sample_state((r, c), (False, False, False, False)))
+    next_states = np.asarray(rng_states[:32], dtype=np.float64)
+    states = next_states.copy()
+
+    np.random.seed(11)
+    batch_rewards = env.reward_model.compute_reward_batch(states, action=1, next_states=next_states)
+
+    np.random.seed(11)
+    scalar_rewards = np.array(
+        [
+            env.reward_model.compute_reward(states[i], action=1, next_state=next_states[i])
+            for i in range(states.shape[0])
+        ]
+    )
+
+    np.testing.assert_array_equal(batch_rewards, scalar_rewards)
+
+
+def test_decaying_at_centre_always_applies_penalty():
+    """At distance zero, the decaying probability is 1.0 — penalty is certain.
+
+    Purpose: Validates the boundary case ``min_dist == 0`` of the
+        ``exp(-dist / penalty_decay)`` gating.
+
+    Given: A decaying env with one centre at (3, 3) and any positive
+        penalty_decay. A next-state exactly at (3, 3).
+    When: ``compute_reward`` is invoked 50 times under a fixed seed.
+    Then: Every call yields ``base_reward + dangerous_area_penalty``.
+
+    Test type: unit
+    """
+    env = _make_decaying_env(penalty_decay=1.0)
+    state = create_rock_sample_state((3, 3), (False, False, False, False))
+    next_state = create_rock_sample_state((3, 3), (False, False, False, False))
+
+    np.random.seed(3)
+    expected = env.step_penalty + env.dangerous_area_penalty
+    for _ in range(50):
+        r = env.reward_model.compute_reward(state, action=1, next_state=next_state)
+        assert r == expected


### PR DESCRIPTION
## Summary

- Adds two new dangerous-area reward-model variants to RockSample, mirroring the layouts already in `light_dark_pomdp` and `laser_tag_pomdp`:
  - **HIGH_VARIANCE_STATES** — ±penalty 50/50 in-zone (zero expected contribution, high variance)
  - **DECAYING_HIT_PROBABILITY** — penalty applied with probability `exp(-min_dist / penalty_decay)` based on distance to closest centre (no radius cutoff). New `penalty_decay` constructor arg.
- New `RewardModelType` enum on `RockSamplePOMDP` + `_build_reward_model()` dispatch. `reward_model_type=STANDARD` (the existing behaviour) is the default.
- Numba batch-path acceleration: new generic `membership_within_radius_batch_kernel` in `dangerous_areas_kernels.py` replaces the per-row Python dangerous-area scan in `compute_reward_batch`. RNG stays in Python so seeded behaviour matches the scalar loop **bit-identically** (deterministic: 0 draws; stochastic: `n_in_zone` draws in row-ascending order — verified by `test_*_batch_seeded_parity_with_scalar_loop` tests).
- Refactor: extracted the dangerous-area contribution into overridable hook methods (`_dangerous_area_contribution_scalar`, `_apply_dangerous_area_contribution_batch`) so variants only customise the dangerous-area branch and share the rest of the scoring.

## Runtime (env-level reward functions)

7x7 map, 4 rocks, 2 dangerous-area centres, default config. 5 repeats per case, median μs.

| Function | BEFORE | After (STANDARD) | After (HIGH_VAR) | After (DECAYING) |
|---|---:|---:|---:|---:|
| `env.reward(state, action)` | 1.87 μs | 1.93 μs | 2.25 μs | 2.91 μs |
| `env.reward_batch` N=512 | 263.3 μs | **21.1 μs** (12.5x) | 31.0 μs | 29.2 μs |
| `env.reward_batch` N=4096 | 2037.5 μs | **47.5 μs** (42.9x) | 89.1 μs | 120.0 μs |
| `env.reward_batch` N=512 (no danger) | 22.0 μs | 21.7 μs | 22.2 μs | 21.8 μs |

Scalar `env.reward` is dominated by `sample_next_state` C++ dispatch and is essentially unchanged. Variants cost ~0.3-1.0 μs more per scalar call (one extra RNG draw / decay-kernel dispatch).

## Test plan

- [x] All 180 existing rock_sample tests pass unchanged
- [x] 10 new tests in `tests/.../rock_sample_pomdp_utils/test_rock_sample_reward_models.py`:
  - Env-level dispatch for each variant (`test_env_builds_*`)
  - `penalty_decay > 0` validation
  - HIGH_VARIANCE Monte Carlo: zero contribution outside zones; in-zone mean ~ base reward; std ~ |penalty|
  - HIGH_VARIANCE bit-identical batch<->scalar seeded parity
  - DECAYING hit-rate decreases with distance (>0.9 near, <0.1 far)
  - DECAYING bit-identical batch<->scalar seeded parity
  - DECAYING at-centre always applies penalty
- [x] Pyright clean on touched files; pylint 10.00/10 on touched files