### PR TITLE
fix(envs): three environment correctness bugs in sanity, tiger, light-dark

### DIFF
--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
@@ -206,6 +206,8 @@ class ContinuousLightDarkDecayingHitProbabilityRewardModel(BaseLightDarkRewardMo
         fuel_cost: float,
         penalty_decay: float,
     ):
+        if penalty_decay <= 0.0:
+            raise ValueError("penalty_decay must be strictly positive")
         self.goal_state = goal_state
         self.obstacles = obstacles
         self.goal_state_radius = goal_state_radius
@@ -215,7 +217,7 @@ class ContinuousLightDarkDecayingHitProbabilityRewardModel(BaseLightDarkRewardMo
         self.obstacle_reward = obstacle_reward
         self.goal_reward = goal_reward
         self.fuel_cost = fuel_cost
-        self.penalty_decay = penalty_decay
+        self.penalty_decay = float(penalty_decay)
 
     def _compute_reward(
         self, state: np.ndarray, action: np.ndarray, next_state: np.ndarray

--- a/POMDPPlanners/environments/sanity_pomdp.py
+++ b/POMDPPlanners/environments/sanity_pomdp.py
@@ -235,8 +235,7 @@ class SanityPOMDP(DiscreteActionsEnvironment):
     ) -> np.ndarray:
         next_states_arr = np.asarray(next_states)
         expected = 0 if action == 0 else 1
-        probs = np.where(next_states_arr == expected, 1.0, 0.0)
-        return np.log(probs + 1e-300)
+        return np.where(next_states_arr == expected, 0.0, -np.inf)
 
     def observation_log_probability(
         self,
@@ -245,8 +244,7 @@ class SanityPOMDP(DiscreteActionsEnvironment):
         observations: Union[Sequence[int], np.ndarray],
     ) -> np.ndarray:
         observations_arr = np.asarray(observations)
-        probs = np.where(observations_arr == next_state, 1.0, 0.0)
-        return np.log(probs + 1e-300)
+        return np.where(observations_arr == next_state, 0.0, -np.inf)
 
     def reward(self, state: int, action: int, next_state: Any = None) -> float:
         # Transition is deterministic: action 0 -> next_state 0 (reward 1.0),

--- a/POMDPPlanners/environments/tiger_pomdp.py
+++ b/POMDPPlanners/environments/tiger_pomdp.py
@@ -289,6 +289,8 @@ class TigerPOMDP(DiscreteActionsEnvironment):
         total_episodes = len(histories)
 
         for history in histories:
+            if not history.history:
+                continue
             # Check if the last action was opening a door
             last_step = history.history[-1]
             if last_step.action in ["open_left", "open_right"]:

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_models.py
@@ -530,6 +530,37 @@ class TestContinuousLightDarkDecayingHitProbabilityRewardModel:
             penalty_decay=self.penalty_decay,
         )
 
+    def test_invalid_penalty_decay_rejected(self):
+        """Regression: penalty_decay <= 0 must be rejected at construction.
+
+        Purpose: Validates that the decaying-hit-probability reward model rejects
+        non-positive ``penalty_decay`` at construction, matching the validation already
+        enforced by the pacman and rock_sample decaying-reward variants. Without this
+        guard a misconfigured planner would crash mid-rollout with a divide-by-zero
+        inside ``np.exp(-d / penalty_decay)``.
+
+        Given: The standard decaying-reward constructor kwargs
+        When: ``ContinuousLightDarkDecayingHitProbabilityRewardModel`` is instantiated
+            with ``penalty_decay`` equal to 0.0 or a negative value
+        Then: ``ValueError`` is raised at construction; no instance is produced
+
+        Test type: unit
+        """
+        for bad_decay in (0.0, -1.0):
+            with pytest.raises(ValueError):
+                ContinuousLightDarkDecayingHitProbabilityRewardModel(
+                    goal_state=self.goal_state,
+                    obstacles=self.obstacles,
+                    goal_state_radius=self.goal_state_radius,
+                    obstacle_radius=self.obstacle_radius,
+                    grid_size=self.grid_size,
+                    obstacle_hit_probability=self.obstacle_hit_probability,
+                    obstacle_reward=self.obstacle_reward,
+                    goal_reward=self.goal_reward,
+                    fuel_cost=self.fuel_cost,
+                    penalty_decay=bad_decay,
+                )
+
     def test_decaying_obstacle_probability(self):
         """Test that obstacle hit probability decreases with distance."""
         # Test positions at different distances from obstacles

