### PR TITLE
feat(pacman_pomdp): add HV and decaying-hit-probability reward variants

### DIFF
--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -35,6 +35,8 @@ from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.environments.pacman_pomdp import _native  # pylint: disable=no-name-in-module
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.pacman_reward_models import (
     BasePacManRewardModel,
+    PacManDecayingHitProbabilityRewardModel,
+    PacManHighVarianceStatesRewardModel,
     PacManRewardModel,
 )
 from POMDPPlanners.utils.statistics_utils import confidence_interval
@@ -51,6 +53,14 @@ class PacManPOMDPMetrics(Enum):
     AVG_EPISODE_LENGTH = "avg_episode_length"
     AVG_PACMAN_CLOSEST_GHOST_DISTANCE = "avg_pacman_closest_ghost_distance"
     AVG_COLLISION_ENCOUNTERS = "avg_collision_encounters"
+
+
+class RewardModelType(Enum):
+    """Reward-model variants selectable on :class:`PacManPOMDP`."""
+
+    STANDARD = "standard"
+    HIGH_VARIANCE_STATES = "high_variance_states"
+    DECAYING_HIT_PROBABILITY = "decaying_hit_probability"
 
 
 class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-methods
@@ -138,6 +148,8 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         name: str = "PacManPOMDP",
         output_dir: Optional[Path] = None,
         debug: bool = False,
+        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        penalty_decay: float = 1.0,
     ):
         """Initialize PacMan POMDP.
 
@@ -168,6 +180,18 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             name: Environment name. Defaults to "PacManPOMDP".
             output_dir: Output directory for logging. Defaults to None.
             debug: Enable debug logging. Defaults to False.
+            reward_model_type: Selects the reward variant. ``STANDARD`` (default)
+                deterministically subtracts ``dangerous_area_penalty`` whenever
+                PacMan's realised next position lies inside a hazard zone.
+                ``HIGH_VARIANCE_STATES`` emits ``±dangerous_area_penalty``
+                (50/50) on a zone hit (expected 0, high variance).
+                ``DECAYING_HIT_PROBABILITY`` applies ``-dangerous_area_penalty``
+                with probability ``exp(-min_dist / penalty_decay)`` against
+                the nearest zone centre (no radius cutoff). Mirrors the
+                light-dark / laser-tag / rock-sample reward-model variants.
+            penalty_decay: Decay length used by the
+                ``DECAYING_HIT_PROBABILITY`` reward model. Ignored by the other
+                variants. Must be strictly positive. Defaults to ``1.0``.
         """
         # Calculate reward range based on parameters. The dangerous-area
         # penalty only contributes to ``min_reward`` when at least one zone
@@ -300,26 +324,46 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             else np.empty((0, 2), dtype=np.int32)
         )
 
