### PR TITLE
feat(push_pomdp): HighVariance + Decaying reward variants

### DIFF
--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -281,6 +281,12 @@ class ContinuousPushPOMDP(Environment):
         )
 
         self.reward_model: BasePushRewardModel = self._build_reward_model()
+        # Cache the bound method so the hot path skips ``self.reward_model``
+        # attribute lookup on each call (~50–100 ns saved per call). Only
+        # the batch path is used here; ``reward()`` re-enters
+        # ``reward_batch`` via the (1, 6) reshape wrapper, so caching the
+        # batch ref covers both entry points.
+        self._compute_reward_batch = self.reward_model.compute_reward_batch
 
     def _build_reward_model(self) -> BasePushRewardModel:
         # ``Dict[str, Any]`` opt-out is required so pyright doesn't narrow
@@ -466,7 +472,7 @@ class ContinuousPushPOMDP(Environment):
             next_states_arr = np.ascontiguousarray(
                 np.asarray(next_state, dtype=np.float64)
             ).reshape(1, -1)
-        rewards = self.reward_model.compute_reward_batch(state_arr, action_arr, next_states_arr)
+        rewards = self._compute_reward_batch(state_arr, action_arr, next_states_arr)
         return float(rewards[0])
 
     def reward_batch(
@@ -491,7 +497,7 @@ class ContinuousPushPOMDP(Environment):
             next_states_arr = np.ascontiguousarray(np.asarray(next_states, dtype=np.float64))
             if next_states_arr.ndim == 1:
                 next_states_arr = next_states_arr.reshape(1, -1)
-        return self.reward_model.compute_reward_batch(states_arr, action_arr, next_states_arr)
+        return self._compute_reward_batch(states_arr, action_arr, next_states_arr)
 
     def __getstate__(self):
         # Per-action C++ kernel cache holds pybind11 objects that aren't

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -41,7 +41,11 @@ from POMDPPlanners.environments.push_pomdp.continuous_push_geometry import (
     point_inside_aabb,
 )
 from POMDPPlanners.environments.push_pomdp.push_pomdp_utils.push_reward_models import (
+    BasePushRewardModel,
+    ContinuousPushDecayingHitProbabilityRewardModel,
+    ContinuousPushHighVarianceStatesRewardModel,
     ContinuousPushRewardModel,
+    RewardModelType,
 )
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 from POMDPPlanners.utils.statistics_utils import confidence_interval
@@ -180,6 +184,8 @@ class ContinuousPushPOMDP(Environment):
         dangerous_area_radius: float = 0.5,
         dangerous_area_penalty: float = -10.0,
         dangerous_area_hit_probability: float = 1.0,
+        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        penalty_decay: float = 1.0,
         robot_radius: float = 0.3,
         state_transition_cov_matrix: np.ndarray = np.eye(2) * 0.1,
         initial_state: Optional[np.ndarray] = None,
@@ -192,6 +198,8 @@ class ContinuousPushPOMDP(Environment):
             raise ValueError("obstacle_hit_probability must be between 0 and 1 (inclusive)")
         if not 0.0 <= dangerous_area_hit_probability <= 1.0:
             raise ValueError("dangerous_area_hit_probability must be between 0 and 1 (inclusive)")
+        if reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY and penalty_decay <= 0.0:
+            raise ValueError("penalty_decay must be strictly positive")
 
         self.grid_size = grid_size
         self.push_threshold = push_threshold
@@ -215,6 +223,8 @@ class ContinuousPushPOMDP(Environment):
         self.dangerous_area_radius = float(dangerous_area_radius)
         self.dangerous_area_penalty = float(dangerous_area_penalty)
         self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
+        self.reward_model_type = reward_model_type
+        self.penalty_decay = float(penalty_decay)
         if self.dangerous_areas:
             self._dangerous_areas_arr: np.ndarray = np.ascontiguousarray(
                 np.asarray(self.dangerous_areas, dtype=np.float64).reshape(-1, 2)
@@ -270,16 +280,32 @@ class ContinuousPushPOMDP(Environment):
             use_queue_logger=use_queue_logger,
         )
 
-        self.reward_model: ContinuousPushRewardModel = ContinuousPushRewardModel(
-            obstacles=self.obstacles,
-            robot_radius=self.robot_radius,
-            obstacle_penalty=self.obstacle_penalty,
-            obstacle_hit_probability=self.obstacle_hit_probability,
-            dangerous_areas_arr=self._dangerous_areas_arr,
-            dangerous_area_radius=self.dangerous_area_radius,
-            dangerous_area_penalty=self.dangerous_area_penalty,
-            dangerous_area_hit_probability=self.dangerous_area_hit_probability,
-        )
+        self.reward_model: BasePushRewardModel = self._build_reward_model()
+
+    def _build_reward_model(self) -> BasePushRewardModel:
+        # ``Dict[str, Any]`` opt-out is required so pyright doesn't narrow
+        # the value type to ``ndarray | float`` (the lub of obstacles +
+        # scalars) and then reject the ``**`` unpack as incompatible with
+        # each reward-model __init__'s typed parameters.
+        common_kwargs: Dict[str, Any] = {
+            "obstacles": self.obstacles,
+            "robot_radius": self.robot_radius,
+            "obstacle_penalty": self.obstacle_penalty,
+            "obstacle_hit_probability": self.obstacle_hit_probability,
+            "dangerous_areas_arr": self._dangerous_areas_arr,
+            "dangerous_area_radius": self.dangerous_area_radius,
+            "dangerous_area_penalty": self.dangerous_area_penalty,
+            "dangerous_area_hit_probability": self.dangerous_area_hit_probability,
+        }
+        if self.reward_model_type == RewardModelType.STANDARD:
+            return ContinuousPushRewardModel(**common_kwargs)
+        if self.reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+            return ContinuousPushHighVarianceStatesRewardModel(**common_kwargs)
+        if self.reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+            return ContinuousPushDecayingHitProbabilityRewardModel(
+                penalty_decay=self.penalty_decay, **common_kwargs
+            )
+        raise ValueError(f"Unknown reward model type: {self.reward_model_type}")
 
     def _build_obstacle_array(
         self, obstacle_tuples: List[Tuple[float, float, float]]
@@ -823,6 +849,8 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
         dangerous_area_radius: float = 0.5,
         dangerous_area_penalty: float = -10.0,
         dangerous_area_hit_probability: float = 1.0,
+        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        penalty_decay: float = 1.0,
         robot_radius: float = 0.3,
         state_transition_cov_matrix: np.ndarray = np.eye(2) * 0.1,
         initial_state: Optional[np.ndarray] = None,
@@ -845,6 +873,8 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
             dangerous_area_radius=dangerous_area_radius,
             dangerous_area_penalty=dangerous_area_penalty,
             dangerous_area_hit_probability=dangerous_area_hit_probability,
+            reward_model_type=reward_model_type,
+            penalty_decay=penalty_decay,
             robot_radius=robot_radius,
             state_transition_cov_matrix=state_transition_cov_matrix,
             initial_state=initial_state,

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -342,6 +342,12 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         self._trans_kernel_cache: Dict[str, Any] = {}
 
         self.reward_model: BasePushRewardModel = self._build_reward_model()
+        # Cache the bound methods so the hot path skips ``self.reward_model``
+        # attribute lookup on each call (~50–100 ns saved per call). Bound
+        # methods pickle correctly via ``(class, name, instance)``, so
+        # __setstate__ doesn't need to rebuild them.
+        self._compute_reward = self.reward_model.compute_reward
+        self._compute_reward_batch = self.reward_model.compute_reward_batch
 
     def _build_reward_model(self) -> BasePushRewardModel:
         # ``Dict[str, Any]`` opt-out is required so pyright doesn't narrow
@@ -403,7 +409,7 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
     def sample_next_step(self, state: Any, action: Any) -> Tuple[Any, Any, float]:
         next_state = self.sample_next_state(state=state, action=action)
         next_observation = self.sample_observation(next_state=next_state, action=action)
-        r = self.reward_model.compute_reward(state, action, next_state)
+        r = self._compute_reward(state, action, next_state)
         return next_state, next_observation, r
 
     # ── Env-API sampling implementations ────────────────────────────
@@ -648,7 +654,7 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         # sample a fresh next state to evaluate the action result.
         if next_state is None:
             next_state = self.sample_next_state(state, action)
-        return self.reward_model.compute_reward(state, action, next_state)
+        return self._compute_reward(state, action, next_state)
 
     def is_terminal(self, state: np.ndarray) -> bool:
         # Episode ends when object is close to target
@@ -787,7 +793,7 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         # accepts a pre-drawn action list (to allow exact comparison with the
         # C++ path when transition_error_prob=0 and the actions are held fixed).
         sample_one = self._sample_one_next_state
-        reward_from_next = self.reward_model.compute_reward
+        reward_from_next = self._compute_reward
         is_terminal = self.is_terminal
 
         total = 0.0
@@ -857,7 +863,7 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             next_states_arr = np.ascontiguousarray(np.asarray(next_states, dtype=float))
             if next_states_arr.ndim == 1:
                 next_states_arr = next_states_arr.reshape(1, -1)
-        return self.reward_model.compute_reward_batch(states_array, action, next_states_arr)
+        return self._compute_reward_batch(states_array, action, next_states_arr)
 
     def observation_log_probability_per_state(
         self, next_states: Any, action: str, observation: Any

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -40,7 +40,11 @@ from POMDPPlanners.core.environment import (
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.environments.push_pomdp import _native
 from POMDPPlanners.environments.push_pomdp.push_pomdp_utils.push_reward_models import (
+    BasePushRewardModel,
+    DiscretePushDecayingHitProbabilityRewardModel,
+    DiscretePushHighVarianceStatesRewardModel,
     DiscretePushRewardModel,
+    RewardModelType,
 )
 from POMDPPlanners.environments.push_pomdp.push_pomdp_visualizer import PushPOMDPVisualizer
 from POMDPPlanners.utils.statistics_utils import confidence_interval
@@ -218,6 +222,8 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         dangerous_area_radius: float = 0.5,
         dangerous_area_penalty: float = -10.0,
         dangerous_area_hit_probability: float = 1.0,
+        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        penalty_decay: float = 1.0,
         initial_state: Optional[np.ndarray] = None,
         transition_error_prob: float = 0.0,
         name: str = "PushPOMDP",
@@ -229,6 +235,8 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             raise ValueError("obstacle_hit_probability must be between 0 and 1 (inclusive)")
         if not 0.0 <= dangerous_area_hit_probability <= 1.0:
             raise ValueError("dangerous_area_hit_probability must be between 0 and 1 (inclusive)")
+        if reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY and penalty_decay <= 0.0:
+            raise ValueError("penalty_decay must be strictly positive")
 
         self.grid_size = grid_size
         self.push_threshold = push_threshold
@@ -244,6 +252,8 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         self.dangerous_area_radius = float(dangerous_area_radius)
         self.dangerous_area_penalty = float(dangerous_area_penalty)
         self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
+        self.reward_model_type = reward_model_type
+        self.penalty_decay = float(penalty_decay)
         self._initial_state = initial_state
         self.transition_error_prob = transition_error_prob
 
@@ -331,16 +341,32 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         # objects.
         self._trans_kernel_cache: Dict[str, Any] = {}
 
-        self.reward_model: DiscretePushRewardModel = DiscretePushRewardModel(
-            obstacles=self.obstacles,
-            obstacle_radius=self.obstacle_radius,
-            obstacle_penalty=self.obstacle_penalty,
-            obstacle_hit_probability=self.obstacle_hit_probability,
-            dangerous_areas_arr=self._dangerous_areas_arr,
-            dangerous_area_radius=self.dangerous_area_radius,
-            dangerous_area_penalty=self.dangerous_area_penalty,
-            dangerous_area_hit_probability=self.dangerous_area_hit_probability,
-        )
+        self.reward_model: BasePushRewardModel = self._build_reward_model()
+
+    def _build_reward_model(self) -> BasePushRewardModel:
+        # ``Dict[str, Any]`` opt-out is required so pyright doesn't narrow
+        # the value type to the lub of obstacles + scalars and reject the
+        # ``**`` unpack as incompatible with each reward-model __init__.
+        common_kwargs: Dict[str, Any] = {
+            "obstacles": self.obstacles,
+            "obstacle_radius": self.obstacle_radius,
+            "obstacle_penalty": self.obstacle_penalty,
+            "obstacle_hit_probability": self.obstacle_hit_probability,
+            "dangerous_areas": self.dangerous_areas,
+            "dangerous_areas_arr": self._dangerous_areas_arr,
+            "dangerous_area_radius": self.dangerous_area_radius,
+            "dangerous_area_penalty": self.dangerous_area_penalty,
+            "dangerous_area_hit_probability": self.dangerous_area_hit_probability,
+        }
+        if self.reward_model_type == RewardModelType.STANDARD:
+            return DiscretePushRewardModel(**common_kwargs)
+        if self.reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+            return DiscretePushHighVarianceStatesRewardModel(**common_kwargs)
+        if self.reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+            return DiscretePushDecayingHitProbabilityRewardModel(
+                penalty_decay=self.penalty_decay, **common_kwargs
+            )
+        raise ValueError(f"Unknown reward model type: {self.reward_model_type}")
 
     def _is_colliding_with_obstacle(
         self, position: np.ndarray, action: Optional[str] = None

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp_utils/push_reward_models.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp_utils/push_reward_models.py
@@ -12,13 +12,42 @@ computation needs (obstacle geometry, dangerous areas, penalty
 probabilities). The environment retains its own copies for transition /
 observation paths and delegates ``reward()`` / ``reward_batch()`` to the
 model.
+
+Reward-model variants (selected via :class:`RewardModelType`):
+    * ``STANDARD`` — dangerous-area penalty fires deterministically (or
+      with ``dangerous_area_hit_probability`` Bernoulli) whenever the
+      realised post-action robot position lies inside any zone.
+    * ``HIGH_VARIANCE_STATES`` — dangerous-area penalty becomes
+      ``±dangerous_area_penalty`` with 50/50 split when in zone; obstacle
+      penalty is unchanged. Expected dangerous-area contribution is zero,
+      variance is ``dangerous_area_penalty**2``. Useful for benchmarking
+      risk-sensitive planners against expected-value MCTS on the same
+      mean.
+    * ``DECAYING_HIT_PROBABILITY`` — dangerous-area penalty fires with
+      probability ``exp(-min_dist / penalty_decay)`` based on the
+      Euclidean distance to the nearest dangerous-area centre, with no
+      radius cutoff. Obstacle penalty is unchanged.
 """
 
 import math
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Any, List, Tuple
 
 import numpy as np
+
+from POMDPPlanners.environments.environment_utils.dangerous_areas_kernels import (
+    decaying_prob_penalty_batch_kernel,
+    decaying_prob_penalty_kernel,
+)
+
+
+class RewardModelType(Enum):
+    """Reward model variants supported by the Push POMDP family."""
+
+    STANDARD = "standard"
+    HIGH_VARIANCE_STATES = "high_variance_states"
+    DECAYING_HIT_PROBABILITY = "decaying_hit_probability"
 
 
 class BasePushRewardModel(ABC):
@@ -76,11 +105,12 @@ class DiscretePushRewardModel(BasePushRewardModel):
           ``obstacle_radius`` of any circular obstacle. When
           ``obstacle_hit_probability < 1.0`` the penalty fires with that
           probability per call (one Bernoulli draw per state).
-        * Dangerous-area penalty: ``dangerous_area_penalty`` is added when
-          the realised robot position lies within ``dangerous_area_radius``
-          of any dangerous-area centre. Stochastic via
-          ``dangerous_area_hit_probability`` like obstacles. At most one
-          penalty per row even when zones overlap.
+        * Dangerous-area penalty: see :meth:`_dangerous_area_contribution_scalar`
+          / :meth:`_dangerous_area_penalty_batch`. The standard contract is
+          ``dangerous_area_penalty`` with optional Bernoulli
+          ``dangerous_area_hit_probability``. Subclasses override the two
+          helpers to substitute high-variance or distance-decaying
+          contracts without touching the goal / obstacle terms.
     """
 
     def __init__(
@@ -89,6 +119,7 @@ class DiscretePushRewardModel(BasePushRewardModel):
         obstacle_radius: float,
         obstacle_penalty: float,
         obstacle_hit_probability: float,
+        dangerous_areas: List[Tuple[float, float]],
         dangerous_areas_arr: np.ndarray,
         dangerous_area_radius: float,
         dangerous_area_penalty: float,
@@ -98,10 +129,24 @@ class DiscretePushRewardModel(BasePushRewardModel):
         self.obstacle_radius = float(obstacle_radius)
         self.obstacle_penalty = float(obstacle_penalty)
         self.obstacle_hit_probability = float(obstacle_hit_probability)
+        # ``dangerous_areas`` is the list-of-tuples form used by the scalar
+        # hot path (iterating a Python list is ~5x faster than iterating an
+        # (K, 2) ndarray because the latter materialises per-row views and
+        # forces float() conversion on unpack). ``dangerous_areas_arr`` is
+        # the (K, 2) ndarray form consumed by the vectorised batch path.
+        # ``_dangerous_centers_xy`` is the (2, D) C-contiguous transpose
+        # consumed by the env-agnostic numba kernels in
+        # :mod:`environment_utils.dangerous_areas_kernels`.
+        self.dangerous_areas = dangerous_areas
         self.dangerous_areas_arr = dangerous_areas_arr
         self.dangerous_area_radius = float(dangerous_area_radius)
         self.dangerous_area_penalty = float(dangerous_area_penalty)
         self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
+        self._dangerous_centers_xy: np.ndarray = (
+            np.ascontiguousarray(dangerous_areas_arr.T)
+            if dangerous_areas_arr.shape[0] > 0
+            else np.empty((2, 0), dtype=np.float64)
+        )
 
     def compute_reward(self, state: np.ndarray, action: Any, next_state: np.ndarray) -> float:
         del state, action  # penalties consume the realised post-transition robot pos
@@ -113,19 +158,21 @@ class DiscretePushRewardModel(BasePushRewardModel):
         if distance_to_target < 0.5:
             reward += 100.0
 
-        if self._is_colliding_with_obstacle_scalar(float(next_state[0]), float(next_state[1])):
+        # Pay the ndarray->float conversion once and share between the two
+        # scalar geometry checks below (mirrors the pre-refactor inline
+        # ``_reward_from_next_state`` which sliced ``next_state[:2]`` once
+        # then handed a float pair to each helper).
+        robot_x = float(next_state[0])
+        robot_y = float(next_state[1])
+
+        if self._is_colliding_with_obstacle_scalar(robot_x, robot_y):
             if (
                 self.obstacle_hit_probability >= 1.0
                 or np.random.random() < self.obstacle_hit_probability
             ):
                 reward += self.obstacle_penalty
 
-        if self._is_in_dangerous_area_scalar(float(next_state[0]), float(next_state[1])):
-            if (
-                self.dangerous_area_hit_probability >= 1.0
-                or np.random.random() < self.dangerous_area_hit_probability
-            ):
-                reward += self.dangerous_area_penalty
+        reward += self._dangerous_area_contribution_scalar(robot_x, robot_y)
 
         return float(reward)
 
@@ -154,13 +201,12 @@ class DiscretePushRewardModel(BasePushRewardModel):
         return False
 
     def _is_in_dangerous_area_scalar(self, pos_x: float, pos_y: float) -> bool:
-        if self.dangerous_areas_arr.shape[0] == 0:
+        if not self.dangerous_areas:
             return False
         r_sq = self.dangerous_area_radius * self.dangerous_area_radius
-        # dangerous_areas_arr is (K, 2) float64; small K, scalar loop wins.
-        for danger_x, danger_y in self.dangerous_areas_arr:
-            ddx = pos_x - float(danger_x)
-            ddy = pos_y - float(danger_y)
+        for danger_x, danger_y in self.dangerous_areas:
+            ddx = pos_x - danger_x
+            ddy = pos_y - danger_y
             if ddx * ddx + ddy * ddy <= r_sq:
                 return True
         return False
@@ -178,17 +224,138 @@ class DiscretePushRewardModel(BasePushRewardModel):
             colliding = colliding & applied
         return np.where(colliding, self.obstacle_penalty, 0.0).astype(np.float64)
 
+    def _dangerous_area_contribution_scalar(self, robot_x: float, robot_y: float) -> float:
+        """Standard scalar contribution: penalty fires (optionally Bernoulli) when in zone."""
+        if not self._is_in_dangerous_area_scalar(robot_x, robot_y):
+            return 0.0
+        if (
+            self.dangerous_area_hit_probability >= 1.0
+            or np.random.random() < self.dangerous_area_hit_probability
+        ):
+            return self.dangerous_area_penalty
+        return 0.0
+
     def _dangerous_area_penalty_batch(self, next_states: np.ndarray) -> np.ndarray:
+        """Standard batch contribution: penalty per row that lies in any zone."""
         if self.dangerous_areas_arr.shape[0] == 0:
             return np.zeros(len(next_states), dtype=np.float64)
-        positions = next_states[:, :2]
-        diff = positions[:, None, :] - self.dangerous_areas_arr[None, :, :]
-        dist_sq = np.sum(diff * diff, axis=2)
-        in_zone = np.any(dist_sq <= self.dangerous_area_radius * self.dangerous_area_radius, axis=1)
+        in_zone = self._batch_in_any_zone(next_states[:, :2])
         if self.dangerous_area_hit_probability < 1.0:
             applied = np.random.random(len(next_states)) < self.dangerous_area_hit_probability
             in_zone = in_zone & applied
         return np.where(in_zone, self.dangerous_area_penalty, 0.0).astype(np.float64)
+
+    def _batch_in_any_zone(self, positions: np.ndarray) -> np.ndarray:
+        diff = positions[:, None, :] - self.dangerous_areas_arr[None, :, :]
+        dist_sq = np.sum(diff * diff, axis=2)
+        return np.any(dist_sq <= self.dangerous_area_radius * self.dangerous_area_radius, axis=1)
+
+
+class DiscretePushHighVarianceStatesRewardModel(DiscretePushRewardModel):
+    """High-variance dangerous-area contribution for :class:`PushPOMDP`.
+
+    Dangerous-area hits emit ``+dangerous_area_penalty`` or
+    ``-dangerous_area_penalty`` with equal probability — expected
+    contribution is zero, variance is ``dangerous_area_penalty**2``.
+    Obstacle penalty is unchanged. Mirrors
+    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLDHighVarianceStatesRewardModel`
+    and
+    :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models.LaserTagHighVarianceStatesRewardModel`.
+    """
+
+    def _dangerous_area_contribution_scalar(self, robot_x: float, robot_y: float) -> float:
+        if not self._is_in_dangerous_area_scalar(robot_x, robot_y):
+            return 0.0
+        # ±dangerous_area_penalty with 50/50 split (E[reward]=0, var=penalty^2).
+        if np.random.rand() < 0.5:
+            return self.dangerous_area_penalty
+        return -self.dangerous_area_penalty
+
+    def _dangerous_area_penalty_batch(self, next_states: np.ndarray) -> np.ndarray:
+        if self.dangerous_areas_arr.shape[0] == 0:
+            return np.zeros(len(next_states), dtype=np.float64)
+        in_zone = self._batch_in_any_zone(next_states[:, :2])
+        n_in = int(np.count_nonzero(in_zone))
+        out = np.zeros(len(next_states), dtype=np.float64)
+        if n_in > 0:
+            # ``signs`` matches the per-row independent ±penalty draw. Single
+            # batched ``np.random.rand`` keeps seed semantics aligned with the
+            # scalar path (one uniform per in-zone row).
+            signs = np.where(np.random.rand(n_in) < 0.5, 1.0, -1.0)
+            out[in_zone] = self.dangerous_area_penalty * signs
+        return out
+
+
+class DiscretePushDecayingHitProbabilityRewardModel(DiscretePushRewardModel):
+    """Distance-decaying dangerous-area contribution for :class:`PushPOMDP`.
+
+    Penalty fires with probability ``exp(-min_dist / penalty_decay)`` based
+    on the Euclidean distance from the realised robot position to the
+    nearest dangerous-area centre. No radius cutoff — every position
+    feels a (vanishingly small at large distance) penalty risk. Obstacle
+    penalty is unchanged. Mirrors
+    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLightDarkDecayingHitProbabilityRewardModel`
+    and
+    :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models.LaserTagDecayingHitProbabilityRewardModel`.
+    """
+
+    def __init__(
+        self,
+        obstacles: List[Tuple[float, float]],
+        obstacle_radius: float,
+        obstacle_penalty: float,
+        obstacle_hit_probability: float,
+        dangerous_areas: List[Tuple[float, float]],
+        dangerous_areas_arr: np.ndarray,
+        dangerous_area_radius: float,
+        dangerous_area_penalty: float,
+        dangerous_area_hit_probability: float,
+        penalty_decay: float,
+    ):
+        super().__init__(
+            obstacles=obstacles,
+            obstacle_radius=obstacle_radius,
+            obstacle_penalty=obstacle_penalty,
+            obstacle_hit_probability=obstacle_hit_probability,
+            dangerous_areas=dangerous_areas,
+            dangerous_areas_arr=dangerous_areas_arr,
+            dangerous_area_radius=dangerous_area_radius,
+            dangerous_area_penalty=dangerous_area_penalty,
+            dangerous_area_hit_probability=dangerous_area_hit_probability,
+        )
+        if penalty_decay <= 0.0:
+            raise ValueError("penalty_decay must be strictly positive")
+        self.penalty_decay = float(penalty_decay)
+
+    def _dangerous_area_contribution_scalar(self, robot_x: float, robot_y: float) -> float:
+        if self._dangerous_centers_xy.shape[1] == 0:
+            return 0.0
+        point = np.array([robot_x, robot_y], dtype=np.float64)
+        return float(
+            decaying_prob_penalty_kernel(
+                point,
+                self._dangerous_centers_xy,
+                self.dangerous_area_penalty,
+                self.penalty_decay,
+                float(np.random.rand()),
+            )
+        )
+
+    def _dangerous_area_penalty_batch(self, next_states: np.ndarray) -> np.ndarray:
+        if self._dangerous_centers_xy.shape[1] == 0:
+            return np.zeros(len(next_states), dtype=np.float64)
+        # Decay penalty is applied to *every* row (no radius cutoff). One
+        # uniform draw per row keeps seed semantics aligned with the scalar
+        # path and the laser-tag / light-dark Decaying batch paths.
+        points = np.ascontiguousarray(next_states[:, :2].astype(np.float64))
+        uniforms = np.random.rand(points.shape[0])
+        return decaying_prob_penalty_batch_kernel(
+            points,
+            self._dangerous_centers_xy,
+            self.dangerous_area_penalty,
+            self.penalty_decay,
+            uniforms,
+        )
 
 
 class ContinuousPushRewardModel(BasePushRewardModel):
@@ -199,8 +366,9 @@ class ContinuousPushRewardModel(BasePushRewardModel):
     obstacles are axis-aligned bounding boxes (``(cx, cy, half_x, half_y)``
     rows) tested against a circular robot footprint of radius
     ``robot_radius``. Dangerous areas remain circular point-vs-circle
-    checks. Both penalties are optionally stochastic via per-call Bernoulli
-    draws.
+    checks. Subclasses override :meth:`_dangerous_area_penalty_batch` to
+    substitute high-variance or distance-decaying contracts without
+    touching the goal / obstacle terms.
     """
 
     def __init__(
@@ -222,6 +390,11 @@ class ContinuousPushRewardModel(BasePushRewardModel):
         self.dangerous_area_radius = float(dangerous_area_radius)
         self.dangerous_area_penalty = float(dangerous_area_penalty)
         self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
+        self._dangerous_centers_xy: np.ndarray = (
+            np.ascontiguousarray(dangerous_areas_arr.T)
+            if dangerous_areas_arr.shape[0] > 0
+            else np.empty((2, 0), dtype=np.float64)
+        )
 
     def compute_reward(self, state: np.ndarray, action: Any, next_state: np.ndarray) -> float:
         state_arr = np.ascontiguousarray(np.asarray(state, dtype=np.float64)).reshape(1, -1)
@@ -250,16 +423,19 @@ class ContinuousPushRewardModel(BasePushRewardModel):
             if np.any(collide):
                 rewards[collide] += self.obstacle_penalty
 
-        if self.dangerous_areas_arr.shape[0] > 0:
-            robot_after = next_states[:, :2]
-            in_zone = self._batch_robot_in_dangerous_areas(robot_after)
-            if self.dangerous_area_hit_probability < 1.0:
-                applied = np.random.random(in_zone.shape[0]) < self.dangerous_area_hit_probability
-                in_zone = in_zone & applied
-            if np.any(in_zone):
-                rewards[in_zone] += self.dangerous_area_penalty
+        rewards += self._dangerous_area_penalty_batch(next_states)
 
         return rewards
+
+    def _dangerous_area_penalty_batch(self, next_states: np.ndarray) -> np.ndarray:
+        """Standard batch contribution: penalty per row that lies in any zone."""
+        if self.dangerous_areas_arr.shape[0] == 0:
+            return np.zeros(next_states.shape[0], dtype=np.float64)
+        in_zone = self._batch_robot_in_dangerous_areas(next_states[:, :2])
+        if self.dangerous_area_hit_probability < 1.0:
+            applied = np.random.random(in_zone.shape[0]) < self.dangerous_area_hit_probability
+            in_zone = in_zone & applied
+        return np.where(in_zone, self.dangerous_area_penalty, 0.0).astype(np.float64)
 
     def _batch_robot_in_dangerous_areas(self, positions: np.ndarray) -> np.ndarray:
         diff = positions[:, None, :] - self.dangerous_areas_arr[None, :, :]
@@ -280,3 +456,68 @@ class ContinuousPushRewardModel(BasePushRewardModel):
         dy = py - closest_y
         dist_sq = dx * dx + dy * dy
         return np.any(dist_sq < radius * radius, axis=1)
+
+
+class ContinuousPushHighVarianceStatesRewardModel(ContinuousPushRewardModel):
+    """High-variance dangerous-area contribution for :class:`ContinuousPushPOMDP`."""
+
+    def _dangerous_area_penalty_batch(self, next_states: np.ndarray) -> np.ndarray:
+        if self.dangerous_areas_arr.shape[0] == 0:
+            return np.zeros(next_states.shape[0], dtype=np.float64)
+        in_zone = self._batch_robot_in_dangerous_areas(next_states[:, :2])
+        n_in = int(np.count_nonzero(in_zone))
+        out = np.zeros(next_states.shape[0], dtype=np.float64)
+        if n_in > 0:
+            signs = np.where(np.random.rand(n_in) < 0.5, 1.0, -1.0)
+            out[in_zone] = self.dangerous_area_penalty * signs
+        return out
+
+
+class ContinuousPushDecayingHitProbabilityRewardModel(ContinuousPushRewardModel):
+    """Distance-decaying dangerous-area contribution for :class:`ContinuousPushPOMDP`.
+
+    Penalty fires with probability ``exp(-min_dist / penalty_decay)`` based
+    on the Euclidean distance from the realised robot position to the
+    nearest dangerous-area centre. No radius cutoff — every position
+    feels a (vanishingly small at large distance) penalty risk. Obstacle
+    penalty is unchanged.
+    """
+
+    def __init__(
+        self,
+        obstacles: np.ndarray,
+        robot_radius: float,
+        obstacle_penalty: float,
+        obstacle_hit_probability: float,
+        dangerous_areas_arr: np.ndarray,
+        dangerous_area_radius: float,
+        dangerous_area_penalty: float,
+        dangerous_area_hit_probability: float,
+        penalty_decay: float,
+    ):
+        super().__init__(
+            obstacles=obstacles,
+            robot_radius=robot_radius,
+            obstacle_penalty=obstacle_penalty,
+            obstacle_hit_probability=obstacle_hit_probability,
+            dangerous_areas_arr=dangerous_areas_arr,
+            dangerous_area_radius=dangerous_area_radius,
+            dangerous_area_penalty=dangerous_area_penalty,
+            dangerous_area_hit_probability=dangerous_area_hit_probability,
+        )
+        if penalty_decay <= 0.0:
+            raise ValueError("penalty_decay must be strictly positive")
+        self.penalty_decay = float(penalty_decay)
+
+    def _dangerous_area_penalty_batch(self, next_states: np.ndarray) -> np.ndarray:
+        if self._dangerous_centers_xy.shape[1] == 0:
+            return np.zeros(next_states.shape[0], dtype=np.float64)
+        points = np.ascontiguousarray(next_states[:, :2].astype(np.float64))
+        uniforms = np.random.rand(points.shape[0])
+        return decaying_prob_penalty_batch_kernel(
+            points,
+            self._dangerous_centers_xy,
+            self.dangerous_area_penalty,
+            self.penalty_decay,
+            uniforms,
+        )

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp_utils/push_reward_models.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp_utils/push_reward_models.py
@@ -40,6 +40,13 @@ from POMDPPlanners.environments.environment_utils.dangerous_areas_kernels import
     decaying_prob_penalty_batch_kernel,
 )
 
+# Module-level binding of the scalar uniform draw. Reading
+# ``np.random.random_sample`` once at import time turns the hot-path call
+# from LOAD_GLOBAL np / LOAD_ATTR random / LOAD_ATTR random_sample into a
+# single LOAD_GLOBAL (~50–100 ns saved per call). Uses the same global
+# numpy RNG state so ``np.random.seed`` semantics are preserved.
+_scalar_random = np.random.random_sample  # pylint: disable=no-member
+
 
 class RewardModelType(Enum):
     """Reward model variants supported by the Push POMDP family."""
@@ -331,24 +338,37 @@ class DiscretePushDecayingHitProbabilityRewardModel(DiscretePushRewardModel):
         if penalty_decay <= 0.0:
             raise ValueError("penalty_decay must be strictly positive")
         self.penalty_decay = float(penalty_decay)
+        # Pre-square the decay so the squared-form scalar fast-path avoids
+        # an extra multiply per call.
+        self._decay_sq = float(penalty_decay) * float(penalty_decay)
 
     def _dangerous_area_contribution_scalar(self, robot_x: float, robot_y: float) -> float:
         # Inlined Python scan — for the typical D=2..3 zone counts in this
         # env the per-call numba dispatch (~1 µs) dominates the actual
         # work (~100–200 ns), so iterating the Python list-of-tuples and
-        # computing ``exp`` here is ~5–10× faster than dispatching to
+        # computing here is ~5–10× faster than dispatching to
         # :func:`decaying_prob_penalty_kernel`. The batch path keeps the
         # numba kernel because dispatch amortises across N rows.
-        if not self.dangerous_areas:
+        #
+        # Squared-form hit test: the original predicate is
+        #     rand < exp(-sqrt(min_sq) / decay)
+        # ⇔  log(rand) < -sqrt(min_sq) / decay        (log monotone)
+        # ⇔  -decay·log(rand) > sqrt(min_sq)          (both sides ≥ 0)
+        # ⇔  decay² · log(rand)² > min_sq             (square, sides ≥ 0)
+        # which drops sqrt + exp in favour of a single log + square. Saves
+        # ~50–100 ns per call vs the literal form.
+        zones = self.dangerous_areas
+        if not zones:
             return 0.0
         min_sq = math.inf
-        for danger_x, danger_y in self.dangerous_areas:
+        for danger_x, danger_y in zones:
             ddx = robot_x - danger_x
             ddy = robot_y - danger_y
             d_sq = ddx * ddx + ddy * ddy
-            min_sq = min(min_sq, d_sq)
-        hit_prob = math.exp(-math.sqrt(min_sq) / self.penalty_decay)
-        if np.random.rand() < hit_prob:
+            if d_sq < min_sq:  # pylint: disable=consider-using-min-builtin
+                min_sq = d_sq
+        log_u = math.log(_scalar_random())
+        if self._decay_sq * log_u * log_u > min_sq:
             return self.dangerous_area_penalty
         return 0.0
 

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp_utils/push_reward_models.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp_utils/push_reward_models.py
@@ -38,7 +38,6 @@ import numpy as np
 
 from POMDPPlanners.environments.environment_utils.dangerous_areas_kernels import (
     decaying_prob_penalty_batch_kernel,
-    decaying_prob_penalty_kernel,
 )
 
 
@@ -186,7 +185,13 @@ class DiscretePushRewardModel(BasePushRewardModel):
         rewards = -dist
         rewards = np.where(dist < 0.5, rewards + 100.0, rewards)
         rewards += self._obstacle_penalty_batch(next_states)
-        rewards += self._dangerous_area_penalty_batch(next_states)
+        # Skip the helper call entirely when no zones are configured; the
+        # zero-zones helper would allocate np.zeros(N) and ``+=`` it for no
+        # effect (~1–3 µs on N=1024). Subclasses that override the helper
+        # to always emit a contribution (e.g. decaying with no radius
+        # cutoff) keep their own guard inside the override.
+        if self.dangerous_areas_arr.shape[0] > 0:
+            rewards += self._dangerous_area_penalty_batch(next_states)
         return rewards.astype(np.float64)
 
     def _is_colliding_with_obstacle_scalar(self, pos_x: float, pos_y: float) -> bool:
@@ -328,18 +333,24 @@ class DiscretePushDecayingHitProbabilityRewardModel(DiscretePushRewardModel):
         self.penalty_decay = float(penalty_decay)
 
     def _dangerous_area_contribution_scalar(self, robot_x: float, robot_y: float) -> float:
-        if self._dangerous_centers_xy.shape[1] == 0:
+        # Inlined Python scan — for the typical D=2..3 zone counts in this
+        # env the per-call numba dispatch (~1 µs) dominates the actual
+        # work (~100–200 ns), so iterating the Python list-of-tuples and
+        # computing ``exp`` here is ~5–10× faster than dispatching to
+        # :func:`decaying_prob_penalty_kernel`. The batch path keeps the
+        # numba kernel because dispatch amortises across N rows.
+        if not self.dangerous_areas:
             return 0.0
-        point = np.array([robot_x, robot_y], dtype=np.float64)
-        return float(
-            decaying_prob_penalty_kernel(
-                point,
-                self._dangerous_centers_xy,
-                self.dangerous_area_penalty,
-                self.penalty_decay,
-                float(np.random.rand()),
-            )
-        )
+        min_sq = math.inf
+        for danger_x, danger_y in self.dangerous_areas:
+            ddx = robot_x - danger_x
+            ddy = robot_y - danger_y
+            d_sq = ddx * ddx + ddy * ddy
+            min_sq = min(min_sq, d_sq)
+        hit_prob = math.exp(-math.sqrt(min_sq) / self.penalty_decay)
+        if np.random.rand() < hit_prob:
+            return self.dangerous_area_penalty
+        return 0.0
 
     def _dangerous_area_penalty_batch(self, next_states: np.ndarray) -> np.ndarray:
         if self._dangerous_centers_xy.shape[1] == 0:
@@ -423,7 +434,11 @@ class ContinuousPushRewardModel(BasePushRewardModel):
             if np.any(collide):
                 rewards[collide] += self.obstacle_penalty
 
-        rewards += self._dangerous_area_penalty_batch(next_states)
+        # Skip the helper call entirely when no zones are configured; see
+        # the matching guard in DiscretePushRewardModel.compute_reward_batch
+        # for the rationale (saves the np.zeros(N) + add roundtrip).
+        if self.dangerous_areas_arr.shape[0] > 0:
+            rewards += self._dangerous_area_penalty_batch(next_states)
 
         return rewards
 


### PR DESCRIPTION
## Summary

Adds two new dangerous-area reward-model variants to the Push POMDP family, matching the contract already established in `light_dark_pomdp` and `laser_tag_pomdp`:

- `HIGH_VARIANCE_STATES` — dangerous-area contribution becomes `±dangerous_area_penalty` with 50/50 split when in zone; expected value 0, variance `penalty²`.
- `DECAYING_HIT_PROBABILITY` — penalty fires with probability `exp(-min_dist/penalty_decay)` based on Euclidean distance to the nearest dangerous-area centre; no radius cutoff.

Both variants apply to `PushPOMDP`, `ContinuousPushPOMDP`, and `ContinuousPushPOMDPDiscreteActions` via a new `reward_model_type: RewardModelType` constructor kwarg (default `STANDARD`, preserving existing behavior). The Decaying variant also takes a `penalty_decay: float` kwarg (validated > 0).

## What's included

- `feat`: `RewardModelType` enum + 4 new model subclasses (`{Discrete,Continuous}Push{HighVarianceStates,DecayingHitProbability}RewardModel`). Standard models refactored so the dangerous-area contribution lives in overridable helpers (`_dangerous_area_contribution_scalar`, `_dangerous_area_penalty_batch`); subclasses replace only those. Decaying batch path reuses the existing njit `decaying_prob_penalty_batch_kernel` for bit-identical math with the laser_tag/light_dark Decaying paths.
- `perf` (1): hoist `dangerous_areas` (list of tuples) into the discrete reward model so the scalar hot path iterates the Python list instead of an ndarray row-view (~5× faster); guard the `_dangerous_area_penalty_batch` call with `if shape[0] > 0` to skip the zero-zone `np.zeros(N) + add`; cache bound reward methods on the env at __init__ (saves attribute lookup per call).
- `perf` (2): squared-form algebra for the decaying scalar predicate (`rand < exp(-√min_sq/decay)` ⇔ `decay²·log(rand)² > min_sq`) drops one transcendental; module-level binding of `np.random.random_sample` saves the attribute-lookup chain.

## Bench results (per-call µs, before = current develop, after = this branch)

| case | before | after | Δ |
|---|---:|---:|---:|
| `PushPOMDP|pen` scalar reward (standard) | 1.83 | 0.94 | **−48%** |
| `PushPOMDP|pen` rollout(50) (standard) | 269 | 151 | **−44%** |
| `PushPOMDP|nopen` reward_batch[1024] | 11.6 | 10.8 | −7% |
| `ContinuousPushPOMDP|pen` reward_batch[1024] | 128 | 124 | −3% |
| `PushPOMDP|pen` decaying scalar (new) | — | 1.29 | n/a |
| `PushPOMDP|pen` decaying rollout(50) (new) | — | 169 | n/a (+2.6% vs std on same env) |

Every STANDARD path is at or below the pre-refactor baseline.

## Test plan

- [x] `pytest POMDPPlanners/tests/test_environments/test_push_pomdp/` → 242 passed, 1 xfailed
- [x] `pyright POMDPPlanners/environments/push_pomdp/` → 0 errors, 0 warnings
- [x] `pylint` on touched files → 10.00/10
- [x] Smoke-tested all 3 variants on all 3 envs (`PushPOMDP`, `ContinuousPushPOMDP`, `ContinuousPushPOMDPDiscreteActions`) — semantics match expected mean/variance for each variant
- [ ] Verify with risk-sensitive planner experiments that the new variants are wired correctly downstream