### PR TITLE
fix(envs): close Python-side reward kernel bugs in pacman + rock_sample

### DIFF
--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/numba_kernels.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/numba_kernels.py
@@ -71,11 +71,26 @@ def compute_reward_batch_kernel(
         new_pac_row = int(neighbor_table[pac_row, pac_col, action, 0])
         new_pac_col = int(neighbor_table[pac_row, pac_col, action, 1])
 
+        # Collision detection mirrors the C++ rollout kernel
+        # (_cpp/pacman.cpp lines 1435-1438): same-cell OR pacman-ghost
+        # swap. The swap arm fires when a ghost previously at pacman's
+        # new cell ends up at pacman's old cell — the transition writes
+        # the ghost back to the old pacman position and sets terminal=1.
+        # Only one penalty per step (break after first hit) to match C++.
         if has_next_states and num_ghosts > 0:
             for g in range(num_ghosts):
                 g_row = int(next_states[i, idx_ghosts_start + 2 * g])
                 g_col = int(next_states[i, idx_ghosts_start + 2 * g + 1])
-                if g_row == new_pac_row and g_col == new_pac_col:
+                prev_g_row = int(states[i, idx_ghosts_start + 2 * g])
+                prev_g_col = int(states[i, idx_ghosts_start + 2 * g + 1])
+                same_cell = g_row == new_pac_row and g_col == new_pac_col
+                swap = (
+                    prev_g_row == new_pac_row
+                    and prev_g_col == new_pac_col
+                    and g_row == pac_row
+                    and g_col == pac_col
+                )
+                if same_cell or swap:
                     reward += ghost_collision_penalty
                     break
 
@@ -149,11 +164,29 @@ def compute_reward_scalar_kernel(
     reward = step_penalty
     next_pac_row = int(next_state[idx_pac_row])
     next_pac_col = int(next_state[idx_pac_col])
+    prev_pac_row = int(state[idx_pac_row])
+    prev_pac_col = int(state[idx_pac_col])
 
+    # Collision detection mirrors the C++ rollout kernel (_cpp/pacman.cpp
+    # lines 1435-1438): same-cell OR pacman-ghost swap. The swap arm fires
+    # when a ghost previously at pacman's new cell ends up on pacman's old
+    # cell — the transition kernel then writes the ghost at the old pacman
+    # position and sets terminal=1 (see apply_transition lines 454-457).
+    # Penalty is credited at most once per step (break after first hit) to
+    # match the C++ break.
     for g in range(num_ghosts):
         g_row = int(next_state[idx_ghosts_start + 2 * g])
         g_col = int(next_state[idx_ghosts_start + 2 * g + 1])
-        if g_row == next_pac_row and g_col == next_pac_col:
+        prev_g_row = int(state[idx_ghosts_start + 2 * g])
+        prev_g_col = int(state[idx_ghosts_start + 2 * g + 1])
+        same_cell = g_row == next_pac_row and g_col == next_pac_col
+        swap = (
+            prev_g_row == next_pac_row
+            and prev_g_col == next_pac_col
+            and g_row == prev_pac_row
+            and g_col == prev_pac_col
+        )
+        if same_cell or swap:
             reward += ghost_collision_penalty
             break
 

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_utils/rock_sample_reward_models.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_utils/rock_sample_reward_models.py
@@ -173,11 +173,10 @@ class RockSampleRewardModel(BaseRockSampleRewardModel):
         rewards = np.full(n, self.step_penalty, dtype=np.float64)
         map_cols = self.map_size[1]
 
+        exits_mask: Optional[np.ndarray] = None
         if action == 2:
-            exits = states[:, 1].astype(int) == (map_cols - 1)
-            terminal = (states[:, 0] < 0) & (states[:, 1] < 0)
-            rewards[exits | terminal] += self.exit_reward
-            return rewards
+            exits_mask = states[:, 1].astype(int) == (map_cols - 1)
+            rewards[exits_mask] += self.exit_reward
 
         if action == 0:
             robot_rows = states[:, 0].astype(int)
@@ -203,7 +202,9 @@ class RockSampleRewardModel(BaseRockSampleRewardModel):
         else:
             next_robot_rows, next_robot_cols = self._closed_form_next_robot_pos(states, action)
 
-        self._apply_dangerous_area_contribution_batch(rewards, next_robot_rows, next_robot_cols)
+        self._apply_dangerous_area_contribution_batch(
+            rewards, next_robot_rows, next_robot_cols, skip_mask=exits_mask
+        )
 
         return rewards
 
@@ -226,15 +227,20 @@ class RockSampleRewardModel(BaseRockSampleRewardModel):
         rewards: np.ndarray,
         next_robot_rows: np.ndarray,
         next_robot_cols: np.ndarray,
+        skip_mask: Optional[np.ndarray] = None,
     ) -> None:
         """Vectorised constant-probability dangerous-area contribution.
 
         RNG stays in Python so seeded behaviour matches the per-row scalar
         loop bit-for-bit: deterministic case draws zero uniforms;
         stochastic case draws exactly ``in_zone.sum()`` uniforms, in
-        ascending row index order.
+        ascending row index order. ``skip_mask`` rows (e.g. East exits)
+        are excluded from both the membership check and the RNG draws so
+        the scalar early-return contract is preserved.
         """
         in_zone = self._compute_in_zone_mask(next_robot_rows, next_robot_cols)
+        if skip_mask is not None:
+            in_zone &= ~skip_mask
         if self.dangerous_area_hit_probability >= 1.0:
             rewards[in_zone] += self.dangerous_area_penalty
         else:
@@ -264,13 +270,19 @@ class RockSampleRewardModel(BaseRockSampleRewardModel):
         # Closed-form post-transition robot position for the dangerous-area
         # check. RockSample movement actions translate by ``(dr, dc)`` and
         # clip to map bounds; sample / sense actions leave position
-        # unchanged. Terminal-sentinel rows (state[:, 0] < 0) keep their
-        # negative coordinates so they never match a dangerous-area cell,
+        # unchanged. East (action=2) on a non-rightmost row moves +1 col;
+        # rightmost-column rows exit and are handled by the exit-mask in
+        # ``compute_reward_batch`` so this method returns the clipped
+        # position (rightmost-column rows stay put after clipping).
+        # Terminal-sentinel rows (state[:, 0] < 0) keep their negative
+        # coordinates so they never match a dangerous-area cell,
         # mirroring the batch-kernel semantics for that path.
         robot_rows = states[:, 0].astype(int)
         robot_cols = states[:, 1].astype(int)
         if action == 1:
             dr, dc = -1, 0
+        elif action == 2:
+            dr, dc = 0, 1
         elif action == 3:
             dr, dc = 1, 0
         elif action == 4:
@@ -312,8 +324,11 @@ class RockSampleHighVarianceRewardModel(RockSampleRewardModel):
         rewards: np.ndarray,
         next_robot_rows: np.ndarray,
         next_robot_cols: np.ndarray,
+        skip_mask: Optional[np.ndarray] = None,
     ) -> None:
         in_zone = self._compute_in_zone_mask(next_robot_rows, next_robot_cols)