-        self.reward_model: BasePacManRewardModel = PacManRewardModel(
-            num_ghosts=self.num_ghosts,
-            pellet_positions_arr=self._pellet_positions_arr,
-            dangerous_areas=self.dangerous_areas,
-            dangerous_areas_arr=self._dangerous_areas_arr,
-            dangerous_area_radius=self.dangerous_area_radius,
-            dangerous_area_penalty=self.dangerous_area_penalty,
-            step_penalty=self.step_penalty,
-            ghost_collision_penalty=self.ghost_collision_penalty,
-            pellet_reward=self.pellet_reward,
-            win_reward=self.win_reward,
-            idx_pac_row=self._idx_pac_row,
-            idx_pac_col=self._idx_pac_col,
-            idx_ghosts_start=self._idx_ghosts_start,
-            idx_pellets_start=self._idx_pellets_start,
-            idx_pellets_end=self._idx_pellets_end,
-            idx_score=self._idx_score,
-            idx_terminal=self._idx_terminal,
-            neighbor_table_getter=self._get_neighbor_table,
+        self.reward_model_type = reward_model_type
+        self.penalty_decay = float(penalty_decay)
+        self.reward_model: BasePacManRewardModel = self._build_reward_model(
+            reward_model_type, self.penalty_decay
         )
+
+    def _build_reward_model(
+        self,
+        reward_model_type: RewardModelType,
+        penalty_decay: float,
+    ) -> BasePacManRewardModel:
+        common_kwargs = {
+            "num_ghosts": self.num_ghosts,
+            "pellet_positions_arr": self._pellet_positions_arr,
+            "dangerous_areas": self.dangerous_areas,
+            "dangerous_areas_arr": self._dangerous_areas_arr,
+            "dangerous_area_radius": self.dangerous_area_radius,
+            "dangerous_area_penalty": self.dangerous_area_penalty,
+            "step_penalty": self.step_penalty,
+            "ghost_collision_penalty": self.ghost_collision_penalty,
+            "pellet_reward": self.pellet_reward,
+            "win_reward": self.win_reward,
+            "idx_pac_row": self._idx_pac_row,
+            "idx_pac_col": self._idx_pac_col,
+            "idx_ghosts_start": self._idx_ghosts_start,
+            "idx_pellets_start": self._idx_pellets_start,
+            "idx_pellets_end": self._idx_pellets_end,
+            "idx_score": self._idx_score,
+            "idx_terminal": self._idx_terminal,
+            "neighbor_table_getter": self._get_neighbor_table,
+        }
+        if reward_model_type == RewardModelType.STANDARD:
+            return PacManRewardModel(**common_kwargs)
+        if reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+            return PacManHighVarianceStatesRewardModel(**common_kwargs)
+        if reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+            return PacManDecayingHitProbabilityRewardModel(
+                **common_kwargs, penalty_decay=penalty_decay
+            )
+        raise ValueError(f"Unknown reward model type: {reward_model_type}")
 
     @property
     def initial_ghost_pos(self) -> Tuple[int, int]:

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/pacman_reward_models.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/pacman_reward_models.py
@@ -6,6 +6,23 @@ and
 :mod:`POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models`,
 so further PacMan reward variants can be added without growing the env class.
 
+Three concrete variants are provided. They share all of the non-dangerous-
+area scoring (step / collision / pellet / win) via the
+``PacManRewardModel`` base; each variant only customises the dangerous-
+area contribution:
+
+* :class:`PacManRewardModel` (STANDARD): deterministic
+  ``-dangerous_area_penalty`` whenever the realised next pacman position
+  lies inside any configured circular hazard zone (squared-distance
+  check against ``dangerous_area_radius``).
+* :class:`PacManHighVarianceStatesRewardModel` (HIGH_VARIANCE_STATES):
+  ``±dangerous_area_penalty`` 50/50 in-zone — zero expected
+  contribution, high variance.
+* :class:`PacManDecayingHitProbabilityRewardModel`
+  (DECAYING_HIT_PROBABILITY): ``-dangerous_area_penalty`` is applied
+  with probability ``exp(-min_dist / penalty_decay)`` based on the
+  *closest* zone centre — no radius cutoff.
+
 The reward model owns all the parameters and pre-built buffers that the
 reward computation needs (state-layout indices, pellet positions,
 dangerous areas, scalar penalties / bonuses, and a callable that returns
@@ -19,6 +36,10 @@ from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 
+from POMDPPlanners.environments.environment_utils.dangerous_areas_kernels import (
+    decaying_prob_penalty_batch_kernel,
+    decaying_prob_penalty_kernel,
+)
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.numba_kernels import (
     compute_reward_batch_kernel,
     compute_reward_scalar_kernel,
@@ -68,6 +89,10 @@ class PacManRewardModel(BasePacManRewardModel):
           scalar path; final-pellet pickup in the batch path).
 
     Terminal states return ``0.0`` reward.
+
+    Subclasses override :meth:`_dangerous_area_contribution_scalar` and
+    :meth:`_apply_dangerous_area_contribution_batch` to express different
+    stochastic penalty models; the rest of the scoring is identical.
     """
 
     def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -110,6 +135,24 @@ class PacManRewardModel(BasePacManRewardModel):
         self._idx_score = idx_score
         self._idx_terminal = idx_terminal
         self._neighbor_table_getter = neighbor_table_getter
+
+        # (2, D) C-contiguous view of dangerous-area centres for the generic
+        # decaying-prob kernels (which expect axis 0 to hold the two coordinate
+        # components). Empty (2, 0) when no zones are configured.
+        if self._dangerous_areas_arr.shape[0] > 0:
+            self._dangerous_centers_xy: np.ndarray = np.ascontiguousarray(
+                self._dangerous_areas_arr.T
+            )
+        else:
+            self._dangerous_centers_xy = np.empty((2, 0), dtype=np.float64)
+        # (0, 2) sentinel passed to the fused kernel by subclasses that want
+        # to compute the dangerous-area contribution in Python instead.
+        self._empty_dangerous_areas: np.ndarray = np.empty((0, 2), dtype=np.float64)
+        # Square-distance comparison cached so the per-row danger check
+        # never sqrts on the hot path.
+        self._dangerous_radius_sq: float = float(dangerous_area_radius) * float(
+            dangerous_area_radius
+        )
 
     def compute_reward(
         self,
@@ -184,3 +227,304 @@ class PacManRewardModel(BasePacManRewardModel):
             int(self._idx_pellets_start),
             int(self._idx_terminal),
         )
+
+    # ------------------------------------------------------------------
+    # Helpers reused by HV / Decaying subclasses (kept private so the
+    # public API stays the abstract ``compute_reward`` / ``compute_reward_batch``).
+    # ------------------------------------------------------------------
+
+    def _compute_base_reward_scalar(self, state: np.ndarray, next_state: np.ndarray) -> float:
+        # Reward without the dangerous-area contribution. Achieved by passing
+        # the ``(0, 2)`` sentinel so the fused kernel's danger loop is skipped
+        # (its first check is ``if n_dangerous > 0``).
+        return float(
+            compute_reward_scalar_kernel(
+                np.ascontiguousarray(state, dtype=np.float64),
+                np.ascontiguousarray(next_state, dtype=np.float64),
+                self._empty_dangerous_areas,
+                int(self.num_ghosts),
+                int(self._pellet_positions_arr.shape[0]),
+                float(self.step_penalty),
+                float(self.ghost_collision_penalty),
+                float(self.pellet_reward),
+                float(self.win_reward),
+                0.0,
+                0.0,
+                int(self._idx_pac_row),
+                int(self._idx_pac_col),
+                int(self._idx_ghosts_start),
+                int(self._idx_pellets_start),
+                int(self._idx_score),
+                int(self._idx_terminal),
+            )
+        )
+
+    def _compute_base_reward_batch(
+        self,
+        states: np.ndarray,
+        action: int,
+        next_states: Optional[np.ndarray],
+    ) -> np.ndarray:
+        # Same fused-kernel call as :meth:`compute_reward_batch` but with the
+        # dangerous-area arg zeroed so the variant can add its own contribution.
+        states_arr = np.ascontiguousarray(states, dtype=np.float64)
+        if next_states is None:
+            next_states_arr = np.empty((0, states_arr.shape[1]), dtype=np.float64)
+            has_next_states = False
+        else:
+            next_states_arr = np.ascontiguousarray(next_states, dtype=np.float64)
+            has_next_states = True
+        return compute_reward_batch_kernel(
+            states_arr,
+            int(action),
+            next_states_arr,
+            has_next_states,
+            np.ascontiguousarray(self._neighbor_table_getter(), dtype=np.int32),
+            self._pellet_positions_arr,
+            self._empty_dangerous_areas,
+            int(self.num_ghosts),
+            float(self.step_penalty),
+            float(self.ghost_collision_penalty),
+            float(self.pellet_reward),
+            float(self.win_reward),
+            0.0,
+            0.0,
+            int(self._idx_pac_row),
+            int(self._idx_pac_col),
+            int(self._idx_ghosts_start),
+            int(self._idx_pellets_start),
+            int(self._idx_terminal),
+        )
+
+    def _is_in_dangerous_area(self, position: Tuple[int, int]) -> bool:
+        if self._dangerous_areas_arr.shape[0] == 0:
+            return False
+        pos_r, pos_c = position
+        for d in range(self._dangerous_areas_arr.shape[0]):
+            dr = pos_r - self._dangerous_areas_arr[d, 0]
+            dc = pos_c - self._dangerous_areas_arr[d, 1]
+            if dr * dr + dc * dc <= self._dangerous_radius_sq:
+                return True
+        return False
+
+    def _compute_next_pacman_positions_batch(
+        self, states: np.ndarray, action: int
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        # Derive realised next pacman (row, col) via the neighbor table —
+        # matches the fused batch kernel exactly so variant contributions
+        # score against the same realised position the base reward used.
+        neighbor_table = self._neighbor_table_getter()
+        pac_rows = states[:, self._idx_pac_row].astype(np.int64)
+        pac_cols = states[:, self._idx_pac_col].astype(np.int64)
+        new_rows = neighbor_table[pac_rows, pac_cols, int(action), 0].astype(np.int64)
+        new_cols = neighbor_table[pac_rows, pac_cols, int(action), 1].astype(np.int64)
+        return new_rows, new_cols
+
+    def _compute_in_zone_mask_batch(
+        self, new_pac_rows: np.ndarray, new_pac_cols: np.ndarray
+    ) -> np.ndarray:
+        n = new_pac_rows.shape[0]
+        if self._dangerous_areas_arr.shape[0] == 0:
+            return np.zeros(n, dtype=bool)
+        in_zone = np.zeros(n, dtype=bool)
+        centers = self._dangerous_areas_arr  # (D, 2)
+        for d in range(centers.shape[0]):
+            dr = new_pac_rows - centers[d, 0]
+            dc = new_pac_cols - centers[d, 1]
+            in_zone |= (dr * dr + dc * dc) <= self._dangerous_radius_sq
+        return in_zone
+
+
+class PacManHighVarianceStatesRewardModel(PacManRewardModel):
+    """HIGH_VARIANCE_STATES variant.
+
+    Replaces the deterministic in-zone penalty with a 50/50 split between
+    ``+dangerous_area_penalty`` and ``-dangerous_area_penalty`` whenever
+    the realised next pacman position is in any dangerous area. Expected
+    contribution is ``0``; variance is ``dangerous_area_penalty**2``.
+    Mirrors
+    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLDHighVarianceStatesRewardModel`
+    and
+    :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models.LaserTagHighVarianceStatesRewardModel`.
+    All non-dangerous-area scoring (collision / pellet / win / step
+    penalty) is identical to the standard model.
+    """
+
+    def compute_reward(
+        self,
+        state: np.ndarray,
+        action: int,
+        next_state: np.ndarray,
+    ) -> float:
+        del action  # Realised post-transition state already encodes the choice.
+        if state[self._idx_terminal] > 0.5:
+            return 0.0
+        base = self._compute_base_reward_scalar(state, next_state)
+        position = (
+            int(next_state[self._idx_pac_row]),
+            int(next_state[self._idx_pac_col]),
+        )
+        return base + self._dangerous_area_contribution_scalar(position)
+
+    def _dangerous_area_contribution_scalar(self, position: Tuple[int, int]) -> float:
+        if not self._is_in_dangerous_area(position):
+            return 0.0
+        if np.random.random() < 0.5:
+            return self.dangerous_area_penalty
+        return -self.dangerous_area_penalty
+
+    def compute_reward_batch(
+        self,
+        states: np.ndarray,
+        action: int,
+        next_states: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
+        states_arr = np.ascontiguousarray(states, dtype=np.float64)
+        next_states_arr = (
+            None if next_states is None else np.ascontiguousarray(next_states, dtype=np.float64)
+        )
+        rewards = self._compute_base_reward_batch(states_arr, action, next_states_arr)
+        if self._dangerous_areas_arr.shape[0] == 0:
+            return rewards
+        new_pac_rows, new_pac_cols = self._compute_next_pacman_positions_batch(states_arr, action)
+        in_zone = self._compute_in_zone_mask_batch(new_pac_rows, new_pac_cols)
+        # Terminal rows return 0 reward (already zeroed by the base kernel) and
+        # must not pick up a stochastic danger contribution either.
+        terminal = states_arr[:, self._idx_terminal] > 0.5
+        in_zone &= ~terminal
+        in_zone_indices = np.flatnonzero(in_zone)
+        if in_zone_indices.size == 0:
+            return rewards
+        # ``signs`` matches the per-row independent ±penalty draw. Single
+        # batched ``np.random.random`` keeps seed semantics aligned with the
+        # light-dark / laser-tag HV batch paths.
+        coins = np.random.random(in_zone_indices.size)
+        signs = np.where(coins < 0.5, 1.0, -1.0)
+        rewards[in_zone_indices] += signs * self.dangerous_area_penalty
+        return rewards
+
+
+class PacManDecayingHitProbabilityRewardModel(PacManRewardModel):
+    """DECAYING_HIT_PROBABILITY variant.
+
+    Penalty is applied with probability
+    ``exp(-min_dist / penalty_decay)`` where ``min_dist`` is the
+    Euclidean distance from the realised next pacman position to the
+    *closest* dangerous-area centre. No radius cutoff — every step
+    risks some (vanishingly small at large distance) penalty. Each
+    call draws one uniform regardless of distance, matching the
+    existing decaying-prob kernel and the light-dark / laser-tag
+    analogous reward models. ``dangerous_area_radius`` is **ignored**
+    in this model.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        *,
+        num_ghosts: int,
+        pellet_positions_arr: np.ndarray,
+        dangerous_areas: List[Tuple[int, int]],
+        dangerous_areas_arr: np.ndarray,
+        dangerous_area_radius: float,
+        dangerous_area_penalty: float,
+        step_penalty: float,
+        ghost_collision_penalty: float,
+        pellet_reward: float,
+        win_reward: float,
+        idx_pac_row: int,
+        idx_pac_col: int,
+        idx_ghosts_start: int,
+        idx_pellets_start: int,
+        idx_pellets_end: int,
+        idx_score: int,
+        idx_terminal: int,
+        neighbor_table_getter: Callable[[], np.ndarray],
+        penalty_decay: float,
+    ):
+        super().__init__(
+            num_ghosts=num_ghosts,
+            pellet_positions_arr=pellet_positions_arr,
+            dangerous_areas=dangerous_areas,
+            dangerous_areas_arr=dangerous_areas_arr,
+            dangerous_area_radius=dangerous_area_radius,
+            dangerous_area_penalty=dangerous_area_penalty,
+            step_penalty=step_penalty,
+            ghost_collision_penalty=ghost_collision_penalty,
+            pellet_reward=pellet_reward,
+            win_reward=win_reward,
+            idx_pac_row=idx_pac_row,
+            idx_pac_col=idx_pac_col,
+            idx_ghosts_start=idx_ghosts_start,
+            idx_pellets_start=idx_pellets_start,
+            idx_pellets_end=idx_pellets_end,
+            idx_score=idx_score,
+            idx_terminal=idx_terminal,
+            neighbor_table_getter=neighbor_table_getter,
+        )
+        if penalty_decay <= 0.0:
+            raise ValueError("penalty_decay must be strictly positive")
+        self.penalty_decay = float(penalty_decay)
+
+    def compute_reward(
+        self,
+        state: np.ndarray,
+        action: int,
+        next_state: np.ndarray,
+    ) -> float:
+        del action  # Realised post-transition state already encodes the choice.
+        if state[self._idx_terminal] > 0.5:
+            return 0.0
+        base = self._compute_base_reward_scalar(state, next_state)
+        position = (
+            int(next_state[self._idx_pac_row]),
+            int(next_state[self._idx_pac_col]),
+        )
+        return base + self._dangerous_area_contribution_scalar(position)
+
+    def _dangerous_area_contribution_scalar(self, position: Tuple[int, int]) -> float:
+        if self._dangerous_centers_xy.shape[1] == 0:
+            return 0.0
+        point = np.array([float(position[0]), float(position[1])])
+        return float(
+            decaying_prob_penalty_kernel(
+                point,
+                self._dangerous_centers_xy,
+                -self.dangerous_area_penalty,
+                self.penalty_decay,
+                float(np.random.random()),
+            )
+        )
+
+    def compute_reward_batch(
+        self,
+        states: np.ndarray,
+        action: int,
+        next_states: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
+        states_arr = np.ascontiguousarray(states, dtype=np.float64)
+        next_states_arr = (
+            None if next_states is None else np.ascontiguousarray(next_states, dtype=np.float64)
+        )
+        rewards = self._compute_base_reward_batch(states_arr, action, next_states_arr)
+        if self._dangerous_centers_xy.shape[1] == 0:
+            return rewards
+        new_pac_rows, new_pac_cols = self._compute_next_pacman_positions_batch(states_arr, action)
+        n = new_pac_rows.shape[0]
+        points = np.empty((n, 2), dtype=np.float64)
+        points[:, 0] = new_pac_rows
+        points[:, 1] = new_pac_cols
+        # Decay penalty is applied to *every* non-terminal row (no radius
+        # cutoff). One uniform draw per row keeps seed semantics aligned
+        # with the light-dark / laser-tag Decaying batch paths.
+        uniforms = np.random.random(n)
+        contributions = decaying_prob_penalty_batch_kernel(
+            points,
+            self._dangerous_centers_xy,
+            -self.dangerous_area_penalty,
+            self.penalty_decay,
+            uniforms,
+        )
+        terminal = states_arr[:, self._idx_terminal] > 0.5
+        contributions[terminal] = 0.0
+        rewards += contributions
+        return rewards

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_utils/test_pacman_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_utils/test_pacman_reward_models.py
@@ -1,0 +1,368 @@
+"""Tests for the PacMan POMDP reward-model variants.
+
+Covers the high-variance and decaying-hit-probability variants added
+alongside the standard model and exposed via
+:class:`PacManPOMDP`'s ``reward_model_type`` parameter. The existing
+standard-model behaviour is already exercised by
+``test_pacman_pomdp.py``.
+"""
+
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import (
+    PacManPOMDP,
+    RewardModelType,
+)
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.pacman_reward_models import (
+    BasePacManRewardModel,
+    PacManDecayingHitProbabilityRewardModel,
+    PacManHighVarianceStatesRewardModel,
+    PacManRewardModel,
+)
+
+
+# Default maze / hazard configuration shared by the scenario-style tests.
+# A 7x7 maze with one zone centred at (3, 3) radius 1.0 mirrors the
+# ``test_pacman_pomdp.py`` scenarios for the standard model.
+_MAZE_SIZE: Tuple[int, int] = (7, 7)
+_DANGER_CENTRE: Tuple[int, int] = (3, 3)
+_DANGER_RADIUS = 1.0
+_DANGER_PENALTY = 5.0
+_STEP_PENALTY = -1.0
+
+
+def _make_env(
+    reward_model_type: RewardModelType,
+    penalty_decay: float = 1.0,
+) -> PacManPOMDP:
+    return PacManPOMDP(
+        maze_size=_MAZE_SIZE,
+        walls=set(),
+        initial_pacman_pos=(0, 0),
+        num_ghosts=1,
+        initial_ghost_positions=[(6, 6)],
+        initial_pellets=[(1, 1)],
+        dangerous_areas={_DANGER_CENTRE},
+        dangerous_area_radius=_DANGER_RADIUS,
+        dangerous_area_penalty=_DANGER_PENALTY,
+        step_penalty=_STEP_PENALTY,
+        ghost_collision_penalty=-100.0,
+        pellet_reward=10.0,
+        win_reward=100.0,
+        reward_model_type=reward_model_type,
+        penalty_decay=penalty_decay,
+    )
+
+
+def _state_with_pac(env: PacManPOMDP, pacman_pos: Tuple[int, int]) -> np.ndarray:
+    return env.make_state(
+        pacman_pos=pacman_pos,
+        ghost_positions=((6, 6),),
+        pellets=((1, 1),),
+        score=0.0,
+        terminal=False,
+    )
+
+
+class TestPacManHighVarianceStatesRewardModel:
+    """Behavioural tests for the HV variant."""
+
+    def test_subclass_inherits_base(self):
+        """HV model is both a ``BasePacManRewardModel`` and a ``PacManRewardModel``.
+
+        Purpose: Validates the class hierarchy so callers that expect either
+            base type can interchangeably use the HV variant.
+
+        Given: A ``PacManPOMDP`` constructed with the HV reward variant.
+        When: ``isinstance`` is checked against the abstract and concrete bases.
+        Then: Both checks return True.
+
+        Test type: unit
+        """
+        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        assert isinstance(env.reward_model, PacManRewardModel)
+        assert isinstance(env.reward_model, BasePacManRewardModel)
+        assert isinstance(env.reward_model, PacManHighVarianceStatesRewardModel)
+
+    def test_outside_zone_matches_step_penalty(self):
+        """Positions outside every zone score exactly the step penalty.
+
+        Purpose: Validates the HV variant leaves non-dangerous-area transitions
+            untouched — only the danger contribution changes versus the standard
+            model.
+
+        Given: An HV env and a transition that ends outside the single zone
+            (distance > radius).
+        When: ``reward(state, action, next_state)`` is called.
+        Then: Reward equals ``step_penalty`` exactly.
+
+        Test type: unit
+        """
+        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        state = _state_with_pac(env, (0, 0))
+        next_state = _state_with_pac(env, (0, 1))
+        reward = env.reward_model.compute_reward(state, action=1, next_state=next_state)
+        assert reward == pytest.approx(_STEP_PENALTY)
+
+    def test_danger_zone_emits_symmetric_penalty(self):
+        """HV dangerous-area contribution is ``±dangerous_area_penalty`` with mean ≈ 0.
+
+        Purpose: Validates the variant's signature property — danger zones
+            contribute zero expected reward with high variance — by averaging
+            over a large sample of seeded draws.
+
+        Given: An HV reward model and a transition whose realised next position
+            is on a zone centre.
+        When: ``compute_reward`` is called over 2000 trials.
+        Then: Each observed reward is exactly
+            ``step_penalty ± dangerous_area_penalty`` and the sample mean of
+            the danger contribution is within 0.5 of zero.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        state = _state_with_pac(env, (3, 2))
+        next_state = _state_with_pac(env, _DANGER_CENTRE)
+        rewards = np.array(
+            [
+                env.reward_model.compute_reward(state, action=1, next_state=next_state)
+                for _ in range(2000)
+            ]
+        )
+        # Contributions are (step_penalty - penalty) or (step_penalty + penalty).
+        contributions = rewards - _STEP_PENALTY
+        assert set(np.unique(contributions).tolist()) == {-_DANGER_PENALTY, _DANGER_PENALTY}
+        assert abs(float(np.mean(contributions))) < 0.5
+
+    def test_batch_danger_zone_matches_scalar_distribution(self):
+        """``compute_reward_batch`` HV draws keep the same ±penalty distribution.
+
+        Purpose: Validates the batch path applies the same per-row ±penalty
+            distribution as the scalar path so vectorised callers see the same
+            expected reward and variance as per-particle callers.
+
+        Given: An HV reward model and an ``(N, state_dim)`` state batch all
+            entering the same zone centre.
+        When: ``compute_reward_batch`` is called once with ``N=4000``.
+        Then: Observed contributions are exactly ``±dangerous_area_penalty``
+            and the sample mean is within 0.5 of zero.
+
+        Test type: unit
+        """
+        np.random.seed(123)
+        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        n = 4000
+        state = _state_with_pac(env, (3, 2))
+        next_state = _state_with_pac(env, _DANGER_CENTRE)
+        states = np.tile(state, (n, 1))
+        next_states = np.tile(next_state, (n, 1))
+        rewards = env.reward_model.compute_reward_batch(states, action=1, next_states=next_states)
+        contributions = rewards - _STEP_PENALTY
+        assert set(np.unique(contributions).tolist()) == {-_DANGER_PENALTY, _DANGER_PENALTY}
+        assert abs(float(np.mean(contributions))) < 0.5
+
+    def test_terminal_state_returns_zero(self):
+        """Terminal states never accrue reward, even in a zone.
+
+        Purpose: Pins the terminal-zero contract on the HV variant so future
+            kernel changes cannot accidentally start scoring danger
+            contributions for terminal rows.
+
+        Given: An HV reward model and a terminal state.
+        When: ``compute_reward`` is called with a transition into the zone.
+        Then: Reward is exactly 0.0 on every trial.
+
+        Test type: unit
+        """
+        np.random.seed(7)
+        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        state = env.make_state(
+            pacman_pos=(3, 3),
+            ghost_positions=((6, 6),),
+            pellets=((1, 1),),
+            score=0.0,
+            terminal=True,
+        )
+        next_state = _state_with_pac(env, _DANGER_CENTRE)
+        for _ in range(30):
+            assert env.reward_model.compute_reward(state, action=1, next_state=next_state) == 0.0
+
+
+class TestPacManDecayingHitProbabilityRewardModel:
+    """Behavioural tests for the Decaying-Hit-Probability variant."""
+
+    def test_rejects_non_positive_decay(self):
+        """``penalty_decay`` must be strictly positive.
+
+        Purpose: Validates the constructor rejects nonsensical decay lengths.
+
+        Given: An env factory invoked with ``penalty_decay <= 0``.
+        When: The constructor runs.
+        Then: ``ValueError`` is raised with a message mentioning ``penalty_decay``.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="penalty_decay"):
+            _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=0.0)
+        with pytest.raises(ValueError, match="penalty_decay"):
+            _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=-1.0)
+
+    def test_at_centre_always_triggers_penalty(self):
+        """When the realised position equals a centre, penalty fires every time.
+
+        Purpose: Validates the boundary case where ``min_dist == 0`` so
+            ``hit_prob == 1.0`` — every trial must emit the full penalty.
+
+        Given: A Decay reward model and a transition whose realised next
+            position is exactly on a zone centre.
+        When: ``compute_reward`` is called over 50 trials.
+        Then: Every call returns ``step_penalty - dangerous_area_penalty``.
+
+        Test type: unit
+        """
+        np.random.seed(7)
+        env = _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=1.0)
+        state = _state_with_pac(env, (3, 2))
+        next_state = _state_with_pac(env, _DANGER_CENTRE)
+        for _ in range(50):
+            reward = env.reward_model.compute_reward(state, action=1, next_state=next_state)
+            assert reward == pytest.approx(_STEP_PENALTY - _DANGER_PENALTY)
+
+    def test_far_position_penalty_rate_decays(self):
+        """Empirical hit rate ≈ ``exp(-dist / penalty_decay)``.
+
+        Purpose: Validates the batch path's hit rate follows the
+            distance-decaying formula by sampling a large batch of identical
+            far-away positions and comparing the observed rate to the analytic
+            target.
+
+        Given: A Decay reward model with ``penalty_decay = 2.0`` and a batch
+            of 6000 states whose realised positions sit at distance 2.0 from
+            the nearest zone centre.
+        When: ``compute_reward_batch`` is called once.
+        Then: The fraction of rows that received the danger penalty is within
+            0.05 of ``exp(-2.0 / 2.0) ≈ 0.368``.
+
+        Test type: unit
+        """
+        np.random.seed(99)
+        decay = 2.0
+        env = _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=decay)
+        n = 6000
+        # Position (3, 1): nearest centre (3, 3) at distance 2.0. Use action 4
+        # (stay) so the batch path's neighbor-table lookup keeps the realised
+        # next position at (3, 1) instead of shifting it by the action vector.
+        state = _state_with_pac(env, (3, 1))
+        states = np.tile(state, (n, 1))
+        next_states = states.copy()
+        rewards = env.reward_model.compute_reward_batch(states, action=4, next_states=next_states)
+        contributions = rewards - _STEP_PENALTY
+        assert set(np.unique(contributions).tolist()) == {0.0, -_DANGER_PENALTY}
+        observed_rate = float(np.mean(contributions == -_DANGER_PENALTY))
+        expected_rate = float(np.exp(-2.0 / decay))
+        assert abs(observed_rate - expected_rate) < 0.05
+
+    def test_no_zones_returns_step_penalty_only(self):
+        """With no zones configured the decay contribution is identically zero.
+
+        Purpose: Guards the no-op path — when ``dangerous_areas`` is empty the
+            decay kernel must not be called and the reward must equal
+            ``step_penalty``.
+
+        Given: A Decay-variant env constructed without dangerous areas.
+        When: ``compute_reward`` is called on an arbitrary transition.
+        Then: Reward equals exactly ``step_penalty``.
+
+        Test type: unit
+        """
+        env = PacManPOMDP(
+            maze_size=_MAZE_SIZE,
+            walls=set(),
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(6, 6)],
+            initial_pellets=[(1, 1)],
+            step_penalty=_STEP_PENALTY,
+            ghost_collision_penalty=-100.0,
+            pellet_reward=10.0,
+            win_reward=100.0,
+            reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY,
+            penalty_decay=1.0,
+        )
+        state = _state_with_pac(env, (0, 0))
+        next_state = _state_with_pac(env, (0, 1))
+        for _ in range(20):
+            reward = env.reward_model.compute_reward(state, action=1, next_state=next_state)
+            assert reward == pytest.approx(_STEP_PENALTY)
+
+    def test_terminal_state_returns_zero(self):
+        """Terminal states never accrue reward, even when the realised next position is at a centre.
+
+        Purpose: Pins the terminal-zero contract on the Decay variant.
+
+        Given: A Decay env and a terminal state with a realised next position at a zone centre.
+        When: ``compute_reward`` is called over 30 trials.
+        Then: Reward is exactly 0.0 every trial.
+
+        Test type: unit
+        """
+        np.random.seed(7)
+        env = _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=1.0)
+        state = env.make_state(
+            pacman_pos=(3, 3),
+            ghost_positions=((6, 6),),
+            pellets=((1, 1),),
+            score=0.0,
+            terminal=True,
+        )
+        next_state = _state_with_pac(env, _DANGER_CENTRE)
+        for _ in range(30):
+            assert env.reward_model.compute_reward(state, action=1, next_state=next_state) == 0.0
+
+
+class TestPacManPOMDPRewardModelTypeWiring:
+    """Sanity tests for the ``reward_model_type`` constructor parameter on the env."""
+
+    @pytest.mark.parametrize(
+        "rmt, expected_cls",
+        [
+            (RewardModelType.STANDARD, PacManRewardModel),
+            (RewardModelType.HIGH_VARIANCE_STATES, PacManHighVarianceStatesRewardModel),
+            (RewardModelType.DECAYING_HIT_PROBABILITY, PacManDecayingHitProbabilityRewardModel),
+        ],
+    )
+    def test_env_instantiates_correct_reward_model_subclass(self, rmt, expected_cls):
+        """``PacManPOMDP`` builds the reward model class selected by ``reward_model_type``.
+
+        Purpose: Validates the env's branching logic from ``reward_model_type``
+            to the concrete reward-model class.
+
+        Given: A ``PacManPOMDP`` constructed with a specific ``reward_model_type``.
+        When: ``env.reward_model`` is inspected.
+        Then: It is an instance of the expected concrete subclass.
+
+        Test type: unit
+        """
+        env = _make_env(rmt, penalty_decay=2.0)
+        assert isinstance(env.reward_model, expected_cls)
+
+    def test_env_default_reward_model_is_standard(self):
+        """The default ``reward_model_type`` preserves the historical standard model.
+
+        Purpose: Regression — ensures that omitting ``reward_model_type``
+            yields the original deterministic reward semantics so existing
+            configs and tests keep their pre-refactor behaviour.
+
+        Given: A ``PacManPOMDP`` constructed without specifying ``reward_model_type``.
+        When: ``env.reward_model`` is inspected.
+        Then: It is exactly a ``PacManRewardModel`` (not a subclass).
+
+        Test type: unit
+        """
+        env = PacManPOMDP(maze_size=_MAZE_SIZE)
+        # pylint: disable-next=unidiomatic-typecheck
+        assert type(env.reward_model) is PacManRewardModel


