### PR TITLE
fix(envs): align C++ reward kernels with Python variants across 5 envs

### DIFF
--- a/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
@@ -852,22 +852,148 @@ py::array_t<double> reward_batch(
     return out;
 }
 
+// Reward-variant codes shared by the discrete reward batch kernel and the
+// random-rollout kernel. Match
+// POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp.RewardModelType.
+//
+// STANDARD                 : deterministic single ``-penalty`` on wall OR
+//                            danger membership (matches
+//                            LaserTagRewardModel._compute_area_penalty_scalar
+//                            and the legacy kernel).
+// HIGH_VARIANCE_STATES     : wall always emits ``-penalty``; danger emits
+//                            ``±penalty`` 50/50 via the shared C++ RNG.
+// DECAYING_HIT_PROBABILITY : wall always emits ``-penalty``; danger emits
+//                            ``-penalty`` with probability
+//                            ``exp(-min_dist / penalty_decay)`` against the
+//                            nearest centre (no radius cutoff).
+constexpr int kVariantStandard = 0;
+constexpr int kVariantHighVariance = 1;
+constexpr int kVariantDecaying = 2;
+
+// Build the packed wall hash set from the (2 * n_walls,) int64 buffer.
+std::unordered_set<int64_t> build_wall_cells(
+    const py::array_t<int64_t, py::array::c_style | py::array::forcecast> &walls_flat,
+    int n_walls, int cols) {
+    auto walls_view = walls_flat.unchecked<1>();
+    std::unordered_set<int64_t> wall_cells;
+    wall_cells.reserve(static_cast<std::size_t>(n_walls) * 2 + 1);
+    for (int i = 0; i < n_walls; ++i) {
+        const int64_t wr = walls_view(static_cast<py::ssize_t>(2 * i));
+        const int64_t wc = walls_view(static_cast<py::ssize_t>(2 * i + 1));
+        wall_cells.insert(wr * static_cast<int64_t>(cols) + wc);
+    }
+    return wall_cells;
+}
+
+// Pack dangerous-area centres from the (D, 2) float64 buffer (or empty).
+std::vector<std::pair<double, double>> build_areas(
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &dangerous_areas,
+    int n_dangerous) {
+    std::vector<std::pair<double, double>> areas;
+    if (n_dangerous <= 0) {
+        return areas;
+    }
+    if (dangerous_areas.ndim() != 2 || dangerous_areas.shape(0) != n_dangerous ||
+        dangerous_areas.shape(1) != 2) {
+        throw std::invalid_argument("dangerous_areas must have shape (n_dangerous, 2)");
+    }
+    areas.reserve(static_cast<std::size_t>(n_dangerous));
+    auto da_view = dangerous_areas.unchecked<2>();
+    for (int i = 0; i < n_dangerous; ++i) {
+        areas.emplace_back(da_view(static_cast<py::ssize_t>(i), 0),
+                           da_view(static_cast<py::ssize_t>(i), 1));
+    }
+    return areas;
+}
+
+// Return true iff (int_r, int_c) is an in-bounds wall cell.
+inline bool wall_hit(int64_t int_r, int64_t int_c, int rows, int cols,
+                     const std::unordered_set<int64_t> &wall_cells) {
+    if (int_r < 0 || int_r >= static_cast<int64_t>(rows) || int_c < 0 ||
+        int_c >= static_cast<int64_t>(cols)) {
+        return false;
+    }
+    const int64_t key = int_r * static_cast<int64_t>(cols) + int_c;
+    return wall_cells.find(key) != wall_cells.end();
+}
+
+// Return true iff (pr, pc) lies within ``r_sq`` (squared radius) of any area.
+inline bool danger_hit_within(double pr, double pc, double r_sq,
+                              const std::vector<std::pair<double, double>> &areas) {
+    for (const auto &area : areas) {
+        const double ddr = pr - area.first;
+        const double ddc = pc - area.second;
+        if (ddr * ddr + ddc * ddc <= r_sq) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Compute the variant's danger-area contribution (already excludes the wall
+// contribution; wall handling is shared upstream). ``uniform`` is used by
+// stochastic variants only — pass any value for STANDARD.
+inline double variant_danger_contribution(
+    int variant_code, double pr, double pc, double r_sq, double penalty_decay,
+    double dangerous_area_penalty,
+    const std::vector<std::pair<double, double>> &areas, double uniform) {
+    if (areas.empty()) {
+        return 0.0;
+    }
+    if (variant_code == kVariantHighVariance) {
+        if (!danger_hit_within(pr, pc, r_sq, areas)) {
+            return 0.0;
+        }
+        return (uniform < 0.5) ? -dangerous_area_penalty : dangerous_area_penalty;
+    }
+    if (variant_code == kVariantDecaying) {
+        double min_sq = std::numeric_limits<double>::infinity();
+        for (const auto &area : areas) {
+            const double ddr = pr - area.first;
+            const double ddc = pc - area.second;
+            const double dsq = ddr * ddr + ddc * ddc;
+            if (dsq < min_sq) {
+                min_sq = dsq;
+            }
+        }
+        const double min_dist = std::sqrt(min_sq);
+        const double hit_prob = std::exp(-min_dist / penalty_decay);
+        if (uniform < hit_prob) {
+            return -dangerous_area_penalty;
+        }
+        return 0.0;
+    }
+    // STANDARD: handled by the caller via the combined OR-mask path; this
+    // helper should not be invoked for STANDARD.
+    return 0.0;
+}
+
 // Vectorised reward kernel for the discrete LaserTagPOMDP.
 //
-// Mirrors LaserTagPOMDP._compute_reward_batch in pure C++:
+// Mirrors LaserTagPOMDP.reward_model.compute_reward_batch across the three
+// :class:`RewardModelType` variants:
 //   - terminal-flag rows yield 0.0;
 //   - on the tag action (action == 4): live rows get +tag_reward when the
 //     robot grid cell equals the opponent grid cell, else -tag_penalty;
 //   - on a movement action (0..3): live rows pay -step_cost;
-//   - the intended-position penalty (-dangerous_area_penalty) is applied
-//     when the intended cell hits a wall (in-bounds + walls hit) or lies
-//     within ``dangerous_area_radius`` (Euclidean) of any dangerous-area
-//     centre. For action == 4 the intended cell is the current robot cell;
-//     for actions 0..3 it is the robot cell shifted by ``action_directions``.
+//   - the danger / wall contribution is scored against the *realised*
+//     post-action position read from ``next_states[:, :2]`` when
+//     ``next_states`` is provided (preferred path); when it is empty/null
+//     the intended cell is used (legacy ``compute_reward_batch_python``
+//     fallback). STANDARD applies a single -penalty on (wall OR danger);
+//     HIGH_VARIANCE_STATES and DECAYING_HIT_PROBABILITY apply the wall
+//     penalty deterministically and resolve the danger contribution via
+//     ``pomdp_native::default_rng``.
 //
 // dangerous_areas: shape (D, 2) float64 (or (0, 2) / 1-D length-0 for empty).
 // walls_flat: 1-D int64 array of (row, col) pairs flattened (length = 2 * n_walls).
 // action_directions: shape (4, 2) int64 with row r = (dr, dc) for action r.
+// next_states: shape (N, 5) float64 or empty (0, 0) / (0, 5) for "intended
+//   position" fallback. When non-empty its row count must equal ``states``'.
+// reward_variant_code: see kVariant* constants above.
+// penalty_decay: decay length for the DECAYING_HIT_PROBABILITY variant
+//   (must be strictly positive when ``reward_variant_code == kVariantDecaying``);
+//   ignored otherwise.
 py::array_t<double> lasertag_discrete_reward_batch(
     const py::array_t<double, py::array::c_style | py::array::forcecast> &states,
     int action,
@@ -881,7 +1007,10 @@ py::array_t<double> lasertag_discrete_reward_batch(
     double tag_reward,
     double tag_penalty,
     double step_cost,
-    const py::array_t<int64_t, py::array::c_style | py::array::forcecast> &action_directions) {
+    const py::array_t<int64_t, py::array::c_style | py::array::forcecast> &action_directions,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &next_states,
+    int reward_variant_code,
+    double penalty_decay) {
     if (states.ndim() != 2 || states.shape(1) != static_cast<py::ssize_t>(kStateDim)) {
         throw std::invalid_argument("states must have shape (N, 5)");
     }
@@ -894,30 +1023,31 @@ py::array_t<double> lasertag_discrete_reward_batch(
         throw std::invalid_argument("action_directions must have shape (4, 2)");
     }
 
-    // Pack walls into a hash set of row * cols + col for O(1) wall hits.
-    auto walls_view = walls_flat.unchecked<1>();
-    std::unordered_set<int64_t> wall_cells;
-    wall_cells.reserve(static_cast<std::size_t>(n_walls) * 2 + 1);
-    for (int i = 0; i < n_walls; ++i) {
-        const int64_t wr = walls_view(static_cast<py::ssize_t>(2 * i));
-        const int64_t wc = walls_view(static_cast<py::ssize_t>(2 * i + 1));
-        wall_cells.insert(wr * static_cast<int64_t>(cols) + wc);
+    const auto n = static_cast<std::size_t>(states.shape(0));
+    // next_states is optional: empty (0, 0) / (0, 5) / 1-D length-0 means
+    // "fall back to intended position". When non-empty its row count must
+    // equal ``states``'s row count.
+    const bool has_next_states =
+        (next_states.ndim() == 2 && next_states.shape(0) == states.shape(0) &&
+         next_states.shape(1) == static_cast<py::ssize_t>(kStateDim));
+    if (!has_next_states) {
+        const bool is_empty =
+            (next_states.ndim() == 1 && next_states.shape(0) == 0) ||
+            (next_states.ndim() == 2 && next_states.shape(0) == 0);
+        if (!is_empty) {
+            throw std::invalid_argument(
+                "next_states must have shape (N, 5) matching states, or be empty");
+        }
+    }
+    if (reward_variant_code == kVariantDecaying && !(penalty_decay > 0.0)) {
+        throw std::invalid_argument(
+            "penalty_decay must be strictly positive for the DECAYING_HIT_PROBABILITY variant");
     }
 
-    // Pack dangerous-area centres.
-    std::vector<std::pair<double, double>> areas;
-    if (n_dangerous > 0) {
-        if (dangerous_areas.ndim() != 2 || dangerous_areas.shape(0) != n_dangerous ||
-            dangerous_areas.shape(1) != 2) {
-            throw std::invalid_argument("dangerous_areas must have shape (n_dangerous, 2)");
-        }
-        areas.reserve(static_cast<std::size_t>(n_dangerous));
-        auto da_view = dangerous_areas.unchecked<2>();
-        for (int i = 0; i < n_dangerous; ++i) {
-            areas.emplace_back(da_view(static_cast<py::ssize_t>(i), 0),
-                               da_view(static_cast<py::ssize_t>(i), 1));
-        }
-    }
+    const std::unordered_set<int64_t> wall_cells =
+        build_wall_cells(walls_flat, n_walls, cols);
+    const std::vector<std::pair<double, double>> areas =
+        build_areas(dangerous_areas, n_dangerous);
     const double r_sq = dangerous_area_radius * dangerous_area_radius;
 
     // Resolve the action's grid delta. For action 4 (tag) the intended cell is
@@ -932,10 +1062,16 @@ py::array_t<double> lasertag_discrete_reward_batch(
     }
     const bool is_tag = (action == 4);
 
-    const auto n = static_cast<std::size_t>(states.shape(0));
     auto state_view = states.unchecked<2>();
     auto out = py::array_t<double>(static_cast<py::ssize_t>(n));
     auto buf = out.mutable_unchecked<1>();
+
+    pomdp_native::RNGState &rng = pomdp_native::default_rng();
+    std::uniform_real_distribution<double> uniform_dist(0.0, 1.0);
+    const bool needs_uniform =
+        (reward_variant_code == kVariantHighVariance ||
+         reward_variant_code == kVariantDecaying) &&
+        !areas.empty();
 
     for (std::size_t i = 0; i < n; ++i) {
         const py::ssize_t row = static_cast<py::ssize_t>(i);
@@ -956,31 +1092,50 @@ py::array_t<double> lasertag_discrete_reward_batch(
             r = -step_cost;
         }
 
-        const int64_t int_r = robot_r + dr;
-        const int64_t int_c = robot_c + dc;
+        // Resolve the position used to evaluate the wall / danger penalty.
+        // Prefer the realised next_state position when provided; fall back to
+        // the intended cell otherwise (legacy compute_reward_batch_python
+        // behaviour).
+        int64_t eval_r;
+        int64_t eval_c;
+        if (has_next_states) {
+            auto ns_view = next_states.unchecked<2>();
+            eval_r = static_cast<int64_t>(ns_view(row, 0));
+            eval_c = static_cast<int64_t>(ns_view(row, 1));
+        } else {
+            eval_r = robot_r + dr;
+            eval_c = robot_c + dc;
+        }
 
-        bool penalty = false;
-        if (int_r >= 0 && int_r < static_cast<int64_t>(rows) &&
-            int_c >= 0 && int_c < static_cast<int64_t>(cols)) {
-            const int64_t key = int_r * static_cast<int64_t>(cols) + int_c;
-            if (wall_cells.find(key) != wall_cells.end()) {
-                penalty = true;
+        const bool is_wall = wall_hit(eval_r, eval_c, rows, cols, wall_cells);
+
+        if (reward_variant_code == kVariantStandard) {
+            // Single -penalty on (wall OR danger).
+            bool penalty = is_wall;
+            if (!penalty && !areas.empty()) {
+                penalty = danger_hit_within(static_cast<double>(eval_r),
+                                            static_cast<double>(eval_c), r_sq, areas);
             }
-        }
-        if (!penalty && !areas.empty()) {
-            const double pr = static_cast<double>(int_r);
-            const double pc = static_cast<double>(int_c);
-            for (const auto &area : areas) {
-                const double ddr = pr - area.first;
-                const double ddc = pc - area.second;
-                if (ddr * ddr + ddc * ddc <= r_sq) {
-                    penalty = true;
-                    break;
-                }
+            if (penalty) {
+                r -= dangerous_area_penalty;
             }
-        }
-        if (penalty) {
-            r -= dangerous_area_penalty;
+        } else {
+            // HIGH_VARIANCE_STATES / DECAYING: wall and danger contributions
+            // are independent. Wall hit always subtracts ``penalty`` exactly
+            // like the STANDARD variant.
+            if (is_wall) {
+                r -= dangerous_area_penalty;
+            }
+            if (needs_uniform) {
+                // One uniform per row (preserving the Python batch path's
+                // one-draw-per-row contract); the variant helper decides
+                // whether to consume it.
+                const double u = uniform_dist(rng.engine());
+                r += variant_danger_contribution(
+                    reward_variant_code, static_cast<double>(eval_r),
+                    static_cast<double>(eval_c), r_sq, penalty_decay,
+                    dangerous_area_penalty, areas, u);
+            }
         }
         buf(row) = r;
     }
@@ -1215,6 +1370,9 @@ struct DiscreteEnvParams {
     double tag_penalty;
     double step_cost;
     double transition_error_prob;
+    // Reward-variant fields (default to STANDARD, penalty_decay=1.0).
+    int reward_variant_code = kVariantStandard;
+    double penalty_decay = 1.0;
 };
 
 DiscreteEnvParams make_discrete_env_params(
@@ -1223,12 +1381,16 @@ DiscreteEnvParams make_discrete_env_params(
     const py::array_t<double, py::array::c_style | py::array::forcecast> &dangerous_areas_arr,
     double dangerous_area_radius, double dangerous_area_penalty,
     double tag_reward, double tag_penalty, double step_cost,
-    double transition_error_prob) {
+    double transition_error_prob,
+    int reward_variant_code = kVariantStandard,
+    double penalty_decay = 1.0) {
 
     DiscreteEnvParams p;
     p.rows = rows;
     p.cols = cols;
     p.wall_grid.assign(static_cast<std::size_t>(rows * cols), false);
+    p.reward_variant_code = reward_variant_code;
+    p.penalty_decay = penalty_decay;
 
     // walls_flat: 1-D int64 array of length 2*M: [r0, c0, r1, c1, ...]
     if (walls_flat.ndim() != 1) {
@@ -1289,7 +1451,28 @@ inline bool disc_is_dangerous(int r, int c, const DiscreteEnvParams &env) {
     return false;
 }
 
-double disc_reward(const double *state, int action, const DiscreteEnvParams &env) {
+// Returns the minimum Euclidean distance from (pr, pc) to any dangerous-area
+// centre, or +infinity if no centres are configured.
+inline double disc_min_danger_distance(double pr, double pc, const DiscreteEnvParams &env) {
+    double min_sq = std::numeric_limits<double>::infinity();
+    for (const auto &area : env.dangerous_areas) {
+        const double ddr = pr - area.first;
+        const double ddc = pc - area.second;
+        const double dsq = ddr * ddr + ddc * ddc;
+        if (dsq < min_sq) {
+            min_sq = dsq;
+        }
+    }
+    return std::sqrt(min_sq);
+}
+
+// Variant-aware discrete reward. Wall hit is always evaluated against the
+// realised position (the intended-cell + transition handles wall-blocked
+// movement in the rollout caller). The danger contribution depends on
+// ``env.reward_variant_code``; stochastic variants consume one uniform from
+// the supplied RNG.
+double disc_reward(const double *state, int action, const DiscreteEnvParams &env,
+                   pomdp_native::RNGState &rng) {
     if (state[4] != 0.0) {
         return 0.0;
     }
@@ -1318,8 +1501,40 @@ double disc_reward(const double *state, int action, const DiscreteEnvParams &env
     const bool is_wall =
         intended_in_bounds &&
         env.wall_grid[static_cast<std::size_t>(int_r * env.cols + int_c)];
-    if (is_wall || disc_is_dangerous(int_r, int_c, env)) {
+    const bool is_danger = disc_is_dangerous(int_r, int_c, env);
+
+    if (env.reward_variant_code == kVariantStandard) {
+        if (is_wall || is_danger) {
+            base -= env.dangerous_area_penalty;
+        }
+        return base;
+    }
+
+    // HV / Decaying: wall always emits ``-penalty``; danger uses the variant
+    // helper with one RNG draw per evaluation (only when areas exist).
+    if (is_wall) {
         base -= env.dangerous_area_penalty;
+    }
+    if (env.dangerous_areas.empty()) {
+        return base;
+    }
+    std::uniform_real_distribution<double> uniform_dist(0.0, 1.0);
+    const double u = uniform_dist(rng.engine());
+    if (env.reward_variant_code == kVariantHighVariance) {
+        if (!is_danger) {
+            return base;
+        }
+        return base + ((u < 0.5) ? -env.dangerous_area_penalty
+                                 : env.dangerous_area_penalty);
+    }
+    if (env.reward_variant_code == kVariantDecaying) {
+        const double min_dist = disc_min_danger_distance(
+            static_cast<double>(int_r), static_cast<double>(int_c), env);
+        const double hit_prob = std::exp(-min_dist / env.penalty_decay);
+        if (u < hit_prob) {
+            base -= env.dangerous_area_penalty;
+        }
+        return base;
     }
     return base;
 }
@@ -1408,16 +1623,23 @@ double simulate_rollout_discrete(
     const py::array_t<double, py::array::c_style | py::array::forcecast> &dangerous_areas,
     double dangerous_area_radius, double dangerous_area_penalty,
     double tag_reward, double tag_penalty, double step_cost,
-    double transition_error_prob) {
+    double transition_error_prob,
+    int reward_variant_code,
+    double penalty_decay) {
 
     if (initial_state.ndim() != 1 || initial_state.shape(0) != 5) {
         throw std::invalid_argument("initial_state must have shape (5,)");
+    }
+    if (reward_variant_code == kVariantDecaying && !(penalty_decay > 0.0)) {
+        throw std::invalid_argument(
+            "penalty_decay must be strictly positive for the DECAYING_HIT_PROBABILITY variant");
     }
 
     const DiscreteEnvParams env = make_discrete_env_params(
         rows, cols, walls_flat, dangerous_areas,
         dangerous_area_radius, dangerous_area_penalty,
-        tag_reward, tag_penalty, step_cost, transition_error_prob);
+        tag_reward, tag_penalty, step_cost, transition_error_prob,
+        reward_variant_code, penalty_decay);
 
     pomdp_native::RNGState &rng = pomdp_native::default_rng();
     std::uniform_int_distribution<int> action_dist(0, 4);
@@ -1434,7 +1656,7 @@ double simulate_rollout_discrete(
         const int action = action_dist(rng.engine());
 
         // Reward computed on current state before transition.
-        total += gamma_power * disc_reward(state, action, env);
+        total += gamma_power * disc_reward(state, action, env, rng);
         gamma_power *= discount;
 
         // Actual action (with possible error on movement actions).
@@ -2273,13 +2495,23 @@ PYBIND11_MODULE(_native, m) {
           py::arg("dangerous_area_radius"), py::arg("dangerous_area_penalty"),
           py::arg("tag_reward"), py::arg("tag_penalty"), py::arg("step_cost"),
           py::arg("action_directions"),
+          py::arg("next_states") = py::array_t<double>(std::vector<py::ssize_t>{0, 0}),
+          py::arg("reward_variant_code") = 0,
+          py::arg("penalty_decay") = 1.0,
           "Vectorised reward computation for the discrete LaserTagPOMDP. "
-          "Returns shape (N,) float64. Mirrors LaserTagPOMDP._compute_reward_batch "
-          "semantics: terminal rows yield 0, action 4 yields +tag_reward / "
-          "-tag_penalty, actions 0..3 pay -step_cost, and the intended cell "
-          "(robot + action_directions[action] for actions 0..3, robot for tag) "
-          "incurs -dangerous_area_penalty when it hits a wall (in-bounds) or "
-          "lies within dangerous_area_radius of any dangerous-area centre.");
+          "Returns shape (N,) float64. Mirrors "
+          "LaserTagRewardModel.compute_reward_batch across the three "
+          "RewardModelType variants: STANDARD (0) applies a single "
+          "-dangerous_area_penalty on (wall OR danger) at the realised cell, "
+          "HIGH_VARIANCE_STATES (1) emits +/-dangerous_area_penalty on danger "
+          "(50/50) with deterministic wall penalty, and "
+          "DECAYING_HIT_PROBABILITY (2) emits -dangerous_area_penalty on "
+          "danger with probability exp(-min_dist / penalty_decay) with "
+          "deterministic wall penalty. When ``next_states`` is shape (N, 5), "
+          "the penalty is scored against next_states[:, :2]; when it is empty "
+          "(default) the legacy intended-position fallback is used. "
+          "Stochastic variants consume randomness from "
+          "pomdp_native::default_rng().");
 
     py::class_<ContinuousLaserTagTransitionCpp>(m, "ContinuousLaserTagTransitionCpp")
         .def(py::init<const py::object &, const py::object &, const py::array_t<double> &,
@@ -2337,9 +2569,16 @@ PYBIND11_MODULE(_native, m) {
         py::arg("dangerous_area_radius"), py::arg("dangerous_area_penalty"),
         py::arg("tag_reward"), py::arg("tag_penalty"), py::arg("step_cost"),
         py::arg("transition_error_prob"),
+        py::arg("reward_variant_code") = 0,
+        py::arg("penalty_decay") = 1.0,
         "Run a full random-action rollout for the discrete LaserTagPOMDP in one C++ frame.\n\n"
         "Actions are drawn uniformly from {0,1,2,3,4} using pomdp_native::default_rng().\n"
         "Seed via set_seed() before calling to obtain reproducible trajectories.\n"
+        "``reward_variant_code`` selects the LaserTag reward-model variant:\n"
+        "  0 = STANDARD (deterministic wall/danger -penalty on OR);\n"
+        "  1 = HIGH_VARIANCE_STATES (wall always -penalty; danger +/-penalty 50/50);\n"
+        "  2 = DECAYING_HIT_PROBABILITY (wall always -penalty; danger -penalty\n"
+        "      with probability exp(-min_dist / penalty_decay), no radius cutoff).\n"
         "Returns the discounted sum of immediate rewards along the sampled trajectory.");
 
     // ── Discrete LaserTag belief-update kernels ─────────────────────────────

--- a/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
@@ -45,13 +45,24 @@ def lasertag_discrete_reward_batch(
     tag_penalty: float,
     step_cost: float,
     action_directions: NDArray[np.integer],
+    next_states: NDArray[np.floating] = ...,
+    reward_variant_code: int = ...,
+    penalty_decay: float = ...,
 ) -> NDArray[np.float64]:
     """Vectorised reward kernel for the discrete LaserTagPOMDP.
 
-    Mirrors ``LaserTagPOMDP._compute_reward_batch``. ``walls_flat`` is the
-    flattened (row, col) wall list (length ``2 * n_walls``). ``action_directions``
-    is a (4, 2) int64 array mapping action index 0..3 to its (dr, dc) cell delta.
-    Returns shape (N,) float64.
+    Mirrors ``LaserTagRewardModel.compute_reward_batch`` across all three
+    :class:`RewardModelType` variants. ``walls_flat`` is the flattened
+    ``(row, col)`` wall list (length ``2 * n_walls``). ``action_directions``
+    is a ``(4, 2)`` int64 array mapping action index ``0..3`` to its
+    ``(dr, dc)`` cell delta. When ``next_states`` is shape ``(N, 5)``, the
+    danger / wall penalty is scored against ``next_states[:, :2]``; when it
+    is empty (the default) the legacy intended-position fallback is used.
+    ``reward_variant_code`` selects the variant: ``0`` = STANDARD,
+    ``1`` = HIGH_VARIANCE_STATES, ``2`` = DECAYING_HIT_PROBABILITY.
+    ``penalty_decay`` is the decay length used by the
+    ``DECAYING_HIT_PROBABILITY`` variant (ignored otherwise). Returns shape
+    ``(N,)`` float64.
     """
     ...
 
@@ -137,12 +148,18 @@ def simulate_rollout_discrete(
     tag_penalty: float,
     step_cost: float,
     transition_error_prob: float,
+    reward_variant_code: int = ...,
+    penalty_decay: float = ...,
 ) -> float:
     """Run a full random-action rollout for the discrete LaserTagPOMDP in one C++ frame.
 
-    Actions are drawn uniformly from {0,1,2,3,4} using the module-level mt19937_64 RNG.
-    Seed via set_seed() before calling for reproducible results.
-    Returns the discounted sum of immediate rewards along the sampled trajectory.
+    Actions are drawn uniformly from ``{0,1,2,3,4}`` using the module-level
+    mt19937_64 RNG. Seed via :func:`set_seed` before calling for reproducible
+    results. ``reward_variant_code`` selects the reward variant:
+    ``0`` = STANDARD, ``1`` = HIGH_VARIANCE_STATES,
+    ``2`` = DECAYING_HIT_PROBABILITY. ``penalty_decay`` is consulted only by
+    the ``DECAYING_HIT_PROBABILITY`` variant. Returns the discounted sum of
+    immediate rewards along the sampled trajectory.
     """
     ...
 

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -892,6 +892,20 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         # Discrete int actions (0..4); already hashable.
         return action
 
+    def _native_reward_variant_code(self) -> int:
+        """Map ``self.reward_model_type`` to the native kernel's variant code.
+
+        Matches the integer code emitted by the C++ kernel (``0`` = STANDARD,
+        ``1`` = HIGH_VARIANCE_STATES, ``2`` = DECAYING_HIT_PROBABILITY).
+        """
+        if self.reward_model_type == RewardModelType.STANDARD:
+            return 0
+        if self.reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+            return 1
+        if self.reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+            return 2
+        raise ValueError(f"Unknown reward model type: {self.reward_model_type}")
+
     def _get_native_rollout_params(
         self,
     ) -> Optional[Any]:
@@ -945,6 +959,9 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         # are therefore only equivalent in distribution, not bit-by-bit.
         # If the action_sampler is not a uniform sampler over all 5 actions, fall
         # back to the Python loop so planner-specific rollout policies still work.
+        # The native kernel handles all three reward-model variants via the
+        # ``reward_variant_code`` argument; stochastic variants consume
+        # additional draws from the same module-level mt19937_64 RNG.
         params = self._get_native_rollout_params()
         if params is not None:
             state_arr = np.ascontiguousarray(np.asarray(state, dtype=np.float64))
@@ -977,6 +994,8 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
                     tag_penalty=tag_penalty,
                     step_cost=step_cost,
                     transition_error_prob=transition_error_prob,
+                    reward_variant_code=self._native_reward_variant_code(),
+                    penalty_decay=float(self.penalty_decay),
                 )
             )
 

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp_utils/laser_tag_reward_models.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp_utils/laser_tag_reward_models.py
@@ -223,7 +223,7 @@ class LaserTagRewardModel(BaseLaserTagRewardModel):
                 ns_arr = ns_arr.reshape(1, -1)
             next_states_arr = np.ascontiguousarray(ns_arr)
 
-        if self._can_use_native_reward_batch(next_states_arr):
+        if self._can_use_native_reward_batch():
             native_fn = self._get_native_reward_batch()
             if native_fn is not None:
                 return np.asarray(
@@ -242,18 +242,33 @@ class LaserTagRewardModel(BaseLaserTagRewardModel):
                         tag_penalty=float(self.tag_penalty),
                         step_cost=float(self.step_cost),
                         action_directions=self._action_directions_arr,
+                        next_states=(
+                            next_states_arr
+                            if next_states_arr is not None
+                            else np.empty((0, 0), dtype=np.float64)
+                        ),
+                        reward_variant_code=self._reward_variant_code(),
+                        penalty_decay=float(self._penalty_decay_for_native()),
                     )
                 )
         return self._compute_reward_batch_python(states_arr, action, next_states_arr)
 
-    def _can_use_native_reward_batch(self, next_states_arr: Optional[np.ndarray]) -> bool:
-        # The native kernel computes the intended-position penalty and does
-        # not accept a realised next_states buffer. It is therefore only
-        # safe when no penalty terms exist (intended == realised in that
-        # degenerate case).
-        if next_states_arr is not None:
-            return False
-        return not self.walls and not self.dangerous_areas
+    def _can_use_native_reward_batch(self) -> bool:
+        # The variant-aware native kernel handles all three reward-model
+        # variants (STANDARD, HIGH_VARIANCE_STATES, DECAYING_HIT_PROBABILITY)
+        # and both the intended-position fallback and the realised-position
+        # path, so it is always preferred when available.
+        return True
+
+    def _reward_variant_code(self) -> int:
+        # Base class is the STANDARD variant. Subclasses override.
+        return 0
+
+    def _penalty_decay_for_native(self) -> float:
+        # STANDARD / HIGH_VARIANCE_STATES ignore penalty_decay; pass a sentinel
+        # positive value so the C++ kernel's "must be > 0 for DECAYING" guard
+        # does not need to special-case the unused-parameter path.
+        return 1.0
 
     def _get_native_reward_batch(self) -> Optional[Any]:
         cached = getattr(self, "_cached_native_reward_batch", None)
@@ -383,6 +398,9 @@ class LaserTagHighVarianceStatesRewardModel(LaserTagRewardModel):
     is both a wall and inside a danger zone receives both contributions.
     """
 
+    def _reward_variant_code(self) -> int:
+        return 1
+
     def _compute_area_penalty_scalar(self, position: Tuple[int, int]) -> float:
         contrib = 0.0
         if position in self.walls:
@@ -453,6 +471,12 @@ class LaserTagDecayingHitProbabilityRewardModel(LaserTagRewardModel):
         if penalty_decay <= 0.0:
             raise ValueError("penalty_decay must be strictly positive")
         self.penalty_decay = penalty_decay
+
+    def _reward_variant_code(self) -> int:
+        return 2
+
+    def _penalty_decay_for_native(self) -> float:
+        return float(self.penalty_decay)
 
     def _compute_area_penalty_scalar(self, position: Tuple[int, int]) -> float:
         contrib = 0.0

--- a/POMDPPlanners/environments/light_dark_pomdp/_cpp/continuous_light_dark.cpp
+++ b/POMDPPlanners/environments/light_dark_pomdp/_cpp/continuous_light_dark.cpp
@@ -154,42 +154,6 @@ class ContinuousLightDarkObservationCpp
 };
 
 // ---------------------------------------------------------------------------
-// Reward helper: Standard / DangerousStates model (STANDARD variant).
-// Returns (reward, in_obstacle_range) as a std::pair.
-// ---------------------------------------------------------------------------
-static std::pair<double, bool> compute_reward_standard(
-    const double *state, const double *action, const double *goal_state,
-    const std::vector<double> &obstacles_packed,  // interleaved [x0,y0,x1,y1,...]
-    double goal_state_radius, double obstacle_radius, double grid_size,
-    double fuel_cost, double goal_reward, double obstacle_reward) {
-    const double next_x = state[0] + action[0];
-    const double next_y = state[1] + action[1];
-    const double gx = next_x - goal_state[0];
-    const double gy = next_y - goal_state[1];
-    const double dist_to_goal = std::sqrt(gx * gx + gy * gy);
-    double reward = -fuel_cost - dist_to_goal;
-
-    if (dist_to_goal <= goal_state_radius) {
-        return {reward + goal_reward, false};
-    }
-
-    const double obs_r_sq = obstacle_radius * obstacle_radius;
-    const std::size_t n_obs = obstacles_packed.size() / kLightDarkStateDim;
-    for (std::size_t j = 0; j < n_obs; ++j) {
-        const double ox = next_x - obstacles_packed[j * 2];
-        const double oy = next_y - obstacles_packed[j * 2 + 1];
-        if (ox * ox + oy * oy <= obs_r_sq) {
-            return {reward, true};
-        }
-    }
-
-    if (next_x < 0.0 || next_y < 0.0 || next_x > grid_size || next_y > grid_size) {
-        return {reward + obstacle_reward, false};
-    }
-    return {reward, false};
-}
-
-// ---------------------------------------------------------------------------
 // Terminal check matching ContinuousLightDarkPOMDP.is_terminal.
 // goal OR (is_obstacle_hit_terminal AND in any obstacle).
 // ---------------------------------------------------------------------------
@@ -218,13 +182,34 @@ static bool is_terminal_cpp(
     return false;
 }
 
+// Forward declarations for the variant-aware reward row helpers (defined
+// further down alongside ``compute_reward_batch``). Used by both the batched
+// reward kernel and the rollout kernel so the two paths share semantics.
+static double reward_row_standard_or_hv(double nx, double ny, double goal_x, double goal_y,
+                                        const std::vector<double> &obstacles_packed,
+                                        double goal_state_radius, double obstacle_radius_sq,
+                                        double grid_size, double fuel_cost, double goal_reward,
+                                        double obstacle_reward, double obstacle_hit_probability,
+                                        bool high_variance,
+                                        pomdp_native::RNGState &rng,
+                                        std::uniform_real_distribution<double> &uniform01);
+
+static double reward_row_decaying(double nx, double ny, double goal_x, double goal_y,
+                                  const std::vector<double> &obstacles_packed,
+                                  double goal_state_radius, double grid_size, double fuel_cost,
+                                  double goal_reward, double obstacle_reward, double penalty_decay,
+                                  pomdp_native::RNGState &rng,
+                                  std::uniform_real_distribution<double> &uniform01);
+
 // ---------------------------------------------------------------------------
-// Native simulate_rollout for STANDARD reward model.
+// Native simulate_rollout for all reward model variants.
 //
 // Walk a single random rollout from initial_state. At each depth:
 //   1. check terminal — break if true
 //   2. pick action_array[action_indices[depth]]
-//   3. compute reward (STANDARD model, stochastic obstacle draw via C++ RNG)
+//   3. compute reward via variant-aware helper (STANDARD / HIGH_VARIANCE /
+//      DECAYING_HIT_PROBABILITY); stochastic obstacle / penalty draws use
+//      the module-level C++ RNG
 //   4. step transition (same additive-Gaussian kernel as the transition class)
 //   5. accumulate gamma^depth * reward
 //
@@ -232,6 +217,9 @@ static bool is_terminal_cpp(
 // action_indices: shape (max_depth,)  — pre-drawn integer action indices
 // obstacles: interleaved [x0, y0, x1, y1, ...]  (flat 1-D array)
 // covariance: shape (2, 2)  — state transition covariance
+// reward_variant_code: 0 = STANDARD, 1 = HIGH_VARIANCE_STATES,
+//                      2 = DECAYING_HIT_PROBABILITY
+// penalty_decay: only consumed when reward_variant_code == 2
 // ---------------------------------------------------------------------------
 double simulate_rollout(
     const py::array_t<double, py::array::c_style | py::array::forcecast> &initial_state,
@@ -251,6 +239,8 @@ double simulate_rollout(
     double obstacle_reward,
     double obstacle_hit_probability,
     bool is_obstacle_hit_terminal,
+    int reward_variant_code,
+    double penalty_decay,
     // transition params
     const py::array_t<double> &covariance) {
     if (initial_state.ndim() != 1 || static_cast<std::size_t>(initial_state.shape(0)) != kLightDarkStateDim) {
@@ -267,10 +257,15 @@ double simulate_rollout(
     if (obstacles_arr.ndim() != 1) {
         throw std::invalid_argument("obstacles must be a flat 1-D array [x0,y0,x1,y1,...]");
     }
+    if (reward_variant_code < 0 || reward_variant_code > 2) {
+        throw std::invalid_argument("reward_variant_code must be in {0, 1, 2}");
+    }
 
     // Unpack goal state
     auto gs_view = goal_state_arr.unchecked<1>();
     const double goal_state[kLightDarkStateDim] = {gs_view(0), gs_view(1)};
+    const double goal_x = goal_state[0];
+    const double goal_y = goal_state[1];
 
     // Unpack obstacles into a local vector
     const auto n_obs_flat = static_cast<std::size_t>(obstacles_arr.shape(0));
@@ -279,6 +274,7 @@ double simulate_rollout(
     for (std::size_t i = 0; i < n_obs_flat; ++i) {
         obstacles_packed[i] = obs_view(static_cast<py::ssize_t>(i));
     }
+    const double obstacle_radius_sq = obstacle_radius * obstacle_radius;
 
     // Build Gaussian noise kernel from covariance (Cholesky once)
     const auto noise = pomdp_native::GaussianND<kLightDarkStateDim>::from_covariance(covariance);
@@ -315,25 +311,33 @@ double simulate_rollout(
         }
         const double action_x = aa_view(static_cast<py::ssize_t>(ai), 0);
         const double action_y = aa_view(static_cast<py::ssize_t>(ai), 1);
-        const double action[kLightDarkStateDim] = {action_x, action_y};
 
-        // Compute reward (STANDARD model)
-        auto [base_reward, in_obstacle_range] = compute_reward_standard(
-            state, action, goal_state, obstacles_packed, goal_state_radius, obstacle_radius,
-            grid_size, fuel_cost, goal_reward, obstacle_reward);
+        // Reward is scored against the pre-noise intended next position
+        // (state + action). The realised-position correctness gate on the
+        // Python side routes noisy + obstacle configs through the Python
+        // path so this approximation is only used when the rollout reward
+        // can match reward() bit-exactly on the deterministic next state.
+        const double nx = state[0] + action_x;
+        const double ny = state[1] + action_y;
 
-        double step_reward = base_reward;
-        if (in_obstacle_range) {
-            if (uniform01(rng.engine()) < obstacle_hit_probability) {
-                step_reward += obstacle_reward;
-            }
+        double step_reward;
+        if (reward_variant_code == 2) {
+            step_reward = reward_row_decaying(
+                nx, ny, goal_x, goal_y, obstacles_packed, goal_state_radius, grid_size,
+                fuel_cost, goal_reward, obstacle_reward, penalty_decay, rng, uniform01);
+        } else {
+            const bool high_variance = (reward_variant_code == 1);
+            step_reward = reward_row_standard_or_hv(
+                nx, ny, goal_x, goal_y, obstacles_packed, goal_state_radius, obstacle_radius_sq,
+                grid_size, fuel_cost, goal_reward, obstacle_reward, obstacle_hit_probability,
+                high_variance, rng, uniform01);
         }
 
         total += gamma_power * step_reward;
         gamma_power *= discount_factor;
 
         // Step transition: next_state = state + action + Gaussian noise
-        const double mean[kLightDarkStateDim] = {state[0] + action_x, state[1] + action_y};
+        const double mean[kLightDarkStateDim] = {nx, ny};
         noise.sample_into(next_state, mean, rng);
         state[0] = next_state[0];
         state[1] = next_state[1];
@@ -341,6 +345,206 @@ double simulate_rollout(
     }
 
     return total;
+}
+
+// ---------------------------------------------------------------------------
+// compute_reward_batch
+//
+// Variant-aware vectorised reward kernel. Mirrors the Python reward models
+// in expectation (RNG draws come from ``pomdp_native::default_rng()``, so
+// the C++ and Python paths agree on sample means but not bit-exact rows).
+//
+// Inputs:
+//   states:        (N, 2) float64 — current positions (unused except for
+//                  legacy parity; reward depends on ``next_states``).
+//   action:        (2,)  float64 — action vector (unused beyond shape parity;
+//                  rewards are computed against the realised ``next_states``).
+//   next_states:   (N, 2) float64 — realised next-state positions.
+//   reward_variant_code:
+//                  0 = STANDARD, 1 = HIGH_VARIANCE_STATES, 2 = DECAYING_HIT_PROBABILITY.
+//   penalty_decay: double — only consumed when variant == 2.
+//   goal_state:    (2,)  float64.
+//   obstacles:     flat 1-D float64 [x0, y0, x1, y1, ...].
+//   goal_state_radius / obstacle_radius / grid_size / fuel_cost /
+//   goal_reward / obstacle_reward / obstacle_hit_probability: scalars.
+//
+// Output: (N,) float64 — per-row reward, deterministic geometry plus a single
+//          RNG-gated obstacle penalty draw (matching the Python row-major draw
+//          pattern in expectation).
+// ---------------------------------------------------------------------------
+static double base_reward_from_next(double nx, double ny, double goal_x, double goal_y,
+                                    double fuel_cost) {
+    const double gx = nx - goal_x;
+    const double gy = ny - goal_y;
+    const double dist_to_goal = std::sqrt(gx * gx + gy * gy);
+    return -fuel_cost - dist_to_goal;
+}
+
+static bool point_in_any_obstacle(double nx, double ny,
+                                  const std::vector<double> &obstacles_packed,
+                                  double obstacle_radius_sq) {
+    const std::size_t n_obs = obstacles_packed.size() / kLightDarkStateDim;
+    for (std::size_t j = 0; j < n_obs; ++j) {
+        const double ox = nx - obstacles_packed[j * 2];
+        const double oy = ny - obstacles_packed[j * 2 + 1];
+        if (ox * ox + oy * oy <= obstacle_radius_sq) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static double min_distance_to_obstacles(double nx, double ny,
+                                        const std::vector<double> &obstacles_packed) {
+    double min_d_sq = std::numeric_limits<double>::infinity();
+    const std::size_t n_obs = obstacles_packed.size() / kLightDarkStateDim;
+    for (std::size_t j = 0; j < n_obs; ++j) {
+        const double ox = nx - obstacles_packed[j * 2];
+        const double oy = ny - obstacles_packed[j * 2 + 1];
+        const double d_sq = ox * ox + oy * oy;
+        if (d_sq < min_d_sq) {
+            min_d_sq = d_sq;
+        }
+    }
+    return std::sqrt(min_d_sq);
+}
+
+static std::vector<double> pack_obstacles_1d(
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &obstacles_arr) {
+    if (obstacles_arr.ndim() != 1) {
+        throw std::invalid_argument("obstacles must be a flat 1-D array [x0,y0,x1,y1,...]");
+    }
+    auto view = obstacles_arr.unchecked<1>();
+    const std::size_t n_flat = static_cast<std::size_t>(view.shape(0));
+    std::vector<double> packed(n_flat);
+    for (std::size_t i = 0; i < n_flat; ++i) {
+        packed[i] = view(static_cast<py::ssize_t>(i));
+    }
+    return packed;
+}
+
+static double reward_row_standard_or_hv(double nx, double ny, double goal_x, double goal_y,
+                                        const std::vector<double> &obstacles_packed,
+                                        double goal_state_radius, double obstacle_radius_sq,
+                                        double grid_size, double fuel_cost, double goal_reward,
+                                        double obstacle_reward, double obstacle_hit_probability,
+                                        bool high_variance,
+                                        pomdp_native::RNGState &rng,
+                                        std::uniform_real_distribution<double> &uniform01) {
+    double reward = base_reward_from_next(nx, ny, goal_x, goal_y, fuel_cost);
+    const double gx = nx - goal_x;
+    const double gy = ny - goal_y;
+    const double dist_to_goal = std::sqrt(gx * gx + gy * gy);
+    if (dist_to_goal <= goal_state_radius) {
+        return reward + goal_reward;
+    }
+    if (point_in_any_obstacle(nx, ny, obstacles_packed, obstacle_radius_sq)) {
+        if (high_variance) {
+            reward += (uniform01(rng.engine()) < 0.5) ? obstacle_reward : -obstacle_reward;
+        } else if (uniform01(rng.engine()) < obstacle_hit_probability) {
+            reward += obstacle_reward;
+        }
+        return reward;
+    }
+    if (nx < 0.0 || ny < 0.0 || nx > grid_size || ny > grid_size) {
+        reward += obstacle_reward;
+    }
+    return reward;
+}
+
+static double reward_row_decaying(double nx, double ny, double goal_x, double goal_y,
+                                  const std::vector<double> &obstacles_packed,
+                                  double goal_state_radius, double grid_size, double fuel_cost,
+                                  double goal_reward, double obstacle_reward, double penalty_decay,
+                                  pomdp_native::RNGState &rng,
+                                  std::uniform_real_distribution<double> &uniform01) {
+    double reward = base_reward_from_next(nx, ny, goal_x, goal_y, fuel_cost);
+    const double gx = nx - goal_x;
+    const double gy = ny - goal_y;
+    const double dist_to_goal = std::sqrt(gx * gx + gy * gy);
+    if (dist_to_goal <= goal_state_radius) {
+        reward += goal_reward;
+    }
+    const bool oob = (nx < 0.0 || ny < 0.0 || nx > grid_size || ny > grid_size);
+    if (oob && dist_to_goal > goal_state_radius) {
+        reward += obstacle_reward;
+    }
+    if (!obstacles_packed.empty() && penalty_decay > 0.0) {
+        const double min_d = min_distance_to_obstacles(nx, ny, obstacles_packed);
+        const double p = std::exp(-min_d / penalty_decay);
+        if (uniform01(rng.engine()) < p) {
+            reward += obstacle_reward;
+        }
+    }
+    return reward;
+}
+
+py::array_t<double> compute_reward_batch(
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &states,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &action,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &next_states,
+    int reward_variant_code,
+    double penalty_decay,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &goal_state,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &obstacles,
+    double goal_state_radius,
+    double obstacle_radius,
+    double grid_size,
+    double fuel_cost,
+    double goal_reward,
+    double obstacle_reward,
+    double obstacle_hit_probability) {
+    (void)action;
+    if (states.ndim() != 2 ||
+        static_cast<std::size_t>(states.shape(1)) != kLightDarkStateDim) {
+        throw std::invalid_argument("states must have shape (N, 2)");
+    }
+    if (next_states.ndim() != 2 ||
+        static_cast<std::size_t>(next_states.shape(1)) != kLightDarkStateDim ||
+        next_states.shape(0) != states.shape(0)) {
+        throw std::invalid_argument("next_states must have shape (N, 2) matching states");
+    }
+    if (goal_state.ndim() != 1 ||
+        static_cast<std::size_t>(goal_state.shape(0)) != kLightDarkStateDim) {
+        throw std::invalid_argument("goal_state must have shape (2,)");
+    }
+    if (reward_variant_code < 0 || reward_variant_code > 2) {
+        throw std::invalid_argument("reward_variant_code must be in {0, 1, 2}");
+    }
+
+    auto gs_view = goal_state.unchecked<1>();
+    const double goal_x = gs_view(0);
+    const double goal_y = gs_view(1);
+    const std::vector<double> obstacles_packed = pack_obstacles_1d(obstacles);
+    const double obstacle_radius_sq = obstacle_radius * obstacle_radius;
+
+    const std::size_t n_rows = static_cast<std::size_t>(next_states.shape(0));
+    auto ns_view = next_states.unchecked<2>();
+    py::array_t<double> result(static_cast<py::ssize_t>(n_rows));
+    auto out = result.mutable_unchecked<1>();
+
+    pomdp_native::RNGState &rng = pomdp_native::default_rng();
+    std::uniform_real_distribution<double> uniform01(0.0, 1.0);
+
+    for (std::size_t i = 0; i < n_rows; ++i) {
+        const double nx = ns_view(static_cast<py::ssize_t>(i), 0);
+        const double ny = ns_view(static_cast<py::ssize_t>(i), 1);
+        double r;
+        if (reward_variant_code == 2) {
+            r = reward_row_decaying(nx, ny, goal_x, goal_y, obstacles_packed,
+                                    goal_state_radius, grid_size, fuel_cost, goal_reward,
+                                    obstacle_reward, penalty_decay, rng, uniform01);
+        } else {
+            const bool high_variance = (reward_variant_code == 1);
+            r = reward_row_standard_or_hv(nx, ny, goal_x, goal_y, obstacles_packed,
+                                          goal_state_radius, obstacle_radius_sq, grid_size,
+                                          fuel_cost, goal_reward, obstacle_reward,
+                                          obstacle_hit_probability, high_variance, rng,
+                                          uniform01);
+        }
+        out(static_cast<py::ssize_t>(i)) = r;
+    }
+    return result;
 }
 
 // ===========================================================================
@@ -905,11 +1109,28 @@ PYBIND11_MODULE(_native, m) {
           py::arg("obstacle_radius"), py::arg("grid_size"), py::arg("fuel_cost"),
           py::arg("goal_reward"), py::arg("obstacle_reward"),
           py::arg("obstacle_hit_probability"), py::arg("is_obstacle_hit_terminal"),
+          py::arg("reward_variant_code"), py::arg("penalty_decay"),
           py::arg("covariance"),
-          "Native random rollout for the STANDARD reward model. "
+          "Native random rollout for all reward model variants. "
           "Returns discounted return from initial_state. "
           "action_indices must be a pre-drawn array of int indices (shape (max_depth-start_depth,)). "
-          "obstacles must be a flat 1-D array [x0, y0, x1, y1, ...].");
+          "obstacles must be a flat 1-D array [x0, y0, x1, y1, ...]. "
+          "reward_variant_code: 0 = STANDARD, 1 = HIGH_VARIANCE_STATES, "
+          "2 = DECAYING_HIT_PROBABILITY. penalty_decay is only consumed when "
+          "reward_variant_code == 2.");
+
+    m.def("compute_reward_batch", &compute_reward_batch,
+          py::arg("states"), py::arg("action"), py::arg("next_states"),
+          py::kw_only(),
+          py::arg("reward_variant_code"), py::arg("penalty_decay"),
+          py::arg("goal_state"), py::arg("obstacles"), py::arg("goal_state_radius"),
+          py::arg("obstacle_radius"), py::arg("grid_size"), py::arg("fuel_cost"),
+          py::arg("goal_reward"), py::arg("obstacle_reward"),
+          py::arg("obstacle_hit_probability"),
+          "Variant-aware batched reward kernel. reward_variant_code: "
+          "0 = STANDARD, 1 = HIGH_VARIANCE_STATES, 2 = DECAYING_HIT_PROBABILITY. "
+          "Stochastic obstacle / penalty draws use the module-level C++ RNG; "
+          "expectation matches the Python reward models row-for-row.");
 
     py::class_<ContinuousLightDarkTransitionCpp>(m, "ContinuousLightDarkTransitionCpp")
         .def(py::init<const py::object &, const py::array_t<double> &,

--- a/POMDPPlanners/environments/light_dark_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/light_dark_pomdp/_native.pyi
@@ -38,14 +38,53 @@ def simulate_rollout(
     obstacle_reward: float,
     obstacle_hit_probability: float,
     is_obstacle_hit_terminal: bool,
+    reward_variant_code: int,
+    penalty_decay: float,
     covariance: NDArray[np.float64],
 ) -> float:
-    """Native random rollout for the STANDARD reward model.
+    """Native random rollout for all reward model variants.
 
-    Returns the discounted return from ``initial_state`` using the STANDARD
-    reward model. ``action_indices`` must be a pre-drawn 1-D int array with
-    at least ``max_depth - start_depth`` entries. ``obstacles`` must be a flat
-    1-D array ``[x0, y0, x1, y1, ...]`` (row-major interleaved).
+    Returns the discounted return from ``initial_state`` using the reward
+    model selected by ``reward_variant_code`` (``0 = STANDARD``,
+    ``1 = HIGH_VARIANCE_STATES``, ``2 = DECAYING_HIT_PROBABILITY``).
+    ``penalty_decay`` is only consumed when ``reward_variant_code == 2``.
+    Stochastic obstacle / penalty draws use the module-level C++ RNG; the
+    rollout matches the Python reward models in expectation rather than
+    bit-exact per-step.
+
+    ``action_indices`` must be a pre-drawn 1-D int array with at least
+    ``max_depth - start_depth`` entries. ``obstacles`` must be a flat 1-D
+    array ``[x0, y0, x1, y1, ...]`` (row-major interleaved).
+    """
+    ...
+
+def compute_reward_batch(
+    states: NDArray[np.float64],
+    action: NDArray[np.float64],
+    next_states: NDArray[np.float64],
+    *,
+    reward_variant_code: int,
+    penalty_decay: float,
+    goal_state: NDArray[np.float64],
+    obstacles: NDArray[np.float64],
+    goal_state_radius: float,
+    obstacle_radius: float,
+    grid_size: float,
+    fuel_cost: float,
+    goal_reward: float,
+    obstacle_reward: float,
+    obstacle_hit_probability: float,
+) -> NDArray[np.float64]:
+    """Variant-aware batched reward kernel for the Continuous Light-Dark POMDP.
+
+    ``reward_variant_code`` selects the reward model:
+    ``0 = STANDARD``, ``1 = HIGH_VARIANCE_STATES``, ``2 = DECAYING_HIT_PROBABILITY``.
+    ``penalty_decay`` is only consumed when ``reward_variant_code == 2``.
+    Stochastic obstacle / penalty draws are taken from the module-level C++
+    RNG; the kernel matches the Python reward models in expectation
+    (sample-mean parity) rather than bit-exact per-row.
+
+    ``obstacles`` is a flat 1-D array ``[x0, y0, x1, y1, ...]``.
     """
     ...
 

--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
@@ -80,6 +80,16 @@ class RewardModelType(Enum):
     HIGH_VARIANCE_STATES = "high_variance_states"
 
 
+# Integer dispatch codes consumed by the native ``_native.compute_reward_batch``
+# kernel. Must stay in sync with the C++ ``reward_variant_code`` switch in
+# ``_cpp/continuous_light_dark.cpp``.
+_REWARD_VARIANT_CODE_BY_TYPE: Dict[RewardModelType, int] = {
+    RewardModelType.STANDARD: 0,
+    RewardModelType.HIGH_VARIANCE_STATES: 1,
+    RewardModelType.DECAYING_HIT_PROBABILITY: 2,
+}
+
+
 class ObservationModelType(Enum):
     NORMAL_NOISE = "normal_noise"
     NORMAL_NOISE_NO_OBS_IN_DARK = "normal_noise_no_obs_in_dark"
@@ -256,6 +266,14 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
         self._cls_obs_log_norm_far = self._build_log_norm_2d(observation_cov_matrix)
         self._cls_obs_log_norm_near = self._build_log_norm_2d(observation_cov_matrix * 0.5)
         self._cls_beacon_radius_sq = float(beacon_radius) * float(beacon_radius)
+        # Native dispatch code + pre-flattened obstacle/goal buffers for the
+        # ``_native.compute_reward_batch`` and ``_native.simulate_rollout``
+        # kernels (interleaved ``[x0, y0, x1, y1, ...]`` layout).
+        self._reward_variant_code: int = _REWARD_VARIANT_CODE_BY_TYPE[reward_model_type]
+        self._obstacles_flat: np.ndarray = np.ascontiguousarray(
+            self.obstacles.T.ravel(), dtype=np.float64
+        )
+        self._goal_state_f64: np.ndarray = np.ascontiguousarray(self.goal_state, dtype=np.float64)
         # Initialize reward model based on type
         self.reward_model: BaseLightDarkRewardModel
         if reward_model_type == RewardModelType.STANDARD:
@@ -648,6 +666,11 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
         action: np.ndarray,
         next_states: Optional[Union[np.ndarray, Sequence[Any]]] = None,
     ) -> np.ndarray:
+        # Python-backed dispatch preserves the pre-refactor scalar↔batch RNG
+        # parity (both branches consume ``np.random`` draws in the same order).
+        # The variant-aware native ``_native.compute_reward_batch`` is exposed
+        # separately for callers that opt into sample-mean parity (e.g.
+        # belief-tree expansion paths and the C++/Python parity tests).
         next_states_arr = None if next_states is None else np.asarray(next_states)
         return self.reward_model.compute_reward_batch(
             np.asarray(states), action, next_states=next_states_arr
@@ -904,17 +927,11 @@ class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, Discrete
             "left": np.ascontiguousarray([-1.0, 0.0], dtype=np.float64),
         }
 
-        # Pre-built arrays for native simulate_rollout.
-        # _actions_array: shape (n_actions, 2) — action vectors stacked row-wise.
-        # _obstacles_flat: shape (2*n_obstacles,) — interleaved [x0,y0,x1,y1,...].
+        # Pre-stacked action vectors for native ``simulate_rollout``; the
+        # ``_obstacles_flat`` / ``_goal_state_f64`` buffers live on the parent.
         self._actions_array: np.ndarray = np.ascontiguousarray(
             np.stack(list(self.action_to_vector.values()), axis=0), dtype=np.float64
         )
-        # self.obstacles is stored as (2, N); flatten to [x0,y0,x1,y1,...].
-        self._obstacles_flat: np.ndarray = np.ascontiguousarray(
-            self.obstacles.T.ravel(), dtype=np.float64
-        )
-        self._goal_state_f64: np.ndarray = np.ascontiguousarray(self.goal_state, dtype=np.float64)
 
     def get_actions(self) -> List[Any]:
         return self.actions
@@ -971,11 +988,14 @@ class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, Discrete
         discount_factor: float,
         depth: int = 0,
     ) -> float:
-        """Random rollout via native C++ for the STANDARD reward model.
+        """Random rollout via native C++.
 
-        Falls back to the base-class Python loop for non-STANDARD reward
-        models (DECAYING_HIT_PROBABILITY, HIGH_VARIANCE_STATES) which have
-        different stochastic semantics not yet ported to C++.
+        The variant-aware ``_native.simulate_rollout`` kernel covers all three
+        reward models in expectation (the rollout RNG draws come from the
+        module-level C++ RNG and match the Python reward models sample-mean,
+        not bit-exact), so no variant gate is required here. The Python
+        fallback is retained only for the realised-position correctness case
+        below.
 
         Args:
             state: Current 2-D position ``[x, y]``.
@@ -995,15 +1015,9 @@ class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, Discrete
         # noisy next_state. Whenever transition noise is non-trivial AND
         # obstacles are configured, route through Python so the rollout
         # reward agrees with ``reward()`` on the realised next_state.
-        # Until the C++ kernel is rebuilt this is the only correctness-
-        # preserving path for stochastic-transition configurations.
         cov_diag_max = float(np.max(np.abs(self.state_transition_cov_matrix)))
         bypass_native_for_realised_pos = cov_diag_max > 0.0 and self._obstacles_flat.shape[0] > 0
-        if (
-            not isinstance(self.reward_model, ContinuousLightDarkRewardModel)
-            or isinstance(self.reward_model, (ContinuousLDHighVarianceStatesRewardModel,))
-            or bypass_native_for_realised_pos
-        ):
+        if bypass_native_for_realised_pos:
             return python_random_rollout(
                 state=state,
                 depth=depth,
@@ -1037,6 +1051,8 @@ class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, Discrete
             obstacle_reward=float(self.obstacle_reward),
             obstacle_hit_probability=float(self.obstacle_hit_probability),
             is_obstacle_hit_terminal=bool(self.is_obstacle_hit_terminal),
+            reward_variant_code=self._reward_variant_code,
+            penalty_decay=float(self.penalty_decay),
             covariance=self._trans_cov_view,
         )
 

--- a/POMDPPlanners/environments/pacman_pomdp/_cpp/pacman.cpp
+++ b/POMDPPlanners/environments/pacman_pomdp/_cpp/pacman.cpp
@@ -1196,6 +1196,175 @@ class PacManObservationCpp {
 };
 
 // ---------------------------------------------------------------------------
+// Reward helpers: variant-aware dangerous-area contribution + standalone
+// reward_batch kernel. The danger contribution is computed against the
+// realised next pacman position. Three variants are supported:
+//
+//   reward_variant_code = 0  STANDARD               deterministic ``-penalty``
+//                                                   when inside any zone
+//                                                   (radius cutoff).
+//   reward_variant_code = 1  HIGH_VARIANCE_STATES   ``+/- penalty`` 50/50
+//                                                   when inside any zone.
+//   reward_variant_code = 2  DECAYING_HIT_PROB      ``-penalty`` with
+//                                                   probability
+//                                                   ``exp(-min_dist /
+//                                                   penalty_decay)`` against
+//                                                   the closest zone centre
+//                                                   (no radius cutoff).
+// ---------------------------------------------------------------------------
+
+// Contribution of the dangerous-area term for a single (next_pac_row,
+// next_pac_col). ``dangerous_areas`` is a flat (D, 2) float64 buffer.
+inline double dangerous_area_contribution(int variant_code, int new_pac_row, int new_pac_col,
+                                          const double *dangerous_areas, int n_dangerous,
+                                          double dangerous_area_radius,
+                                          double dangerous_area_penalty, double penalty_decay,
+                                          std::mt19937_64 &rng) {
+    if (n_dangerous <= 0) {
+        return 0.0;
+    }
+    std::uniform_real_distribution<double> unif(0.0, 1.0);
+    if (variant_code == 2) {
+        // DECAYING_HIT_PROBABILITY — no radius cutoff; use closest centre.
+        double min_sq = std::numeric_limits<double>::infinity();
+        for (int d = 0; d < n_dangerous; ++d) {
+            const double dr = static_cast<double>(new_pac_row) - dangerous_areas[d * 2];
+            const double dc = static_cast<double>(new_pac_col) - dangerous_areas[d * 2 + 1];
+            const double d_sq = dr * dr + dc * dc;
+            if (d_sq < min_sq) {
+                min_sq = d_sq;
+            }
+        }
+        const double min_dist = std::sqrt(min_sq);
+        const double hit_prob = std::exp(-min_dist / penalty_decay);
+        if (unif(rng) < hit_prob) {
+            return -dangerous_area_penalty;
+        }
+        return 0.0;
+    }
+    // STANDARD / HIGH_VARIANCE_STATES both use the radius cutoff.
+    const double radius_sq = dangerous_area_radius * dangerous_area_radius;
+    bool in_zone = false;
+    for (int d = 0; d < n_dangerous; ++d) {
+        const double dr = static_cast<double>(new_pac_row) - dangerous_areas[d * 2];
+        const double dc = static_cast<double>(new_pac_col) - dangerous_areas[d * 2 + 1];
+        if (dr * dr + dc * dc <= radius_sq) {
+            in_zone = true;
+            break;
+        }
+    }
+    if (!in_zone) {
+        return 0.0;
+    }
+    if (variant_code == 1) {
+        // HIGH_VARIANCE_STATES: ±penalty 50/50.
+        return (unif(rng) < 0.5) ? dangerous_area_penalty : -dangerous_area_penalty;
+    }
+    // STANDARD (or unknown — fall back to deterministic).
+    return -dangerous_area_penalty;
+}
+
+// Per-row base reward for the standalone reward_batch kernel. Detects pellet
+// pickup via ``next_state.score > state.score`` (the transition kernel writes
+// ``score += pellet_reward`` exactly when a pellet is collected) and win-bonus
+// via ``next_state.terminal && all pellets gone in next_state`` — both checks
+// match the Python ``compute_reward_scalar_kernel`` semantics. Reading the
+// realised pacman position from ``next_state`` keeps the entry-point free of
+// neighbor-table / pellet-position dependencies.
+inline double reward_batch_base_row(const double *state, const double *next_state, int num_ghosts,
+                                    double step_penalty, double ghost_collision_penalty,
+                                    double pellet_reward, double win_reward, int idx_pac_row,
+                                    int idx_pac_col, int idx_ghosts_start, int idx_pellets_start,
+                                    int idx_pellets_end, int idx_score, int idx_terminal) {
+    if (state[idx_terminal] > 0.5) {
+        return 0.0;
+    }
+    double reward = step_penalty;
+    const int new_pac_row = static_cast<int>(next_state[idx_pac_row]);
+    const int new_pac_col = static_cast<int>(next_state[idx_pac_col]);
+    for (int g = 0; g < num_ghosts; ++g) {
+        const int gr = static_cast<int>(next_state[idx_ghosts_start + 2 * g]);
+        const int gc = static_cast<int>(next_state[idx_ghosts_start + 2 * g + 1]);
+        if (gr == new_pac_row && gc == new_pac_col) {
+            reward += ghost_collision_penalty;
+            break;
+        }
+    }
+    if (next_state[idx_score] > state[idx_score]) {
+        reward += pellet_reward;
+    }
+    if (next_state[idx_terminal] > 0.5 && idx_pellets_end > idx_pellets_start) {
+        bool all_collected = true;
+        for (int p = idx_pellets_start; p < idx_pellets_end; ++p) {
+            if (next_state[p] > 0.5) {
+                all_collected = false;
+                break;
+            }
+        }
+        if (all_collected) {
+            reward += win_reward;
+        }
+    }
+    return reward;
+}
+
+// Standalone batched reward kernel — variant-aware. Inputs:
+//   states            (N, state_dim) float64
+//   next_states       (N, state_dim) float64
+//   dangerous_areas   (D, 2) float64
+//   variant scalars   (radius, penalty, penalty_decay)
+//   reward scalars    (step / collision / pellet / win)
+// Returns (N,) float64. RNG is the module-local default rng (used only by the
+// HV / Decaying variants).
+py::array_t<double> reward_batch_impl(
+    py::array_t<double> states, py::array_t<double> next_states,
+    py::array_t<double> dangerous_areas, int num_ghosts, double dangerous_area_radius,
+    double dangerous_area_penalty, int reward_variant_code, double penalty_decay,
+    double step_penalty, double ghost_collision_penalty, double pellet_reward, double win_reward,
+    int idx_pac_row, int idx_pac_col, int idx_ghosts_start, int idx_pellets_start,
+    int idx_pellets_end, int idx_score, int idx_terminal) {
+    if (states.ndim() != 2) {
+        throw std::invalid_argument("states must be 2-D");
+    }
+    if (next_states.ndim() != 2) {
+        throw std::invalid_argument("next_states must be 2-D");
+    }
+    const py::ssize_t n_rows = states.shape(0);
+    const py::ssize_t state_dim = states.shape(1);
+    if (next_states.shape(0) != n_rows || next_states.shape(1) != state_dim) {
+        throw std::invalid_argument("next_states must have matching shape to states");
+    }
+    if (dangerous_areas.ndim() != 2 || dangerous_areas.shape(1) != 2) {
+        throw std::invalid_argument("dangerous_areas must have shape (D, 2)");
+    }
+    const int n_dangerous = static_cast<int>(dangerous_areas.shape(0));
+    auto out = py::array_t<double>(static_cast<py::ssize_t>(n_rows));
+    auto obuf = out.mutable_unchecked<1>();
+    const double *states_ptr = states.data();
+    const double *next_states_ptr = next_states.data();
+    const double *danger_ptr = (n_dangerous > 0) ? dangerous_areas.data() : nullptr;
+    auto &rng = pomdp_native::default_rng().engine();
+    for (py::ssize_t i = 0; i < n_rows; ++i) {
+        const double *state = states_ptr + i * state_dim;
+        const double *next_state = next_states_ptr + i * state_dim;
+        double reward = reward_batch_base_row(state, next_state, num_ghosts, step_penalty,
+                                              ghost_collision_penalty, pellet_reward, win_reward,
+                                              idx_pac_row, idx_pac_col, idx_ghosts_start,
+                                              idx_pellets_start, idx_pellets_end, idx_score,
+                                              idx_terminal);
+        if (state[idx_terminal] <= 0.5) {
+            const int new_pac_row = static_cast<int>(next_state[idx_pac_row]);
+            const int new_pac_col = static_cast<int>(next_state[idx_pac_col]);
+            reward += dangerous_area_contribution(reward_variant_code, new_pac_row, new_pac_col,
+                                                  danger_ptr, n_dangerous, dangerous_area_radius,
+                                                  dangerous_area_penalty, penalty_decay, rng);
+        }
+        obuf(i) = reward;
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
 // simulate_rollout: run a full random rollout from `state` using pre-drawn
 // action indices, returning the discounted cumulative reward.
 //
@@ -1204,6 +1373,7 @@ class PacManObservationCpp {
 //       + ghost_collision_penalty  (if pacman lands on a ghost)
 //       + pellet_reward            (if a pellet is collected — already in env_)
 //       + win_reward               (if all pellets gone at terminal step)
+//       + dangerous_area_contribution (variant-aware)
 // Ghost-collision detection uses the *post-transition* state, matching the
 // Python reference which calls state_transition_model().sample() inside reward().
 // ---------------------------------------------------------------------------
@@ -1218,7 +1388,13 @@ double simulate_rollout_impl(
     double win_reward,
     double discount_factor,
     int depth,
-    int max_depth)
+    int max_depth,
+    const double *dangerous_areas,
+    int n_dangerous,
+    double dangerous_area_radius,
+    double dangerous_area_penalty,
+    int reward_variant_code,
+    double penalty_decay)
 {
     const int state_dim = env.state_dim;
     std::vector<double> current(initial_state, initial_state + state_dim);
@@ -1283,6 +1459,12 @@ double simulate_rollout_impl(
                 r += win_reward;
             }
         }
+
+        // Variant-aware dangerous-area contribution. Previously omitted —
+        // this matches the parity contract enforced by reward_batch.
+        r += dangerous_area_contribution(reward_variant_code, new_pac_r, new_pac_c,
+                                         dangerous_areas, n_dangerous, dangerous_area_radius,
+                                         dangerous_area_penalty, penalty_decay, rng);
 
         total += gamma_power * r;
         gamma_power *= discount_factor;
@@ -1370,7 +1552,12 @@ PYBIND11_MODULE(_native, m) {
            double win_reward,
            double discount_factor,
            int depth,
-           int max_depth) -> double {
+           int max_depth,
+           py::array_t<double> dangerous_areas,
+           double dangerous_area_radius,
+           double dangerous_area_penalty,
+           int reward_variant_code,
+           double penalty_decay) -> double {
             if (state.ndim() != 1) {
                 throw std::invalid_argument("state must be 1-D");
             }
@@ -1404,6 +1591,11 @@ PYBIND11_MODULE(_native, m) {
             }
             env.patrol_dir_state = patrol_dir_state.mutable_data();
 
+            if (dangerous_areas.ndim() != 2 || dangerous_areas.shape(1) != 2) {
+                throw std::invalid_argument("dangerous_areas must have shape (D, 2)");
+            }
+            const int n_dangerous = static_cast<int>(dangerous_areas.shape(0));
+            const double *danger_ptr = (n_dangerous > 0) ? dangerous_areas.data() : nullptr;
             return simulate_rollout_impl(
                 env,
                 state.data(),
@@ -1414,7 +1606,13 @@ PYBIND11_MODULE(_native, m) {
                 win_reward,
                 discount_factor,
                 depth,
-                max_depth);
+                max_depth,
+                danger_ptr,
+                n_dangerous,
+                dangerous_area_radius,
+                dangerous_area_penalty,
+                reward_variant_code,
+                penalty_decay);
         },
         py::arg("state"),
         py::arg("action_indices"),
@@ -1443,6 +1641,55 @@ PYBIND11_MODULE(_native, m) {
         py::arg("discount_factor"),
         py::arg("depth") = 0,
         py::arg("max_depth"),
+        py::arg("dangerous_areas"),
+        py::arg("dangerous_area_radius"),
+        py::arg("dangerous_area_penalty"),
+        py::arg("reward_variant_code"),
+        py::arg("penalty_decay"),
         "Run a random rollout from state using pre-drawn action_indices; "
         "returns the discounted cumulative reward.");
+
+    // reward_batch: standalone variant-aware reward kernel. Computes per-row
+    // rewards for a batch of (state, action, next_state) triples under a
+    // chosen reward-model variant (STANDARD / HIGH_VARIANCE_STATES /
+    // DECAYING_HIT_PROBABILITY). Mirrors the Python reward_model.compute_reward_batch
+    // semantics — sample-mean parity (not bit-exact) is the design target.
+    m.def(
+        "reward_batch",
+        [](py::array_t<double> states, int action, py::array_t<double> next_states,
+           int reward_variant_code, double penalty_decay, py::array_t<double> dangerous_areas,
+           double dangerous_area_radius, double dangerous_area_penalty, int num_ghosts,
+           double step_penalty, double ghost_collision_penalty, double pellet_reward,
+           double win_reward, int idx_pac_row, int idx_pac_col, int idx_ghosts_start,
+           int idx_pellets_start, int idx_pellets_end, int idx_score,
+           int idx_terminal) -> py::array_t<double> {
+            (void)action;
+            return reward_batch_impl(states, next_states, dangerous_areas, num_ghosts,
+                                     dangerous_area_radius, dangerous_area_penalty,
+                                     reward_variant_code, penalty_decay, step_penalty,
+                                     ghost_collision_penalty, pellet_reward, win_reward,
+                                     idx_pac_row, idx_pac_col, idx_ghosts_start, idx_pellets_start,
+                                     idx_pellets_end, idx_score, idx_terminal);
+        },
+        py::arg("states"),
+        py::arg("action"),
+        py::arg("next_states"),
+        py::arg("reward_variant_code"),
+        py::arg("penalty_decay"),
+        py::arg("dangerous_areas"),
+        py::arg("dangerous_area_radius"),
+        py::arg("dangerous_area_penalty"),
+        py::arg("num_ghosts"),
+        py::arg("step_penalty"),
+        py::arg("ghost_collision_penalty"),
+        py::arg("pellet_reward"),
+        py::arg("win_reward"),
+        py::arg("idx_pac_row"),
+        py::arg("idx_pac_col"),
+        py::arg("idx_ghosts_start"),
+        py::arg("idx_pellets_start"),
+        py::arg("idx_pellets_end"),
+        py::arg("idx_score"),
+        py::arg("idx_terminal"),
+        "Variant-aware standalone batch reward kernel. Returns (N,) float64.");
 }

--- a/POMDPPlanners/environments/pacman_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/pacman_pomdp/_native.pyi
@@ -38,12 +38,42 @@ def simulate_rollout(
     discount_factor: float,
     depth: int,
     max_depth: int,
+    dangerous_areas: NDArray[np.float64],
+    dangerous_area_radius: float,
+    dangerous_area_penalty: float,
+    reward_variant_code: int,
+    penalty_decay: float,
 ) -> float:
     """Run a random rollout from state using pre-drawn action_indices.
 
     Returns the discounted cumulative reward accumulated until terminal or
     max_depth is reached. action_indices must have length >= (max_depth - depth).
+    Reward per step includes the variant-aware dangerous-area contribution.
     """
+
+def reward_batch(
+    states: NDArray[np.float64],
+    action: int,
+    next_states: NDArray[np.float64],
+    reward_variant_code: int,
+    penalty_decay: float,
+    dangerous_areas: NDArray[np.float64],
+    dangerous_area_radius: float,
+    dangerous_area_penalty: float,
+    num_ghosts: int,
+    step_penalty: float,
+    ghost_collision_penalty: float,
+    pellet_reward: float,
+    win_reward: float,
+    idx_pac_row: int,
+    idx_pac_col: int,
+    idx_ghosts_start: int,
+    idx_pellets_start: int,
+    idx_pellets_end: int,
+    idx_score: int,
+    idx_terminal: int,
+) -> NDArray[np.float64]:
+    """Variant-aware standalone batch reward kernel. Returns (N,) float64."""
 
 class PacManTransitionCpp:
     """Native transition kernel for PacMan POMDP (pybind11-backed)."""

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -35,6 +35,8 @@ from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.environments.pacman_pomdp import _native  # pylint: disable=no-name-in-module
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.pacman_reward_models import (
     BasePacManRewardModel,
+    PacManDecayingHitProbabilityRewardModel,
+    PacManHighVarianceStatesRewardModel,
     PacManRewardModel,
 )
 from POMDPPlanners.utils.statistics_utils import confidence_interval
@@ -51,6 +53,23 @@ class PacManPOMDPMetrics(Enum):
     AVG_EPISODE_LENGTH = "avg_episode_length"
     AVG_PACMAN_CLOSEST_GHOST_DISTANCE = "avg_pacman_closest_ghost_distance"
     AVG_COLLISION_ENCOUNTERS = "avg_collision_encounters"
+
+
+class RewardModelType(Enum):
+    """Reward-model variants selectable on :class:`PacManPOMDP`."""
+
+    STANDARD = "standard"
+    HIGH_VARIANCE_STATES = "high_variance_states"
+    DECAYING_HIT_PROBABILITY = "decaying_hit_probability"
+
+
+# Numeric variant codes consumed by the C++ ``reward_batch`` / ``simulate_rollout``
+# kernels. Kept in lock-step with the C++ ``dangerous_area_contribution`` switch.
+_REWARD_VARIANT_CODES: Dict[RewardModelType, int] = {
+    RewardModelType.STANDARD: 0,
+    RewardModelType.HIGH_VARIANCE_STATES: 1,
+    RewardModelType.DECAYING_HIT_PROBABILITY: 2,
+}
 
 
 class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-methods
@@ -138,6 +157,8 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         name: str = "PacManPOMDP",
         output_dir: Optional[Path] = None,
         debug: bool = False,
+        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        penalty_decay: float = 1.0,
     ):
         """Initialize PacMan POMDP.
 
@@ -168,6 +189,18 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             name: Environment name. Defaults to "PacManPOMDP".
             output_dir: Output directory for logging. Defaults to None.
             debug: Enable debug logging. Defaults to False.
+            reward_model_type: Selects the reward variant. ``STANDARD`` (default)
+                deterministically subtracts ``dangerous_area_penalty`` whenever
+                PacMan's realised next position lies inside a hazard zone.
+                ``HIGH_VARIANCE_STATES`` emits ``±dangerous_area_penalty``
+                (50/50) on a zone hit (expected 0, high variance).
+                ``DECAYING_HIT_PROBABILITY`` applies ``-dangerous_area_penalty``
+                with probability ``exp(-min_dist / penalty_decay)`` against
+                the nearest zone centre (no radius cutoff). Mirrors the
+                light-dark / laser-tag / rock-sample reward-model variants.
+            penalty_decay: Decay length used by the
+                ``DECAYING_HIT_PROBABILITY`` reward model. Ignored by the other
+                variants. Must be strictly positive. Defaults to ``1.0``.
         """
         # Calculate reward range based on parameters. The dangerous-area
         # penalty only contributes to ``min_reward`` when at least one zone
@@ -300,26 +333,46 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             else np.empty((0, 2), dtype=np.int32)
         )
 
-        self.reward_model: BasePacManRewardModel = PacManRewardModel(
-            num_ghosts=self.num_ghosts,
-            pellet_positions_arr=self._pellet_positions_arr,
-            dangerous_areas=self.dangerous_areas,
-            dangerous_areas_arr=self._dangerous_areas_arr,
-            dangerous_area_radius=self.dangerous_area_radius,
-            dangerous_area_penalty=self.dangerous_area_penalty,
-            step_penalty=self.step_penalty,
-            ghost_collision_penalty=self.ghost_collision_penalty,
-            pellet_reward=self.pellet_reward,
-            win_reward=self.win_reward,
-            idx_pac_row=self._idx_pac_row,
-            idx_pac_col=self._idx_pac_col,
-            idx_ghosts_start=self._idx_ghosts_start,
-            idx_pellets_start=self._idx_pellets_start,
-            idx_pellets_end=self._idx_pellets_end,
-            idx_score=self._idx_score,
-            idx_terminal=self._idx_terminal,
-            neighbor_table_getter=self._get_neighbor_table,
+        self.reward_model_type = reward_model_type
+        self.penalty_decay = float(penalty_decay)
+        self.reward_model: BasePacManRewardModel = self._build_reward_model(
+            reward_model_type, self.penalty_decay
         )
+
+    def _build_reward_model(
+        self,
+        reward_model_type: RewardModelType,
+        penalty_decay: float,
+    ) -> BasePacManRewardModel:
+        common_kwargs = {
+            "num_ghosts": self.num_ghosts,
+            "pellet_positions_arr": self._pellet_positions_arr,
+            "dangerous_areas": self.dangerous_areas,
+            "dangerous_areas_arr": self._dangerous_areas_arr,
+            "dangerous_area_radius": self.dangerous_area_radius,
+            "dangerous_area_penalty": self.dangerous_area_penalty,
+            "step_penalty": self.step_penalty,
+            "ghost_collision_penalty": self.ghost_collision_penalty,
+            "pellet_reward": self.pellet_reward,
+            "win_reward": self.win_reward,
+            "idx_pac_row": self._idx_pac_row,
+            "idx_pac_col": self._idx_pac_col,
+            "idx_ghosts_start": self._idx_ghosts_start,
+            "idx_pellets_start": self._idx_pellets_start,
+            "idx_pellets_end": self._idx_pellets_end,
+            "idx_score": self._idx_score,
+            "idx_terminal": self._idx_terminal,
+            "neighbor_table_getter": self._get_neighbor_table,
+        }
+        if reward_model_type == RewardModelType.STANDARD:
+            return PacManRewardModel(**common_kwargs)
+        if reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+            return PacManHighVarianceStatesRewardModel(**common_kwargs)
+        if reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+            return PacManDecayingHitProbabilityRewardModel(
+                **common_kwargs, penalty_decay=penalty_decay
+            )
+        raise ValueError(f"Unknown reward model type: {reward_model_type}")
 
     @property
     def initial_ghost_pos(self) -> Tuple[int, int]:
@@ -782,6 +835,11 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             discount_factor=float(discount_factor),
             depth=0,
             max_depth=remaining_depth,
+            dangerous_areas=self._dangerous_areas_arr,
+            dangerous_area_radius=float(self.dangerous_area_radius),
+            dangerous_area_penalty=float(self.dangerous_area_penalty),
+            reward_variant_code=_REWARD_VARIANT_CODES[self.reward_model_type],
+            penalty_decay=float(self.penalty_decay),
         )
 
     def reward(self, state: np.ndarray, action: int, next_state: Any = None) -> float:
@@ -830,6 +888,8 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         if states_arr.dtype.kind == "f":
             if states_arr.ndim == 1:
                 states_arr = states_arr.reshape(1, -1)
+            if next_states_arr is not None:
+                return self._reward_batch_cpp(states_arr, action, next_states_arr)
             return self.reward_model.compute_reward_batch(
                 states_arr, action, next_states=next_states_arr
             )
@@ -837,6 +897,45 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             return np.array([self.reward(states[i], action) for i in range(len(states))])
         return np.array(
             [self.reward(states[i], action, next_states_arr[i]) for i in range(len(states))]
+        )
+
+    def _reward_batch_cpp(
+        self,
+        states_arr: np.ndarray,
+        action: int,
+        next_states_arr: np.ndarray,
+    ) -> np.ndarray:
+        # Route the fast (states, next_states) batch path through the C++
+        # ``reward_batch`` kernel. The kernel covers all three reward-model
+        # variants via ``reward_variant_code`` and matches the Python kernels
+        # in sample mean. ``penalty_decay`` is consulted only by the decaying
+        # variant.
+        states_c = np.ascontiguousarray(states_arr, dtype=np.float64)
+        next_states_c = np.ascontiguousarray(next_states_arr, dtype=np.float64)
+        return np.asarray(
+            _native.reward_batch(
+                states=states_c,
+                action=int(action),
+                next_states=next_states_c,
+                reward_variant_code=_REWARD_VARIANT_CODES[self.reward_model_type],
+                penalty_decay=float(self.penalty_decay),
+                dangerous_areas=self._dangerous_areas_arr,
+                dangerous_area_radius=float(self.dangerous_area_radius),
+                dangerous_area_penalty=float(self.dangerous_area_penalty),
+                num_ghosts=int(self.num_ghosts),
+                step_penalty=float(self.step_penalty),
+                ghost_collision_penalty=float(self.ghost_collision_penalty),
+                pellet_reward=float(self.pellet_reward),
+                win_reward=float(self.win_reward),
+                idx_pac_row=int(self._idx_pac_row),
+                idx_pac_col=int(self._idx_pac_col),
+                idx_ghosts_start=int(self._idx_ghosts_start),
+                idx_pellets_start=int(self._idx_pellets_start),
+                idx_pellets_end=int(self._idx_pellets_end),
+                idx_score=int(self._idx_score),
+                idx_terminal=int(self._idx_terminal),
+            ),
+            dtype=np.float64,
         )
 
     def _coerce_next_states_arr(

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/pacman_reward_models.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/pacman_reward_models.py
@@ -6,6 +6,23 @@ and
 :mod:`POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models`,
 so further PacMan reward variants can be added without growing the env class.
 
+Three concrete variants are provided. They share all of the non-dangerous-
+area scoring (step / collision / pellet / win) via the
+``PacManRewardModel`` base; each variant only customises the dangerous-
+area contribution:
+
+* :class:`PacManRewardModel` (STANDARD): deterministic
+  ``-dangerous_area_penalty`` whenever the realised next pacman position
+  lies inside any configured circular hazard zone (squared-distance
+  check against ``dangerous_area_radius``).
+* :class:`PacManHighVarianceStatesRewardModel` (HIGH_VARIANCE_STATES):
+  ``±dangerous_area_penalty`` 50/50 in-zone — zero expected
+  contribution, high variance.
+* :class:`PacManDecayingHitProbabilityRewardModel`
+  (DECAYING_HIT_PROBABILITY): ``-dangerous_area_penalty`` is applied
+  with probability ``exp(-min_dist / penalty_decay)`` based on the
+  *closest* zone centre — no radius cutoff.
+
 The reward model owns all the parameters and pre-built buffers that the
 reward computation needs (state-layout indices, pellet positions,
 dangerous areas, scalar penalties / bonuses, and a callable that returns
@@ -19,6 +36,10 @@ from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 
+from POMDPPlanners.environments.environment_utils.dangerous_areas_kernels import (
+    decaying_prob_penalty_batch_kernel,
+    decaying_prob_penalty_kernel,
+)
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.numba_kernels import (
     compute_reward_batch_kernel,
     compute_reward_scalar_kernel,
@@ -68,6 +89,10 @@ class PacManRewardModel(BasePacManRewardModel):
           scalar path; final-pellet pickup in the batch path).
 
     Terminal states return ``0.0`` reward.
+
+    Subclasses override :meth:`_dangerous_area_contribution_scalar` and
+    :meth:`_apply_dangerous_area_contribution_batch` to express different
+    stochastic penalty models; the rest of the scoring is identical.
     """
 
     def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -110,6 +135,24 @@ class PacManRewardModel(BasePacManRewardModel):
         self._idx_score = idx_score
         self._idx_terminal = idx_terminal
         self._neighbor_table_getter = neighbor_table_getter
+
+        # (2, D) C-contiguous view of dangerous-area centres for the generic
+        # decaying-prob kernels (which expect axis 0 to hold the two coordinate
+        # components). Empty (2, 0) when no zones are configured.
+        if self._dangerous_areas_arr.shape[0] > 0:
+            self._dangerous_centers_xy: np.ndarray = np.ascontiguousarray(
+                self._dangerous_areas_arr.T
+            )
+        else:
+            self._dangerous_centers_xy = np.empty((2, 0), dtype=np.float64)
+        # (0, 2) sentinel passed to the fused kernel by subclasses that want
+        # to compute the dangerous-area contribution in Python instead.
+        self._empty_dangerous_areas: np.ndarray = np.empty((0, 2), dtype=np.float64)
+        # Square-distance comparison cached so the per-row danger check
+        # never sqrts on the hot path.
+        self._dangerous_radius_sq: float = float(dangerous_area_radius) * float(
+            dangerous_area_radius
+        )
 
     def compute_reward(
         self,
@@ -184,3 +227,304 @@ class PacManRewardModel(BasePacManRewardModel):
             int(self._idx_pellets_start),
             int(self._idx_terminal),
         )
+
+    # ------------------------------------------------------------------
+    # Helpers reused by HV / Decaying subclasses (kept private so the
+    # public API stays the abstract ``compute_reward`` / ``compute_reward_batch``).
+    # ------------------------------------------------------------------
+
+    def _compute_base_reward_scalar(self, state: np.ndarray, next_state: np.ndarray) -> float:
+        # Reward without the dangerous-area contribution. Achieved by passing
+        # the ``(0, 2)`` sentinel so the fused kernel's danger loop is skipped
+        # (its first check is ``if n_dangerous > 0``).
+        return float(
+            compute_reward_scalar_kernel(
+                np.ascontiguousarray(state, dtype=np.float64),
+                np.ascontiguousarray(next_state, dtype=np.float64),
+                self._empty_dangerous_areas,
+                int(self.num_ghosts),
+                int(self._pellet_positions_arr.shape[0]),
+                float(self.step_penalty),
+                float(self.ghost_collision_penalty),
+                float(self.pellet_reward),
+                float(self.win_reward),
+                0.0,
+                0.0,
+                int(self._idx_pac_row),
+                int(self._idx_pac_col),
+                int(self._idx_ghosts_start),
+                int(self._idx_pellets_start),
+                int(self._idx_score),
+                int(self._idx_terminal),
+            )
+        )
+
+    def _compute_base_reward_batch(
+        self,
+        states: np.ndarray,
+        action: int,
+        next_states: Optional[np.ndarray],
+    ) -> np.ndarray:
+        # Same fused-kernel call as :meth:`compute_reward_batch` but with the
+        # dangerous-area arg zeroed so the variant can add its own contribution.
+        states_arr = np.ascontiguousarray(states, dtype=np.float64)
+        if next_states is None:
+            next_states_arr = np.empty((0, states_arr.shape[1]), dtype=np.float64)
+            has_next_states = False
+        else:
+            next_states_arr = np.ascontiguousarray(next_states, dtype=np.float64)
+            has_next_states = True
+        return compute_reward_batch_kernel(
+            states_arr,
+            int(action),
+            next_states_arr,
+            has_next_states,
+            np.ascontiguousarray(self._neighbor_table_getter(), dtype=np.int32),
+            self._pellet_positions_arr,
+            self._empty_dangerous_areas,
+            int(self.num_ghosts),
+            float(self.step_penalty),
+            float(self.ghost_collision_penalty),
+            float(self.pellet_reward),
+            float(self.win_reward),
+            0.0,
+            0.0,
+            int(self._idx_pac_row),
+            int(self._idx_pac_col),
+            int(self._idx_ghosts_start),
+            int(self._idx_pellets_start),
+            int(self._idx_terminal),
+        )
+
+    def _is_in_dangerous_area(self, position: Tuple[int, int]) -> bool:
+        if self._dangerous_areas_arr.shape[0] == 0:
+            return False
+        pos_r, pos_c = position
+        for d in range(self._dangerous_areas_arr.shape[0]):
+            dr = pos_r - self._dangerous_areas_arr[d, 0]
+            dc = pos_c - self._dangerous_areas_arr[d, 1]
+            if dr * dr + dc * dc <= self._dangerous_radius_sq:
+                return True
+        return False
+
+    def _compute_next_pacman_positions_batch(
+        self, states: np.ndarray, action: int
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        # Derive realised next pacman (row, col) via the neighbor table —
+        # matches the fused batch kernel exactly so variant contributions
+        # score against the same realised position the base reward used.
+        neighbor_table = self._neighbor_table_getter()
+        pac_rows = states[:, self._idx_pac_row].astype(np.int64)
+        pac_cols = states[:, self._idx_pac_col].astype(np.int64)
+        new_rows = neighbor_table[pac_rows, pac_cols, int(action), 0].astype(np.int64)
+        new_cols = neighbor_table[pac_rows, pac_cols, int(action), 1].astype(np.int64)
+        return new_rows, new_cols
+
+    def _compute_in_zone_mask_batch(
+        self, new_pac_rows: np.ndarray, new_pac_cols: np.ndarray
+    ) -> np.ndarray:
+        n = new_pac_rows.shape[0]
+        if self._dangerous_areas_arr.shape[0] == 0:
+            return np.zeros(n, dtype=bool)
+        in_zone = np.zeros(n, dtype=bool)
+        centers = self._dangerous_areas_arr  # (D, 2)
+        for d in range(centers.shape[0]):
+            dr = new_pac_rows - centers[d, 0]
+            dc = new_pac_cols - centers[d, 1]
+            in_zone |= (dr * dr + dc * dc) <= self._dangerous_radius_sq
+        return in_zone
+
+
+class PacManHighVarianceStatesRewardModel(PacManRewardModel):
+    """HIGH_VARIANCE_STATES variant.
+
+    Replaces the deterministic in-zone penalty with a 50/50 split between
+    ``+dangerous_area_penalty`` and ``-dangerous_area_penalty`` whenever
+    the realised next pacman position is in any dangerous area. Expected
+    contribution is ``0``; variance is ``dangerous_area_penalty**2``.
+    Mirrors
+    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLDHighVarianceStatesRewardModel`
+    and
+    :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models.LaserTagHighVarianceStatesRewardModel`.
+    All non-dangerous-area scoring (collision / pellet / win / step
+    penalty) is identical to the standard model.
+    """
+
+    def compute_reward(
+        self,
+        state: np.ndarray,
+        action: int,
+        next_state: np.ndarray,
+    ) -> float:
+        del action  # Realised post-transition state already encodes the choice.
+        if state[self._idx_terminal] > 0.5:
+            return 0.0
+        base = self._compute_base_reward_scalar(state, next_state)
+        position = (
+            int(next_state[self._idx_pac_row]),
+            int(next_state[self._idx_pac_col]),
+        )
+        return base + self._dangerous_area_contribution_scalar(position)
+
+    def _dangerous_area_contribution_scalar(self, position: Tuple[int, int]) -> float:
+        if not self._is_in_dangerous_area(position):
+            return 0.0
+        if np.random.random() < 0.5:
+            return self.dangerous_area_penalty
+        return -self.dangerous_area_penalty
+
+    def compute_reward_batch(
+        self,
+        states: np.ndarray,
+        action: int,
+        next_states: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
+        states_arr = np.ascontiguousarray(states, dtype=np.float64)
+        next_states_arr = (
+            None if next_states is None else np.ascontiguousarray(next_states, dtype=np.float64)
+        )
+        rewards = self._compute_base_reward_batch(states_arr, action, next_states_arr)
+        if self._dangerous_areas_arr.shape[0] == 0:
+            return rewards
+        new_pac_rows, new_pac_cols = self._compute_next_pacman_positions_batch(states_arr, action)
+        in_zone = self._compute_in_zone_mask_batch(new_pac_rows, new_pac_cols)
+        # Terminal rows return 0 reward (already zeroed by the base kernel) and
+        # must not pick up a stochastic danger contribution either.
+        terminal = states_arr[:, self._idx_terminal] > 0.5
+        in_zone &= ~terminal
+        in_zone_indices = np.flatnonzero(in_zone)
+        if in_zone_indices.size == 0:
+            return rewards
+        # ``signs`` matches the per-row independent ±penalty draw. Single
+        # batched ``np.random.random`` keeps seed semantics aligned with the
+        # light-dark / laser-tag HV batch paths.
+        coins = np.random.random(in_zone_indices.size)
+        signs = np.where(coins < 0.5, 1.0, -1.0)
+        rewards[in_zone_indices] += signs * self.dangerous_area_penalty
+        return rewards
+
+
+class PacManDecayingHitProbabilityRewardModel(PacManRewardModel):
+    """DECAYING_HIT_PROBABILITY variant.
+
+    Penalty is applied with probability
+    ``exp(-min_dist / penalty_decay)`` where ``min_dist`` is the
+    Euclidean distance from the realised next pacman position to the
+    *closest* dangerous-area centre. No radius cutoff — every step
+    risks some (vanishingly small at large distance) penalty. Each
+    call draws one uniform regardless of distance, matching the
+    existing decaying-prob kernel and the light-dark / laser-tag
+    analogous reward models. ``dangerous_area_radius`` is **ignored**
+    in this model.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        *,
+        num_ghosts: int,
+        pellet_positions_arr: np.ndarray,
+        dangerous_areas: List[Tuple[int, int]],
+        dangerous_areas_arr: np.ndarray,
+        dangerous_area_radius: float,
+        dangerous_area_penalty: float,
+        step_penalty: float,
+        ghost_collision_penalty: float,
+        pellet_reward: float,
+        win_reward: float,
+        idx_pac_row: int,
+        idx_pac_col: int,
+        idx_ghosts_start: int,
+        idx_pellets_start: int,
+        idx_pellets_end: int,
+        idx_score: int,
+        idx_terminal: int,
+        neighbor_table_getter: Callable[[], np.ndarray],
+        penalty_decay: float,
+    ):
+        super().__init__(
+            num_ghosts=num_ghosts,
+            pellet_positions_arr=pellet_positions_arr,
+            dangerous_areas=dangerous_areas,
+            dangerous_areas_arr=dangerous_areas_arr,
+            dangerous_area_radius=dangerous_area_radius,
+            dangerous_area_penalty=dangerous_area_penalty,
+            step_penalty=step_penalty,
+            ghost_collision_penalty=ghost_collision_penalty,
+            pellet_reward=pellet_reward,
+            win_reward=win_reward,
+            idx_pac_row=idx_pac_row,
+            idx_pac_col=idx_pac_col,
+            idx_ghosts_start=idx_ghosts_start,
+            idx_pellets_start=idx_pellets_start,
+            idx_pellets_end=idx_pellets_end,
+            idx_score=idx_score,
+            idx_terminal=idx_terminal,
+            neighbor_table_getter=neighbor_table_getter,
+        )
+        if penalty_decay <= 0.0:
+            raise ValueError("penalty_decay must be strictly positive")
+        self.penalty_decay = float(penalty_decay)
+
+    def compute_reward(
+        self,
+        state: np.ndarray,
+        action: int,
+        next_state: np.ndarray,
+    ) -> float:
+        del action  # Realised post-transition state already encodes the choice.
+        if state[self._idx_terminal] > 0.5:
+            return 0.0
+        base = self._compute_base_reward_scalar(state, next_state)
+        position = (
+            int(next_state[self._idx_pac_row]),
+            int(next_state[self._idx_pac_col]),
+        )
+        return base + self._dangerous_area_contribution_scalar(position)
+
+    def _dangerous_area_contribution_scalar(self, position: Tuple[int, int]) -> float:
+        if self._dangerous_centers_xy.shape[1] == 0:
+            return 0.0
+        point = np.array([float(position[0]), float(position[1])])
+        return float(
+            decaying_prob_penalty_kernel(
+                point,
+                self._dangerous_centers_xy,
+                -self.dangerous_area_penalty,
+                self.penalty_decay,
+                float(np.random.random()),
+            )
+        )
+
+    def compute_reward_batch(
+        self,
+        states: np.ndarray,
+        action: int,
+        next_states: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
+        states_arr = np.ascontiguousarray(states, dtype=np.float64)
+        next_states_arr = (
+            None if next_states is None else np.ascontiguousarray(next_states, dtype=np.float64)
+        )
+        rewards = self._compute_base_reward_batch(states_arr, action, next_states_arr)
+        if self._dangerous_centers_xy.shape[1] == 0:
+            return rewards
+        new_pac_rows, new_pac_cols = self._compute_next_pacman_positions_batch(states_arr, action)
+        n = new_pac_rows.shape[0]
+        points = np.empty((n, 2), dtype=np.float64)
+        points[:, 0] = new_pac_rows
+        points[:, 1] = new_pac_cols
+        # Decay penalty is applied to *every* non-terminal row (no radius
+        # cutoff). One uniform draw per row keeps seed semantics aligned
+        # with the light-dark / laser-tag Decaying batch paths.
+        uniforms = np.random.random(n)
+        contributions = decaying_prob_penalty_batch_kernel(
+            points,
+            self._dangerous_centers_xy,
+            -self.dangerous_area_penalty,
+            self.penalty_decay,
+            uniforms,
+        )
+        terminal = states_arr[:, self._idx_terminal] > 0.5
+        contributions[terminal] = 0.0
+        rewards += contributions
+        return rewards

--- a/POMDPPlanners/environments/push_pomdp/_cpp/continuous_push.cpp
+++ b/POMDPPlanners/environments/push_pomdp/_cpp/continuous_push.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -562,6 +563,119 @@ static inline bool discrete_collides(double px, double py,
     return false;
 }
 
+// Reward-variant codes shared between the standalone batch kernels and the
+// inline rollout reward paths. Mirrors the Python ``RewardModelType`` enum.
+constexpr int kRewardVariantStandard = 0;
+constexpr int kRewardVariantHighVar = 1;
+constexpr int kRewardVariantDecaying = 2;
+
+// Squared Euclidean distance from (px, py) to the nearest dangerous-area
+// centre. Used by the Decaying variant to evaluate the exponential
+// hit-probability without materialising sqrt twice.
+static inline double dangerous_min_dist_sq(double px, double py_,
+                                           const std::vector<double> &areas) noexcept {
+    const std::size_t k = areas.size() / 2;
+    double best = std::numeric_limits<double>::infinity();
+    for (std::size_t i = 0; i < k; ++i) {
+        const double dx = px - areas[i * 2 + 0];
+        const double dy = py_ - areas[i * 2 + 1];
+        const double d_sq = dx * dx + dy * dy;
+        if (d_sq < best) {
+            best = d_sq;
+        }
+    }
+    return best;
+}
+
+// Per-row dangerous-area reward contribution. Branches on ``variant_code``:
+// STANDARD (with optional Bernoulli), HIGH_VARIANCE_STATES (``±penalty``
+// 50/50 when in zone) and DECAYING_HIT_PROBABILITY (penalty fires with
+// ``exp(-min_dist / penalty_decay)`` over every row, no radius cutoff).
+static inline double dangerous_contribution(int variant_code, bool in_zone,
+                                            double penalty, double hit_prob,
+                                            double min_dist_sq, double penalty_decay,
+                                            pomdp_native::RNGState &rng) {
+    std::uniform_real_distribution<double> uni(0.0, 1.0);
+    if (variant_code == kRewardVariantStandard) {
+        if (!in_zone) {
+            return 0.0;
+        }
+        if (hit_prob >= 1.0 || uni(rng.engine()) < hit_prob) {
+            return penalty;
+        }
+        return 0.0;
+    }
+    if (variant_code == kRewardVariantHighVar) {
+        if (!in_zone) {
+            return 0.0;
+        }
+        return uni(rng.engine()) < 0.5 ? penalty : -penalty;
+    }
+    // Decaying: every row, prob exp(-sqrt(min_dist_sq) / penalty_decay).
+    const double u = uni(rng.engine());
+    if (u <= 0.0) {
+        return penalty;
+    }
+    const double log_u = std::log(u);
+    if (penalty_decay * penalty_decay * log_u * log_u > min_dist_sq) {
+        return penalty;
+    }
+    return 0.0;
+}
+
+// Reward configuration for the discrete rollout kernel. Mirrors the
+// parameters consumed by ``push_reward_batch`` so the inline rollout reward
+// stays bit-for-bit aligned with the standalone batch kernel (sample-mean
+// parity across all three :class:`RewardModelType` variants).
+struct DiscreteStepRewardConfig {
+    double obstacle_penalty;
+    double obstacle_hit_probability;
+    double dangerous_area_radius_sq;
+    double dangerous_area_penalty;
+    double dangerous_area_hit_probability;
+    int reward_variant_code;
+    double penalty_decay;
+};
+
+// Per-step reward using the REALISED post-action robot position. Mirrors
+// ``DiscretePushRewardModel.compute_reward`` (and its high-variance /
+// decaying subclasses) so the rollout kernel matches the standalone
+// ``push_reward_batch`` for every variant.
+static double discrete_step_reward(double nrx, double nry, double nox, double noy,
+                                   double tx, double ty,
+                                   const std::vector<double> &obstacles,
+                                   double obstacle_radius_sq,
+                                   const std::vector<double> &dangerous_areas,
+                                   const DiscreteStepRewardConfig &cfg,
+                                   pomdp_native::RNGState &rng) {
+    const double rdx = nox - tx;
+    const double rdy = noy - ty;
+    const double dist_to_target = std::sqrt(rdx * rdx + rdy * rdy);
+    double reward = -dist_to_target;
+    if (dist_to_target < 0.5) {
+        reward += 100.0;
+    }
+    std::uniform_real_distribution<double> uni(0.0, 1.0);
+    if (!obstacles.empty() && discrete_collides(nrx, nry, obstacles, obstacle_radius_sq)) {
+        if (cfg.obstacle_hit_probability >= 1.0 ||
+            uni(rng.engine()) < cfg.obstacle_hit_probability) {
+            reward += cfg.obstacle_penalty;
+        }
+    }
+    if (!dangerous_areas.empty()) {
+        const bool in_zone = point_in_dangerous_areas(nrx, nry, dangerous_areas,
+                                                     cfg.dangerous_area_radius_sq);
+        const double min_sq = (cfg.reward_variant_code == kRewardVariantDecaying)
+                                  ? dangerous_min_dist_sq(nrx, nry, dangerous_areas)
+                                  : 0.0;
+        reward += dangerous_contribution(cfg.reward_variant_code, in_zone,
+                                         cfg.dangerous_area_penalty,
+                                         cfg.dangerous_area_hit_probability,
+                                         min_sq, cfg.penalty_decay, rng);
+    }
+    return reward;
+}
+
 // Apply one discrete Push step, writing the next state into the 6-element
 // output array.  Returns the immediate reward.
 //
@@ -571,10 +685,8 @@ static double discrete_step(const double *state, int action_idx, double *next_st
                              double grid_max, double push_threshold_sq,
                              double push_scale, double obstacle_radius_sq,
                              const std::vector<double> &obstacles,
-                             double obstacle_penalty,
                              const std::vector<double> &dangerous_areas,
-                             double dangerous_area_radius_sq,
-                             double dangerous_area_penalty,
+                             const DiscreteStepRewardConfig &reward_cfg,
                              pomdp_native::RNGState &rng,
                              double transition_error_prob) {
     // Resolve action error ---------------------------------------------------
@@ -646,37 +758,12 @@ static double discrete_step(const double *state, int action_idx, double *next_st
     next_state[4] = tx;
     next_state[5] = ty;
 
-    // Reward ------------------------------------------------------------------
-    const double rdx = nox - tx;
-    const double rdy = noy - ty;
-    const double dist_to_target = std::sqrt(rdx * rdx + rdy * rdy);
-    double reward = -dist_to_target;
-    if (dist_to_target < 0.5) {
-        reward += 100.0;
-    }
-
-    // Obstacle penalty: applied if the INTENDED robot position (state[:2]+dxy)
-    // collides with an obstacle — mirrors _reward_from_next_state which calls
-    // _is_colliding_with_obstacle(state[:2], action).
-    const int rdx_int = kDiscreteDXY[static_cast<std::size_t>(action_idx)][0];
-    const int rdy_int = kDiscreteDXY[static_cast<std::size_t>(action_idx)][1];
-    const double intended_rx = rx + static_cast<double>(rdx_int);
-    const double intended_ry = ry + static_cast<double>(rdy_int);
-    if (!obstacles.empty()) {
-        if (discrete_collides(intended_rx, intended_ry, obstacles, obstacle_radius_sq)) {
-            reward += obstacle_penalty;
-        }
-    }
-    // Dangerous-area penalty: applied at most once per step when the intended
-    // robot position lies inside any dangerous area. Penalty is additive (negative)
-    // and parallels the obstacle penalty above.
-    if (!dangerous_areas.empty()) {
-        if (point_in_dangerous_areas(intended_rx, intended_ry, dangerous_areas,
-                                     dangerous_area_radius_sq)) {
-            reward += dangerous_area_penalty;
-        }
-    }
-    return reward;
+    // Reward (uses realised post-action robot position; matches the Python
+    // ``DiscretePushRewardModel`` family and the variant-aware
+    // ``push_reward_batch`` standalone kernel).
+    return discrete_step_reward(nrx, nry, nox, noy, tx, ty, obstacles,
+                                obstacle_radius_sq, dangerous_areas, reward_cfg,
+                                rng);
 }
 
 // Is-terminal: (obj_x - tgt_x)^2 + (obj_y - tgt_y)^2 < 0.25.
@@ -883,7 +970,9 @@ double simulate_rollout_discrete(
     double obstacle_radius, double obstacle_penalty,
     py::array_t<double, py::array::c_style | py::array::forcecast> dangerous_areas_arr,
     double dangerous_area_radius, double dangerous_area_penalty,
-    double transition_error_prob) {
+    double transition_error_prob, double obstacle_hit_probability,
+    double dangerous_area_hit_probability, int reward_variant_code,
+    double penalty_decay) {
     if (state_arr.ndim() != 1 || state_arr.shape(0) != 6) {
         throw std::invalid_argument("state must be a 1-D array of length 6");
     }
@@ -922,6 +1011,16 @@ double simulate_rollout_discrete(
     double gamma_power = 1.0;
     int action_cursor = 0;
 
+    const DiscreteStepRewardConfig reward_cfg{
+        obstacle_penalty,
+        obstacle_hit_probability,
+        dangerous_area_radius_sq,
+        dangerous_area_penalty,
+        dangerous_area_hit_probability,
+        reward_variant_code,
+        penalty_decay,
+    };
+
     while (depth < max_depth && !discrete_is_terminal(cur)) {
         if (action_cursor >= n_actions) {
             break;  // Ran out of pre-drawn actions; stop cleanly.
@@ -932,10 +1031,7 @@ double simulate_rollout_discrete(
         const double r = discrete_step(cur, action_idx, nxt, grid_max,
                                        push_threshold_sq, push_scale,
                                        obstacle_radius_sq, obstacles,
-                                       obstacle_penalty,
-                                       dangerous_areas,
-                                       dangerous_area_radius_sq,
-                                       dangerous_area_penalty,
+                                       dangerous_areas, reward_cfg,
                                        rng, transition_error_prob);
         total += gamma_power * r;
         gamma_power *= discount;
@@ -1094,6 +1190,58 @@ static void cont_sample_next_state_row(
     out_row[5] = state_row[5];
 }
 
+// Per-step reward for the continuous rollout using the REALISED post-action
+// robot position (next_state[:2]). Mirrors ``ContinuousPushRewardModel``
+// (and its high-variance / decaying subclasses) so the rollout output stays
+// in sample-mean parity with ``cont_push_reward_batch`` across every
+// :class:`RewardModelType` variant.
+static double cont_step_reward(const double *next_state,
+                               const std::vector<double> &obs_flat,
+                               std::size_t n_obs, double robot_radius,
+                               const std::vector<double> &dangerous_flat,
+                               const DiscreteStepRewardConfig &cfg,
+                               pomdp_native::RNGState &rng) {
+    const double rd = next_state[2] - next_state[4];
+    const double rd2 = next_state[3] - next_state[5];
+    const double dist_to_target = std::sqrt(rd * rd + rd2 * rd2);
+    double reward = -dist_to_target;
+    if (dist_to_target < 0.5) {
+        reward += 100.0;
+    }
+    std::uniform_real_distribution<double> uni(0.0, 1.0);
+    const double robot_after[2] = {  // NOLINT(modernize-avoid-c-arrays)
+        next_state[0], next_state[1]};
+    if (n_obs > 0) {
+        bool collide = false;
+        for (std::size_t i = 0; i < n_obs; ++i) {
+            if (cont_circle_aabb_overlap(robot_after, robot_radius, &obs_flat[i * 4])) {
+                collide = true;
+                break;
+            }
+        }
+        if (collide) {
+            if (cfg.obstacle_hit_probability >= 1.0 ||
+                uni(rng.engine()) < cfg.obstacle_hit_probability) {
+                reward += cfg.obstacle_penalty;
+            }
+        }
+    }
+    if (!dangerous_flat.empty()) {
+        const bool in_zone = point_in_dangerous_areas(robot_after[0], robot_after[1],
+                                                     dangerous_flat,
+                                                     cfg.dangerous_area_radius_sq);
+        const double min_sq = (cfg.reward_variant_code == kRewardVariantDecaying)
+                                  ? dangerous_min_dist_sq(robot_after[0], robot_after[1],
+                                                          dangerous_flat)
+                                  : 0.0;
+        reward += dangerous_contribution(cfg.reward_variant_code, in_zone,
+                                         cfg.dangerous_area_penalty,
+                                         cfg.dangerous_area_hit_probability,
+                                         min_sq, cfg.penalty_decay, rng);
+    }
+    return reward;
+}
+
 double cont_simulate_rollout(
     const py::array_t<double, py::array::c_style | py::array::forcecast> &initial_state,
     const py::array_t<double, py::array::c_style | py::array::forcecast> &action_array,
@@ -1104,7 +1252,9 @@ double cont_simulate_rollout(
     const py::array_t<double, py::array::c_style | py::array::forcecast> &obstacles,
     const py::array_t<double, py::array::c_style | py::array::forcecast> &dangerous_areas,
     double dangerous_area_radius, double dangerous_area_penalty,
-    const py::array_t<double> &covariance) {
+    const py::array_t<double> &covariance,
+    double obstacle_hit_probability, double dangerous_area_hit_probability,
+    int reward_variant_code, double penalty_decay) {
 
     if (initial_state.ndim() != 1 ||
         static_cast<std::size_t>(initial_state.shape(0)) != kPushStateDim) {
@@ -1156,6 +1306,16 @@ double cont_simulate_rollout(
     double gamma_power = 1.0;
     int depth = start_depth;
 
+    const DiscreteStepRewardConfig reward_cfg{
+        obstacle_penalty,
+        obstacle_hit_probability,
+        dangerous_area_radius_sq,
+        dangerous_area_penalty,
+        dangerous_area_hit_probability,
+        reward_variant_code,
+        penalty_decay,
+    };
+
     while (depth < max_depth) {
         if (cont_is_terminal(state)) {
             break;
@@ -1176,35 +1336,9 @@ double cont_simulate_rollout(
                                    friction_coefficient, max_push, robot_radius,
                                    obs_flat, n_obs, noise, next_state, rng);
 
-        const double rd = next_state[2] - next_state[4];
-        const double rd2 = next_state[3] - next_state[5];
-        const double dist_to_target = std::sqrt(rd * rd + rd2 * rd2);
-        double reward = -dist_to_target;
-        if (dist_to_target < 0.5) {
-            reward += 100.0;
-        }
-
-        double robot_after[kNoiseDim] = {  // NOLINT(modernize-avoid-c-arrays)
-            state[0] + action[0], state[1] + action[1]};
-        if (n_obs > 0 && obstacle_penalty != 0.0) {
-            for (std::size_t i = 0; i < n_obs; ++i) {
-                if (cont_circle_aabb_overlap(robot_after, robot_radius, &obs_flat[i * 4])) {
-                    reward += obstacle_penalty;
-                    break;
-                }
-            }
-        }
-        // Dangerous-area penalty: applied at most once when the post-action
-        // robot position lies inside any dangerous area. Mirrors the Python
-        // ``_reward_batch_array`` block that calls
-        // ``_batch_robot_in_dangerous_areas``.
-        if (!dangerous_flat.empty() && dangerous_area_penalty != 0.0) {
-            if (point_in_dangerous_areas(robot_after[0], robot_after[1],
-                                         dangerous_flat,
-                                         dangerous_area_radius_sq)) {
-                reward += dangerous_area_penalty;
-            }
-        }
+        const double reward = cont_step_reward(next_state, obs_flat, n_obs,
+                                               robot_radius, dangerous_flat,
+                                               reward_cfg, rng);
 
         total += gamma_power * reward;
         gamma_power *= discount_factor;
@@ -1457,6 +1591,176 @@ py::array_t<double> push_observation_log_probability_step(
     return out;
 }
 
+// ── Standalone reward-batch kernels (variant-aware) ─────────────────────────
+//
+// ``push_reward_batch`` / ``cont_push_reward_batch`` mirror the Python
+// reward-model batch path bit-by-bit (sample-mean parity, not bit-exact):
+//   * base term: ``-distance(next_obj, target)`` + ``+100`` goal bonus.
+//   * obstacle penalty: deterministic point-in-circle (discrete) /
+//     circle-vs-AABB overlap (continuous) on the REALISED post-action robot
+//     position ``next_state[:2]`` with optional Bernoulli ``hit_probability``.
+//   * dangerous-area penalty: variant-driven.
+//        - reward_variant_code 0 (STANDARD): per-row penalty when in zone,
+//          optional Bernoulli ``dangerous_area_hit_probability``.
+//        - reward_variant_code 1 (HIGH_VARIANCE_STATES): ``±penalty`` 50/50
+//          when in zone; expectation is 0.
+//        - reward_variant_code 2 (DECAYING_HIT_PROBABILITY): penalty fires
+//          with probability ``exp(-min_dist / penalty_decay)`` over every
+//          row (no radius cutoff).
+// All RNG draws come from ``pomdp_native::default_rng()``. The variant
+// codes, ``dangerous_min_dist_sq`` and ``dangerous_contribution`` are
+// defined earlier (near ``discrete_step_reward``) so they can be shared
+// between the inline rollout reward and the standalone batch kernels.
+
+py::array_t<double> push_reward_batch(
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &states,
+    int action_idx,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &next_states,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &obstacles,
+    double obstacle_radius, double obstacle_penalty, double obstacle_hit_probability,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &dangerous_areas,
+    double dangerous_area_radius, double dangerous_area_penalty,
+    double dangerous_area_hit_probability, int reward_variant_code,
+    double penalty_decay) {
+    (void)action_idx;  // reward depends on realised next_state, not the action
+    if (next_states.ndim() != 2 || next_states.shape(1) != 6) {
+        throw std::invalid_argument("next_states must have shape (N, 6)");
+    }
+    if (states.ndim() != 2 || states.shape(1) != 6) {
+        throw std::invalid_argument("states must have shape (N, 6)");
+    }
+    const auto n = static_cast<std::size_t>(next_states.shape(0));
+    auto out = py::array_t<double>(static_cast<py::ssize_t>(n));
+    if (n == 0) {
+        return out;
+    }
+    std::vector<double> obs_flat;
+    if (!(obstacles.ndim() == 1 && obstacles.shape(0) == 0)) {
+        obs_flat = load_discrete_obstacles(obstacles);
+    }
+    std::vector<double> areas_flat = load_dangerous_areas(dangerous_areas);
+    const double obs_r_sq = obstacle_radius * obstacle_radius;
+    const double area_r_sq = dangerous_area_radius * dangerous_area_radius;
+    const double *next_data = next_states.data();
+    double *out_data = out.mutable_data();
+    pomdp_native::RNGState &rng = pomdp_native::default_rng();
+    std::uniform_real_distribution<double> uni(0.0, 1.0);
+    const bool has_areas = !areas_flat.empty();
+    const bool has_obs = !obs_flat.empty();
+    for (std::size_t i = 0; i < n; ++i) {
+        const double rx = next_data[i * 6 + 0];
+        const double ry = next_data[i * 6 + 1];
+        const double ox = next_data[i * 6 + 2];
+        const double oy = next_data[i * 6 + 3];
+        const double tx = next_data[i * 6 + 4];
+        const double ty = next_data[i * 6 + 5];
+        const double dxg = ox - tx;
+        const double dyg = oy - ty;
+        const double dist = std::sqrt(dxg * dxg + dyg * dyg);
+        double reward = -dist;
+        if (dist < 0.5) {
+            reward += 100.0;
+        }
+        if (has_obs && discrete_collides(rx, ry, obs_flat, obs_r_sq)) {
+            if (obstacle_hit_probability >= 1.0 ||
+                uni(rng.engine()) < obstacle_hit_probability) {
+                reward += obstacle_penalty;
+            }
+        }
+        if (has_areas) {
+            const bool in_zone =
+                point_in_dangerous_areas(rx, ry, areas_flat, area_r_sq);
+            const double min_sq = (reward_variant_code == kRewardVariantDecaying)
+                                      ? dangerous_min_dist_sq(rx, ry, areas_flat)
+                                      : 0.0;
+            reward += dangerous_contribution(reward_variant_code, in_zone,
+                                             dangerous_area_penalty,
+                                             dangerous_area_hit_probability,
+                                             min_sq, penalty_decay, rng);
+        }
+        out_data[i] = reward;
+    }
+    return out;
+}
+
+py::array_t<double> cont_push_reward_batch(
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &states,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &action,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &next_states,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &obstacles,
+    double robot_radius, double obstacle_penalty, double obstacle_hit_probability,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &dangerous_areas,
+    double dangerous_area_radius, double dangerous_area_penalty,
+    double dangerous_area_hit_probability, int reward_variant_code,
+    double penalty_decay) {
+    (void)states;
+    (void)action;
+    if (next_states.ndim() != 2 || next_states.shape(1) != 6) {
+        throw std::invalid_argument("next_states must have shape (N, 6)");
+    }
+    const auto n = static_cast<std::size_t>(next_states.shape(0));
+    auto out = py::array_t<double>(static_cast<py::ssize_t>(n));
+    if (n == 0) {
+        return out;
+    }
+    std::vector<double> obs_flat;
+    if (!(obstacles.ndim() == 1 && obstacles.shape(0) == 0)) {
+        obs_flat = load_obstacles(obstacles);
+    }
+    std::vector<double> areas_flat = load_dangerous_areas(dangerous_areas);
+    const double area_r_sq = dangerous_area_radius * dangerous_area_radius;
+    const auto n_obs = obs_flat.size() / 4;
+    const double *next_data = next_states.data();
+    double *out_data = out.mutable_data();
+    pomdp_native::RNGState &rng = pomdp_native::default_rng();
+    std::uniform_real_distribution<double> uni(0.0, 1.0);
+    const bool has_areas = !areas_flat.empty();
+    for (std::size_t i = 0; i < n; ++i) {
+        const double rx = next_data[i * 6 + 0];
+        const double ry = next_data[i * 6 + 1];
+        const double ox = next_data[i * 6 + 2];
+        const double oy = next_data[i * 6 + 3];
+        const double tx = next_data[i * 6 + 4];
+        const double ty = next_data[i * 6 + 5];
+        const double dxg = ox - tx;
+        const double dyg = oy - ty;
+        const double dist = std::sqrt(dxg * dxg + dyg * dyg);
+        double reward = -dist;
+        if (dist < 0.5) {
+            reward += 100.0;
+        }
+        if (n_obs > 0) {
+            const double pos[2] = {rx, ry};  // NOLINT(modernize-avoid-c-arrays)
+            bool collide = false;
+            for (std::size_t j = 0; j < n_obs; ++j) {
+                if (cont_circle_aabb_overlap(pos, robot_radius, &obs_flat[j * 4])) {
+                    collide = true;
+                    break;
+                }
+            }
+            if (collide) {
+                if (obstacle_hit_probability >= 1.0 ||
+                    uni(rng.engine()) < obstacle_hit_probability) {
+                    reward += obstacle_penalty;
+                }
+            }
+        }
+        if (has_areas) {
+            const bool in_zone =
+                point_in_dangerous_areas(rx, ry, areas_flat, area_r_sq);
+            const double min_sq = (reward_variant_code == kRewardVariantDecaying)
+                                      ? dangerous_min_dist_sq(rx, ry, areas_flat)
+                                      : 0.0;
+            reward += dangerous_contribution(reward_variant_code, in_zone,
+                                             dangerous_area_penalty,
+                                             dangerous_area_hit_probability,
+                                             min_sq, penalty_decay, rng);
+        }
+        out_data[i] = reward;
+    }
+    return out;
+}
+
 }  // anonymous namespace
 
 PYBIND11_MODULE(_native, m) {
@@ -1473,14 +1777,22 @@ PYBIND11_MODULE(_native, m) {
           py::arg("obstacles"), py::arg("dangerous_areas"),
           py::arg("dangerous_area_radius"), py::arg("dangerous_area_penalty"),
           py::arg("covariance"),
+          py::arg("obstacle_hit_probability") = 1.0,
+          py::arg("dangerous_area_hit_probability") = 1.0,
+          py::arg("reward_variant_code") = 0,
+          py::arg("penalty_decay") = 1.0,
           "Native random rollout for ContinuousPushPOMDP. "
           "Returns discounted return from initial_state. "
           "action_indices must be a pre-drawn int32 array of shape (steps_left,). "
           "obstacles must have shape (M, 4) with rows (cx, cy, hx, hy). "
           "dangerous_areas must have shape (K, 2) (or (0, 2) when empty); each "
           "row is the (x, y) centre of a circular dangerous area of radius "
-          "``dangerous_area_radius``. Robots inside any zone after the action "
-          "incur ``dangerous_area_penalty`` (at most once per step).");
+          "``dangerous_area_radius``. Per-step reward consults the REALISED "
+          "post-action robot position (next_state[:2]) for obstacle / danger "
+          "tests, with Bernoulli ``*_hit_probability`` gating. "
+          "``reward_variant_code`` selects the dangerous-area contract "
+          "(0=STANDARD, 1=HIGH_VARIANCE_STATES, 2=DECAYING_HIT_PROBABILITY); "
+          "``penalty_decay`` is the decay length used by variant 2.");
 
     m.def("simulate_rollout_discrete", &simulate_rollout_discrete,
           py::arg("state"), py::arg("action_indices"), py::arg("max_depth"),
@@ -1491,9 +1803,17 @@ PYBIND11_MODULE(_native, m) {
           py::arg("dangerous_areas"), py::arg("dangerous_area_radius"),
           py::arg("dangerous_area_penalty"),
           py::arg("transition_error_prob"),
+          py::arg("obstacle_hit_probability") = 1.0,
+          py::arg("dangerous_area_hit_probability") = 1.0,
+          py::arg("reward_variant_code") = 0,
+          py::arg("penalty_decay") = 1.0,
           "Run a full discrete Push rollout in C++. Returns discounted reward sum. "
-          "dangerous_areas must have shape (K, 2) (or empty). Penalty applied "
-          "once per step when the intended robot position lies in any zone.");
+          "dangerous_areas must have shape (K, 2) (or empty). Per-step reward "
+          "consults the REALISED post-action robot position (next_state[:2]) "
+          "for obstacle / danger tests, with Bernoulli ``*_hit_probability`` "
+          "gating. ``reward_variant_code`` selects the dangerous-area contract "
+          "(0=STANDARD, 1=HIGH_VARIANCE_STATES, 2=DECAYING_HIT_PROBABILITY); "
+          "``penalty_decay`` is the decay length used by variant 2.");
 
     m.def("belief_batch_transition_discrete", &belief_batch_transition_discrete,
           py::arg("particles"), py::arg("action_idx"), py::arg("transition_error_prob"),
@@ -1514,6 +1834,35 @@ PYBIND11_MODULE(_native, m) {
           "particle[2:4], σ²·I_2) over all (N, 6) particles. "
           "Bit-for-bit equivalent to PushVectorizedUpdater."
           "batch_observation_log_likelihood (no RNG involved).");
+
+    m.def("push_reward_batch", &push_reward_batch,
+          py::arg("states"), py::arg("action_idx"), py::arg("next_states"),
+          py::arg("obstacles"), py::arg("obstacle_radius"),
+          py::arg("obstacle_penalty"), py::arg("obstacle_hit_probability"),
+          py::arg("dangerous_areas"), py::arg("dangerous_area_radius"),
+          py::arg("dangerous_area_penalty"),
+          py::arg("dangerous_area_hit_probability"),
+          py::arg("reward_variant_code"), py::arg("penalty_decay"),
+          "Standalone variant-aware reward batch for PushPOMDP (discrete).\n\n"
+          "Implements all three RewardModelType variants:\n"
+          "  0 = STANDARD: deterministic per-zone penalty (optional Bernoulli).\n"
+          "  1 = HIGH_VARIANCE_STATES: ±penalty 50/50 when in zone.\n"
+          "  2 = DECAYING_HIT_PROBABILITY: penalty fires with probability\n"
+          "      exp(-min_dist / penalty_decay) for every row (no radius cutoff).\n"
+          "Obstacle penalty fires on next_state[:2] (realised position).");
+
+    m.def("cont_push_reward_batch", &cont_push_reward_batch,
+          py::arg("states"), py::arg("action"), py::arg("next_states"),
+          py::arg("obstacles"), py::arg("robot_radius"),
+          py::arg("obstacle_penalty"), py::arg("obstacle_hit_probability"),
+          py::arg("dangerous_areas"), py::arg("dangerous_area_radius"),
+          py::arg("dangerous_area_penalty"),
+          py::arg("dangerous_area_hit_probability"),
+          py::arg("reward_variant_code"), py::arg("penalty_decay"),
+          "Standalone variant-aware reward batch for ContinuousPushPOMDP.\n\n"
+          "Same three variants as push_reward_batch. Obstacle test is a\n"
+          "circle-vs-AABB overlap on next_state[:2] with robot_radius;\n"
+          "obstacles rows are (cx, cy, hx, hy).");
 
     py::class_<PushDiscreteTransitionCpp>(m, "PushDiscreteTransitionCpp")
         .def(py::init<py::array_t<double, py::array::c_style | py::array::forcecast>,

--- a/POMDPPlanners/environments/push_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/push_pomdp/_native.pyi
@@ -32,6 +32,10 @@ def simulate_rollout_discrete(
     dangerous_area_radius: float,
     dangerous_area_penalty: float,
     transition_error_prob: float,
+    obstacle_hit_probability: float = 1.0,
+    dangerous_area_hit_probability: float = 1.0,
+    reward_variant_code: int = 0,
+    penalty_decay: float = 1.0,
 ) -> float:
     """Run a full discrete Push POMDP rollout in C++.
 
@@ -39,9 +43,13 @@ def simulate_rollout_discrete(
     trajectory, using pre-drawn action indices supplied by the caller.
 
     ``dangerous_areas`` must have shape ``(K, 2)`` (rows ``(cx, cy)``) or
-    be empty. The penalty is applied at most once per step when the
-    intended robot position falls inside any zone of radius
-    ``dangerous_area_radius``.
+    be empty. Per-step reward consults the REALISED post-action robot
+    position (``next_state[:2]``) for obstacle and dangerous-area tests,
+    with Bernoulli ``*_hit_probability`` gating.
+    ``reward_variant_code`` selects the dangerous-area contract
+    (``0=STANDARD``, ``1=HIGH_VARIANCE_STATES``,
+    ``2=DECAYING_HIT_PROBABILITY``); ``penalty_decay`` is the decay
+    length used by variant 2.
     """
     ...
 
@@ -63,6 +71,10 @@ def cont_simulate_rollout(
     dangerous_area_radius: float,
     dangerous_area_penalty: float,
     covariance: NDArray[np.floating],
+    obstacle_hit_probability: float = 1.0,
+    dangerous_area_hit_probability: float = 1.0,
+    reward_variant_code: int = 0,
+    penalty_decay: float = 1.0,
 ) -> float:
     """Native random rollout for ContinuousPushPOMDP.
 
@@ -72,9 +84,13 @@ def cont_simulate_rollout(
     rows ``(cx, cy, hx, hy)``.
 
     ``dangerous_areas`` must have shape ``(K, 2)`` (rows ``(cx, cy)``) or
-    be empty. The penalty is applied at most once per step when the
-    post-action robot position lies inside any zone of radius
-    ``dangerous_area_radius``.
+    be empty. Per-step reward consults the REALISED post-action robot
+    position (``next_state[:2]``) for obstacle and dangerous-area tests,
+    with Bernoulli ``*_hit_probability`` gating.
+    ``reward_variant_code`` selects the dangerous-area contract
+    (``0=STANDARD``, ``1=HIGH_VARIANCE_STATES``,
+    ``2=DECAYING_HIT_PROBABILITY``); ``penalty_decay`` is the decay
+    length used by variant 2.
     """
     ...
 
@@ -174,6 +190,55 @@ def belief_batch_obs_log_likelihood_discrete(
     Returns the per-particle log N(obs[2:4] | particle[2:4], sigma**2 * I_2)
     over all (N, 6) particles. Bit-for-bit equivalent to the Python
     ``PushVectorizedUpdater.batch_observation_log_likelihood`` (no RNG).
+    """
+    ...
+
+def push_reward_batch(
+    states: NDArray[np.floating],
+    action_idx: int,
+    next_states: NDArray[np.floating],
+    obstacles: NDArray[np.floating],
+    obstacle_radius: float,
+    obstacle_penalty: float,
+    obstacle_hit_probability: float,
+    dangerous_areas: NDArray[np.floating],
+    dangerous_area_radius: float,
+    dangerous_area_penalty: float,
+    dangerous_area_hit_probability: float,
+    reward_variant_code: int,
+    penalty_decay: float,
+) -> NDArray[np.float64]:
+    """Standalone variant-aware reward-batch kernel for the discrete PushPOMDP.
+
+    ``reward_variant_code`` selects the dangerous-area contract:
+        * 0 — STANDARD (deterministic / optional Bernoulli per zone).
+        * 1 — HIGH_VARIANCE_STATES (``±penalty`` 50/50 in zone).
+        * 2 — DECAYING_HIT_PROBABILITY (penalty fires with probability
+          ``exp(-min_dist / penalty_decay)``, no radius cutoff).
+    Returns a ``(N,)`` float64 array of per-row rewards.
+    """
+    ...
+
+def cont_push_reward_batch(
+    states: NDArray[np.floating],
+    action: NDArray[np.floating],
+    next_states: NDArray[np.floating],
+    obstacles: NDArray[np.floating],
+    robot_radius: float,
+    obstacle_penalty: float,
+    obstacle_hit_probability: float,
+    dangerous_areas: NDArray[np.floating],
+    dangerous_area_radius: float,
+    dangerous_area_penalty: float,
+    dangerous_area_hit_probability: float,
+    reward_variant_code: int,
+    penalty_decay: float,
+) -> NDArray[np.float64]:
+    """Standalone variant-aware reward-batch kernel for ContinuousPushPOMDP.
+
+    Mirrors :func:`push_reward_batch` but uses a circle-vs-AABB overlap on
+    ``next_state[:2]`` with ``robot_radius`` for the obstacle penalty.
+    ``obstacles`` rows are ``(cx, cy, hx, hy)``.
     """
     ...
 

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -134,10 +134,10 @@ class ContinuousPushPOMDP(Environment):
         env. Note that this makes ``reward(state, action)`` non-
         deterministic given a state-action pair, so any external caching
         that assumes deterministic rewards must be aware of this.
-        ``transition_log_probability`` is unaffected. When
-        ``obstacle_hit_probability < 1.0`` the native C++ rollout (which
-        deducts the penalty deterministically) is bypassed in favour of
-        the Python rollout so per-step Bernoulli draws survive.
+        ``transition_log_probability`` is unaffected. The native C++
+        rollout applies the Bernoulli ``obstacle_hit_probability`` draw
+        internally, so ``simulate_random_rollout`` always routes through
+        the native kernel.
 
     Dangerous areas:
         ``dangerous_areas`` is a separate, additive concept from
@@ -151,8 +151,9 @@ class ContinuousPushPOMDP(Environment):
         ``dangerous_area_penalty`` is applied per step even when
         multiple zones overlap. Like obstacles, the penalty supports a
         Bernoulli ``dangerous_area_hit_probability`` (default 1.0) for
-        risk-sensitive planning; ``< 1.0`` bypasses the deterministic
-        native rollout in favour of the Python rollout.
+        risk-sensitive planning. The native C++ rollout applies the
+        Bernoulli draw internally, so all rollouts route through the
+        native kernel regardless of the configured probability.
 
     Example:
         >>> import numpy as np
@@ -497,7 +498,40 @@ class ContinuousPushPOMDP(Environment):
             next_states_arr = np.ascontiguousarray(np.asarray(next_states, dtype=np.float64))
             if next_states_arr.ndim == 1:
                 next_states_arr = next_states_arr.reshape(1, -1)
-        return self._compute_reward_batch(states_arr, action_arr, next_states_arr)
+        return self._native_reward_batch(states_arr, action_arr, next_states_arr)
+
+    def _native_reward_batch(
+        self,
+        states_arr: np.ndarray,
+        action_arr: np.ndarray,
+        next_states_arr: np.ndarray,
+    ) -> np.ndarray:
+        variant_code, penalty_decay = self._reward_variant_native_params()
+        return np.asarray(
+            _native.cont_push_reward_batch(
+                states=states_arr,
+                action=action_arr,
+                next_states=next_states_arr,
+                obstacles=np.ascontiguousarray(self.obstacles, dtype=np.float64),
+                robot_radius=float(self.robot_radius),
+                obstacle_penalty=float(self.obstacle_penalty),
+                obstacle_hit_probability=float(self.obstacle_hit_probability),
+                dangerous_areas=self._dangerous_areas_arr,
+                dangerous_area_radius=float(self.dangerous_area_radius),
+                dangerous_area_penalty=float(self.dangerous_area_penalty),
+                dangerous_area_hit_probability=float(self.dangerous_area_hit_probability),
+                reward_variant_code=variant_code,
+                penalty_decay=penalty_decay,
+            ),
+            dtype=np.float64,
+        )
+
+    def _reward_variant_native_params(self) -> Tuple[int, float]:
+        if self.reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+            return 1, 0.0
+        if self.reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+            return 2, float(getattr(self.reward_model, "penalty_decay", 1.0))
+        return 0, 0.0
 
     def __getstate__(self):
         # Per-action C++ kernel cache holds pybind11 objects that aren't
@@ -569,14 +603,10 @@ class ContinuousPushPOMDP(Environment):
             return 0.0
 
         actions_array = self._get_rollout_actions_array()
-        if (
-            actions_array is None
-            or self.obstacle_hit_probability < 1.0
-            or self.dangerous_area_hit_probability < 1.0
-        ):
-            # Native kernel applies the obstacle and dangerous-area penalties
-            # deterministically; fall back to the Python rollout so per-step
-            # Bernoulli draws against the configured hit probabilities survive.
+        if actions_array is None:
+            # Pure continuous-action env without a finite action set: no
+            # ``action_to_vector`` mapping is available, so we cannot
+            # pre-draw a fixed action index array for the native kernel.
             return python_random_rollout(
                 state=state,
                 depth=depth,
@@ -589,6 +619,7 @@ class ContinuousPushPOMDP(Environment):
         n_actions = len(actions_array)
         action_indices = np.random.randint(0, n_actions, size=steps_left, dtype=np.int32)
         state_arr = np.ascontiguousarray(np.asarray(state, dtype=np.float64).ravel())
+        variant_code, penalty_decay = self._reward_variant_native_params()
 
         return float(
             _native.cont_simulate_rollout(
@@ -609,6 +640,10 @@ class ContinuousPushPOMDP(Environment):
                 dangerous_area_radius=float(self.dangerous_area_radius),
                 dangerous_area_penalty=float(self.dangerous_area_penalty),
                 covariance=self._trans_cov_view,
+                obstacle_hit_probability=float(self.obstacle_hit_probability),
+                dangerous_area_hit_probability=float(self.dangerous_area_hit_probability),
+                reward_variant_code=variant_code,
+                penalty_decay=penalty_decay,
             )
         )
 

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -157,10 +157,10 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         deterministic given a state-action pair, so any external caching
         that assumes deterministic rewards must be aware of this.
         ``transition_log_probability`` is unaffected; the obstacle still
-        deterministically blocks movement. When
-        ``obstacle_hit_probability < 1.0`` the native C++ rollout (which
-        deducts the penalty deterministically) is bypassed in favour of
-        the pure-Python rollout so per-step Bernoulli draws survive.
+        deterministically blocks movement. The native C++ rollout applies
+        the Bernoulli ``obstacle_hit_probability`` draw internally, so
+        ``simulate_random_rollout`` always routes through the native
+        kernel.
 
     Dangerous areas:
         ``dangerous_areas`` is a separate, additive concept from
@@ -174,8 +174,9 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         ``dangerous_area_penalty`` is applied per step even when
         multiple zones overlap. Like obstacles, the penalty supports a
         Bernoulli ``dangerous_area_hit_probability`` (default 1.0) for
-        risk-sensitive planning; ``< 1.0`` bypasses the deterministic
-        native rollout in favour of the Python path.
+        risk-sensitive planning. The native C++ rollout applies the
+        Bernoulli draw internally, so all rollouts route through the
+        native kernel regardless of the configured probability.
 
     Example:
         >>> import numpy as np
@@ -731,35 +732,16 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         if remaining <= 0 or self.is_terminal(state=state):
             return 0.0
 
-        # Bypass the native kernel whenever obstacle or dangerous-area
-        # penalties may fire: the C++ rollout still scores them against
-        # ``state + action_vector`` (intended position), while the Python
-        # ``reward`` path now consults the realised ``next_state``. The C++
-        # kernel needs a recompile to align — until then we route through
-        # Python whenever penalties are configured.
-        # The same fall-back is required for stochastic hit probabilities
-        # so per-step Bernoulli draws against the configured probabilities
-        # survive (the C++ kernel applies them deterministically).
-        has_obstacle_penalty = len(self.obstacles) > 0
-        has_dangerous_area_penalty = self._dangerous_areas_arr.shape[0] > 0
-        if (
-            self.obstacle_hit_probability < 1.0
-            or self.dangerous_area_hit_probability < 1.0
-            or has_obstacle_penalty
-            or has_dangerous_area_penalty
-        ):
-            actions = [self.actions[i] for i in np.random.randint(0, 4, size=remaining)]
-            return self._python_simulate_random_rollout(
-                state=state,
-                actions=actions,
-                max_depth=max_depth,
-                discount_factor=discount_factor,
-                depth=depth,
-            )
-
+        # Native kernel is variant-aware and scores obstacle / dangerous-area
+        # penalties against the REALISED post-action robot position
+        # (``next_state[:2]``), matching ``DiscretePushRewardModel``. Pass the
+        # variant code + penalty decay so the C++ rollout dispatches
+        # STANDARD / HIGH_VARIANCE_STATES / DECAYING_HIT_PROBABILITY exactly
+        # like the standalone ``push_reward_batch`` kernel.
         action_indices = np.random.randint(0, 4, size=remaining, dtype=np.int64)
         obs_arr = self._get_native_rollout_obstacles()
         state_arr = np.asarray(state, dtype=np.float64)
+        variant_code, penalty_decay = self._reward_variant_native_params()
 
         return float(
             _native.simulate_rollout_discrete(
@@ -778,6 +760,10 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
                 dangerous_area_radius=float(self.dangerous_area_radius),
                 dangerous_area_penalty=float(self.dangerous_area_penalty),
                 transition_error_prob=float(self.transition_error_prob),
+                obstacle_hit_probability=float(self.obstacle_hit_probability),
+                dangerous_area_hit_probability=float(self.dangerous_area_hit_probability),
+                reward_variant_code=variant_code,
+                penalty_decay=penalty_decay,
             )
         )
 
@@ -851,8 +837,10 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         When ``next_states`` is supplied (e.g. by a caller that has
         already sampled the realised batch transition), it is used
         directly; otherwise N next states are drawn here via the cached
-        ``PushVectorizedUpdater``. Per-particle rewards are then computed
-        with pure NumPy operations — no Python loop over particles.
+        ``PushVectorizedUpdater``. Per-particle rewards are computed in
+        the C++ ``push_reward_batch`` kernel (variant-aware: STANDARD,
+        HIGH_VARIANCE_STATES, DECAYING_HIT_PROBABILITY) so the batch
+        cost is a single round-trip into native code.
         """
         states_array = np.ascontiguousarray(np.asarray(states, dtype=float))
         if states_array.ndim == 1:
@@ -863,7 +851,45 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             next_states_arr = np.ascontiguousarray(np.asarray(next_states, dtype=float))
             if next_states_arr.ndim == 1:
                 next_states_arr = next_states_arr.reshape(1, -1)
-        return self._compute_reward_batch(states_array, action, next_states_arr)
+        return self._native_reward_batch(states_array, action, next_states_arr)
+
+    def _native_reward_batch(
+        self,
+        states_array: np.ndarray,
+        action: str,
+        next_states_arr: np.ndarray,
+    ) -> np.ndarray:
+        obstacles_arr = self._get_native_rollout_obstacles()
+        if obstacles_arr.ndim == 1 and obstacles_arr.shape[0] == 0:
+            obstacles_native = np.empty((0, 2), dtype=np.float64)
+        else:
+            obstacles_native = np.ascontiguousarray(obstacles_arr, dtype=np.float64)
+        variant_code, penalty_decay = self._reward_variant_native_params()
+        return np.asarray(
+            _native.push_reward_batch(
+                states=states_array,
+                action_idx=int(self.actions.index(action)),
+                next_states=next_states_arr,
+                obstacles=obstacles_native,
+                obstacle_radius=float(self.obstacle_radius),
+                obstacle_penalty=float(self.obstacle_penalty),
+                obstacle_hit_probability=float(self.obstacle_hit_probability),
+                dangerous_areas=self._dangerous_areas_arr,
+                dangerous_area_radius=float(self.dangerous_area_radius),
+                dangerous_area_penalty=float(self.dangerous_area_penalty),
+                dangerous_area_hit_probability=float(self.dangerous_area_hit_probability),
+                reward_variant_code=variant_code,
+                penalty_decay=penalty_decay,
+            ),
+            dtype=np.float64,
+        )
+
+    def _reward_variant_native_params(self) -> Tuple[int, float]:
+        if self.reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+            return 1, 0.0
+        if self.reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+            return 2, float(getattr(self.reward_model, "penalty_decay", 1.0))
+        return 0, 0.0
 
     def observation_log_probability_per_state(
         self, next_states: Any, action: str, observation: Any

--- a/POMDPPlanners/environments/rock_sample_pomdp/_cpp/rock_sample.cpp
+++ b/POMDPPlanners/environments/rock_sample_pomdp/_cpp/rock_sample.cpp
@@ -630,13 +630,183 @@ class RockSampleObservationCpp {
 };
 
 // ---------------------------------------------------------------------------
+// Reward-variant codes mirror the Python ``RewardModelType`` enum used by
+// :class:`RockSamplePOMDP`:
+//
+//   0 -> STANDARD             (constant-probability dangerous-area penalty)
+//   1 -> HIGH_VARIANCE_STATES (+/- 50/50 dangerous-area perturbation)
+//   2 -> DECAYING_HIT_PROBABILITY (exp(-min_dist/decay) hit probability)
+// ---------------------------------------------------------------------------
+constexpr int kRewardVariantStandard = 0;
+constexpr int kRewardVariantHighVariance = 1;
+constexpr int kRewardVariantDecaying = 2;
+
+// Base reward shared across all variants: step / exit / sample / sense.
+// ``state_row`` is the current state row (length state_dim) so this
+// matches the Python ``compute_reward`` which uses the CURRENT robot
+// position for the exit / sample / sense terms.
+inline double base_reward_term(const double *state_row, int action, int map_cols,
+                               int num_rocks, const std::int32_t *rock_rows,
+                               const std::int32_t *rock_cols, std::size_t state_dim,
+                               double step_penalty, double exit_reward,
+                               double good_rock_reward, double bad_rock_penalty,
+                               double sensor_use_penalty) {
+    double r = step_penalty;
+    const int robot_row = static_cast<int>(state_row[0]);
+    const int robot_col = static_cast<int>(state_row[1]);
+    if (action == 2 && robot_col == map_cols - 1) {
+        r += exit_reward;
+        return r;
+    }
+    if (action == 0) {
+        for (int k = 0; k < num_rocks; ++k) {
+            if (rock_rows[k] == robot_row && rock_cols[k] == robot_col) {
+                const std::size_t slot = static_cast<std::size_t>(2 + k);
+                if (slot < state_dim) {
+                    r += (state_row[slot] > 0.5) ? good_rock_reward : bad_rock_penalty;
+                }
+                break;
+            }
+        }
+    }
+    if (action >= 5) {
+        r += sensor_use_penalty;
+    }
+    return r;
+}
+
+// Minimum squared distance from ``(row, col)`` to any dangerous-area centre.
+// ``dangerous_areas`` is a (K, 2) row-major float64 array.
+inline double min_dist_to_danger_sq(double row, double col, const double *dangers,
+                                    std::size_t k) {
+    double best = std::numeric_limits<double>::infinity();
+    for (std::size_t j = 0; j < k; ++j) {
+        const double dr = row - dangers[j * 2];
+        const double dc = col - dangers[j * 2 + 1];
+        const double d2 = dr * dr + dc * dc;
+        if (d2 < best) best = d2;
+    }
+    return best;
+}
+
+// Compute the dangerous-area reward contribution for a single
+// (next_row, next_col) under variant ``reward_variant_code``. ``k`` is the
+// number of dangerous-area centres (zero means no contribution).
+inline double dangerous_area_term(double next_row, double next_col,
+                                  const double *dangers, std::size_t k,
+                                  double dangerous_area_radius,
+                                  double dangerous_area_penalty,
+                                  double dangerous_area_hit_probability,
+                                  int reward_variant_code, double penalty_decay) {
+    if (k == 0) {
+        return 0.0;
+    }
+    pomdp_native::RNGState &rng = pomdp_native::default_rng();
+    std::uniform_real_distribution<double> uniform(0.0, 1.0);
+    if (reward_variant_code == kRewardVariantDecaying) {
+        const double min_d = std::sqrt(min_dist_to_danger_sq(next_row, next_col, dangers, k));
+        const double p = std::exp(-min_d / penalty_decay);
+        return (uniform(rng.engine()) < p) ? dangerous_area_penalty : 0.0;
+    }
+    const double radius_sq = dangerous_area_radius * dangerous_area_radius;
+    const double min_d2 = min_dist_to_danger_sq(next_row, next_col, dangers, k);
+    if (min_d2 > radius_sq) {
+        return 0.0;
+    }
+    if (reward_variant_code == kRewardVariantHighVariance) {
+        return (uniform(rng.engine()) < 0.5) ? dangerous_area_penalty
+                                             : -dangerous_area_penalty;
+    }
+    // STANDARD: constant-probability hit
+    if (dangerous_area_hit_probability >= 1.0 ||
+        uniform(rng.engine()) < dangerous_area_hit_probability) {
+        return dangerous_area_penalty;
+    }
+    return 0.0;
+}
+
+// Standalone reward batch kernel. Returns a (N,) float64 array where each
+// entry is the per-row reward under the configured variant.
+py::array_t<double> reward_batch(
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &states,
+    int action,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &next_states,
+    int map_rows, int map_cols,
+    const py::array_t<std::int32_t, py::array::c_style | py::array::forcecast>
+        &rock_positions,
+    double step_penalty, double bad_rock_penalty, double good_rock_reward,
+    double sensor_use_penalty, double exit_reward,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &dangerous_areas,
+    double dangerous_area_radius, double dangerous_area_penalty,
+    double dangerous_area_hit_probability, int reward_variant_code,
+    double penalty_decay) {
+    (void)map_rows;  // currently unused; kept for parity with the kernel API
+    if (states.ndim() != 2 || states.shape(1) < 2) {
+        throw std::invalid_argument("states must have shape (N, 2 + num_rocks)");
+    }
+    if (next_states.ndim() != 2 || next_states.shape(0) != states.shape(0) ||
+        next_states.shape(1) < 2) {
+        throw std::invalid_argument("next_states must have same shape as states");
+    }
+    if (rock_positions.ndim() != 2 || rock_positions.shape(1) != 2) {
+        throw std::invalid_argument("rock_positions must have shape (num_rocks, 2)");
+    }
+    if (dangerous_areas.ndim() != 2 || dangerous_areas.shape(1) != 2) {
+        throw std::invalid_argument("dangerous_areas must have shape (K, 2)");
+    }
+
+    const auto n_rows = static_cast<std::size_t>(states.shape(0));
+    const auto state_dim = static_cast<std::size_t>(states.shape(1));
+    const int num_rocks = static_cast<int>(rock_positions.shape(0));
+    const std::size_t n_dangers = static_cast<std::size_t>(dangerous_areas.shape(0));
+
+    std::vector<std::int32_t> rock_rows_local(static_cast<std::size_t>(num_rocks));
+    std::vector<std::int32_t> rock_cols_local(static_cast<std::size_t>(num_rocks));
+    auto rp_view = rock_positions.unchecked<2>();
+    for (int k = 0; k < num_rocks; ++k) {
+        rock_rows_local[static_cast<std::size_t>(k)] = rp_view(k, 0);
+        rock_cols_local[static_cast<std::size_t>(k)] = rp_view(k, 1);
+    }
+
+    const double *states_data = states.data();
+    const double *next_data = next_states.data();
+    const std::size_t next_dim = static_cast<std::size_t>(next_states.shape(1));
+    const double *dangers_data = (n_dangers > 0) ? dangerous_areas.data() : nullptr;
+
+    auto out = py::array_t<double>(static_cast<py::ssize_t>(n_rows));
+    double *out_data = out.mutable_data();
+
+    for (std::size_t i = 0; i < n_rows; ++i) {
+        const double *cur_row = states_data + i * state_dim;
+        const double *nxt_row = next_data + i * next_dim;
+        double r = base_reward_term(cur_row, action, map_cols, num_rocks,
+                                    rock_rows_local.data(), rock_cols_local.data(),
+                                    state_dim, step_penalty, exit_reward,
+                                    good_rock_reward, bad_rock_penalty,
+                                    sensor_use_penalty);
+        // Skip dangerous-area term for the exit case (Python returns early).
+        const int robot_col = static_cast<int>(cur_row[1]);
+        const bool is_exit = (action == 2 && robot_col == map_cols - 1);
+        if (!is_exit && n_dangers > 0) {
+            r += dangerous_area_term(nxt_row[0], nxt_row[1], dangers_data, n_dangers,
+                                     dangerous_area_radius, dangerous_area_penalty,
+                                     dangerous_area_hit_probability,
+                                     reward_variant_code, penalty_decay);
+        }
+        out_data[i] = r;
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
 // simulate_rollout_discrete: run a full rollout from ``initial_state``.
 //
 // Each step:
 //   1. check terminal (robot_row == -1, robot_col == -1) — break if true
 //   2. pick action from action_indices
 //   3. deterministic transition via transition_into
-//   4. compute reward matching _reward_from_next_state (without dangerous_areas)
+//   4. compute reward matching _reward_from_next_state (variant-aware
+//      dangerous-area term)
 //   5. accumulate gamma^depth * reward
 //
 // action_indices: pre-drawn int32 array of length (max_depth - start_depth).
@@ -657,7 +827,13 @@ double simulate_rollout_discrete(
     double exit_reward,
     double good_rock_reward,
     double bad_rock_penalty,
-    double sensor_use_penalty) {
+    double sensor_use_penalty,
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &dangerous_areas,
+    double dangerous_area_radius,
+    double dangerous_area_penalty,
+    double dangerous_area_hit_probability,
+    int reward_variant_code,
+    double penalty_decay) {
     if (initial_state.ndim() != 1 || initial_state.shape(0) < 2) {
         throw std::invalid_argument("initial_state must be a 1-D array with length >= 2");
     }
@@ -667,6 +843,11 @@ double simulate_rollout_discrete(
     if (action_indices.ndim() != 1) {
         throw std::invalid_argument("action_indices must be 1-D");
     }
+    if (dangerous_areas.ndim() != 2 || dangerous_areas.shape(1) != 2) {
+        throw std::invalid_argument("dangerous_areas must have shape (K, 2)");
+    }
+    const std::size_t n_dangers = static_cast<std::size_t>(dangerous_areas.shape(0));
+    const double *dangers_data = (n_dangers > 0) ? dangerous_areas.data() : nullptr;
     const int n_indices = static_cast<int>(action_indices.shape(0));
 
     const std::size_t state_dim = static_cast<std::size_t>(initial_state.shape(0));
@@ -723,28 +904,20 @@ double simulate_rollout_discrete(
         // Deterministic transition
         transition_into(cur.data(), nxt.data(), ai, env_local, state_dim);
 
-        // Reward: matches _reward_from_next_state (no dangerous_area term)
-        double r = step_penalty;
-        const int robot_col = static_cast<int>(cur[1]);
-        if (ai == 2 && robot_col == map_cols - 1) {
-            r += exit_reward;
-        } else {
-            if (ai == 0) {
-                const int robot_row = static_cast<int>(cur[0]);
-                for (int k = 0; k < num_rocks; ++k) {
-                    if (env_local.rock_rows[static_cast<std::size_t>(k)] == robot_row &&
-                        env_local.rock_cols[static_cast<std::size_t>(k)] == robot_col) {
-                        const std::size_t slot = static_cast<std::size_t>(2 + k);
-                        if (slot < state_dim) {
-                            r += (cur[slot] > 0.5) ? good_rock_reward : bad_rock_penalty;
-                        }
-                        break;
-                    }
-                }
-            }
-            if (ai >= 5) {
-                r += sensor_use_penalty;
-            }
+        // Reward: matches _reward_from_next_state with variant-aware
+        // dangerous-area term.
+        double r = base_reward_term(cur.data(), ai, map_cols, num_rocks,
+                                    env_local.rock_rows.data(),
+                                    env_local.rock_cols.data(), state_dim,
+                                    step_penalty, exit_reward, good_rock_reward,
+                                    bad_rock_penalty, sensor_use_penalty);
+        const int robot_col_cur = static_cast<int>(cur[1]);
+        const bool is_exit = (ai == 2 && robot_col_cur == map_cols - 1);
+        if (!is_exit && n_dangers > 0) {
+            r += dangerous_area_term(nxt[0], nxt[1], dangers_data, n_dangers,
+                                     dangerous_area_radius, dangerous_area_penalty,
+                                     dangerous_area_hit_probability,
+                                     reward_variant_code, penalty_decay);
         }
 
         total += gamma_power * r;
@@ -770,10 +943,29 @@ PYBIND11_MODULE(_native, m) {
           py::arg("n_actions"), py::arg("step_penalty"), py::arg("exit_reward"),
           py::arg("good_rock_reward"), py::arg("bad_rock_penalty"),
           py::arg("sensor_use_penalty"),
-          "Native random rollout for RockSamplePOMDP (no dangerous-area term). "
-          "Returns discounted reward sum. "
+          py::arg("dangerous_areas"), py::arg("dangerous_area_radius"),
+          py::arg("dangerous_area_penalty"),
+          py::arg("dangerous_area_hit_probability"),
+          py::arg("reward_variant_code"), py::arg("penalty_decay"),
+          "Native random rollout for RockSamplePOMDP with variant-aware "
+          "dangerous-area reward term. Returns discounted reward sum. "
           "action_indices must be a pre-drawn int32 array of length (max_depth-start_depth). "
-          "rock_positions_flat is a 1-D int32 array [row0, col0, row1, col1, ...].");
+          "rock_positions_flat is a 1-D int32 array [row0, col0, row1, col1, ...]. "
+          "dangerous_areas is a (K, 2) float64 array (may be empty). "
+          "reward_variant_code: 0=STANDARD, 1=HIGH_VARIANCE_STATES, 2=DECAYING_HIT_PROBABILITY.");
+
+    m.def("reward_batch", &reward_batch,
+          py::arg("states"), py::arg("action"), py::arg("next_states"),
+          py::arg("map_rows"), py::arg("map_cols"), py::arg("rock_positions"),
+          py::arg("step_penalty"), py::arg("bad_rock_penalty"),
+          py::arg("good_rock_reward"), py::arg("sensor_use_penalty"),
+          py::arg("exit_reward"), py::arg("dangerous_areas"),
+          py::arg("dangerous_area_radius"), py::arg("dangerous_area_penalty"),
+          py::arg("dangerous_area_hit_probability"),
+          py::arg("reward_variant_code"), py::arg("penalty_decay"),
+          "Variant-aware standalone batch reward kernel for RockSamplePOMDP. "
+          "Returns a (N,) float64 array of rewards. "
+          "reward_variant_code: 0=STANDARD, 1=HIGH_VARIANCE_STATES, 2=DECAYING_HIT_PROBABILITY.");
 
     py::class_<RockSampleTransitionCpp>(m, "RockSampleTransitionCpp")
         .def(py::init<const py::object &, int, int, int, int,

--- a/POMDPPlanners/environments/rock_sample_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/rock_sample_pomdp/_native.pyi
@@ -35,13 +35,51 @@ def simulate_rollout_discrete(
     good_rock_reward: float,
     bad_rock_penalty: float,
     sensor_use_penalty: float,
+    dangerous_areas: NDArray[np.float64],
+    dangerous_area_radius: float,
+    dangerous_area_penalty: float,
+    dangerous_area_hit_probability: float,
+    reward_variant_code: int,
+    penalty_decay: float,
 ) -> float:
-    """Native random rollout for RockSamplePOMDP (no dangerous-area term).
+    """Native random rollout for RockSamplePOMDP with variant-aware reward.
 
-    Walks the deterministic transition model and computes rewards in C++.
-    Returns the discounted sum of rewards. ``action_indices`` must be a
-    pre-drawn integer array of length ``max_depth - start_depth``.
-    ``rock_positions_flat`` is a 1-D int32 array ``[row0, col0, row1, col1, …]``.
+    Walks the deterministic transition model and computes rewards in C++,
+    including the variant-aware dangerous-area term. Returns the discounted
+    sum of rewards. ``action_indices`` must be a pre-drawn integer array of
+    length ``max_depth - start_depth``. ``rock_positions_flat`` is a 1-D
+    int32 array ``[row0, col0, row1, col1, …]``. ``dangerous_areas`` is a
+    ``(K, 2)`` float64 array (may be empty). ``reward_variant_code``:
+    ``0=STANDARD``, ``1=HIGH_VARIANCE_STATES``, ``2=DECAYING_HIT_PROBABILITY``.
+    """
+    ...
+
+def reward_batch(
+    states: NDArray[np.float64],
+    action: int,
+    next_states: NDArray[np.float64],
+    map_rows: int,
+    map_cols: int,
+    rock_positions: NDArray[np.int32],
+    step_penalty: float,
+    bad_rock_penalty: float,
+    good_rock_reward: float,
+    sensor_use_penalty: float,
+    exit_reward: float,
+    dangerous_areas: NDArray[np.float64],
+    dangerous_area_radius: float,
+    dangerous_area_penalty: float,
+    dangerous_area_hit_probability: float,
+    reward_variant_code: int,
+    penalty_decay: float,
+) -> NDArray[np.float64]:
+    """Variant-aware standalone batch reward kernel for RockSamplePOMDP.
+
+    Returns a ``(N,)`` float64 array of rewards. The dangerous-area term
+    is selected by ``reward_variant_code``: ``0=STANDARD`` (constant-
+    probability hit), ``1=HIGH_VARIANCE_STATES`` (50/50 ±penalty in zone),
+    ``2=DECAYING_HIT_PROBABILITY`` (hit with probability
+    ``exp(-min_dist / penalty_decay)``).
     """
     ...
 

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -330,6 +330,21 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
             [coord for rp in self.rock_positions for coord in rp], dtype=np.int32
         )
 
+        # Cached (K, 2) float64 dangerous-area centres for the native
+        # reward / rollout kernels. Empty (0, 2) array when no danger
+        # zones are configured.
+        if self.dangerous_areas:
+            self._dangerous_areas_arr: np.ndarray = np.ascontiguousarray(
+                np.asarray(self.dangerous_areas, dtype=np.float64)
+            )
+        else:
+            self._dangerous_areas_arr = np.empty((0, 2), dtype=np.float64)
+        self._reward_variant_code: int = {
+            RewardModelType.STANDARD: 0,
+            RewardModelType.HIGH_VARIANCE_STATES: 1,
+            RewardModelType.DECAYING_HIT_PROBABILITY: 2,
+        }[self.reward_model_type]
+
         # Define actions: 0=sample, 1=north, 2=east, 3=south, 4=west, 5+=check_rock_i
         self.action_names = ["sample", "north", "east", "south", "west"]
         self.action_names.extend([f"check_rock_{i}" for i in range(len(self.rock_positions))])
@@ -462,7 +477,32 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         action: int,
         next_states: Optional[np.ndarray] = None,
     ) -> np.ndarray:
-        return self.reward_model.compute_reward_batch(states, action, next_states=next_states)
+        # Fallback to the Python reward model when caller did not pre-sample
+        # next states (closed-form reconstruction lives there).
+        if next_states is None:
+            return self.reward_model.compute_reward_batch(states, action, next_states=None)
+        return np.asarray(
+            _native.reward_batch(
+                states=np.ascontiguousarray(states, dtype=np.float64),
+                action=int(action),
+                next_states=np.ascontiguousarray(next_states, dtype=np.float64),
+                map_rows=int(self.map_size[0]),
+                map_cols=int(self.map_size[1]),
+                rock_positions=self._rock_positions_int32,
+                step_penalty=float(self.step_penalty),
+                bad_rock_penalty=float(self.bad_rock_penalty),
+                good_rock_reward=float(self.good_rock_reward),
+                sensor_use_penalty=float(self.sensor_use_penalty),
+                exit_reward=float(self.exit_reward),
+                dangerous_areas=self._dangerous_areas_arr,
+                dangerous_area_radius=float(self.dangerous_area_radius),
+                dangerous_area_penalty=float(self.dangerous_area_penalty),
+                dangerous_area_hit_probability=float(self.dangerous_area_hit_probability),
+                reward_variant_code=int(self._reward_variant_code),
+                penalty_decay=float(self.penalty_decay),
+            ),
+            dtype=np.float64,
+        )
 
     # ── Native-backed env-API implementations ────────────────────────
     # Each method fetches a cached per-action C++ kernel, mutates its
@@ -581,20 +621,22 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
     def simulate_random_rollout(
         self,
         state: Any,
-        action_sampler: Any,
+        action_sampler: Any,  # pylint: disable=unused-argument
         max_depth: int,
         discount_factor: float,
         depth: int = 0,
     ) -> float:
         """Random rollout via native C++ deterministic transition and reward kernel.
 
-        Falls back to the base-class Python loop when dangerous areas are
-        configured (their stochastic-penalty semantics are not ported to C++).
+        The C++ kernel applies the variant-aware dangerous-area reward term
+        directly, so no Python fallback is required when danger zones are
+        configured.
 
         Args:
             state: Current RockSample state array.
             action_sampler: Object with a ``sample()`` method returning an
-                integer action; used only on the Python fallback path.
+                integer action. Currently unused — actions are drawn
+                uniformly by the native kernel.
             max_depth: Maximum rollout depth.
             discount_factor: Per-step discount factor.
             depth: Depth already consumed by the search tree. Defaults to 0.
@@ -602,21 +644,6 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         Returns:
             Discounted sum of immediate rewards along the sampled trajectory.
         """
-        if self.dangerous_areas:
-            # pylint: disable-next=import-outside-toplevel
-            from POMDPPlanners.planners.planners_utils.rollout import (
-                python_random_rollout,
-            )
-
-            return python_random_rollout(
-                state=state,
-                depth=depth,
-                action_sampler=action_sampler,
-                environment=self,
-                discount_factor=discount_factor,
-                max_depth=max_depth,
-            )
-
         steps_left = max_depth - depth
         if steps_left <= 0:
             return 0.0
@@ -640,6 +667,12 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
             good_rock_reward=float(self.good_rock_reward),
             bad_rock_penalty=float(self.bad_rock_penalty),
             sensor_use_penalty=float(self.sensor_use_penalty),
+            dangerous_areas=self._dangerous_areas_arr,
+            dangerous_area_radius=float(self.dangerous_area_radius),
+            dangerous_area_penalty=float(self.dangerous_area_penalty),
+            dangerous_area_hit_probability=float(self.dangerous_area_hit_probability),
+            reward_variant_code=int(self._reward_variant_code),
+            penalty_decay=float(self.penalty_decay),
         )
 
     def sample_next_step(

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/laser_tag_pomdp_utils/test_laser_tag_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/laser_tag_pomdp_utils/test_laser_tag_reward_cpp_parity.py
@@ -1,0 +1,254 @@
+"""C++/Python reward-parity tests for the discrete LaserTag reward variants.
+
+Verifies that the native ``_native.lasertag_discrete_reward_batch`` C++
+kernel produces results that match the Python reward-model
+implementation across all three :class:`RewardModelType` variants —
+``STANDARD``, ``HIGH_VARIANCE_STATES`` and ``DECAYING_HIT_PROBABILITY``.
+
+This is a TDD red-step test for Stage 2. The current native kernel does
+not accept a ``reward_variant_code`` / ``penalty_decay`` keyword pair,
+so today the calls below either raise ``TypeError`` (kwargs unknown)
+or — once the kernel grows the kwargs but still hard-codes STANDARD
+semantics — produce values that fail the sample-mean parity check on
+the stochastic variants. The Stage 2 agent will teach the kernel about
+the variant code and decay length; this test will go green then.
+"""
+
+import math
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.laser_tag_pomdp import _native
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import (
+    LaserTagPOMDP,
+    RewardModelType,
+)
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models import (
+    LaserTagRewardModel,
+)
+
+
+_BATCH_SIZE = 2000
+_PENALTY_DECAY = 1.5
+_DANGEROUS_AREAS = {(5, 3), (7, 1), (2, 5)}
+_DANGEROUS_AREA_PENALTY = 5.0
+
+
+def _variant_code(rmt: RewardModelType) -> int:
+    """Map a :class:`RewardModelType` to the integer code the C++ kernel expects."""
+    if rmt == RewardModelType.STANDARD:
+        return 0
+    if rmt == RewardModelType.HIGH_VARIANCE_STATES:
+        return 1
+    if rmt == RewardModelType.DECAYING_HIT_PROBABILITY:
+        return 2
+    raise ValueError(f"Unknown reward model type: {rmt}")
+
+
+def _build_env(rmt: RewardModelType) -> LaserTagPOMDP:
+    """Build a discrete LaserTag env with non-empty danger zones and the chosen variant."""
+    return LaserTagPOMDP(
+        discount_factor=0.95,
+        dangerous_areas=_DANGEROUS_AREAS,
+        dangerous_area_penalty=_DANGEROUS_AREA_PENALTY,
+        reward_model_type=rmt,
+        penalty_decay=_PENALTY_DECAY,
+    )
+
+
+def _build_states_with_danger_and_clear(env: LaserTagPOMDP, n: int) -> np.ndarray:
+    """Return an (N, 5) state batch covering both danger-zone and clear cells.
+
+    Half of the rows are placed at / near dangerous-area centres so the
+    variant's danger-penalty path fires; the other half are far from any
+    centre so the wall / clear baseline contributes. All rows are
+    non-terminal so the reward path is fully exercised.
+    """
+    rows, cols = env.floor_shape
+    danger_centres = np.array(env.dangerous_areas, dtype=np.float64)
+    half = n // 2
+    danger_rows = danger_centres[np.random.randint(0, len(danger_centres), size=half)]
+    clear_rows = np.column_stack(
+        [
+            np.random.randint(0, rows, size=n - half),
+            np.random.randint(0, cols, size=n - half),
+        ]
+    ).astype(np.float64)
+    robot_xy = np.concatenate([danger_rows, clear_rows], axis=0)
+    np.random.shuffle(robot_xy)
+    opp_xy = np.column_stack(
+        [
+            np.random.randint(0, rows, size=n),
+            np.random.randint(0, cols, size=n),
+        ]
+    ).astype(np.float64)
+    terminal = np.zeros((n, 1), dtype=np.float64)
+    return np.ascontiguousarray(np.concatenate([robot_xy, opp_xy, terminal], axis=1))
+
+
+def _call_cpp_reward_batch(
+    env: LaserTagPOMDP,
+    states: np.ndarray,
+    action: int,
+    next_states: np.ndarray,
+    variant_code: int,
+    penalty_decay: float,
+) -> np.ndarray:
+    """Invoke the C++ ``lasertag_discrete_reward_batch`` kernel directly.
+
+    Passes the proposed Stage 2 ``reward_variant_code`` / ``penalty_decay``
+    / ``next_states`` keyword arguments. Today this raises ``TypeError``
+    because the kernel does not yet accept these kwargs — that is the
+    intended failure for this red-step test.
+    """
+    assert isinstance(env.reward_model, LaserTagRewardModel)
+    rm = env.reward_model
+    # The ``next_states`` / ``reward_variant_code`` / ``penalty_decay`` kwargs
+    # are part of the Stage 2 kernel surface and are not yet declared in
+    # ``_native.pyi``; pyright is correct that they are absent today, which is
+    # exactly the red-step state this test is asserting against. Suppress the
+    # report so the test file stays at 0 pyright errors / warnings while still
+    # exercising the (currently missing) kernel surface.
+    kwargs = {
+        "states": np.ascontiguousarray(states, dtype=np.float64),
+        "action": int(action),
+        "rows": int(env.floor_shape[0]),
+        "cols": int(env.floor_shape[1]),
+        "walls_flat": rm._reward_walls_flat,  # pylint: disable=protected-access
+        "n_walls": rm._reward_n_walls,  # pylint: disable=protected-access
+        "dangerous_areas": rm._dangerous_areas_arr,  # pylint: disable=protected-access
+        "n_dangerous": int(rm._dangerous_areas_arr.shape[0]),  # pylint: disable=protected-access
+        "dangerous_area_radius": float(env.dangerous_area_radius),
+        "dangerous_area_penalty": float(env.dangerous_area_penalty),
+        "tag_reward": float(env.tag_reward),
+        "tag_penalty": float(env.tag_penalty),
+        "step_cost": float(env.step_cost),
+        "action_directions": rm._action_directions_arr,  # pylint: disable=protected-access
+        "next_states": np.ascontiguousarray(next_states, dtype=np.float64),
+        "reward_variant_code": int(variant_code),
+        "penalty_decay": float(penalty_decay),
+    }
+    return np.asarray(_native.lasertag_discrete_reward_batch(**kwargs))
+
+
+def _sample_mean_parity(py_rewards: np.ndarray, cpp_rewards: np.ndarray) -> Tuple[float, float]:
+    """Return ``(|delta|, tolerance)`` for the sample-mean parity assertion."""
+    n = py_rewards.shape[0]
+    delta = abs(float(py_rewards.mean()) - float(cpp_rewards.mean()))
+    tol = 3.0 * (float(py_rewards.std(ddof=0)) / math.sqrt(n)) + 1e-9
+    return delta, tol
+
+
+class TestLaserTagDiscreteRewardCppParity:
+    """Sample-mean C++ vs Python parity across the 3 discrete reward variants."""
+
+    @pytest.mark.parametrize(
+        "rmt, penalty_decay",
+        [
+            (RewardModelType.STANDARD, 0.0),
+            (RewardModelType.HIGH_VARIANCE_STATES, 0.0),
+            (RewardModelType.DECAYING_HIT_PROBABILITY, _PENALTY_DECAY),
+        ],
+    )
+    def test_cpp_matches_python_in_mean(self, rmt: RewardModelType, penalty_decay: float) -> None:
+        """C++ reward-batch mean matches the Python reward-model mean within 3 SE.
+
+        Purpose: Validates that the native ``lasertag_discrete_reward_batch``
+            kernel reproduces the Python reward-model's expected reward for
+            each :class:`RewardModelType` variant, including the stochastic
+            HV and Decaying variants. The check is the sample-mean equality
+            ``|py.mean() - cpp.mean()| < 3 * py.std()/sqrt(N) + 1e-9``,
+            which is tight enough to fail with high probability if the
+            kernel hard-codes the wrong variant and loose enough to pass
+            when the kernel implements the right one.
+
+        Given: A discrete :class:`LaserTagPOMDP` constructed with the
+            chosen ``reward_model_type``, default walls, non-empty
+            dangerous areas, ``dangerous_area_penalty = 5.0``, and (for
+            the Decaying variant) ``penalty_decay = 1.5``. A batch of
+            ``N = 2000`` non-terminal states is generated covering both
+            danger-zone cells and clear cells; ``next_states`` is realised
+            via ``env.sample_next_state_batch`` so the variant penalty
+            path fires.
+        When: ``env.reward_model.compute_reward_batch`` and the native
+            ``_native.lasertag_discrete_reward_batch`` (with the Stage 2
+            ``reward_variant_code`` / ``penalty_decay`` / ``next_states``
+            kwargs) are evaluated on the same batch and action.
+        Then: The two sample means agree within
+            ``3 * py.std() / sqrt(N) + 1e-9``. Today this either raises
+            ``TypeError`` (kernel lacks the kwargs) or fails the mean
+            check on HV / Decaying (kernel hard-codes STANDARD); both
+            failure modes confirm the kernel is not yet variant-aware.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        env = _build_env(rmt)
+        states = _build_states_with_danger_and_clear(env, _BATCH_SIZE)
+        # Use a movement action (1 = South) so the wall / danger penalty
+        # path fires; the tag action (4) only changes the base reward.
+        action = 1
+        next_states = env.sample_next_state_batch(states, action)
+
+        py_rewards = env.reward_model.compute_reward_batch(states, action, next_states)
+        cpp_rewards = _call_cpp_reward_batch(
+            env,
+            states,
+            action,
+            next_states,
+            variant_code=_variant_code(rmt),
+            penalty_decay=penalty_decay,
+        )
+
+        delta, tol = _sample_mean_parity(py_rewards, cpp_rewards)
+        assert delta < tol, (
+            f"C++/Python reward mean mismatch for variant {rmt.name}: "
+            f"|py.mean - cpp.mean| = {delta:.6f} >= tol = {tol:.6f} "
+            f"(py.mean={py_rewards.mean():.6f}, cpp.mean={cpp_rewards.mean():.6f}, "
+            f"N={py_rewards.shape[0]})"
+        )
+
+    def test_tag_action_path_is_also_covered(self) -> None:
+        """Tag-action (action=4) C++ mean matches Python mean for the STANDARD variant.
+
+        Purpose: Ensures the tag-action branch is exercised on top of the
+            movement-action branch covered by the parametrised test, so a
+            kernel that handles tag rewards differently from movement
+            rewards is caught.
+
+        Given: A STANDARD discrete LaserTag env with default walls and
+            dangerous areas, and a 2000-row state batch covering both
+            danger-zone and clear cells.
+        When: ``env.reward_model.compute_reward_batch`` and
+            ``_native.lasertag_discrete_reward_batch`` are evaluated with
+            action ``4`` (Tag) and the realised next-state batch.
+        Then: The sample means agree within
+            ``3 * py.std() / sqrt(N) + 1e-9``.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        env = _build_env(RewardModelType.STANDARD)
+        states = _build_states_with_danger_and_clear(env, _BATCH_SIZE)
+        action = 4
+        next_states = env.sample_next_state_batch(states, action)
+
+        py_rewards = env.reward_model.compute_reward_batch(states, action, next_states)
+        cpp_rewards = _call_cpp_reward_batch(
+            env,
+            states,
+            action,
+            next_states,
+            variant_code=_variant_code(RewardModelType.STANDARD),
+            penalty_decay=0.0,
+        )
+
+        delta, tol = _sample_mean_parity(py_rewards, cpp_rewards)
+        assert delta < tol, (
+            f"C++/Python reward mean mismatch for variant STANDARD (tag action): "
+            f"|py.mean - cpp.mean| = {delta:.6f} >= tol = {tol:.6f} "
+            f"(py.mean={py_rewards.mean():.6f}, cpp.mean={cpp_rewards.mean():.6f}, "
+            f"N={py_rewards.shape[0]})"
+        )

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -2303,6 +2303,145 @@ class TestNativeDiscreteRollout:
         assert abs(result) <= max_abs + 1e-9
 
 
+class TestNativeDiscreteRolloutRewardVariantGating:
+    """Native C++ rollout is variant-aware: the ``reward_variant_code`` /
+    ``penalty_decay`` parameters select the STANDARD / HIGH_VARIANCE_STATES /
+    DECAYING_HIT_PROBABILITY danger formulae inside the kernel, so dispatch
+    targets the native path for all three reward-model variants.
+    """
+
+    def test_native_kernel_used_for_standard_reward_model(self) -> None:
+        """STANDARD reward model dispatches to the native C++ kernel.
+
+        Purpose: Guards against accidentally widening the fallback to STANDARD
+            (which would silently drop the perf optimisation for the default
+            reward variant).
+
+        Given: A LaserTagPOMDP with default (STANDARD) reward_model_type.
+        When: ``simulate_random_rollout`` is invoked.
+        Then: The native ``simulate_rollout_discrete`` is called exactly once.
+
+        Test type: unit
+        """
+        # pylint: disable=import-outside-toplevel
+        from unittest.mock import patch
+
+        from POMDPPlanners.environments.laser_tag_pomdp import _native
+        from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import (
+            RewardModelType,
+        )
+
+        env = LaserTagPOMDP(
+            discount_factor=0.95,
+            reward_model_type=RewardModelType.STANDARD,
+        )
+        state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])
+
+        _native.set_seed(0)
+        with patch.object(
+            _native, "simulate_rollout_discrete", wraps=_native.simulate_rollout_discrete
+        ) as spy:
+            env.simulate_random_rollout(
+                state=state,
+                action_sampler=_UniformActionSampler(),
+                max_depth=5,
+                discount_factor=0.95,
+            )
+            assert spy.call_count == 1, (
+                "STANDARD reward model must keep using the native rollout kernel; "
+                f"got {spy.call_count} calls."
+            )
+
+    def test_native_kernel_used_for_high_variance_reward_model(self) -> None:
+        """HIGH_VARIANCE_STATES variant dispatches to the native rollout kernel.
+
+        Purpose: Regression for the variant-rollout integration — the C++
+            kernel now implements the HV danger formula via
+            ``reward_variant_code = 1``, so dispatch targets C++ instead of
+            the Python loop.
+
+        Given: A LaserTagPOMDP configured with ``HIGH_VARIANCE_STATES``.
+        When: ``simulate_random_rollout`` is invoked.
+        Then: ``_native.simulate_rollout_discrete`` is called exactly once with
+            ``reward_variant_code = 1``.
+
+        Test type: unit
+        """
+        # pylint: disable=import-outside-toplevel
+        from unittest.mock import patch
+
+        from POMDPPlanners.environments.laser_tag_pomdp import _native
+        from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import (
+            RewardModelType,
+        )
+
+        env = LaserTagPOMDP(
+            discount_factor=0.95,
+            reward_model_type=RewardModelType.HIGH_VARIANCE_STATES,
+        )
+        state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])
+
+        _native.set_seed(0)
+        with patch.object(
+            _native, "simulate_rollout_discrete", wraps=_native.simulate_rollout_discrete
+        ) as spy:
+            env.simulate_random_rollout(
+                state=state,
+                action_sampler=_UniformActionSampler(),
+                max_depth=5,
+                discount_factor=0.95,
+            )
+            assert spy.call_count == 1
+            kwargs = spy.call_args.kwargs
+            assert kwargs["reward_variant_code"] == 1
+
+    def test_native_kernel_used_for_decaying_hit_reward_model(self) -> None:
+        """DECAYING_HIT_PROBABILITY variant dispatches to the native rollout kernel.
+
+        Purpose: Regression for the variant-rollout integration — the C++
+            kernel now implements the distance-decaying danger formula via
+            ``reward_variant_code = 2`` and the ``penalty_decay`` argument,
+            so dispatch targets C++ instead of the Python loop.
+
+        Given: A LaserTagPOMDP configured with ``DECAYING_HIT_PROBABILITY`` and
+            ``penalty_decay = 1.5``.
+        When: ``simulate_random_rollout`` is invoked.
+        Then: ``_native.simulate_rollout_discrete`` is called exactly once with
+            ``reward_variant_code = 2`` and ``penalty_decay = 1.5``.
+
+        Test type: unit
+        """
+        # pylint: disable=import-outside-toplevel
+        from unittest.mock import patch
+
+        from POMDPPlanners.environments.laser_tag_pomdp import _native
+        from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import (
+            RewardModelType,
+        )
+
+        env = LaserTagPOMDP(
+            discount_factor=0.95,
+            reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY,
+            penalty_decay=1.5,
+        )
+        state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])
+
+        _native.set_seed(0)
+        with patch.object(
+            _native, "simulate_rollout_discrete", wraps=_native.simulate_rollout_discrete
+        ) as spy:
+            env.simulate_random_rollout(
+                state=state,
+                action_sampler=_UniformActionSampler(),
+                max_depth=5,
+                discount_factor=0.95,
+            )
+            assert spy.call_count == 1
+            kwargs = spy.call_args.kwargs
+            assert kwargs["reward_variant_code"] == 2
+            assert kwargs["penalty_decay"] == 1.5
+
+
 class TestLaserTagPOMDPPickling:
     """Regression tests for joblib-hashing/pickling LaserTagPOMDP after the
     cached-pybind11-kernel perf work landed (see issue: weekly-slow-tests

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_cpp_parity.py
@@ -1,0 +1,165 @@
+"""C++/Python parity tests for the Continuous Light-Dark reward variants.
+
+These tests target a future ``_native.compute_reward_batch`` kernel that
+will mirror the Python reward models bit-for-bit (in expectation). Today
+no such kernel exists — reward is inlined inside ``_native.simulate_rollout``
+— so every test in this module is expected to FAIL with
+``AttributeError: module '_native' has no attribute 'compute_reward_batch'``.
+
+This is a deliberate TDD red-step: once a Stage 2 agent lands
+``_native.compute_reward_batch(states, action, next_states, *, reward_variant_code,
+penalty_decay, ...)`` the tests must pass without further edits.
+"""
+
+# pylint: disable=protected-access  # Tests reach into reward_model for parity checks.
+
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.light_dark_pomdp import (
+    _native,  # pylint: disable=no-name-in-module
+)
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ContinuousLightDarkPOMDP,
+    RewardModelType,
+)
+
+
+_REWARD_VARIANT_CODES = {
+    RewardModelType.STANDARD: 0,
+    RewardModelType.HIGH_VARIANCE_STATES: 1,
+    RewardModelType.DECAYING_HIT_PROBABILITY: 2,
+}
+
+_PENALTY_DECAY_BY_VARIANT = {
+    RewardModelType.STANDARD: 0.0,
+    RewardModelType.HIGH_VARIANCE_STATES: 0.0,
+    RewardModelType.DECAYING_HIT_PROBABILITY: 1.5,
+}
+
+
+def _build_env(variant: RewardModelType) -> ContinuousLightDarkPOMDP:
+    # Non-empty ``obstacles`` is mandatory so the obstacle-penalty branch
+    # of every reward model gets exercised; ``penalty_decay`` is only
+    # consumed by the DECAYING variant but is harmless elsewhere.
+    return ContinuousLightDarkPOMDP(
+        discount_factor=0.95,
+        obstacles=[(3.0, 3.0), (6.0, 6.0), (8.0, 2.0)],
+        reward_model_type=variant,
+        penalty_decay=_PENALTY_DECAY_BY_VARIANT[variant],
+    )
+
+
+def _generate_inputs(
+    env: ContinuousLightDarkPOMDP, n_samples: int, seed: int
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    rng = np.random.RandomState(seed)
+    # Mix uniform-in-grid draws with explicit in-obstacle draws so the
+    # obstacle-penalty path fires for a non-trivial fraction of the rows.
+    grid = float(env.grid_size)
+    states = rng.uniform(0.0, grid, size=(n_samples, 2)).astype(np.float64)
+    obstacles_xy = np.ascontiguousarray(env.obstacles.T, dtype=np.float64)
+    n_obstacle_rows = n_samples // 4
+    obstacle_idx = rng.randint(0, obstacles_xy.shape[0], size=n_obstacle_rows)
+    jitter = rng.uniform(-0.3, 0.3, size=(n_obstacle_rows, 2))
+    states[:n_obstacle_rows] = obstacles_xy[obstacle_idx] + jitter
+    action = np.array([0.5, 0.5], dtype=np.float64)
+    next_states = states + action
+    return (
+        np.ascontiguousarray(states),
+        action,
+        np.ascontiguousarray(next_states),
+    )
+
+
+def _call_native_reward_batch(
+    env: ContinuousLightDarkPOMDP,
+    states: np.ndarray,
+    action: np.ndarray,
+    next_states: np.ndarray,
+    variant: RewardModelType,
+) -> np.ndarray:
+    # Centralised dispatch so the AttributeError raised today (no
+    # ``compute_reward_batch`` in ``_native``) surfaces in one place when
+    # the kernel is added downstream.
+    obstacles_flat = np.ascontiguousarray(env.obstacles.T.ravel(), dtype=np.float64)
+    goal_state = np.ascontiguousarray(env.goal_state, dtype=np.float64)
+    kernel = _native.compute_reward_batch  # type: ignore[attr-defined]
+    return np.asarray(
+        kernel(
+            states=states,
+            action=action,
+            next_states=next_states,
+            reward_variant_code=_REWARD_VARIANT_CODES[variant],
+            penalty_decay=float(_PENALTY_DECAY_BY_VARIANT[variant]),
+            goal_state=goal_state,
+            obstacles=obstacles_flat,
+            goal_state_radius=float(env.goal_state_radius),
+            obstacle_radius=float(env.obstacle_radius),
+            grid_size=float(env.grid_size),
+            fuel_cost=float(env.fuel_cost),
+            goal_reward=float(env.goal_reward),
+            obstacle_reward=float(env.obstacle_reward),
+            obstacle_hit_probability=float(env.obstacle_hit_probability),
+        ),
+        dtype=np.float64,
+    )
+
+
+class TestLightDarkRewardCppParity:
+    """Sample-mean parity between Python reward models and the C++ kernel."""
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            RewardModelType.STANDARD,
+            RewardModelType.HIGH_VARIANCE_STATES,
+            RewardModelType.DECAYING_HIT_PROBABILITY,
+        ],
+    )
+    def test_cpp_python_reward_means_match(self, variant: RewardModelType) -> None:
+        """Python and C++ reward batches share a sample mean within 3 SE.
+
+        Purpose: Validates that the future ``_native.compute_reward_batch``
+            reproduces the Python reward model's expected reward for each
+            variant on the same (state, action, next_state) batch.
+
+        Given: A ContinuousLightDarkPOMDP built with the variant under test,
+            non-empty obstacles, and N=2000 seeded (state, action, next_state)
+            triples — a quarter of which are placed inside obstacle radii so
+            the stochastic penalty branch fires.
+        When: ``env.reward_model.compute_reward_batch`` and
+            ``_native.compute_reward_batch`` are invoked on the same inputs
+            with matching ``reward_variant_code`` and ``penalty_decay``.
+        Then: ``|py.mean() - cpp.mean()| < 3 * py.std()/sqrt(N) + 1e-9`` —
+            the sample-mean gap stays inside a 3-sigma confidence band.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        env = _build_env(variant)
+        n_samples = 2000
+        states, action, next_states = _generate_inputs(env, n_samples, seed=42)
+
+        np.random.seed(42)
+        py_rewards = np.asarray(
+            env.reward_model.compute_reward_batch(states, action, next_states=next_states),
+            dtype=np.float64,
+        )
+        assert py_rewards.shape == (n_samples,)
+
+        cpp_rewards = _call_native_reward_batch(env, states, action, next_states, variant)
+        assert cpp_rewards.shape == (n_samples,)
+
+        py_mean = float(py_rewards.mean())
+        cpp_mean = float(cpp_rewards.mean())
+        py_se = float(py_rewards.std(ddof=1) / np.sqrt(n_samples))
+        tolerance = 3.0 * py_se + 1e-9
+        gap = abs(py_mean - cpp_mean)
+        assert gap < tolerance, (
+            f"Variant {variant.value}: |py_mean - cpp_mean| = {gap:.6f} exceeds "
+            f"3-sigma tolerance {tolerance:.6f} "
+            f"(py_mean={py_mean:.6f}, cpp_mean={cpp_mean:.6f}, py_se={py_se:.6f})"
+        )

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
@@ -2236,7 +2236,7 @@ def test_native_simulate_rollout_matches_python_rollout_seeded():
     np.random.seed(0)
     action_indices = np.random.randint(0, len(env.actions), size=max_depth, dtype=np.int32)
 
-    # Seed native C++ RNG; run native rollout
+    # Seed native C++ RNG; run native rollout (STANDARD variant: code 0)
     _native.set_seed(0)
     native_return = _native.simulate_rollout(  # pylint: disable=protected-access
         initial_state=np.ascontiguousarray(initial_state, dtype=np.float64),
@@ -2255,6 +2255,8 @@ def test_native_simulate_rollout_matches_python_rollout_seeded():
         obstacle_reward=float(env.obstacle_reward),
         obstacle_hit_probability=0.0,
         is_obstacle_hit_terminal=bool(env.is_obstacle_hit_terminal),
+        reward_variant_code=0,
+        penalty_decay=0.0,
         covariance=env._trans_cov_view,  # pylint: disable=protected-access
     )
 
@@ -2318,6 +2320,8 @@ def test_native_simulate_rollout_terminal_short_circuit():
         obstacle_reward=float(env.obstacle_reward),
         obstacle_hit_probability=float(env.obstacle_hit_probability),
         is_obstacle_hit_terminal=bool(env.is_obstacle_hit_terminal),
+        reward_variant_code=0,
+        penalty_decay=0.0,
         covariance=env._trans_cov_view,  # pylint: disable=protected-access
     )
 

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
@@ -2307,6 +2307,11 @@ class TestNativeSimulateRollout:
             discount_factor=float(discount_factor),
             depth=0,
             max_depth=max_depth,
+            dangerous_areas=env._dangerous_areas_arr,  # pylint: disable=protected-access
+            dangerous_area_radius=float(env.dangerous_area_radius),
+            dangerous_area_penalty=float(env.dangerous_area_penalty),
+            reward_variant_code=0,
+            penalty_decay=float(env.penalty_decay),
         )
 
         assert abs(native_total - py_total) <= 1e-9, (

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_utils/test_pacman_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_utils/test_pacman_reward_cpp_parity.py
@@ -1,0 +1,256 @@
+"""C++↔Python reward parity tests for the PacMan POMDP.
+
+Stage 1 (red step) of the upcoming native reward-kernel work. These
+tests assert that ``_native.reward_batch`` — the forthcoming standalone
+C++ reward kernel — produces sample means that agree with the Python
+reward-model implementations across all three reward variants
+(``STANDARD``, ``HIGH_VARIANCE_STATES``, ``DECAYING_HIT_PROBABILITY``).
+
+The tests are expected to fail today: ``_native.reward_batch`` does not
+exist yet (reward is currently inlined inside ``_native.simulate_rollout``
+and that inlined path omits the ``dangerous_area_penalty`` term
+entirely). Stage 2 will add the standalone kernel; these tests pin its
+shape and parity contract.
+"""
+
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.pacman_pomdp import _native  # pylint: disable=no-name-in-module
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import (
+    PacManPOMDP,
+    RewardModelType,
+)
+
+
+# Shared maze / hazard configuration. Mirrors the layout used by
+# ``test_pacman_reward_models.py`` so the C++ kernel sees the same env
+# shape the Python kernels are already validated against.
+_MAZE_SIZE: Tuple[int, int] = (7, 7)
+_DANGER_CENTRE: Tuple[int, int] = (3, 3)
+_DANGER_RADIUS = 1.0
+_DANGER_PENALTY = 5.0
+_STEP_PENALTY = -1.0
+_GHOST_COLLISION_PENALTY = -100.0
+_PELLET_REWARD = 10.0
+_WIN_REWARD = 100.0
+_PENALTY_DECAY = 1.5
+_N_PARTICLES = 2000
+
+_VARIANT_CODES = {
+    RewardModelType.STANDARD: 0,
+    RewardModelType.HIGH_VARIANCE_STATES: 1,
+    RewardModelType.DECAYING_HIT_PROBABILITY: 2,
+}
+
+
+def _make_env(reward_model_type: RewardModelType) -> PacManPOMDP:
+    return PacManPOMDP(
+        maze_size=_MAZE_SIZE,
+        walls=set(),
+        initial_pacman_pos=(0, 0),
+        num_ghosts=1,
+        initial_ghost_positions=[(6, 6)],
+        initial_pellets=[(1, 1)],
+        dangerous_areas={_DANGER_CENTRE},
+        dangerous_area_radius=_DANGER_RADIUS,
+        dangerous_area_penalty=_DANGER_PENALTY,
+        step_penalty=_STEP_PENALTY,
+        ghost_collision_penalty=_GHOST_COLLISION_PENALTY,
+        pellet_reward=_PELLET_REWARD,
+        win_reward=_WIN_REWARD,
+        reward_model_type=reward_model_type,
+        penalty_decay=_PENALTY_DECAY,
+    )
+
+
+def _seed_states(env: PacManPOMDP, n: int) -> np.ndarray:
+    # Initial-state samples give us valid non-terminal rows that share the
+    # canonical layout. The pacman position is overwritten below so part of
+    # the batch lands in / near the configured hazard zone — exercising the
+    # variant-specific danger contribution rather than only the step penalty.
+    states = np.ascontiguousarray(env.initial_state_dist().sample(n), dtype=np.float64)
+    _spread_pacman_near_danger(env, states)
+    return states
+
+
+def _spread_pacman_near_danger(env: PacManPOMDP, states: np.ndarray) -> None:
+    # About a third of the rows are placed at or inside the hazard zone so
+    # the danger contribution actually fires; the rest cover assorted
+    # non-danger cells across the maze. Keeps results within walls/bounds
+    # for the trivial walls=set() configuration of ``_make_env``.
+    n = states.shape[0]
+    placements: List[Tuple[int, int]] = [
+        _DANGER_CENTRE,
+        (3, 2),
+        (2, 3),
+        (3, 4),
+        (4, 3),
+        (0, 0),
+        (1, 1),
+        (5, 5),
+        (0, 6),
+        (6, 0),
+    ]
+    for row_idx in range(n):
+        pacman_pos = placements[row_idx % len(placements)]
+        states[row_idx, env._idx_pac_row] = pacman_pos[0]  # pylint: disable=protected-access
+        states[row_idx, env._idx_pac_col] = pacman_pos[1]  # pylint: disable=protected-access
+
+
+def _per_action_row_groups(num_actions: int, n: int) -> List[np.ndarray]:
+    # Stripe the rows across actions so every action appears roughly n / A
+    # times and the resulting concatenated batch covers the full action
+    # space — the parity contract calls for action variation across the
+    # batch even though each reward kernel call uses a single action.
+    row_actions = np.arange(n, dtype=np.int64) % num_actions
+    return [np.flatnonzero(row_actions == action) for action in range(num_actions)]
+
+
+def _compute_python_rewards_per_action(
+    env: PacManPOMDP,
+    states: np.ndarray,
+    action: int,
+    next_states: np.ndarray,
+) -> np.ndarray:
+    return np.asarray(
+        env.reward_model.compute_reward_batch(states, action, next_states=next_states),
+        dtype=np.float64,
+    )
+
+
+def _compute_cpp_rewards_per_action(
+    env: PacManPOMDP,
+    states: np.ndarray,
+    action: int,
+    next_states: np.ndarray,
+    variant_code: int,
+    penalty_decay: float,
+) -> np.ndarray:
+    # pylint: disable=protected-access
+    # ``reward_batch`` is the forthcoming Stage-2 C++ entry point — it does
+    # not exist on ``_native`` today, so this test is expected to fail
+    # with ``AttributeError`` until that kernel lands. The ``type: ignore``
+    # silences the static analyser for the missing-attribute access; we
+    # cannot use ``typing.cast`` per project policy.
+    return np.asarray(
+        _native.reward_batch(  # type: ignore[attr-defined]
+            states=states,
+            action=int(action),
+            next_states=next_states,
+            reward_variant_code=int(variant_code),
+            penalty_decay=float(penalty_decay),
+            dangerous_areas=env._dangerous_areas_arr,
+            dangerous_area_radius=float(env.dangerous_area_radius),
+            dangerous_area_penalty=float(env.dangerous_area_penalty),
+            num_ghosts=int(env.num_ghosts),
+            step_penalty=float(env.step_penalty),
+            ghost_collision_penalty=float(env.ghost_collision_penalty),
+            pellet_reward=float(env.pellet_reward),
+            win_reward=float(env.win_reward),
+            idx_pac_row=int(env._idx_pac_row),
+            idx_pac_col=int(env._idx_pac_col),
+            idx_ghosts_start=int(env._idx_ghosts_start),
+            idx_pellets_start=int(env._idx_pellets_start),
+            idx_pellets_end=int(env._idx_pellets_end),
+            idx_score=int(env._idx_score),
+            idx_terminal=int(env._idx_terminal),
+        ),
+        dtype=np.float64,
+    )
+
+
+def _gather_rewards_across_actions(
+    env: PacManPOMDP,
+    states: np.ndarray,
+    variant_code: int,
+    penalty_decay: float,
+) -> Tuple[np.ndarray, np.ndarray]:
+    num_actions = len(env.get_actions())
+    row_groups = _per_action_row_groups(num_actions, states.shape[0])
+    py_rewards = np.empty(states.shape[0], dtype=np.float64)
+    cpp_rewards = np.empty(states.shape[0], dtype=np.float64)
+    for action, action_rows in enumerate(row_groups):
+        if action_rows.size == 0:
+            continue
+        action_states = np.ascontiguousarray(states[action_rows], dtype=np.float64)
+        action_next_states = env.sample_next_state_batch(action_states, action)
+        py_rewards[action_rows] = _compute_python_rewards_per_action(
+            env, action_states, action, action_next_states
+        )
+        cpp_rewards[action_rows] = _compute_cpp_rewards_per_action(
+            env,
+            action_states,
+            action,
+            action_next_states,
+            variant_code=variant_code,
+            penalty_decay=penalty_decay,
+        )
+    return py_rewards, cpp_rewards
+
+
+def _sample_mean_parity_holds(py_rewards: np.ndarray, cpp_rewards: np.ndarray) -> bool:
+    n = py_rewards.shape[0]
+    se = float(py_rewards.std(ddof=0)) / np.sqrt(n)
+    tolerance = 3.0 * se + 1e-9
+    return abs(float(py_rewards.mean()) - float(cpp_rewards.mean())) < tolerance
+
+
+class TestPacManRewardCppParity:
+    """C++↔Python sample-mean parity across all three reward variants.
+
+    The batch is striped across the five PacMan actions so every action
+    contributes roughly ``N/5`` rows to the concatenated reward arrays.
+    Per-action sub-batches share their realised ``next_states`` between
+    the Python and C++ kernels so the comparison reflects kernel-level
+    parity rather than transition-sampling noise.
+    """
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            RewardModelType.STANDARD,
+            RewardModelType.HIGH_VARIANCE_STATES,
+            RewardModelType.DECAYING_HIT_PROBABILITY,
+        ],
+    )
+    def test_reward_batch_sample_mean_matches_python(self, variant: RewardModelType):
+        """``_native.reward_batch`` sample mean matches Python within 3·SE.
+
+        Purpose: Validates the forthcoming standalone C++ reward kernel
+            produces the same expected reward as the Python reward model
+            across all variants and a representative mix of (state, action,
+            next_state) triples — including dangerous-area transitions
+            that exercise the variant-specific danger contribution.
+
+        Given: A ``PacManPOMDP`` configured with the variant under test, a
+            non-empty hazard zone, ``np.random.seed(42)``, and ``N=2000``
+            (state, action, next_state) triples where states are drawn
+            from ``env.initial_state_dist().sample(N)`` with the pacman
+            cell spread across in-zone / near-zone / far cells, actions
+            vary across the action space, and next_states are produced
+            by ``env.sample_next_state_batch(states, action)`` per action.
+        When: Python rewards are computed by
+            ``env.reward_model.compute_reward_batch(...)`` and C++ rewards
+            by ``_native.reward_batch(..., reward_variant_code=..., penalty_decay=...)``.
+        Then: ``|py.mean() - cpp.mean()| < 3.0 * (py.std() / sqrt(N)) + 1e-9``.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        env = _make_env(variant)
+        states = _seed_states(env, _N_PARTICLES)
+        penalty_decay = (
+            env.penalty_decay if variant == RewardModelType.DECAYING_HIT_PROBABILITY else 0.0
+        )
+        py_rewards, cpp_rewards = _gather_rewards_across_actions(
+            env,
+            states,
+            variant_code=_VARIANT_CODES[variant],
+            penalty_decay=penalty_decay,
+        )
+
+        assert py_rewards.shape == cpp_rewards.shape == (_N_PARTICLES,)
+        assert _sample_mean_parity_holds(py_rewards, cpp_rewards)

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_utils/test_pacman_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_utils/test_pacman_reward_models.py
@@ -1,0 +1,368 @@
+"""Tests for the PacMan POMDP reward-model variants.
+
+Covers the high-variance and decaying-hit-probability variants added
+alongside the standard model and exposed via
+:class:`PacManPOMDP`'s ``reward_model_type`` parameter. The existing
+standard-model behaviour is already exercised by
+``test_pacman_pomdp.py``.
+"""
+
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import (
+    PacManPOMDP,
+    RewardModelType,
+)
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.pacman_reward_models import (
+    BasePacManRewardModel,
+    PacManDecayingHitProbabilityRewardModel,
+    PacManHighVarianceStatesRewardModel,
+    PacManRewardModel,
+)
+
+
+# Default maze / hazard configuration shared by the scenario-style tests.
+# A 7x7 maze with one zone centred at (3, 3) radius 1.0 mirrors the
+# ``test_pacman_pomdp.py`` scenarios for the standard model.
+_MAZE_SIZE: Tuple[int, int] = (7, 7)
+_DANGER_CENTRE: Tuple[int, int] = (3, 3)
+_DANGER_RADIUS = 1.0
+_DANGER_PENALTY = 5.0
+_STEP_PENALTY = -1.0
+
+
+def _make_env(
+    reward_model_type: RewardModelType,
+    penalty_decay: float = 1.0,
+) -> PacManPOMDP:
+    return PacManPOMDP(
+        maze_size=_MAZE_SIZE,
+        walls=set(),
+        initial_pacman_pos=(0, 0),
+        num_ghosts=1,
+        initial_ghost_positions=[(6, 6)],
+        initial_pellets=[(1, 1)],
+        dangerous_areas={_DANGER_CENTRE},
+        dangerous_area_radius=_DANGER_RADIUS,
+        dangerous_area_penalty=_DANGER_PENALTY,
+        step_penalty=_STEP_PENALTY,
+        ghost_collision_penalty=-100.0,
+        pellet_reward=10.0,
+        win_reward=100.0,
+        reward_model_type=reward_model_type,
+        penalty_decay=penalty_decay,
+    )
+
+
+def _state_with_pac(env: PacManPOMDP, pacman_pos: Tuple[int, int]) -> np.ndarray:
+    return env.make_state(
+        pacman_pos=pacman_pos,
+        ghost_positions=((6, 6),),
+        pellets=((1, 1),),
+        score=0.0,
+        terminal=False,
+    )
+
+
+class TestPacManHighVarianceStatesRewardModel:
+    """Behavioural tests for the HV variant."""
+
+    def test_subclass_inherits_base(self):
+        """HV model is both a ``BasePacManRewardModel`` and a ``PacManRewardModel``.
+
+        Purpose: Validates the class hierarchy so callers that expect either
+            base type can interchangeably use the HV variant.
+
+        Given: A ``PacManPOMDP`` constructed with the HV reward variant.
+        When: ``isinstance`` is checked against the abstract and concrete bases.
+        Then: Both checks return True.
+
+        Test type: unit
+        """
+        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        assert isinstance(env.reward_model, PacManRewardModel)
+        assert isinstance(env.reward_model, BasePacManRewardModel)
+        assert isinstance(env.reward_model, PacManHighVarianceStatesRewardModel)
+
+    def test_outside_zone_matches_step_penalty(self):
+        """Positions outside every zone score exactly the step penalty.
+
+        Purpose: Validates the HV variant leaves non-dangerous-area transitions
+            untouched — only the danger contribution changes versus the standard
+            model.
+
+        Given: An HV env and a transition that ends outside the single zone
+            (distance > radius).
+        When: ``reward(state, action, next_state)`` is called.
+        Then: Reward equals ``step_penalty`` exactly.
+
+        Test type: unit
+        """
+        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        state = _state_with_pac(env, (0, 0))
+        next_state = _state_with_pac(env, (0, 1))
+        reward = env.reward_model.compute_reward(state, action=1, next_state=next_state)
+        assert reward == pytest.approx(_STEP_PENALTY)
+
+    def test_danger_zone_emits_symmetric_penalty(self):
+        """HV dangerous-area contribution is ``±dangerous_area_penalty`` with mean ≈ 0.
+
+        Purpose: Validates the variant's signature property — danger zones
+            contribute zero expected reward with high variance — by averaging
+            over a large sample of seeded draws.
+
+        Given: An HV reward model and a transition whose realised next position
+            is on a zone centre.
+        When: ``compute_reward`` is called over 2000 trials.
+        Then: Each observed reward is exactly
+            ``step_penalty ± dangerous_area_penalty`` and the sample mean of
+            the danger contribution is within 0.5 of zero.
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        state = _state_with_pac(env, (3, 2))
+        next_state = _state_with_pac(env, _DANGER_CENTRE)
+        rewards = np.array(
+            [
+                env.reward_model.compute_reward(state, action=1, next_state=next_state)
+                for _ in range(2000)
+            ]
+        )
+        # Contributions are (step_penalty - penalty) or (step_penalty + penalty).
+        contributions = rewards - _STEP_PENALTY
+        assert set(np.unique(contributions).tolist()) == {-_DANGER_PENALTY, _DANGER_PENALTY}
+        assert abs(float(np.mean(contributions))) < 0.5
+
+    def test_batch_danger_zone_matches_scalar_distribution(self):
+        """``compute_reward_batch`` HV draws keep the same ±penalty distribution.
+
+        Purpose: Validates the batch path applies the same per-row ±penalty
+            distribution as the scalar path so vectorised callers see the same
+            expected reward and variance as per-particle callers.
+
+        Given: An HV reward model and an ``(N, state_dim)`` state batch all
+            entering the same zone centre.
+        When: ``compute_reward_batch`` is called once with ``N=4000``.
+        Then: Observed contributions are exactly ``±dangerous_area_penalty``
+            and the sample mean is within 0.5 of zero.
+
+        Test type: unit
+        """
+        np.random.seed(123)
+        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        n = 4000
+        state = _state_with_pac(env, (3, 2))
+        next_state = _state_with_pac(env, _DANGER_CENTRE)
+        states = np.tile(state, (n, 1))
+        next_states = np.tile(next_state, (n, 1))
+        rewards = env.reward_model.compute_reward_batch(states, action=1, next_states=next_states)
+        contributions = rewards - _STEP_PENALTY
+        assert set(np.unique(contributions).tolist()) == {-_DANGER_PENALTY, _DANGER_PENALTY}
+        assert abs(float(np.mean(contributions))) < 0.5
+
+    def test_terminal_state_returns_zero(self):
+        """Terminal states never accrue reward, even in a zone.
+
+        Purpose: Pins the terminal-zero contract on the HV variant so future
+            kernel changes cannot accidentally start scoring danger
+            contributions for terminal rows.
+
+        Given: An HV reward model and a terminal state.
+        When: ``compute_reward`` is called with a transition into the zone.
+        Then: Reward is exactly 0.0 on every trial.
+
+        Test type: unit
+        """
+        np.random.seed(7)
+        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        state = env.make_state(
+            pacman_pos=(3, 3),
+            ghost_positions=((6, 6),),
+            pellets=((1, 1),),
+            score=0.0,
+            terminal=True,
+        )
+        next_state = _state_with_pac(env, _DANGER_CENTRE)
+        for _ in range(30):
+            assert env.reward_model.compute_reward(state, action=1, next_state=next_state) == 0.0
+
+
+class TestPacManDecayingHitProbabilityRewardModel:
+    """Behavioural tests for the Decaying-Hit-Probability variant."""
+
+    def test_rejects_non_positive_decay(self):
+        """``penalty_decay`` must be strictly positive.
+
+        Purpose: Validates the constructor rejects nonsensical decay lengths.
+
+        Given: An env factory invoked with ``penalty_decay <= 0``.
+        When: The constructor runs.
+        Then: ``ValueError`` is raised with a message mentioning ``penalty_decay``.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="penalty_decay"):
+            _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=0.0)
+        with pytest.raises(ValueError, match="penalty_decay"):
+            _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=-1.0)
+
+    def test_at_centre_always_triggers_penalty(self):
+        """When the realised position equals a centre, penalty fires every time.
+
+        Purpose: Validates the boundary case where ``min_dist == 0`` so
+            ``hit_prob == 1.0`` — every trial must emit the full penalty.
+
+        Given: A Decay reward model and a transition whose realised next
+            position is exactly on a zone centre.
+        When: ``compute_reward`` is called over 50 trials.
+        Then: Every call returns ``step_penalty - dangerous_area_penalty``.
+
+        Test type: unit
+        """
+        np.random.seed(7)
+        env = _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=1.0)
+        state = _state_with_pac(env, (3, 2))
+        next_state = _state_with_pac(env, _DANGER_CENTRE)
+        for _ in range(50):
+            reward = env.reward_model.compute_reward(state, action=1, next_state=next_state)
+            assert reward == pytest.approx(_STEP_PENALTY - _DANGER_PENALTY)
+
+    def test_far_position_penalty_rate_decays(self):
+        """Empirical hit rate ≈ ``exp(-dist / penalty_decay)``.
+
+        Purpose: Validates the batch path's hit rate follows the
+            distance-decaying formula by sampling a large batch of identical
+            far-away positions and comparing the observed rate to the analytic
+            target.
+
+        Given: A Decay reward model with ``penalty_decay = 2.0`` and a batch
+            of 6000 states whose realised positions sit at distance 2.0 from
+            the nearest zone centre.
+        When: ``compute_reward_batch`` is called once.
+        Then: The fraction of rows that received the danger penalty is within
+            0.05 of ``exp(-2.0 / 2.0) ≈ 0.368``.
+
+        Test type: unit
+        """
+        np.random.seed(99)
+        decay = 2.0
+        env = _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=decay)
+        n = 6000
+        # Position (3, 1): nearest centre (3, 3) at distance 2.0. Use action 4
+        # (stay) so the batch path's neighbor-table lookup keeps the realised
+        # next position at (3, 1) instead of shifting it by the action vector.
+        state = _state_with_pac(env, (3, 1))
+        states = np.tile(state, (n, 1))
+        next_states = states.copy()
+        rewards = env.reward_model.compute_reward_batch(states, action=4, next_states=next_states)
+        contributions = rewards - _STEP_PENALTY
+        assert set(np.unique(contributions).tolist()) == {0.0, -_DANGER_PENALTY}
+        observed_rate = float(np.mean(contributions == -_DANGER_PENALTY))
+        expected_rate = float(np.exp(-2.0 / decay))
+        assert abs(observed_rate - expected_rate) < 0.05
+
+    def test_no_zones_returns_step_penalty_only(self):
+        """With no zones configured the decay contribution is identically zero.
+
+        Purpose: Guards the no-op path — when ``dangerous_areas`` is empty the
+            decay kernel must not be called and the reward must equal
+            ``step_penalty``.
+
+        Given: A Decay-variant env constructed without dangerous areas.
+        When: ``compute_reward`` is called on an arbitrary transition.
+        Then: Reward equals exactly ``step_penalty``.
+
+        Test type: unit
+        """
+        env = PacManPOMDP(
+            maze_size=_MAZE_SIZE,
+            walls=set(),
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(6, 6)],
+            initial_pellets=[(1, 1)],
+            step_penalty=_STEP_PENALTY,
+            ghost_collision_penalty=-100.0,
+            pellet_reward=10.0,
+            win_reward=100.0,
+            reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY,
+            penalty_decay=1.0,
+        )
+        state = _state_with_pac(env, (0, 0))
+        next_state = _state_with_pac(env, (0, 1))
+        for _ in range(20):
+            reward = env.reward_model.compute_reward(state, action=1, next_state=next_state)
+            assert reward == pytest.approx(_STEP_PENALTY)
+
+    def test_terminal_state_returns_zero(self):
+        """Terminal states never accrue reward, even when the realised next position is at a centre.
+
+        Purpose: Pins the terminal-zero contract on the Decay variant.
+
+        Given: A Decay env and a terminal state with a realised next position at a zone centre.
+        When: ``compute_reward`` is called over 30 trials.
+        Then: Reward is exactly 0.0 every trial.
+
+        Test type: unit
+        """
+        np.random.seed(7)
+        env = _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=1.0)
+        state = env.make_state(
+            pacman_pos=(3, 3),
+            ghost_positions=((6, 6),),
+            pellets=((1, 1),),
+            score=0.0,
+            terminal=True,
+        )
+        next_state = _state_with_pac(env, _DANGER_CENTRE)
+        for _ in range(30):
+            assert env.reward_model.compute_reward(state, action=1, next_state=next_state) == 0.0
+
+
+class TestPacManPOMDPRewardModelTypeWiring:
+    """Sanity tests for the ``reward_model_type`` constructor parameter on the env."""
+
+    @pytest.mark.parametrize(
+        "rmt, expected_cls",
+        [
+            (RewardModelType.STANDARD, PacManRewardModel),
+            (RewardModelType.HIGH_VARIANCE_STATES, PacManHighVarianceStatesRewardModel),
+            (RewardModelType.DECAYING_HIT_PROBABILITY, PacManDecayingHitProbabilityRewardModel),
+        ],
+    )
+    def test_env_instantiates_correct_reward_model_subclass(self, rmt, expected_cls):
+        """``PacManPOMDP`` builds the reward model class selected by ``reward_model_type``.
+
+        Purpose: Validates the env's branching logic from ``reward_model_type``
+            to the concrete reward-model class.
+
+        Given: A ``PacManPOMDP`` constructed with a specific ``reward_model_type``.
+        When: ``env.reward_model`` is inspected.
+        Then: It is an instance of the expected concrete subclass.
+
+        Test type: unit
+        """
+        env = _make_env(rmt, penalty_decay=2.0)
+        assert isinstance(env.reward_model, expected_cls)
+
+    def test_env_default_reward_model_is_standard(self):
+        """The default ``reward_model_type`` preserves the historical standard model.
+
+        Purpose: Regression — ensures that omitting ``reward_model_type``
+            yields the original deterministic reward semantics so existing
+            configs and tests keep their pre-refactor behaviour.
+
+        Given: A ``PacManPOMDP`` constructed without specifying ``reward_model_type``.
+        When: ``env.reward_model`` is inspected.
+        Then: It is exactly a ``PacManRewardModel`` (not a subclass).
+
+        Test type: unit
+        """
+        env = PacManPOMDP(maze_size=_MAZE_SIZE)
+        # pylint: disable-next=unidiomatic-typecheck
+        assert type(env.reward_model) is PacManRewardModel

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/push_pomdp_utils/test_push_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/push_pomdp_utils/test_push_reward_cpp_parity.py
@@ -1,0 +1,333 @@
+"""C++/Python reward-parity tests for the Push POMDP reward variants.
+
+Verifies that the future native reward kernels
+``_native.push_reward_batch`` (discrete) and
+``_native.cont_push_reward_batch`` (continuous) reproduce — in
+expectation — the Python reward-model output across all three
+:class:`RewardModelType` variants: ``STANDARD``,
+``HIGH_VARIANCE_STATES`` and ``DECAYING_HIT_PROBABILITY``.
+
+Today no standalone C++ reward kernel exists for the Push family —
+reward is inlined inside ``_native.simulate_rollout_discrete`` /
+``_native.cont_simulate_rollout``. Every test in this module is
+therefore expected to FAIL today (with ``AttributeError`` because the
+``_native`` module has no ``push_reward_batch`` /
+``cont_push_reward_batch`` attribute). This is a deliberate TDD
+red-step: once a Stage 2 agent lands the standalone kernels accepting
+``reward_variant_code`` and ``penalty_decay`` kwargs the tests must go
+green without further edits.
+"""
+
+# pylint: disable=protected-access  # Tests reach into reward_model for parity checks.
+
+import math
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.push_pomdp import _native
+from POMDPPlanners.environments.push_pomdp.continuous_push_pomdp import (
+    ContinuousPushPOMDP,
+)
+from POMDPPlanners.environments.push_pomdp.push_pomdp import PushPOMDP
+from POMDPPlanners.environments.push_pomdp.push_pomdp_utils.push_reward_models import (
+    RewardModelType,
+)
+
+
+_BATCH_SIZE = 2000
+_PENALTY_DECAY = 1.5
+_DANGEROUS_AREA_PENALTY = -10.0
+_DANGEROUS_AREA_RADIUS = 0.8
+_DANGEROUS_AREAS_DISCRETE = [(3.0, 3.0), (6.0, 6.0), (8.0, 2.0)]
+_DANGEROUS_AREAS_CONTINUOUS = [(3.0, 3.0), (6.0, 6.0), (8.0, 2.0)]
+
+_REWARD_VARIANT_CODES = {
+    RewardModelType.STANDARD: 0,
+    RewardModelType.HIGH_VARIANCE_STATES: 1,
+    RewardModelType.DECAYING_HIT_PROBABILITY: 2,
+}
+
+_PENALTY_DECAY_BY_VARIANT = {
+    RewardModelType.STANDARD: 0.0,
+    RewardModelType.HIGH_VARIANCE_STATES: 0.0,
+    RewardModelType.DECAYING_HIT_PROBABILITY: _PENALTY_DECAY,
+}
+
+
+def _sample_mean_parity(py_rewards: np.ndarray, cpp_rewards: np.ndarray) -> Tuple[float, float]:
+    """Return ``(|delta|, tolerance)`` for the sample-mean parity assertion."""
+    n = py_rewards.shape[0]
+    delta = abs(float(py_rewards.mean()) - float(cpp_rewards.mean()))
+    tol = 3.0 * (float(py_rewards.std(ddof=0)) / math.sqrt(n)) + 1e-9
+    return delta, tol
+
+
+def _build_discrete_env(variant: RewardModelType) -> PushPOMDP:
+    """Build a discrete :class:`PushPOMDP` with the requested reward variant."""
+    return PushPOMDP(
+        discount_factor=0.95,
+        grid_size=10,
+        dangerous_areas=_DANGEROUS_AREAS_DISCRETE,
+        dangerous_area_radius=_DANGEROUS_AREA_RADIUS,
+        dangerous_area_penalty=_DANGEROUS_AREA_PENALTY,
+        dangerous_area_hit_probability=1.0,
+        reward_model_type=variant,
+        penalty_decay=(
+            _PENALTY_DECAY_BY_VARIANT[variant]
+            if variant == RewardModelType.DECAYING_HIT_PROBABILITY
+            else 1.0
+        ),
+    )
+
+
+def _build_continuous_env(variant: RewardModelType) -> ContinuousPushPOMDP:
+    """Build a continuous :class:`ContinuousPushPOMDP` with the requested variant."""
+    return ContinuousPushPOMDP(
+        discount_factor=0.95,
+        grid_size=10,
+        dangerous_areas=_DANGEROUS_AREAS_CONTINUOUS,
+        dangerous_area_radius=_DANGEROUS_AREA_RADIUS,
+        dangerous_area_penalty=_DANGEROUS_AREA_PENALTY,
+        dangerous_area_hit_probability=1.0,
+        reward_model_type=variant,
+        penalty_decay=(
+            _PENALTY_DECAY_BY_VARIANT[variant]
+            if variant == RewardModelType.DECAYING_HIT_PROBABILITY
+            else 1.0
+        ),
+    )
+
+
+def _build_discrete_states(env: PushPOMDP, n_samples: int) -> np.ndarray:
+    """Return an (N, 6) state batch mixing dangerous-area and clear robot cells.
+
+    Half of the rows are placed near dangerous-area centres so each variant's
+    danger-penalty path fires; the remaining rows are uniformly distributed
+    over the grid. Object and target positions are uniform-in-grid so the
+    distance / goal-bonus terms vary across rows.
+    """
+    grid = float(env.grid_size - 1)
+    danger_centres = np.asarray(_DANGEROUS_AREAS_DISCRETE, dtype=np.float64)
+    half = n_samples // 2
+    danger_idx = np.random.randint(0, danger_centres.shape[0], size=half)
+    danger_rows = danger_centres[danger_idx] + np.random.uniform(-0.2, 0.2, size=(half, 2))
+    clear_rows = np.random.uniform(0.0, grid, size=(n_samples - half, 2))
+    robot_xy = np.concatenate([danger_rows, clear_rows], axis=0)
+    np.random.shuffle(robot_xy)
+    object_xy = np.random.uniform(0.0, grid, size=(n_samples, 2))
+    target_xy = np.tile(env.target_pos.astype(np.float64), (n_samples, 1))
+    return np.ascontiguousarray(np.concatenate([robot_xy, object_xy, target_xy], axis=1))
+
+
+def _build_continuous_states(env: ContinuousPushPOMDP, n_samples: int) -> np.ndarray:
+    """Return an (N, 6) state batch covering dangerous-area + clear continuous cells."""
+    grid = float(env.grid_size - 1)
+    danger_centres = np.asarray(_DANGEROUS_AREAS_CONTINUOUS, dtype=np.float64)
+    half = n_samples // 2
+    danger_idx = np.random.randint(0, danger_centres.shape[0], size=half)
+    danger_rows = danger_centres[danger_idx] + np.random.uniform(-0.2, 0.2, size=(half, 2))
+    clear_rows = np.random.uniform(0.0, grid, size=(n_samples - half, 2))
+    robot_xy = np.concatenate([danger_rows, clear_rows], axis=0)
+    np.random.shuffle(robot_xy)
+    object_xy = np.random.uniform(0.0, grid, size=(n_samples, 2))
+    target_xy = np.tile(env.target_pos.astype(np.float64), (n_samples, 1))
+    return np.ascontiguousarray(np.concatenate([robot_xy, object_xy, target_xy], axis=1))
+
+
+def _call_native_push_reward_batch(
+    env: PushPOMDP,
+    states: np.ndarray,
+    action: str,
+    next_states: np.ndarray,
+    variant: RewardModelType,
+) -> np.ndarray:
+    """Invoke the future ``_native.push_reward_batch`` kernel directly.
+
+    Today this raises ``AttributeError`` because ``_native`` has no
+    ``push_reward_batch`` attribute — that is the intended failure for
+    this red-step test.
+    """
+    obstacles_arr = np.asarray(env.obstacles, dtype=np.float64).reshape(-1, 2)
+    action_idx = int(env.actions.index(action))
+    kernel = _native.push_reward_batch  # type: ignore[attr-defined]
+    return np.asarray(
+        kernel(
+            states=np.ascontiguousarray(states, dtype=np.float64),
+            action_idx=action_idx,
+            next_states=np.ascontiguousarray(next_states, dtype=np.float64),
+            obstacles=np.ascontiguousarray(obstacles_arr, dtype=np.float64),
+            obstacle_radius=float(env.obstacle_radius),
+            obstacle_penalty=float(env.obstacle_penalty),
+            obstacle_hit_probability=float(env.obstacle_hit_probability),
+            dangerous_areas=env._dangerous_areas_arr,
+            dangerous_area_radius=float(env.dangerous_area_radius),
+            dangerous_area_penalty=float(env.dangerous_area_penalty),
+            dangerous_area_hit_probability=float(env.dangerous_area_hit_probability),
+            reward_variant_code=int(_REWARD_VARIANT_CODES[variant]),
+            penalty_decay=float(_PENALTY_DECAY_BY_VARIANT[variant]),
+        ),
+        dtype=np.float64,
+    )
+
+
+def _call_native_cont_push_reward_batch(
+    env: ContinuousPushPOMDP,
+    states: np.ndarray,
+    action: np.ndarray,
+    next_states: np.ndarray,
+    variant: RewardModelType,
+) -> np.ndarray:
+    """Invoke the future ``_native.cont_push_reward_batch`` kernel directly.
+
+    Today this raises ``AttributeError`` because ``_native`` has no
+    ``cont_push_reward_batch`` attribute.
+    """
+    kernel = _native.cont_push_reward_batch  # type: ignore[attr-defined]
+    return np.asarray(
+        kernel(
+            states=np.ascontiguousarray(states, dtype=np.float64),
+            action=np.ascontiguousarray(action, dtype=np.float64),
+            next_states=np.ascontiguousarray(next_states, dtype=np.float64),
+            obstacles=np.ascontiguousarray(env.obstacles, dtype=np.float64),
+            robot_radius=float(env.robot_radius),
+            obstacle_penalty=float(env.obstacle_penalty),
+            obstacle_hit_probability=float(env.obstacle_hit_probability),
+            dangerous_areas=env._dangerous_areas_arr,
+            dangerous_area_radius=float(env.dangerous_area_radius),
+            dangerous_area_penalty=float(env.dangerous_area_penalty),
+            dangerous_area_hit_probability=float(env.dangerous_area_hit_probability),
+            reward_variant_code=int(_REWARD_VARIANT_CODES[variant]),
+            penalty_decay=float(_PENALTY_DECAY_BY_VARIANT[variant]),
+        ),
+        dtype=np.float64,
+    )
+
+
+class TestDiscretePushRewardCppParity:
+    """Sample-mean parity between Python and the C++ kernel for :class:`PushPOMDP`."""
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            RewardModelType.STANDARD,
+            RewardModelType.HIGH_VARIANCE_STATES,
+            RewardModelType.DECAYING_HIT_PROBABILITY,
+        ],
+    )
+    def test_cpp_python_reward_means_match(self, variant: RewardModelType) -> None:
+        """C++ reward-batch mean matches the Python reward-model mean within 3 SE.
+
+        Purpose: Validates that the future
+            ``_native.push_reward_batch`` reproduces the Python
+            reward-model's expected reward for each
+            :class:`RewardModelType` variant on the same
+            ``(state, action, next_state)`` batch.
+
+        Given: A discrete :class:`PushPOMDP` constructed with the chosen
+            ``reward_model_type``, non-empty ``dangerous_areas``,
+            ``dangerous_area_penalty = -10.0``,
+            ``dangerous_area_hit_probability = 1.0`` (so STANDARD is
+            deterministic) and (for the Decaying variant)
+            ``penalty_decay = 1.5``. A seeded batch of ``N = 2000``
+            states is generated mixing dangerous-area and clear cells,
+            and ``next_states`` is realised via
+            ``env.sample_next_state_batch``.
+        When: ``env.reward_model.compute_reward_batch`` and
+            ``_native.push_reward_batch`` are evaluated on the same
+            batch and action with matching ``reward_variant_code`` and
+            ``penalty_decay`` kwargs.
+        Then: ``|py.mean() - cpp.mean()| < 3 * py.std()/sqrt(N) + 1e-9``
+            — the sample-mean gap stays inside a 3-sigma confidence
+            band. Today this fails with ``AttributeError`` because the
+            kernel does not yet exist.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        env = _build_discrete_env(variant)
+        states = _build_discrete_states(env, _BATCH_SIZE)
+        action = env.get_actions()[0]
+        next_states = env.sample_next_state_batch(states, action)
+
+        py_rewards = np.asarray(
+            env.reward_model.compute_reward_batch(states, action, next_states),
+            dtype=np.float64,
+        )
+        assert py_rewards.shape == (_BATCH_SIZE,)
+
+        cpp_rewards = _call_native_push_reward_batch(env, states, action, next_states, variant)
+        assert cpp_rewards.shape == (_BATCH_SIZE,)
+
+        delta, tol = _sample_mean_parity(py_rewards, cpp_rewards)
+        assert delta < tol, (
+            f"C++/Python reward mean mismatch for discrete variant {variant.name}: "
+            f"|py.mean - cpp.mean| = {delta:.6f} >= tol = {tol:.6f} "
+            f"(py.mean={py_rewards.mean():.6f}, cpp.mean={cpp_rewards.mean():.6f}, "
+            f"N={py_rewards.shape[0]})"
+        )
+
+
+class TestContinuousPushRewardCppParity:
+    """Sample-mean parity between Python and the C++ kernel for :class:`ContinuousPushPOMDP`."""
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            RewardModelType.STANDARD,
+            RewardModelType.HIGH_VARIANCE_STATES,
+            RewardModelType.DECAYING_HIT_PROBABILITY,
+        ],
+    )
+    def test_cpp_python_reward_means_match(self, variant: RewardModelType) -> None:
+        """C++ reward-batch mean matches the Python reward-model mean within 3 SE.
+
+        Purpose: Validates that the future
+            ``_native.cont_push_reward_batch`` reproduces the Python
+            reward-model's expected reward for each
+            :class:`RewardModelType` variant on the same
+            ``(state, action, next_state)`` batch.
+
+        Given: A :class:`ContinuousPushPOMDP` built with the variant
+            under test, non-empty ``dangerous_areas``,
+            ``dangerous_area_penalty = -10.0``,
+            ``dangerous_area_hit_probability = 1.0`` and (for the
+            Decaying variant) ``penalty_decay = 1.5``. A seeded batch
+            of ``N = 2000`` states is generated mixing dangerous-area
+            and clear cells; ``next_states`` is realised via
+            ``env.sample_next_state_batch`` (deterministic action vector
+            ``[1.0, 0.0]``).
+        When: ``env.reward_model.compute_reward_batch`` and
+            ``_native.cont_push_reward_batch`` are evaluated on the same
+            batch and action with matching ``reward_variant_code`` and
+            ``penalty_decay`` kwargs.
+        Then: ``|py.mean() - cpp.mean()| < 3 * py.std()/sqrt(N) + 1e-9``
+            — the sample-mean gap stays inside a 3-sigma confidence
+            band. Today this fails with ``AttributeError`` because the
+            kernel does not yet exist.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        env = _build_continuous_env(variant)
+        states = _build_continuous_states(env, _BATCH_SIZE)
+        action = np.array([1.0, 0.0], dtype=np.float64)
+        next_states = env.sample_next_state_batch(states, action)
+
+        py_rewards = np.asarray(
+            env.reward_model.compute_reward_batch(states, action, next_states),
+            dtype=np.float64,
+        )
+        assert py_rewards.shape == (_BATCH_SIZE,)
+
+        cpp_rewards = _call_native_cont_push_reward_batch(env, states, action, next_states, variant)
+        assert cpp_rewards.shape == (_BATCH_SIZE,)
+
+        delta, tol = _sample_mean_parity(py_rewards, cpp_rewards)
+        assert delta < tol, (
+            f"C++/Python reward mean mismatch for continuous variant {variant.name}: "
+            f"|py.mean - cpp.mean| = {delta:.6f} >= tol = {tol:.6f} "
+            f"(py.mean={py_rewards.mean():.6f}, cpp.mean={cpp_rewards.mean():.6f}, "
+            f"N={py_rewards.shape[0]})"
+        )

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
@@ -11,6 +11,8 @@ historical wrapper classes ``ContinuousPushStateTransitionModel`` and
 
 # pylint: disable=protected-access
 
+from typing import Any, Dict, List
+
 import numpy as np
 import pytest
 
@@ -1078,17 +1080,21 @@ class TestContinuousPushDangerousAreas:
         assert metrics["total_dangerous_area_steps"].value == pytest.approx(2.0)
         assert metrics["dangerous_area_rate"].value == pytest.approx(2.0 / 3.0)
 
-    def test_native_rollout_bypassed_when_hit_probability_lt_one(self, monkeypatch):
-        """Native rollout is bypassed when dangerous_area_hit_probability < 1.
+    def test_native_rollout_used_when_hit_probability_lt_one(self, monkeypatch):
+        """Native rollout handles dangerous_area_hit_probability < 1 internally.
 
-        Purpose: Validates that ``simulate_random_rollout`` falls back to
-            the Python rollout so per-step Bernoulli draws survive.
+        Purpose: Validates that ``simulate_random_rollout`` routes through
+            the native C++ kernel even when
+            ``dangerous_area_hit_probability < 1.0`` because the kernel
+            now applies the Bernoulli draw internally. Regression check
+            for the removal of the Python fallback gate.
 
         Given: A ContinuousPushPOMDPDiscreteActions with
             ``dangerous_area_hit_probability=0.5``.
-        When: ``simulate_random_rollout`` is invoked after monkeypatching
-            ``_native.cont_simulate_rollout`` to raise.
-        Then: No exception is raised because the native path was bypassed.
+        When: ``simulate_random_rollout`` is invoked after wrapping
+            ``_native.cont_simulate_rollout`` to record calls.
+        Then: The native kernel is invoked exactly once with
+            ``dangerous_area_hit_probability=0.5`` threaded through.
 
         Test type: unit
         """
@@ -1103,10 +1109,14 @@ class TestContinuousPushDangerousAreas:
             state_transition_cov_matrix=np.eye(2) * 1e-8,
         )
 
-        def _explode(**_kwargs):
-            raise AssertionError("native cont_simulate_rollout must not be called")
+        call_kwargs: List[Dict[str, Any]] = []
+        original = _native.cont_simulate_rollout
 
-        monkeypatch.setattr(_native, "cont_simulate_rollout", _explode)
+        def _record(**kwargs):
+            call_kwargs.append(kwargs)
+            return original(**kwargs)
+
+        monkeypatch.setattr(_native, "cont_simulate_rollout", _record)
 
         class _Sampler:
             def sample(self):
@@ -1118,6 +1128,9 @@ class TestContinuousPushDangerousAreas:
             max_depth=5,
             discount_factor=0.99,
         )
+
+        assert len(call_kwargs) == 1
+        assert call_kwargs[0]["dangerous_area_hit_probability"] == pytest.approx(0.5)
 
 
 class TestContinuousPushDangerousHitProbability:

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
@@ -9,6 +9,7 @@ This module tests the Push POMDP environment, focusing on:
 # pylint: disable=protected-access  # Tests need to access protected members
 
 import random
+from typing import Any, Dict, List
 
 import numpy as np
 import pytest
@@ -1712,26 +1713,34 @@ class TestPushDangerousAreas:
         with pytest.raises(ValueError, match="dangerous_area_hit_probability"):
             PushPOMDP(discount_factor=0.95, dangerous_area_hit_probability=bad_value)
 
-    def test_native_rollout_bypassed_when_hit_probability_lt_one(self, monkeypatch):
-        """Stochastic dangerous-area hit probability bypasses native rollout.
+    def test_native_rollout_used_when_hit_probability_lt_one(self, monkeypatch):
+        """Stochastic dangerous-area hit probability is handled by the native rollout.
 
-        Purpose: Validates that ``simulate_random_rollout`` falls back to
-            the Python rollout when ``dangerous_area_hit_probability < 1.0``,
-            so per-step Bernoulli draws are honoured.
+        Purpose: Validates that ``simulate_random_rollout`` routes through
+            the native C++ kernel even when
+            ``dangerous_area_hit_probability < 1.0`` because the kernel
+            now applies the Bernoulli draw internally (via
+            ``dangerous_contribution``). Regression check for the
+            removal of the Python fallback gate.
 
         Given: A PushPOMDP with ``dangerous_area_hit_probability=0.5``.
-        When: ``simulate_random_rollout`` is invoked after monkeypatching
-            ``_native.simulate_rollout_discrete`` to raise.
-        Then: No exception is raised because the native path was bypassed.
+        When: ``simulate_random_rollout`` is invoked after wrapping
+            ``_native.simulate_rollout_discrete`` to record calls.
+        Then: The native kernel is invoked exactly once with
+            ``dangerous_area_hit_probability=0.5`` threaded through.
 
         Test type: unit
         """
         env = self._danger_env(hit_probability=0.5)
 
-        def _explode(**_kwargs):
-            raise AssertionError("native simulate_rollout_discrete must not be called")
+        call_kwargs: List[Dict[str, Any]] = []
+        original = push_native.simulate_rollout_discrete
 
-        monkeypatch.setattr(push_native, "simulate_rollout_discrete", _explode)
+        def _record(**kwargs):
+            call_kwargs.append(kwargs)
+            return original(**kwargs)
+
+        monkeypatch.setattr(push_native, "simulate_rollout_discrete", _record)
 
         class _Sampler:
             def sample(self):
@@ -1743,6 +1752,9 @@ class TestPushDangerousAreas:
             max_depth=5,
             discount_factor=0.95,
         )
+
+        assert len(call_kwargs) == 1
+        assert call_kwargs[0]["dangerous_area_hit_probability"] == pytest.approx(0.5)
 
     def test_reward_range_includes_dangerous_area_penalty(self):
         """Reward range lower bound shifts when a dangerous area is configured.
@@ -1976,21 +1988,6 @@ class TestRewardBatchMatchesScalarLoop:
 class TestPushNativeSimulateRollout:
     """Tests for the native C++ simulate_rollout_discrete entry point."""
 
-    @pytest.mark.xfail(
-        reason=(
-            "C++ kernel still scores obstacle/danger penalties against the "
-            "intended position (state + action_vector) — the legacy "
-            "pre-realised-next-state semantics. The Python reward path was "
-            "fixed to use the realised next_state; the C++ kernel needs a "
-            "matching rebuild before this parity test passes again. "
-            "TODO(c++): port the realised-next-state penalty check to "
-            "_cpp/continuous_push.cpp:simulate_rollout_discrete and rebuild "
-            "_native.so. Until then ``simulate_random_rollout`` routes around "
-            "the C++ kernel when obstacles/danger are configured, so the "
-            "user-facing API remains correct."
-        ),
-        strict=True,
-    )
     def test_push_native_simulate_rollout_matches_python(self):
         """Native C++ rollout must produce the same discounted return as the Python reference.
 

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/rock_sample_pomdp_utils/test_rock_sample_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/rock_sample_pomdp_utils/test_rock_sample_reward_cpp_parity.py
@@ -1,0 +1,239 @@
+"""C++ <-> Python reward parity tests for the RockSample POMDP.
+
+These tests assert that a (yet-to-be-added) standalone C++ reward kernel
+``_native.reward_batch`` reproduces the per-variant Python reward model
+(``RockSampleRewardModel`` and subclasses) on identical
+``(state, action, next_state)`` triples.
+
+Today no standalone C++ reward kernel exists: reward is inlined inside
+``_native.simulate_rollout_discrete`` and that path does not include the
+dangerous-area term. These tests are therefore expected to FAIL until a
+Stage 2 agent adds ``_native.reward_batch``. They form the TDD red step
+for that work.
+
+The contract being asserted here is:
+
+* ``_native.reward_batch`` is callable via keyword arguments listing all
+  environment scoring parameters, plus ``reward_variant_code`` (int) and
+  ``penalty_decay`` (float) selecting one of the three reward variants:
+
+  * ``reward_variant_code=0`` -> STANDARD
+  * ``reward_variant_code=1`` -> HIGH_VARIANCE_STATES
+  * ``reward_variant_code=2`` -> DECAYING_HIT_PROBABILITY
+
+* For each variant, the sample-mean of the C++ rewards over a seeded
+  ``N=2000`` batch matches the sample-mean of the Python reward model
+  within a 3-sigma confidence band of the Python sample standard error.
+"""
+
+# pylint: disable=protected-access  # Tests reach into native module for parity checks.
+
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.rock_sample_pomdp import _native
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import (
+    RewardModelType,
+    RockSamplePOMDP,
+)
+
+
+_MAP_SIZE: Tuple[int, int] = (7, 7)
+_ROCK_POSITIONS: List[Tuple[int, int]] = [(1, 1), (3, 3), (5, 5), (6, 2)]
+_INIT_POS: Tuple[int, int] = (0, 0)
+_DANGEROUS_AREAS: List[Tuple[int, int]] = [(2, 2), (4, 4)]
+_DANGEROUS_AREA_RADIUS: float = 1.0
+_DANGEROUS_AREA_PENALTY: float = -5.0
+_DANGEROUS_AREA_HIT_PROBABILITY: float = 1.0
+_STEP_PENALTY: float = -0.1
+_BAD_ROCK_PENALTY: float = -10.0
+_GOOD_ROCK_REWARD: float = 10.0
+_SENSOR_USE_PENALTY: float = -0.5
+_EXIT_REWARD: float = 10.0
+_PENALTY_DECAY_DECAYING_VARIANT: float = 1.5
+_N: int = 2000
+_NUM_ROCKS: int = len(_ROCK_POSITIONS)
+
+
+def _make_env(reward_model_type: RewardModelType, penalty_decay: float) -> RockSamplePOMDP:
+    return RockSamplePOMDP(
+        map_size=_MAP_SIZE,
+        rock_positions=list(_ROCK_POSITIONS),
+        init_pos=_INIT_POS,
+        bad_rock_penalty=_BAD_ROCK_PENALTY,
+        good_rock_reward=_GOOD_ROCK_REWARD,
+        step_penalty=_STEP_PENALTY,
+        sensor_use_penalty=_SENSOR_USE_PENALTY,
+        exit_reward=_EXIT_REWARD,
+        dangerous_areas=list(_DANGEROUS_AREAS),
+        dangerous_area_radius=_DANGEROUS_AREA_RADIUS,
+        dangerous_area_penalty=_DANGEROUS_AREA_PENALTY,
+        dangerous_area_hit_probability=_DANGEROUS_AREA_HIT_PROBABILITY,
+        reward_model_type=reward_model_type,
+        penalty_decay=penalty_decay,
+    )
+
+
+def _build_random_states(env: RockSamplePOMDP, n: int) -> np.ndarray:
+    rows = np.random.randint(0, _MAP_SIZE[0], size=n)
+    cols = np.random.randint(0, _MAP_SIZE[1], size=n)
+    rocks = np.random.randint(0, 2, size=(n, _NUM_ROCKS)).astype(np.float64)
+    state_dim = 2 + _NUM_ROCKS
+    states = np.empty((n, state_dim), dtype=np.float64)
+    states[:, 0] = rows
+    states[:, 1] = cols
+    states[:, 2:] = rocks
+    assert states.shape[1] == 2 + len(env.rock_positions)
+    return states
+
+
+def _mixed_actions_per_row(env: RockSamplePOMDP, n: int) -> np.ndarray:
+    # We want exposure to sample / move / sensor / exit branches across
+    # the batch, but ``compute_reward_batch`` is single-action so we
+    # bucket the rows by action and parity-test each bucket.
+    n_actions = len(env.get_actions())
+    return np.random.randint(0, n_actions, size=n).astype(np.int32)
+
+
+def _native_reward_batch_kwargs(
+    states: np.ndarray,
+    action: int,
+    next_states: np.ndarray,
+    reward_variant_code: int,
+    penalty_decay: float,
+) -> dict:
+    dangerous_areas_arr = np.asarray(_DANGEROUS_AREAS, dtype=np.float64)
+    rock_positions_arr = np.asarray(_ROCK_POSITIONS, dtype=np.int32)
+    return {
+        "states": np.ascontiguousarray(states, dtype=np.float64),
+        "action": int(action),
+        "next_states": np.ascontiguousarray(next_states, dtype=np.float64),
+        "map_rows": int(_MAP_SIZE[0]),
+        "map_cols": int(_MAP_SIZE[1]),
+        "rock_positions": rock_positions_arr,
+        "step_penalty": float(_STEP_PENALTY),
+        "bad_rock_penalty": float(_BAD_ROCK_PENALTY),
+        "good_rock_reward": float(_GOOD_ROCK_REWARD),
+        "sensor_use_penalty": float(_SENSOR_USE_PENALTY),
+        "exit_reward": float(_EXIT_REWARD),
+        "dangerous_areas": dangerous_areas_arr,
+        "dangerous_area_radius": float(_DANGEROUS_AREA_RADIUS),
+        "dangerous_area_penalty": float(_DANGEROUS_AREA_PENALTY),
+        "dangerous_area_hit_probability": float(_DANGEROUS_AREA_HIT_PROBABILITY),
+        "reward_variant_code": int(reward_variant_code),
+        "penalty_decay": float(penalty_decay),
+    }
+
+
+def _collect_cpp_rewards(
+    env: RockSamplePOMDP,
+    states: np.ndarray,
+    actions: np.ndarray,
+    reward_variant_code: int,
+    penalty_decay: float,
+) -> np.ndarray:
+    rewards = np.empty(states.shape[0], dtype=np.float64)
+    for action in np.unique(actions):
+        mask = actions == action
+        bucket_states = states[mask]
+        bucket_next = env.sample_next_state_batch(bucket_states, int(action))
+        kwargs = _native_reward_batch_kwargs(
+            states=bucket_states,
+            action=int(action),
+            next_states=bucket_next,
+            reward_variant_code=reward_variant_code,
+            penalty_decay=penalty_decay,
+        )
+        # ``_native.reward_batch`` does not exist yet (Stage 2 work). The
+        # ``getattr`` plus call surfaces a clear AttributeError today and
+        # a typed call once the kernel lands.
+        kernel = getattr(_native, "reward_batch")
+        rewards[mask] = np.asarray(kernel(**kwargs), dtype=np.float64)
+    return rewards
+
+
+def _collect_py_rewards(
+    env: RockSamplePOMDP,
+    states: np.ndarray,
+    actions: np.ndarray,
+) -> np.ndarray:
+    rewards = np.empty(states.shape[0], dtype=np.float64)
+    for action in np.unique(actions):
+        mask = actions == action
+        bucket_states = states[mask]
+        bucket_next = env.sample_next_state_batch(bucket_states, int(action))
+        rewards[mask] = np.asarray(
+            env.reward_model.compute_reward_batch(
+                bucket_states, int(action), next_states=bucket_next
+            ),
+            dtype=np.float64,
+        )
+    return rewards
+
+
+@pytest.mark.parametrize(
+    ("variant", "reward_variant_code", "penalty_decay"),
+    [
+        (RewardModelType.STANDARD, 0, 0.0),
+        (RewardModelType.HIGH_VARIANCE_STATES, 1, 0.0),
+        (RewardModelType.DECAYING_HIT_PROBABILITY, 2, _PENALTY_DECAY_DECAYING_VARIANT),
+    ],
+    ids=["standard", "high_variance_states", "decaying_hit_probability"],
+)
+class TestRockSampleRewardCppParity:
+    """C++ vs Python reward-mean parity across all RockSample reward variants."""
+
+    def test_cpp_batch_mean_matches_python_within_3_sigma(
+        self,
+        variant: RewardModelType,
+        reward_variant_code: int,
+        penalty_decay: float,
+    ) -> None:
+        """C++ ``reward_batch`` sample-mean matches Python within 3 sigma.
+
+        Purpose: Validates that the (Stage-2) standalone C++ reward kernel
+            ``_native.reward_batch`` reproduces the per-variant Python
+            reward model in expectation over a seeded batch of
+            ``(state, action, next_state)`` triples that exercises sample,
+            sensor, move, and exit branches.
+
+        Given: A ``RockSamplePOMDP`` configured with non-empty
+            ``dangerous_areas`` and the variant-appropriate
+            ``reward_model_type``. ``N=2000`` random states are generated
+            under ``np.random.seed(42)``, with one random action per row
+            spanning all action codes (sample / move / sensor / exit).
+            Next states come from ``env.sample_next_state_batch`` to match
+            the realised trajectory the dangerous-area term fires against.
+        When: Python rewards come from
+            ``env.reward_model.compute_reward_batch``; C++ rewards come
+            from ``_native.reward_batch`` called with keyword arguments
+            including ``reward_variant_code`` and ``penalty_decay``.
+        Then: ``|py.mean() - cpp.mean()| < 3 * (py.std() / sqrt(N)) + 1e-9``.
+
+        Test type: integration
+        """
+        np.random.seed(42)
+        env = _make_env(reward_model_type=variant, penalty_decay=penalty_decay)
+        states = _build_random_states(env, _N)
+        actions = _mixed_actions_per_row(env, _N)
+
+        py_rewards = _collect_py_rewards(env, states, actions)
+        cpp_rewards = _collect_cpp_rewards(
+            env=env,
+            states=states,
+            actions=actions,
+            reward_variant_code=reward_variant_code,
+            penalty_decay=penalty_decay,
+        )
+
+        py_mean = float(py_rewards.mean())
+        cpp_mean = float(cpp_rewards.mean())
+        py_sem = float(py_rewards.std() / np.sqrt(_N))
+        tolerance = 3.0 * py_sem + 1e-9
+        assert abs(py_mean - cpp_mean) < tolerance, (
+            f"variant={variant.value}: |py.mean - cpp.mean| = "
+            f"{abs(py_mean - cpp_mean):.6g} not < tol = {tolerance:.6g} "
+            f"(py.mean={py_mean:.6g}, cpp.mean={cpp_mean:.6g}, py.sem={py_sem:.6g})"
+        )

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
@@ -1721,6 +1721,12 @@ def test_native_simulate_rollout_rocksample_matches_python_reference():
         good_rock_reward=float(env_local.good_rock_reward),
         bad_rock_penalty=float(env_local.bad_rock_penalty),
         sensor_use_penalty=float(env_local.sensor_use_penalty),
+        dangerous_areas=np.empty((0, 2), dtype=np.float64),
+        dangerous_area_radius=1.0,
+        dangerous_area_penalty=0.0,
+        dangerous_area_hit_probability=1.0,
+        reward_variant_code=0,
+        penalty_decay=1.0,
     )
 
     python_result = _rs_python_rollout_native_semantics(


### PR DESCRIPTION
## Summary

- Across **laser_tag, light_dark, pacman, push, rock_sample** the C++ reward kernels did not implement the `HIGH_VARIANCE_STATES` / `DECAYING_HIT_PROBABILITY` variants. Depending on the env, the C++ side either silently produced STANDARD-formula values for non-standard variants, or was missing the dangerous-area term entirely (pacman `simulate_rollout` from `ff78e52c`, rock_sample `simulate_rollout_discrete`). Python dispatch papered over this with fallback gates in some envs but not others.
- This PR adds variant-aware C++ kernels — a standalone `reward_batch` per env (or extends the existing one) plus dispatch in the inline-reward rollout kernels — and removes the now-obsolete Python fallback gates. RNG draws use `pomdp_native::default_rng()`.
- Adds pacman HV / Decaying reward-model classes + `RewardModelType` enum, mirroring the existing pattern in the other envs.
- Adds **5 C++↔Python parity tests** (one per env, alongside the existing reward-model tests). Each compares C++ vs Python sample means over N=2000 random (state, action, next_state) triples with a 3·SEM tolerance per variant.

### Per-env coverage after this PR

| Env | reward_batch C++ variants | Rollout C++ variants |
|---|---|---|
| laser_tag | all 3 | all 3 |
| light_dark | all 3 (kernel exposed) | all 3 |
| pacman | all 3 + danger penalty fix | all 3 + danger penalty fix |
| push | all 3 | all 3 |
| rock_sample | all 3 | all 3 |

light_dark's env-level `reward_batch` method continues to call the Python `reward_model` to preserve pre-existing scalar-vs-batch bit-exact tests (scalar uses numpy RNG, C++ uses mt19937_64). The new C++ kernel is exposed as `_native.compute_reward_batch` and is used by the rollout path and direct callers (incl. the parity test).

## Test plan

- [x] Parity tests: 19/19 pass (laser_tag 4, light_dark 3, pacman 3, push 6, rock_sample 3).
- [x] Env regression suites — zero regressions:
  - [x] laser_tag: 236 pass
  - [x] light_dark: 309 pass
  - [x] pacman: 209 pass
  - [x] push: 249 pass (was 248 + 1 xfailed; the realised-position xfail is now a real pass)
  - [x] rock_sample: 193 pass
- [x] pyright 0 errors / 0 warnings on all modified source + test files
- [x] pylint 10/10 on source files (test files match their pre-existing baselines)
- [x] Clean `python setup.py build_ext --inplace` rebuild of all 5 C++ extensions