+        if skip_mask is not None:
+            in_zone &= ~skip_mask
         in_zone_indices = np.flatnonzero(in_zone)
         coins = np.random.random(in_zone_indices.size)
         signs = np.where(coins < 0.5, 1.0, -1.0)
@@ -387,6 +402,7 @@ class RockSampleDecayingHitProbabilityRewardModel(RockSampleRewardModel):
         rewards: np.ndarray,
         next_robot_rows: np.ndarray,
         next_robot_cols: np.ndarray,
+        skip_mask: Optional[np.ndarray] = None,
     ) -> None:
         # Single allocation + cast-on-assign beats column_stack(astype, astype),
         # which materialises two extra intermediate float64 arrays before
@@ -395,10 +411,13 @@ class RockSampleDecayingHitProbabilityRewardModel(RockSampleRewardModel):
         points[:, 0] = next_robot_rows
         points[:, 1] = next_robot_cols
         uniforms = np.random.random(points.shape[0])
-        rewards += decaying_prob_penalty_batch_kernel(
+        contributions = decaying_prob_penalty_batch_kernel(
             points,
             self._dangerous_areas_xy,
             self.dangerous_area_penalty,
             self.penalty_decay,
             uniforms,
         )
+        if skip_mask is not None:
+            contributions = np.where(skip_mask, 0.0, contributions)
+        rewards += contributions

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_utils/test_pacman_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_utils/test_pacman_reward_models.py
@@ -366,3 +366,129 @@ class TestPacManPOMDPRewardModelTypeWiring:
         env = PacManPOMDP(maze_size=_MAZE_SIZE)
         # pylint: disable-next=unidiomatic-typecheck
         assert type(env.reward_model) is PacManRewardModel
+
+
+# Helper builders for swap-collision tests. The standard ``_state_with_pac``
+# uses a fixed ghost cell at (6, 6) which is incompatible with a swap test —
+# the swap test needs the ghost adjacent to pacman in the pre-state.
+def _make_swap_state(
+    env: PacManPOMDP, pacman_pos: Tuple[int, int], ghost_pos: Tuple[int, int]
+) -> np.ndarray:
+    return env.make_state(
+        pacman_pos=pacman_pos,
+        ghost_positions=(ghost_pos,),
+        pellets=((1, 1),),
+        score=0.0,
+        terminal=False,
+    )
+
+
+def _make_terminal_after_swap(
+    env: PacManPOMDP,
+    pacman_pos: Tuple[int, int],
+    ghost_pos: Tuple[int, int],
+) -> np.ndarray:
+    return env.make_state(
+        pacman_pos=pacman_pos,
+        ghost_positions=(ghost_pos,),
+        pellets=((1, 1),),
+        score=0.0,
+        terminal=True,
+    )
+
+
+class TestPacManGhostSwapCollisionDetection:
+    """Regression coverage for the ghost-swap arm of the collision rule.
+
+    The C++ transition (``apply_transition``) and C++ rollout reward both
+    treat pacman and a ghost trading cells in a single step as a collision
+    that terminates and accrues ``ghost_collision_penalty``. The Python
+    reward kernels previously only detected same-cell collisions and so
+    silently lost the penalty on every swap, breaking C++/Python reward
+    parity at the per-step level.
+    """
+
+    def test_scalar_swap_arm_credits_collision_penalty(self):
+        """Scalar kernel charges ghost_collision_penalty on a pacman-ghost swap.
+
+        Purpose: Validates that ``compute_reward`` detects the swap arm
+            of the canonical Pacman collision rule (pacman and a ghost
+            trade cells) and credits ``ghost_collision_penalty`` exactly
+            like the C++ rollout reward kernel.
+
+        Given: A standard reward model with pacman at (0, 0) and a ghost
+            at (0, 1) in the pre-state, a next-state where pacman moved
+            east to (0, 1) and the ghost is now at (0, 0) with terminal
+            flag set (mirroring what the C++ transition writes on a swap
+            collision). Positions sit well outside the danger zone so the
+            expected value isolates the step + collision contributions.
+        When: ``compute_reward(state, action=1, next_state=next_state)``
+            is called on the env's reward model.
+        Then: Reward equals ``step_penalty + ghost_collision_penalty``.
+
+        Test type: unit
+        """
+        env = _make_env(RewardModelType.STANDARD)
+        # Use cells well clear of the danger zone (centred at (3, 3), radius 1)
+        # so the expected reward depends only on step + collision penalties.
+        # Action 1 (east) moves pacman (0, 0) -> (0, 1); ghost (0, 1) -> (0, 0)
+        # completes the swap.
+        state = _make_swap_state(env, pacman_pos=(0, 0), ghost_pos=(0, 1))
+        next_state = _make_terminal_after_swap(env, pacman_pos=(0, 1), ghost_pos=(0, 0))
+        reward = env.reward_model.compute_reward(state, action=1, next_state=next_state)
+        assert reward == pytest.approx(_STEP_PENALTY + env.ghost_collision_penalty)
+
+    def test_batch_swap_arm_credits_collision_penalty(self):
+        """Batch kernel charges ghost_collision_penalty on a pacman-ghost swap.
+
+        Purpose: Validates that ``compute_reward_batch`` detects the same
+            swap arm as the scalar path so vectorised callers (e.g. PFT
+            planners) do not silently drop the collision penalty.
+
+        Given: A standard reward model, a batch with one row whose
+            pre-state has pacman at (0, 0) and a ghost at (0, 1), and a
+            matching next-state batch where pacman moved east to (0, 1)
+            and the ghost is at (0, 0) (a swap, with terminal set).
+            Positions are clear of the danger zone.
+        When: ``compute_reward_batch(states, action=1, next_states=...)``
+            is called.
+        Then: The single returned reward equals
+            ``step_penalty + ghost_collision_penalty``.
+
+        Test type: unit
+        """
+        env = _make_env(RewardModelType.STANDARD)
+        # Use cells well clear of the danger zone (centred at (3, 3), radius 1)
+        # so the expected reward depends only on step + collision penalties.
+        state = _make_swap_state(env, pacman_pos=(0, 0), ghost_pos=(0, 1))
+        next_state = _make_terminal_after_swap(env, pacman_pos=(0, 1), ghost_pos=(0, 0))
+        states = state.reshape(1, -1)
+        next_states = next_state.reshape(1, -1)
+        rewards = env.reward_model.compute_reward_batch(states, action=1, next_states=next_states)
+        assert rewards.shape == (1,)
+        assert float(rewards[0]) == pytest.approx(_STEP_PENALTY + env.ghost_collision_penalty)
+
+    def test_scalar_and_batch_agree_on_swap(self):
+        """Scalar and batch reward kernels agree on a swap-collision row.
+
+        Purpose: Pins scalar/batch parity for the swap arm so future
+            kernel edits cannot diverge the two code paths.
+
+        Given: The same swap-collision (state, action, next_state) used
+            by the dedicated scalar and batch tests above.
+        When: Both ``compute_reward`` and ``compute_reward_batch`` are
+            invoked on the standard reward model.
+        Then: The two outputs are exactly equal.
+
+        Test type: unit
+        """
+        env = _make_env(RewardModelType.STANDARD)
+        # Use cells well clear of the danger zone (centred at (3, 3), radius 1)
+        # so the expected reward depends only on step + collision penalties.
+        state = _make_swap_state(env, pacman_pos=(0, 0), ghost_pos=(0, 1))
+        next_state = _make_terminal_after_swap(env, pacman_pos=(0, 1), ghost_pos=(0, 0))
+        scalar = env.reward_model.compute_reward(state, action=1, next_state=next_state)
+        batch = env.reward_model.compute_reward_batch(
+            state.reshape(1, -1), action=1, next_states=next_state.reshape(1, -1)
+        )
+        assert float(batch[0]) == pytest.approx(scalar)

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_env_api_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_env_api_parity.py
@@ -511,20 +511,22 @@ def test_sample_next_state_terminal_is_absorbing() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_reward_batch_exit_branch_treats_terminal_as_exited() -> None:
-    """reward_batch east-action: terminal rows receive exit_reward.
+def test_reward_batch_exit_branch_matches_scalar_and_cpp_contract() -> None:
+    """reward_batch east-action: only right-edge rows receive exit_reward.
 
-    Purpose: Validates the documented behaviour in
-        ``RockSamplePOMDP._reward_batch_vectorized`` that terminal rows are
-        merged with rows whose col == map_cols - 1 and both receive
-        exit_reward. This ensures the batch path is consistent across the
-        live-edge and terminal-sentinel populations.
+    Purpose: Validates that the Python batch path matches the scalar
+        ``compute_reward`` contract (and the C++ ``reward_batch`` kernel)
+        for the east action: only rows whose ``col == map_cols - 1`` get
+        the exit bonus. Terminal-sentinel rows (``(-1, -1, ...)``) are
+        NOT treated as exited — they receive ``step_penalty`` only.
 
-    Given: A batch of 4 particles: [right-edge live, terminal, interior live,
-        right-edge live with different rocks].
-    When: ``reward_batch(particles, action=2)`` is invoked.
-    Then: Both right-edge rows and the terminal row receive
-        step_penalty + exit_reward; the interior row receives only step_penalty.
+    Given: A batch of 4 particles: [right-edge live, terminal sentinel,
+        interior live, another right-edge live].
+    When: ``reward_batch(particles, action=2)`` is invoked (no
+        ``next_states`` supplied, so the Python reward model runs).
+    Then: Right-edge rows receive ``step_penalty + exit_reward``;
+        the terminal-sentinel row and the interior row receive
+        ``step_penalty`` only — matching the scalar / C++ behaviour.
 
     Test type: integration
     """
@@ -546,9 +548,85 @@ def test_reward_batch_exit_branch_treats_terminal_as_exited() -> None:
     )
     rewards = env.reward_batch(particles, 2)
     assert rewards[0] == pytest.approx(-1.0 + 10.0)
-    assert rewards[1] == pytest.approx(-1.0 + 10.0)
+    assert rewards[1] == pytest.approx(-1.0)
     assert rewards[2] == pytest.approx(-1.0)
     assert rewards[3] == pytest.approx(-1.0 + 10.0)
+
+
+def test_reward_batch_east_non_exit_includes_dangerous_area_penalty() -> None:
+    """East action from a non-rightmost column applies dangerous-area penalty.
+
+    Purpose: Regression for a Python-batch bug where the East branch
+        returned unconditionally after handling exits, dropping the
+        dangerous-area term for rows that move East into a danger cell
+        without exiting. Scalar ``compute_reward`` and the C++
+        ``reward_batch`` kernel both include the danger penalty here, so
+        the Python batch must agree.
+
+    Given: A 5x5 env with a deterministic dangerous area at (2, 1)
+        radius 1.0, penalty -100.0, step_penalty -1.0. A single
+        particle at (2, 0) moves East (action=2) into (2, 1), which is
+        the danger centre. The current column is 0, far from the
+        rightmost column, so this is a non-exiting East move.
+    When: ``reward(state, 2)`` (scalar) and ``reward_batch(states, 2)``
+        (Python batch, no ``next_states`` supplied) are evaluated.
+    Then: Both return ``step_penalty + dangerous_area_penalty`` = -101.0.
+
+    Test type: integration
+    """
+    env = RockSamplePOMDP(
+        map_size=(5, 5),
+        rock_positions=[(0, 0)],
+        init_pos=(0, 0),
+        dangerous_areas=[(2, 1)],
+        dangerous_area_radius=1.0,
+        dangerous_area_penalty=-100.0,
+        step_penalty=-1.0,
+        exit_reward=10.0,
+    )
+    state = create_rock_sample_state((2, 0), (True,))
+    scalar_reward = env.reward(state, 2)
+    batch_rewards = env.reward_batch(state.reshape(1, -1), 2)
+    assert scalar_reward == pytest.approx(-101.0)
+    assert batch_rewards[0] == pytest.approx(-101.0)
+    assert batch_rewards[0] == pytest.approx(scalar_reward)
+
+
+def test_reward_batch_east_on_terminal_sentinel_equals_step_penalty() -> None:
+    """East action on a terminal-sentinel row returns step_penalty only.
+
+    Purpose: Regression for a Python-batch bug where terminal-sentinel
+        rows (``(-1, -1, ...)``) were granted ``exit_reward`` under the
+        East action. Scalar ``compute_reward`` only awards the exit
+        bonus when ``robot_col == map_cols - 1``; the C++ batch kernel
+        does the same. A sentinel's col is -1, so neither path emits
+        the bonus.
+
+    Given: A 5x5 env (with a dangerous area positioned so the sentinel
+        is safely outside its radius) and a single terminal-sentinel
+        particle.
+    When: ``reward(state, 2)`` (scalar) and ``reward_batch(states, 2)``
+        (Python batch, no ``next_states``) are evaluated.
+    Then: Both return ``step_penalty`` (no exit bonus, no danger term).
+
+    Test type: integration
+    """
+    env = RockSamplePOMDP(
+        map_size=(5, 5),
+        rock_positions=[(0, 0)],
+        init_pos=(0, 0),
+        dangerous_areas=[(2, 2)],
+        dangerous_area_radius=1.0,
+        dangerous_area_penalty=-50.0,
+        step_penalty=-1.0,
+        exit_reward=10.0,
+    )
+    terminal = create_rock_sample_state((-1, -1), (True,))
+    scalar_reward = env.reward(terminal, 2)
+    batch_rewards = env.reward_batch(terminal.reshape(1, -1), 2)
+    assert scalar_reward == pytest.approx(-1.0)
+    assert batch_rewards[0] == pytest.approx(-1.0)
+    assert batch_rewards[0] == pytest.approx(scalar_reward)
 
 
 if __name__ == "__main__":

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_kernel_cache.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_kernel_cache.py
@@ -245,17 +245,21 @@ def _reward_batch_via_native_transition(
     """Reference implementation: re-creates the pre-refactor reward path
     that calls ``sample_next_state_batch`` to get post-step robot positions
     for the dangerous-area check.
+
+    Mirrors the scalar ``compute_reward`` / C++ ``reward_batch`` contract:
+    only true exits (``robot_col == map_cols - 1`` under action=2) get the
+    exit bonus — terminal-sentinel rows do not. Non-exiting East rows
+    continue into the dangerous-area branch.
     """
     n = states.shape[0]
     next_states = env.sample_next_state_batch(states, action)
     rewards = np.full(n, env.step_penalty, dtype=np.float64)
     map_cols = env.map_size[1]
 
+    exits_mask: np.ndarray | None = None
     if action == 2:
-        exits = states[:, 1].astype(int) == (map_cols - 1)
-        terminal = (states[:, 0] < 0) & (states[:, 1] < 0)
-        rewards[exits | terminal] += env.exit_reward
-        return rewards
+        exits_mask = states[:, 1].astype(int) == (map_cols - 1)
+        rewards[exits_mask] += env.exit_reward
 
     if action == 0:
         robot_rows = states[:, 0].astype(int)
@@ -276,6 +280,8 @@ def _reward_batch_via_native_transition(
         next_robot_rows = next_states[:, 0].astype(int)
         next_robot_cols = next_states[:, 1].astype(int)
         for j in range(n):
+            if exits_mask is not None and exits_mask[j]:
+                continue
             if env._is_in_dangerous_area((next_robot_rows[j], next_robot_cols[j])):
                 rewards[j] += env.dangerous_area_penalty
 


### PR DESCRIPTION
## Summary
- **pacman**: scalar and batch reward kernels missed the swap-arm of the ghost-collision rule (pacman and a ghost trade cells in one step). C++ transition + rollout (`_cpp/pacman.cpp:454-457`, `:1435-1438`) treat swap as a collision; Python only checked same-cell, so the `ghost_collision_penalty` was silently dropped (next step is terminal → penalty lost forever).
- **rock_sample (batch)**: `compute_reward_batch` had an unconditional `return rewards` on `action == 2`, so non-exiting East moves landing in a danger cell skipped the dangerous-area penalty present in scalar and C++ paths.
- **rock_sample (batch)**: same block awarded `exit_reward` to already-terminal sentinel rows `(-1, -1, ...)`. Scalar (`compute_reward`) and C++ (`_cpp/rock_sample.cpp:788-789`) only award on `robot_col == map_cols - 1`. The parity test pinning the buggy behaviour has been updated to assert the scalar/C++ contract.

This is the Python-side follow-up to `6b5e4c9c` (which aligned C++ kernels with Python variants); these bugs were on the Python side and were masked by reference implementations that encoded the same defect.

## Test plan
- [x] Regression test for pacman swap-arm collision (scalar + batch + scalar==batch).
- [x] Regression test for rock_sample non-exiting East into a danger cell (scalar == batch == -101).
- [x] Regression test for rock_sample East on terminal sentinel (scalar == batch == step_penalty).
- [x] Existing kernel-cache reference impl corrected (it encoded both rock_sample bugs).
- [x] Full pacman test suite passes (144/144).
- [x] Full rock_sample test suite passes (195/195).
- [x] Whole-tree pyright clean (1 pre-existing unrelated warning).
- [x] Pre-commit hooks (black/pylint/pyright) green.