### PR DESCRIPTION
## Summary
- Adds `PacManHighVarianceStatesRewardModel` (in-zone ±penalty 50/50, mean 0) and `PacManDecayingHitProbabilityRewardModel` (penalty with probability `exp(-min_dist / penalty_decay)` from nearest zone centre, no radius cutoff), mirroring the variants already in light_dark / laser_tag / rock_sample.
- Wires them via a new `RewardModelType` enum + `reward_model_type` / `penalty_decay` kwargs on `PacManPOMDP`; default `STANDARD` preserves prior behaviour.
- Subclasses reuse the fused njit reward kernel with danger fields zeroed, then add the variant contribution in Python — standard fast path unchanged.

## Test plan
- [x] 14 new unit tests in `test_pacman_pomdp_utils/test_pacman_reward_models.py` (subclass wiring, in-zone ±penalty distribution, decay rate `exp(-d/decay)`, terminal-zero contract, no-zones no-op, env enum dispatch)
- [x] 124 existing pacman tests still pass (`test_pacman_pomdp.py`, `test_pacman_visualizer.py`, `test_pacman_pomdp_beliefs/`, `test_pacman_native/`)
- [x] Whole-tree pyright clean for changes; pylint 10/10 on the new test, 9.96/10 on `pacman_pomdp.py` (unchanged from baseline)