--- a/POMDPPlanners/tests/test_environments/test_sanity_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_sanity_pomdp.py
@@ -361,7 +361,7 @@ class TestSanityStateTransition:
         log_probs = sanity_pomdp.transition_log_probability(state=0, action=0, next_states=values)
         probs = np.exp(log_probs)
         expected = np.array([1.0, 0.0, 1.0, 0.0])
-        np.testing.assert_allclose(probs, expected, atol=1e-200)
+        np.testing.assert_array_equal(probs, expected)
 
     def test_probability_action_1(self, sanity_pomdp):
         """Test probability calculation for action 1.
@@ -378,7 +378,7 @@ class TestSanityStateTransition:
         log_probs = sanity_pomdp.transition_log_probability(state=0, action=1, next_states=values)
         probs = np.exp(log_probs)
         expected = np.array([0.0, 1.0, 0.0, 1.0])
-        np.testing.assert_allclose(probs, expected, atol=1e-200)
+        np.testing.assert_array_equal(probs, expected)
 
 
 class TestSanityObservation:
@@ -456,7 +456,7 @@ class TestSanityObservation:
         )
         probs = np.exp(log_probs)
         expected = np.array([1.0, 0.0, 1.0, 0.0])
-        np.testing.assert_allclose(probs, expected, atol=1e-200)
+        np.testing.assert_array_equal(probs, expected)
 
     def test_probability_state_1(self, sanity_pomdp):
         """Test probability calculation for state 1.
@@ -475,7 +475,49 @@ class TestSanityObservation:
         )
         probs = np.exp(log_probs)
         expected = np.array([0.0, 1.0, 0.0, 1.0])
-        np.testing.assert_allclose(probs, expected, atol=1e-200)
+        np.testing.assert_array_equal(probs, expected)
+
+    def test_impossible_transition_log_prob_is_neg_inf(self, sanity_pomdp):
+        """Regression: impossible state transitions must return log-prob -inf, not finite tiny value.
+
+        Purpose: Validates that impossible transitions are flagged as -inf log-prob so particle-filter
+        importance weights are exactly zero (no ghost mass)
+
+        Given: SanityPOMDP with deterministic transitions (action 0 -> state 0, action 1 -> state 1)
+        When: transition_log_probability is queried with the impossible next_state for each action
+        Then: All impossible entries equal -np.inf (not log(epsilon))
+
+        Test type: unit
+        """
+        log_probs_a0 = sanity_pomdp.transition_log_probability(
+            state=0, action=0, next_states=[1, 1, 1]
+        )
+        log_probs_a1 = sanity_pomdp.transition_log_probability(
+            state=0, action=1, next_states=[0, 0, 0]
+        )
+        assert np.all(np.isneginf(log_probs_a0))
+        assert np.all(np.isneginf(log_probs_a1))
+
+    def test_impossible_observation_log_prob_is_neg_inf(self, sanity_pomdp):
+        """Regression: impossible observations must return log-prob -inf, not finite tiny value.
+
+        Purpose: Validates that observations of impossible outcomes are flagged as -inf log-prob so
+        belief updates assign exactly zero weight (no ghost mass)
+
+        Given: SanityPOMDP with deterministic observations (next_state == observation)
+        When: observation_log_probability is queried with the impossible observation for each state
+        Then: All impossible entries equal -np.inf (not log(epsilon))
+
+        Test type: unit
+        """
+        log_probs_s0 = sanity_pomdp.observation_log_probability(
+            next_state=0, action=0, observations=[1, 1, 1]
+        )
+        log_probs_s1 = sanity_pomdp.observation_log_probability(
+            next_state=1, action=0, observations=[0, 0, 0]
+        )
+        assert np.all(np.isneginf(log_probs_s0))
+        assert np.all(np.isneginf(log_probs_s1))
 
 
 class TestSanityInitialStateDist:

--- a/POMDPPlanners/tests/test_environments/test_tiger_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_tiger_pomdp.py
@@ -6,7 +6,7 @@ import pytest
 
 from POMDPPlanners.core.belief import Belief
 from POMDPPlanners.core.policy import PolicyRunData
-from POMDPPlanners.core.simulation import StepData
+from POMDPPlanners.core.simulation import History, StepData
 from POMDPPlanners.environments.tiger_pomdp import STATES, TigerPOMDP
 from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
     verify_metrics_within_confidence_intervals,
@@ -592,6 +592,38 @@ class TestTigerPOMDPMetrics:
 
         # Should have 0 listens
         listens_metric = next(m for m in metrics if m.name == "average_listens")
+        assert listens_metric.value == 0.0
+
+    def test_compute_metrics_history_with_zero_steps(self, tiger_pomdp: TigerPOMDP):
+        """Regression: compute_metrics must not IndexError when an episode has zero steps.
+
+        Purpose: Validates that TigerPOMDP compute_metrics tolerates History objects whose
+        ``history`` step-list is empty (e.g., episode terminated before any action was taken)
+
+        Given: A TigerPOMDP environment and a list containing one History with history=[]
+        When: compute_metrics is called
+        Then: The call returns metrics without raising IndexError; the zero-step episode is
+            treated as a non-success contributing 0 listens
+
+        Test type: unit
+        """
+        empty_history = History(
+            history=[],
+            discount_factor=0.95,
+            average_state_sampling_time=0.0,
+            average_action_time=0.0,
+            average_observation_time=0.0,
+            average_belief_update_time=0.0,
+            average_reward_time=0.0,
+            actual_num_steps=0,
+            reach_terminal_state=False,
+            policy_run_data=[],
+        )
+        metrics = tiger_pomdp.compute_metrics([empty_history])
+
+        success_metric = next(m for m in metrics if m.name == "success_rate")
+        listens_metric = next(m for m in metrics if m.name == "average_listens")
+        assert success_metric.value == 0.0
         assert listens_metric.value == 0.0
 
 


### PR DESCRIPTION
## Summary

Three independent correctness bugs surfaced by a multi-agent scan of `POMDPPlanners/environments/`. Each fix follows the TDD gate — failing regression test first, then source fix.

- **sanity_pomdp** (`sanity_pomdp.py:238,247`) — `transition_log_probability` and `observation_log_probability` returned `log(1e-300) ≈ -690.78` for impossible outcomes instead of `-inf`. This leaked ghost mass into particle-filter belief updates: an impossible observation got weight `exp(-690.78) ≈ 1e-300` instead of exactly zero. Existing parity tests used `atol=1e-200` to mask the gap; tolerances are tightened to exact equality.
- **tiger_pomdp** (`tiger_pomdp.py:293`) — `compute_metrics` crashed with `IndexError` on any `History` whose step list was empty (e.g. episode terminated before any action was taken). Guarded `history.history[-1]` with an empty-list skip.
- **light_dark decaying-hit-probability reward model** (`light_dark_reward_models.py:218`) — missing `penalty_decay > 0` validation made a misconfigured planner crash mid-rollout with a divide-by-zero inside `np.exp(-d / penalty_decay)`. Now matches the validation already enforced by the pacman and rock_sample decaying variants.

## Test plan

- [x] New regression tests added (each confirmed failing on pre-fix source before patch applied):
  - `test_impossible_transition_log_prob_is_neg_inf` / `test_impossible_observation_log_prob_is_neg_inf` (sanity)
  - `test_compute_metrics_history_with_zero_steps` (tiger)
  - `test_invalid_penalty_decay_rejected` (light_dark)
- [x] Affected suites pass: 112/112 in `test_sanity_pomdp.py` + `test_tiger_pomdp.py` + `test_light_dark_reward_models.py`
- [x] Pyright: 0 errors, 0 warnings on changed files
- [x] Pylint: 10.00/10 on changed source; test files unchanged-or-improved vs baseline
- [x] Pre-commit hooks (black, pylint, pyright) pass