### PR TITLE
refactor(envs): rename reward variants to hazard-centric names across 5 envs

### DIFF
--- a/POMDPPlanners/configs/environment_configs.py
+++ b/POMDPPlanners/configs/environment_configs.py
@@ -202,7 +202,7 @@ class EnvironmentConfigsAPI:
         GOAL_STATE_RADIUS = 1.5  # Radius around goal to consider as reached
         BEACON_RADIUS = 1.0  # Radius around beacons for observations
         OBSTACLE_RADIUS = 1.5  # Radius around obstacles for collision
-        REWARD_MODEL_TYPE = RewardModelType.STANDARD  # Standard reward model
+        REWARD_MODEL_TYPE = RewardModelType.CONSTANT_HAZARD_PENALTY  # Standard reward model
         PENALTY_DECAY = 1.0  # No decay in penalty
 
         pomdp = ContinuousLightDarkPOMDPDiscreteActions(
@@ -249,7 +249,7 @@ class EnvironmentConfigsAPI:
         GOAL_STATE_RADIUS = 1.5  # Radius around goal to consider as reached
         BEACON_RADIUS = 1.0  # Radius around beacons for observations
         OBSTACLE_RADIUS = 1.5  # Radius around obstacles for collision
-        REWARD_MODEL_TYPE = RewardModelType.STANDARD  # Standard reward model
+        REWARD_MODEL_TYPE = RewardModelType.CONSTANT_HAZARD_PENALTY  # Standard reward model
         PENALTY_DECAY = 1.0  # No decay in penalty
 
         pomdp = ContinuousLightDarkPOMDP(
@@ -372,7 +372,7 @@ class RiskAverseEnvironmentConfigsAPI:
         GOAL_STATE_RADIUS = 1.5  # Radius around goal to consider as reached
         BEACON_RADIUS = 1.0  # Radius around beacons for observations
         OBSTACLE_RADIUS = 1.2  # Radius around obstacles for collision
-        REWARD_MODEL_TYPE = RewardModelType.HIGH_VARIANCE_STATES  # Standard reward model
+        REWARD_MODEL_TYPE = RewardModelType.ZERO_MEAN_HAZARD_SHOCK  # Standard reward model
         PENALTY_DECAY = 1.0  # No decay in penalty
 
         pomdp = ContinuousLightDarkPOMDPDiscreteActions(
@@ -423,7 +423,7 @@ class RiskAverseEnvironmentConfigsAPI:
         GOAL_STATE_RADIUS = 1.5  # Radius around goal to consider as reached
         BEACON_RADIUS = 1.0  # Radius around beacons for observations
         OBSTACLE_RADIUS = 1.2  # Radius around obstacles for collision
-        REWARD_MODEL_TYPE = RewardModelType.HIGH_VARIANCE_STATES  # Standard reward model
+        REWARD_MODEL_TYPE = RewardModelType.ZERO_MEAN_HAZARD_SHOCK  # Standard reward model
         PENALTY_DECAY = 1.0  # No decay in penalty
 
         pomdp = ContinuousLightDarkPOMDP(

--- a/POMDPPlanners/environments/environment_utils/dangerous_areas_kernels.py
+++ b/POMDPPlanners/environments/environment_utils/dangerous_areas_kernels.py
@@ -14,7 +14,7 @@ Three reward-model variants are provided, each as a scalar / batch pair:
   case ``hit_probability=1.0``).
 - **high_variance**: ``±penalty`` with 50/50 split whenever the point
   lies inside any zone. Zero expected contribution, high variance.
-  Matches the light-dark HIGH_VARIANCE_STATES reward model.
+  Matches the light-dark ZERO_MEAN_HAZARD_SHOCK reward model.
 - **decaying_prob**: penalty applied with probability
   ``exp(-min_dist / penalty_decay)`` based on the *closest* zone centre
   (no radius cutoff). Matches the light-dark Decaying-Hit-Probability

--- a/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
@@ -856,19 +856,19 @@ py::array_t<double> reward_batch(
 // random-rollout kernel. Match
 // POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp.RewardModelType.
 //
-// STANDARD                 : deterministic single ``-penalty`` on wall OR
+// CONSTANT_HAZARD_PENALTY                 : deterministic single ``-penalty`` on wall OR
 //                            danger membership (matches
 //                            LaserTagRewardModel._compute_area_penalty_scalar
 //                            and the legacy kernel).
-// HIGH_VARIANCE_STATES     : wall always emits ``-penalty``; danger emits
+// ZERO_MEAN_HAZARD_SHOCK     : wall always emits ``-penalty``; danger emits
 //                            ``±penalty`` 50/50 via the shared C++ RNG.
-// DECAYING_HIT_PROBABILITY : wall always emits ``-penalty``; danger emits
+// DISTANCE_DECAYED_HAZARD_PENALTY : wall always emits ``-penalty``; danger emits
 //                            ``-penalty`` with probability
 //                            ``exp(-min_dist / penalty_decay)`` against the
 //                            nearest centre (no radius cutoff).
-constexpr int kVariantStandard = 0;
-constexpr int kVariantHighVariance = 1;
-constexpr int kVariantDecaying = 2;
+constexpr int kVariantConstantHazardPenalty = 0;
+constexpr int kVariantZeroMeanHazardShock = 1;
+constexpr int kVariantDistanceDecayedHazardPenalty = 2;
 
 // Build the packed wall hash set from the (2 * n_walls,) int64 buffer.
 std::unordered_set<int64_t> build_wall_cells(
@@ -932,7 +932,7 @@ inline bool danger_hit_within(double pr, double pc, double r_sq,
 
 // Compute the variant's danger-area contribution (already excludes the wall
 // contribution; wall handling is shared upstream). ``uniform`` is used by
-// stochastic variants only — pass any value for STANDARD.
+// stochastic variants only — pass any value for CONSTANT_HAZARD_PENALTY.
 inline double variant_danger_contribution(
     int variant_code, double pr, double pc, double r_sq, double penalty_decay,
     double dangerous_area_penalty,
@@ -940,13 +940,13 @@ inline double variant_danger_contribution(
     if (areas.empty()) {
         return 0.0;
     }
-    if (variant_code == kVariantHighVariance) {
+    if (variant_code == kVariantZeroMeanHazardShock) {
         if (!danger_hit_within(pr, pc, r_sq, areas)) {
             return 0.0;
         }
         return (uniform < 0.5) ? -dangerous_area_penalty : dangerous_area_penalty;
     }
-    if (variant_code == kVariantDecaying) {
+    if (variant_code == kVariantDistanceDecayedHazardPenalty) {
         double min_sq = std::numeric_limits<double>::infinity();
         for (const auto &area : areas) {
             const double ddr = pr - area.first;
@@ -963,8 +963,8 @@ inline double variant_danger_contribution(
         }
         return 0.0;
     }
-    // STANDARD: handled by the caller via the combined OR-mask path; this
-    // helper should not be invoked for STANDARD.
+    // CONSTANT_HAZARD_PENALTY: handled by the caller via the combined OR-mask path; this
+    // helper should not be invoked for CONSTANT_HAZARD_PENALTY.
     return 0.0;
 }
 
@@ -980,8 +980,8 @@ inline double variant_danger_contribution(
 //     post-action position read from ``next_states[:, :2]`` when
 //     ``next_states`` is provided (preferred path); when it is empty/null
 //     the intended cell is used (legacy ``compute_reward_batch_python``
-//     fallback). STANDARD applies a single -penalty on (wall OR danger);
-//     HIGH_VARIANCE_STATES and DECAYING_HIT_PROBABILITY apply the wall
+//     fallback). CONSTANT_HAZARD_PENALTY applies a single -penalty on (wall OR danger);
+//     ZERO_MEAN_HAZARD_SHOCK and DISTANCE_DECAYED_HAZARD_PENALTY apply the wall
 //     penalty deterministically and resolve the danger contribution via
 //     ``pomdp_native::default_rng``.
 //
@@ -991,8 +991,8 @@ inline double variant_danger_contribution(
 // next_states: shape (N, 5) float64 or empty (0, 0) / (0, 5) for "intended
 //   position" fallback. When non-empty its row count must equal ``states``'.
 // reward_variant_code: see kVariant* constants above.
-// penalty_decay: decay length for the DECAYING_HIT_PROBABILITY variant
-//   (must be strictly positive when ``reward_variant_code == kVariantDecaying``);
+// penalty_decay: decay length for the DISTANCE_DECAYED_HAZARD_PENALTY variant
+//   (must be strictly positive when ``reward_variant_code == kVariantDistanceDecayedHazardPenalty``);
 //   ignored otherwise.
 py::array_t<double> lasertag_discrete_reward_batch(
     const py::array_t<double, py::array::c_style | py::array::forcecast> &states,
@@ -1039,9 +1039,9 @@ py::array_t<double> lasertag_discrete_reward_batch(
                 "next_states must have shape (N, 5) matching states, or be empty");
         }
     }
-    if (reward_variant_code == kVariantDecaying && !(penalty_decay > 0.0)) {
+    if (reward_variant_code == kVariantDistanceDecayedHazardPenalty && !(penalty_decay > 0.0)) {
         throw std::invalid_argument(
-            "penalty_decay must be strictly positive for the DECAYING_HIT_PROBABILITY variant");
+            "penalty_decay must be strictly positive for the DISTANCE_DECAYED_HAZARD_PENALTY variant");
     }
 
     const std::unordered_set<int64_t> wall_cells =
@@ -1069,8 +1069,8 @@ py::array_t<double> lasertag_discrete_reward_batch(
     pomdp_native::RNGState &rng = pomdp_native::default_rng();
     std::uniform_real_distribution<double> uniform_dist(0.0, 1.0);
     const bool needs_uniform =
-        (reward_variant_code == kVariantHighVariance ||
-         reward_variant_code == kVariantDecaying) &&
+        (reward_variant_code == kVariantZeroMeanHazardShock ||
+         reward_variant_code == kVariantDistanceDecayedHazardPenalty) &&
         !areas.empty();
 
     for (std::size_t i = 0; i < n; ++i) {
@@ -1109,7 +1109,7 @@ py::array_t<double> lasertag_discrete_reward_batch(
 
         const bool is_wall = wall_hit(eval_r, eval_c, rows, cols, wall_cells);
 
-        if (reward_variant_code == kVariantStandard) {
+        if (reward_variant_code == kVariantConstantHazardPenalty) {
             // Single -penalty on (wall OR danger).
             bool penalty = is_wall;
             if (!penalty && !areas.empty()) {
@@ -1120,9 +1120,9 @@ py::array_t<double> lasertag_discrete_reward_batch(
                 r -= dangerous_area_penalty;
             }
         } else {
-            // HIGH_VARIANCE_STATES / DECAYING: wall and danger contributions
+            // ZERO_MEAN_HAZARD_SHOCK / DECAYING: wall and danger contributions
             // are independent. Wall hit always subtracts ``penalty`` exactly
-            // like the STANDARD variant.
+            // like the CONSTANT_HAZARD_PENALTY variant.
             if (is_wall) {
                 r -= dangerous_area_penalty;
             }
@@ -1370,8 +1370,8 @@ struct DiscreteEnvParams {
     double tag_penalty;
     double step_cost;
     double transition_error_prob;
-    // Reward-variant fields (default to STANDARD, penalty_decay=1.0).
-    int reward_variant_code = kVariantStandard;
+    // Reward-variant fields (default to CONSTANT_HAZARD_PENALTY, penalty_decay=1.0).
+    int reward_variant_code = kVariantConstantHazardPenalty;
     double penalty_decay = 1.0;
 };
 
@@ -1382,7 +1382,7 @@ DiscreteEnvParams make_discrete_env_params(
     double dangerous_area_radius, double dangerous_area_penalty,
     double tag_reward, double tag_penalty, double step_cost,
     double transition_error_prob,
-    int reward_variant_code = kVariantStandard,
+    int reward_variant_code = kVariantConstantHazardPenalty,
     double penalty_decay = 1.0) {
 
     DiscreteEnvParams p;
@@ -1503,7 +1503,7 @@ double disc_reward(const double *state, int action, const DiscreteEnvParams &env
         env.wall_grid[static_cast<std::size_t>(int_r * env.cols + int_c)];
     const bool is_danger = disc_is_dangerous(int_r, int_c, env);
 
-    if (env.reward_variant_code == kVariantStandard) {
+    if (env.reward_variant_code == kVariantConstantHazardPenalty) {
         if (is_wall || is_danger) {
             base -= env.dangerous_area_penalty;
         }
@@ -1520,14 +1520,14 @@ double disc_reward(const double *state, int action, const DiscreteEnvParams &env
     }
     std::uniform_real_distribution<double> uniform_dist(0.0, 1.0);
     const double u = uniform_dist(rng.engine());
-    if (env.reward_variant_code == kVariantHighVariance) {
+    if (env.reward_variant_code == kVariantZeroMeanHazardShock) {
         if (!is_danger) {
             return base;
         }
         return base + ((u < 0.5) ? -env.dangerous_area_penalty
                                  : env.dangerous_area_penalty);
     }
-    if (env.reward_variant_code == kVariantDecaying) {
+    if (env.reward_variant_code == kVariantDistanceDecayedHazardPenalty) {
         const double min_dist = disc_min_danger_distance(
             static_cast<double>(int_r), static_cast<double>(int_c), env);
         const double hit_prob = std::exp(-min_dist / env.penalty_decay);
@@ -1630,9 +1630,9 @@ double simulate_rollout_discrete(
     if (initial_state.ndim() != 1 || initial_state.shape(0) != 5) {
         throw std::invalid_argument("initial_state must have shape (5,)");
     }
-    if (reward_variant_code == kVariantDecaying && !(penalty_decay > 0.0)) {
+    if (reward_variant_code == kVariantDistanceDecayedHazardPenalty && !(penalty_decay > 0.0)) {
         throw std::invalid_argument(
-            "penalty_decay must be strictly positive for the DECAYING_HIT_PROBABILITY variant");
+            "penalty_decay must be strictly positive for the DISTANCE_DECAYED_HAZARD_PENALTY variant");
     }
 
     const DiscreteEnvParams env = make_discrete_env_params(
@@ -2501,11 +2501,11 @@ PYBIND11_MODULE(_native, m) {
           "Vectorised reward computation for the discrete LaserTagPOMDP. "
           "Returns shape (N,) float64. Mirrors "
           "LaserTagRewardModel.compute_reward_batch across the three "
-          "RewardModelType variants: STANDARD (0) applies a single "
+          "RewardModelType variants: CONSTANT_HAZARD_PENALTY (0) applies a single "
           "-dangerous_area_penalty on (wall OR danger) at the realised cell, "
-          "HIGH_VARIANCE_STATES (1) emits +/-dangerous_area_penalty on danger "
+          "ZERO_MEAN_HAZARD_SHOCK (1) emits +/-dangerous_area_penalty on danger "
           "(50/50) with deterministic wall penalty, and "
-          "DECAYING_HIT_PROBABILITY (2) emits -dangerous_area_penalty on "
+          "DISTANCE_DECAYED_HAZARD_PENALTY (2) emits -dangerous_area_penalty on "
           "danger with probability exp(-min_dist / penalty_decay) with "
           "deterministic wall penalty. When ``next_states`` is shape (N, 5), "
           "the penalty is scored against next_states[:, :2]; when it is empty "
@@ -2575,9 +2575,9 @@ PYBIND11_MODULE(_native, m) {
         "Actions are drawn uniformly from {0,1,2,3,4} using pomdp_native::default_rng().\n"
         "Seed via set_seed() before calling to obtain reproducible trajectories.\n"
         "``reward_variant_code`` selects the LaserTag reward-model variant:\n"
-        "  0 = STANDARD (deterministic wall/danger -penalty on OR);\n"
-        "  1 = HIGH_VARIANCE_STATES (wall always -penalty; danger +/-penalty 50/50);\n"
-        "  2 = DECAYING_HIT_PROBABILITY (wall always -penalty; danger -penalty\n"
+        "  0 = CONSTANT_HAZARD_PENALTY (deterministic wall/danger -penalty on OR);\n"
+        "  1 = ZERO_MEAN_HAZARD_SHOCK (wall always -penalty; danger +/-penalty 50/50);\n"
+        "  2 = DISTANCE_DECAYED_HAZARD_PENALTY (wall always -penalty; danger -penalty\n"
         "      with probability exp(-min_dist / penalty_decay), no radius cutoff).\n"
         "Returns the discounted sum of immediate rewards along the sampled trajectory.");
 

--- a/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
@@ -58,10 +58,10 @@ def lasertag_discrete_reward_batch(
     ``(dr, dc)`` cell delta. When ``next_states`` is shape ``(N, 5)``, the
     danger / wall penalty is scored against ``next_states[:, :2]``; when it
     is empty (the default) the legacy intended-position fallback is used.
-    ``reward_variant_code`` selects the variant: ``0`` = STANDARD,
-    ``1`` = HIGH_VARIANCE_STATES, ``2`` = DECAYING_HIT_PROBABILITY.
+    ``reward_variant_code`` selects the variant: ``0`` = CONSTANT_HAZARD_PENALTY,
+    ``1`` = ZERO_MEAN_HAZARD_SHOCK, ``2`` = DISTANCE_DECAYED_HAZARD_PENALTY.
     ``penalty_decay`` is the decay length used by the
-    ``DECAYING_HIT_PROBABILITY`` variant (ignored otherwise). Returns shape
+    ``DISTANCE_DECAYED_HAZARD_PENALTY`` variant (ignored otherwise). Returns shape
     ``(N,)`` float64.
     """
     ...
@@ -156,9 +156,9 @@ def simulate_rollout_discrete(
     Actions are drawn uniformly from ``{0,1,2,3,4}`` using the module-level
     mt19937_64 RNG. Seed via :func:`set_seed` before calling for reproducible
     results. ``reward_variant_code`` selects the reward variant:
-    ``0`` = STANDARD, ``1`` = HIGH_VARIANCE_STATES,
-    ``2`` = DECAYING_HIT_PROBABILITY. ``penalty_decay`` is consulted only by
-    the ``DECAYING_HIT_PROBABILITY`` variant. Returns the discounted sum of
+    ``0`` = CONSTANT_HAZARD_PENALTY, ``1`` = ZERO_MEAN_HAZARD_SHOCK,
+    ``2`` = DISTANCE_DECAYED_HAZARD_PENALTY. ``penalty_decay`` is consulted only by
+    the ``DISTANCE_DECAYED_HAZARD_PENALTY`` variant. Returns the discounted sum of
     immediate rewards along the sampled trajectory.
     """
     ...

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -40,8 +40,8 @@ from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_visualizer import (  #
 )
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models import (
     BaseLaserTagRewardModel,
-    LaserTagDecayingHitProbabilityRewardModel,
-    LaserTagHighVarianceStatesRewardModel,
+    LaserTagDistanceDecayedHazardPenaltyRewardModel,
+    LaserTagZeroMeanHazardShockRewardModel,
     LaserTagRewardModel,
 )
 
@@ -74,9 +74,9 @@ class LaserTagPOMDPMetrics(Enum):
 class RewardModelType(Enum):
     """Reward-model variants selectable on :class:`LaserTagPOMDP`."""
 
-    STANDARD = "standard"
-    HIGH_VARIANCE_STATES = "high_variance_states"
-    DECAYING_HIT_PROBABILITY = "decaying_hit_probability"
+    CONSTANT_HAZARD_PENALTY = "constant_hazard_penalty"
+    ZERO_MEAN_HAZARD_SHOCK = "zero_mean_hazard_shock"
+    DISTANCE_DECAYED_HAZARD_PENALTY = "distance_decayed_hazard_penalty"
 
 
 # State representation for LaserTag POMDP as numpy array
@@ -171,7 +171,7 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         use_queue_logger: bool = False,
         initial_state: Optional[np.ndarray] = None,
         transition_error_prob: float = 0.0,
-        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         penalty_decay: float = 1.0,
     ):
         """Initialize the LaserTag POMDP environment.
@@ -199,18 +199,18 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
                 With probability (1-p), the intended action is executed. With probability p, a random
                 action is selected uniformly from {0,1,2,3} excluding the intended action.
                 Defaults to 0.0 (deterministic transitions).
-            reward_model_type: Selects the reward variant. ``STANDARD`` (default)
+            reward_model_type: Selects the reward variant. ``CONSTANT_HAZARD_PENALTY`` (default)
                 deterministically subtracts ``dangerous_area_penalty`` on a wall
-                or dangerous-area hit. ``HIGH_VARIANCE_STATES`` keeps the wall
+                or dangerous-area hit. ``ZERO_MEAN_HAZARD_SHOCK`` keeps the wall
                 penalty deterministic but emits ``±dangerous_area_penalty``
                 (50/50) on a dangerous-area hit (expected 0, high variance).
-                ``DECAYING_HIT_PROBABILITY`` keeps the wall penalty
+                ``DISTANCE_DECAYED_HAZARD_PENALTY`` keeps the wall penalty
                 deterministic and applies ``-dangerous_area_penalty`` with
                 probability ``exp(-min_dist / penalty_decay)`` against the
                 nearest dangerous-area centre (no radius cutoff). Mirrors the
                 light-dark reward-model variants.
             penalty_decay: Decay length used by the
-                ``DECAYING_HIT_PROBABILITY`` reward model. Ignored by the other
+                ``DISTANCE_DECAYED_HAZARD_PENALTY`` reward model. Ignored by the other
                 variants. Must be strictly positive. Defaults to ``1.0``.
 
         Raises:
@@ -280,7 +280,7 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
     def _build_reward_model(
         self, reward_model_type: RewardModelType, penalty_decay: float
     ) -> BaseLaserTagRewardModel:
-        if reward_model_type == RewardModelType.STANDARD:
+        if reward_model_type == RewardModelType.CONSTANT_HAZARD_PENALTY:
             return LaserTagRewardModel(
                 floor_shape=self.floor_shape,
                 walls=self.walls,
@@ -292,8 +292,8 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
                 step_cost=self.step_cost,
                 action_directions=self._action_directions,
             )
-        if reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
-            return LaserTagHighVarianceStatesRewardModel(
+        if reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
+            return LaserTagZeroMeanHazardShockRewardModel(
                 floor_shape=self.floor_shape,
                 walls=self.walls,
                 dangerous_areas=self.dangerous_areas,
@@ -304,8 +304,8 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
                 step_cost=self.step_cost,
                 action_directions=self._action_directions,
             )
-        if reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
-            return LaserTagDecayingHitProbabilityRewardModel(
+        if reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY:
+            return LaserTagDistanceDecayedHazardPenaltyRewardModel(
                 floor_shape=self.floor_shape,
                 walls=self.walls,
                 dangerous_areas=self.dangerous_areas,
@@ -895,14 +895,14 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
     def _native_reward_variant_code(self) -> int:
         """Map ``self.reward_model_type`` to the native kernel's variant code.
 
-        Matches the integer code emitted by the C++ kernel (``0`` = STANDARD,
-        ``1`` = HIGH_VARIANCE_STATES, ``2`` = DECAYING_HIT_PROBABILITY).
+        Matches the integer code emitted by the C++ kernel (``0`` = CONSTANT_HAZARD_PENALTY,
+        ``1`` = ZERO_MEAN_HAZARD_SHOCK, ``2`` = DISTANCE_DECAYED_HAZARD_PENALTY).
         """
-        if self.reward_model_type == RewardModelType.STANDARD:
+        if self.reward_model_type == RewardModelType.CONSTANT_HAZARD_PENALTY:
             return 0
-        if self.reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+        if self.reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
             return 1
-        if self.reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+        if self.reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY:
             return 2
         raise ValueError(f"Unknown reward model type: {self.reward_model_type}")
 

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp_utils/laser_tag_reward_models.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp_utils/laser_tag_reward_models.py
@@ -255,17 +255,17 @@ class LaserTagRewardModel(BaseLaserTagRewardModel):
 
     def _can_use_native_reward_batch(self) -> bool:
         # The variant-aware native kernel handles all three reward-model
-        # variants (STANDARD, HIGH_VARIANCE_STATES, DECAYING_HIT_PROBABILITY)
+        # variants (CONSTANT_HAZARD_PENALTY, ZERO_MEAN_HAZARD_SHOCK, DISTANCE_DECAYED_HAZARD_PENALTY)
         # and both the intended-position fallback and the realised-position
         # path, so it is always preferred when available.
         return True
 
     def _reward_variant_code(self) -> int:
-        # Base class is the STANDARD variant. Subclasses override.
+        # Base class is the CONSTANT_HAZARD_PENALTY variant. Subclasses override.
         return 0
 
     def _penalty_decay_for_native(self) -> float:
-        # STANDARD / HIGH_VARIANCE_STATES ignore penalty_decay; pass a sentinel
+        # CONSTANT_HAZARD_PENALTY / ZERO_MEAN_HAZARD_SHOCK ignore penalty_decay; pass a sentinel
         # positive value so the C++ kernel's "must be > 0 for DECAYING" guard
         # does not need to special-case the unused-parameter path.
         return 1.0
@@ -387,13 +387,13 @@ class LaserTagRewardModel(BaseLaserTagRewardModel):
         return grid
 
 
-class LaserTagHighVarianceStatesRewardModel(LaserTagRewardModel):
+class LaserTagZeroMeanHazardShockRewardModel(LaserTagRewardModel):
     """Dangerous-area penalty has zero mean and high variance.
 
     Wall hits remain deterministically penalised by ``-dangerous_area_penalty``.
     Dangerous-area hits emit ``+dangerous_area_penalty`` or
     ``-dangerous_area_penalty`` with equal probability, mirroring
-    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLDHighVarianceStatesRewardModel`.
+    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLDZeroMeanHazardShockRewardModel`.
     Walls and danger zones are scored independently — a position that
     is both a wall and inside a danger zone receives both contributions.
     """
@@ -432,7 +432,7 @@ class LaserTagHighVarianceStatesRewardModel(LaserTagRewardModel):
             rewards[danger_mask] += self.dangerous_area_penalty * signs
 
 
-class LaserTagDecayingHitProbabilityRewardModel(LaserTagRewardModel):
+class LaserTagDistanceDecayedHazardPenaltyRewardModel(LaserTagRewardModel):
     """Dangerous-area penalty fires with distance-decaying probability.
 
     Wall hits remain deterministically penalised by ``-dangerous_area_penalty``.
@@ -441,7 +441,7 @@ class LaserTagDecayingHitProbabilityRewardModel(LaserTagRewardModel):
     the Euclidean distance from the realised position to the nearest
     dangerous-area centre. No radius cutoff is applied, so even faraway
     positions feel a (vanishingly small) penalty risk. Mirrors
-    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLightDarkDecayingHitProbabilityRewardModel`.
+    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel`.
     """
 
     def __init__(

--- a/POMDPPlanners/environments/light_dark_pomdp/_cpp/continuous_light_dark.cpp
+++ b/POMDPPlanners/environments/light_dark_pomdp/_cpp/continuous_light_dark.cpp
@@ -207,8 +207,8 @@ static double reward_row_decaying(double nx, double ny, double goal_x, double go
 // Walk a single random rollout from initial_state. At each depth:
 //   1. check terminal — break if true
 //   2. pick action_array[action_indices[depth]]
-//   3. compute reward via variant-aware helper (STANDARD / HIGH_VARIANCE /
-//      DECAYING_HIT_PROBABILITY); stochastic obstacle / penalty draws use
+//   3. compute reward via variant-aware helper (CONSTANT_HAZARD_PENALTY / HIGH_VARIANCE /
+//      DISTANCE_DECAYED_HAZARD_PENALTY); stochastic obstacle / penalty draws use
 //      the module-level C++ RNG
 //   4. step transition (same additive-Gaussian kernel as the transition class)
 //   5. accumulate gamma^depth * reward
@@ -217,8 +217,8 @@ static double reward_row_decaying(double nx, double ny, double goal_x, double go
 // action_indices: shape (max_depth,)  — pre-drawn integer action indices
 // obstacles: interleaved [x0, y0, x1, y1, ...]  (flat 1-D array)
 // covariance: shape (2, 2)  — state transition covariance
-// reward_variant_code: 0 = STANDARD, 1 = HIGH_VARIANCE_STATES,
-//                      2 = DECAYING_HIT_PROBABILITY
+// reward_variant_code: 0 = CONSTANT_HAZARD_PENALTY, 1 = ZERO_MEAN_HAZARD_SHOCK,
+//                      2 = DISTANCE_DECAYED_HAZARD_PENALTY
 // penalty_decay: only consumed when reward_variant_code == 2
 // ---------------------------------------------------------------------------
 double simulate_rollout(
@@ -361,7 +361,7 @@ double simulate_rollout(
 //                  rewards are computed against the realised ``next_states``).
 //   next_states:   (N, 2) float64 — realised next-state positions.
 //   reward_variant_code:
-//                  0 = STANDARD, 1 = HIGH_VARIANCE_STATES, 2 = DECAYING_HIT_PROBABILITY.
+//                  0 = CONSTANT_HAZARD_PENALTY, 1 = ZERO_MEAN_HAZARD_SHOCK, 2 = DISTANCE_DECAYED_HAZARD_PENALTY.
 //   penalty_decay: double — only consumed when variant == 2.
 //   goal_state:    (2,)  float64.
 //   obstacles:     flat 1-D float64 [x0, y0, x1, y1, ...].
@@ -1115,8 +1115,8 @@ PYBIND11_MODULE(_native, m) {
           "Returns discounted return from initial_state. "
           "action_indices must be a pre-drawn array of int indices (shape (max_depth-start_depth,)). "
           "obstacles must be a flat 1-D array [x0, y0, x1, y1, ...]. "
-          "reward_variant_code: 0 = STANDARD, 1 = HIGH_VARIANCE_STATES, "
-          "2 = DECAYING_HIT_PROBABILITY. penalty_decay is only consumed when "
+          "reward_variant_code: 0 = CONSTANT_HAZARD_PENALTY, 1 = ZERO_MEAN_HAZARD_SHOCK, "
+          "2 = DISTANCE_DECAYED_HAZARD_PENALTY. penalty_decay is only consumed when "
           "reward_variant_code == 2.");
 
     m.def("compute_reward_batch", &compute_reward_batch,
@@ -1128,7 +1128,7 @@ PYBIND11_MODULE(_native, m) {
           py::arg("goal_reward"), py::arg("obstacle_reward"),
           py::arg("obstacle_hit_probability"),
           "Variant-aware batched reward kernel. reward_variant_code: "
-          "0 = STANDARD, 1 = HIGH_VARIANCE_STATES, 2 = DECAYING_HIT_PROBABILITY. "
+          "0 = CONSTANT_HAZARD_PENALTY, 1 = ZERO_MEAN_HAZARD_SHOCK, 2 = DISTANCE_DECAYED_HAZARD_PENALTY. "
           "Stochastic obstacle / penalty draws use the module-level C++ RNG; "
           "expectation matches the Python reward models row-for-row.");
 

--- a/POMDPPlanners/environments/light_dark_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/light_dark_pomdp/_native.pyi
@@ -45,8 +45,8 @@ def simulate_rollout(
     """Native random rollout for all reward model variants.
 
     Returns the discounted return from ``initial_state`` using the reward
-    model selected by ``reward_variant_code`` (``0 = STANDARD``,
-    ``1 = HIGH_VARIANCE_STATES``, ``2 = DECAYING_HIT_PROBABILITY``).
+    model selected by ``reward_variant_code`` (``0 = CONSTANT_HAZARD_PENALTY``,
+    ``1 = ZERO_MEAN_HAZARD_SHOCK``, ``2 = DISTANCE_DECAYED_HAZARD_PENALTY``).
     ``penalty_decay`` is only consumed when ``reward_variant_code == 2``.
     Stochastic obstacle / penalty draws use the module-level C++ RNG; the
     rollout matches the Python reward models in expectation rather than
@@ -78,7 +78,7 @@ def compute_reward_batch(
     """Variant-aware batched reward kernel for the Continuous Light-Dark POMDP.
 
     ``reward_variant_code`` selects the reward model:
-    ``0 = STANDARD``, ``1 = HIGH_VARIANCE_STATES``, ``2 = DECAYING_HIT_PROBABILITY``.
+    ``0 = CONSTANT_HAZARD_PENALTY``, ``1 = ZERO_MEAN_HAZARD_SHOCK``, ``2 = DISTANCE_DECAYED_HAZARD_PENALTY``.
     ``penalty_decay`` is only consumed when ``reward_variant_code == 2``.
     Stochastic obstacle / penalty draws are taken from the module-level C++
     RNG; the kernel matches the Python reward models in expectation

--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
@@ -51,8 +51,8 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.numba_ke
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models import (
     BaseLightDarkRewardModel,
-    ContinuousLDHighVarianceStatesRewardModel,
-    ContinuousLightDarkDecayingHitProbabilityRewardModel,
+    ContinuousLDZeroMeanHazardShockRewardModel,
+    ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel,
     ContinuousLightDarkRewardModel,
 )
 from POMDPPlanners.utils.numba_kernels import (
@@ -75,18 +75,18 @@ class ContinuousLightDarkPOMDPMetrics(Enum):
 
 
 class RewardModelType(Enum):
-    STANDARD = "standard"
-    DECAYING_HIT_PROBABILITY = "decaying_hit_probability"
-    HIGH_VARIANCE_STATES = "high_variance_states"
+    CONSTANT_HAZARD_PENALTY = "constant_hazard_penalty"
+    DISTANCE_DECAYED_HAZARD_PENALTY = "distance_decayed_hazard_penalty"
+    ZERO_MEAN_HAZARD_SHOCK = "zero_mean_hazard_shock"
 
 
 # Integer dispatch codes consumed by the native ``_native.compute_reward_batch``
 # kernel. Must stay in sync with the C++ ``reward_variant_code`` switch in
 # ``_cpp/continuous_light_dark.cpp``.
 _REWARD_VARIANT_CODE_BY_TYPE: Dict[RewardModelType, int] = {
-    RewardModelType.STANDARD: 0,
-    RewardModelType.HIGH_VARIANCE_STATES: 1,
-    RewardModelType.DECAYING_HIT_PROBABILITY: 2,
+    RewardModelType.CONSTANT_HAZARD_PENALTY: 0,
+    RewardModelType.ZERO_MEAN_HAZARD_SHOCK: 1,
+    RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY: 2,
 }
 
 
@@ -163,7 +163,7 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
         goal_state_radius: float = 1.5,
         beacon_radius: float = 1.0,
         obstacle_radius: float = 1.5,
-        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         observation_model_type: ObservationModelType = ObservationModelType.NORMAL_NOISE,
         penalty_decay: float = 1.0,
         is_obstacle_hit_terminal: bool = True,
@@ -175,18 +175,18 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
         # Maximum distance to goal is diagonal of grid: sqrt(2) * grid_size
         max_distance_to_goal = np.sqrt(2) * grid_size
 
-        if reward_model_type == RewardModelType.STANDARD:
+        if reward_model_type == RewardModelType.CONSTANT_HAZARD_PENALTY:
             # Min: -fuel_cost - max_distance + obstacle_reward (always negative)
             # Max: -fuel_cost - 0 + goal_reward (at goal)
             min_reward = -fuel_cost - max_distance_to_goal + obstacle_reward
             max_reward = -fuel_cost + goal_reward
-        elif reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+        elif reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY:
             # Similar to standard but with distance-based penalties
             # Min: -fuel_cost - max_distance + obstacle_reward (max penalty)
             # Max: -fuel_cost - 0 + goal_reward (at goal, no penalty)
             min_reward = -fuel_cost - max_distance_to_goal + obstacle_reward
             max_reward = -fuel_cost + goal_reward
-        elif reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+        elif reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
             # Min: -fuel_cost - max_distance + obstacle_reward (negative)
             # Max: -fuel_cost - 0 + goal_reward OR -fuel_cost - distance - obstacle_reward (if obstacle_reward is negative)
             min_reward = -fuel_cost - max_distance_to_goal + obstacle_reward
@@ -276,7 +276,7 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
         self._goal_state_f64: np.ndarray = np.ascontiguousarray(self.goal_state, dtype=np.float64)
         # Initialize reward model based on type
         self.reward_model: BaseLightDarkRewardModel
-        if reward_model_type == RewardModelType.STANDARD:
+        if reward_model_type == RewardModelType.CONSTANT_HAZARD_PENALTY:
             self.reward_model = ContinuousLightDarkRewardModel(
                 goal_state=self.goal_state,
                 obstacles=self.obstacles,
@@ -288,8 +288,8 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
                 goal_reward=self.goal_reward,
                 fuel_cost=self.fuel_cost,
             )
-        elif reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
-            self.reward_model = ContinuousLightDarkDecayingHitProbabilityRewardModel(
+        elif reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY:
+            self.reward_model = ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel(
                 goal_state=self.goal_state,
                 obstacles=self.obstacles,
                 goal_state_radius=self.goal_state_radius,
@@ -301,8 +301,8 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
                 fuel_cost=self.fuel_cost,
                 penalty_decay=self.penalty_decay,
             )
-        elif reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
-            self.reward_model = ContinuousLDHighVarianceStatesRewardModel(
+        elif reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
+            self.reward_model = ContinuousLDZeroMeanHazardShockRewardModel(
                 goal_state=self.goal_state,
                 obstacles=self.obstacles,
                 goal_state_radius=self.goal_state_radius,
@@ -884,7 +884,7 @@ class ContinuousLightDarkPOMDPDiscreteActions(ContinuousLightDarkPOMDP, Discrete
         goal_state: np.ndarray = np.array([10, 5]),
         start_state: np.ndarray = np.array([0, 5]),
         obstacles: List[Tuple[float, float]] = [(3, 7), (5, 5)],
-        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         observation_model_type: ObservationModelType = ObservationModelType.NORMAL_NOISE,
         penalty_decay: float = 1.0,
         is_obstacle_hit_terminal: bool = True,

--- a/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
@@ -25,7 +25,7 @@ class DiscreteLightDarkPOMDPMetrics(Enum):
     OBSTACLE_HIT_RATE = "obstacle_hit_rate"
     AVG_OBSTACLE_HIT_COUNTER = "avg_obstacle_hit_counter"
     OUT_OF_GRID_RATE = "out_of_grid_rate"
-    AVG_HIGH_VARIANCE_STATES_COUNTER = "avg_high_variance_states_counter"
+    AVG_ZERO_MEAN_HAZARD_SHOCK_COUNTER = "avg_high_variance_states_counter"
 
 
 class ObservationModelType(Enum):
@@ -909,7 +909,7 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
                 upper_confidence_bound=out_of_grid_ci[1],
             ),
             MetricValue(
-                name=DiscreteLightDarkPOMDPMetrics.AVG_HIGH_VARIANCE_STATES_COUNTER.value,
+                name=DiscreteLightDarkPOMDPMetrics.AVG_ZERO_MEAN_HAZARD_SHOCK_COUNTER.value,
                 value=avg_high_variance_states_counter,
                 lower_confidence_bound=high_variance_states_counter_ci[0],
                 upper_confidence_bound=high_variance_states_counter_ci[1],

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/light_dark_reward_models.py
@@ -178,7 +178,7 @@ class ContinuousLightDarkRewardModel(BaseLightDarkRewardModel):
         return np.where(hits, self.obstacle_reward, 0.0)
 
 
-class ContinuousLDHighVarianceStatesRewardModel(ContinuousLightDarkRewardModel):
+class ContinuousLDZeroMeanHazardShockRewardModel(ContinuousLightDarkRewardModel):
     def _obstacle_reward_scalar(self) -> float:
         """The expected reward is 0.0, but the variance is high."""
         return self.obstacle_reward if np.random.rand() < 0.5 else -self.obstacle_reward
@@ -192,7 +192,7 @@ class ContinuousLDHighVarianceStatesRewardModel(ContinuousLightDarkRewardModel):
         return self.obstacle_reward * signs
 
 
-class ContinuousLightDarkDecayingHitProbabilityRewardModel(BaseLightDarkRewardModel):
+class ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel(BaseLightDarkRewardModel):
     def __init__(
         self,
         goal_state: np.ndarray,

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/numba_kernels.py
@@ -14,7 +14,7 @@ Public kernels
 --------------
 - :func:`is_terminal_kernel` — replaces ``ContinuousLightDarkPOMDP.is_terminal``.
 - :func:`compute_reward_base_kernel` — deterministic part of the Standard /
-  HighVarianceStates reward model plus an ``is_obstacle_hit_region`` flag so the
+  ZeroMeanHazardShock reward model plus an ``is_obstacle_hit_region`` flag so the
   Python caller can decide whether to draw a uniform.
 - :func:`compute_reward_base_batch_kernel` — batched version of
   :func:`compute_reward_base_kernel`. Returns ``(rewards, obstacle_mask)`` so
@@ -81,7 +81,7 @@ def compute_reward_base_kernel(
     out-of-grid penalty. The caller (Python) must add the stochastic
     obstacle-hit contribution when ``is_obstacle_hit_region`` is ``True``,
     using its own ``np.random.rand()`` draw so seeded tests stay bit-identical.
-    Used by Standard and HighVarianceStates reward models.
+    Used by Standard and ZeroMeanHazardShock reward models.
 
     ``next_state`` is the realised post-transition position. The Python
     caller threads either the draw from

--- a/POMDPPlanners/environments/pacman_pomdp/_cpp/pacman.cpp
+++ b/POMDPPlanners/environments/pacman_pomdp/_cpp/pacman.cpp
@@ -1200,10 +1200,10 @@ class PacManObservationCpp {
 // reward_batch kernel. The danger contribution is computed against the
 // realised next pacman position. Three variants are supported:
 //
-//   reward_variant_code = 0  STANDARD               deterministic ``-penalty``
+//   reward_variant_code = 0  CONSTANT_HAZARD_PENALTY               deterministic ``-penalty``
 //                                                   when inside any zone
 //                                                   (radius cutoff).
-//   reward_variant_code = 1  HIGH_VARIANCE_STATES   ``+/- penalty`` 50/50
+//   reward_variant_code = 1  ZERO_MEAN_HAZARD_SHOCK   ``+/- penalty`` 50/50
 //                                                   when inside any zone.
 //   reward_variant_code = 2  DECAYING_HIT_PROB      ``-penalty`` with
 //                                                   probability
@@ -1225,7 +1225,7 @@ inline double dangerous_area_contribution(int variant_code, int new_pac_row, int
     }
     std::uniform_real_distribution<double> unif(0.0, 1.0);
     if (variant_code == 2) {
-        // DECAYING_HIT_PROBABILITY — no radius cutoff; use closest centre.
+        // DISTANCE_DECAYED_HAZARD_PENALTY — no radius cutoff; use closest centre.
         double min_sq = std::numeric_limits<double>::infinity();
         for (int d = 0; d < n_dangerous; ++d) {
             const double dr = static_cast<double>(new_pac_row) - dangerous_areas[d * 2];
@@ -1242,7 +1242,7 @@ inline double dangerous_area_contribution(int variant_code, int new_pac_row, int
         }
         return 0.0;
     }
-    // STANDARD / HIGH_VARIANCE_STATES both use the radius cutoff.
+    // CONSTANT_HAZARD_PENALTY / ZERO_MEAN_HAZARD_SHOCK both use the radius cutoff.
     const double radius_sq = dangerous_area_radius * dangerous_area_radius;
     bool in_zone = false;
     for (int d = 0; d < n_dangerous; ++d) {
@@ -1257,10 +1257,10 @@ inline double dangerous_area_contribution(int variant_code, int new_pac_row, int
         return 0.0;
     }
     if (variant_code == 1) {
-        // HIGH_VARIANCE_STATES: ±penalty 50/50.
+        // ZERO_MEAN_HAZARD_SHOCK: ±penalty 50/50.
         return (unif(rng) < 0.5) ? dangerous_area_penalty : -dangerous_area_penalty;
     }
-    // STANDARD (or unknown — fall back to deterministic).
+    // CONSTANT_HAZARD_PENALTY (or unknown — fall back to deterministic).
     return -dangerous_area_penalty;
 }
 
@@ -1651,8 +1651,8 @@ PYBIND11_MODULE(_native, m) {
 
     // reward_batch: standalone variant-aware reward kernel. Computes per-row
     // rewards for a batch of (state, action, next_state) triples under a
-    // chosen reward-model variant (STANDARD / HIGH_VARIANCE_STATES /
-    // DECAYING_HIT_PROBABILITY). Mirrors the Python reward_model.compute_reward_batch
+    // chosen reward-model variant (CONSTANT_HAZARD_PENALTY / ZERO_MEAN_HAZARD_SHOCK /
+    // DISTANCE_DECAYED_HAZARD_PENALTY). Mirrors the Python reward_model.compute_reward_batch
     // semantics — sample-mean parity (not bit-exact) is the design target.
     m.def(
         "reward_batch",

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -35,8 +35,8 @@ from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.environments.pacman_pomdp import _native  # pylint: disable=no-name-in-module
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.pacman_reward_models import (
     BasePacManRewardModel,
-    PacManDecayingHitProbabilityRewardModel,
-    PacManHighVarianceStatesRewardModel,
+    PacManDistanceDecayedHazardPenaltyRewardModel,
+    PacManZeroMeanHazardShockRewardModel,
     PacManRewardModel,
 )
 from POMDPPlanners.utils.statistics_utils import confidence_interval
@@ -58,17 +58,17 @@ class PacManPOMDPMetrics(Enum):
 class RewardModelType(Enum):
     """Reward-model variants selectable on :class:`PacManPOMDP`."""
 
-    STANDARD = "standard"
-    HIGH_VARIANCE_STATES = "high_variance_states"
-    DECAYING_HIT_PROBABILITY = "decaying_hit_probability"
+    CONSTANT_HAZARD_PENALTY = "constant_hazard_penalty"
+    ZERO_MEAN_HAZARD_SHOCK = "zero_mean_hazard_shock"
+    DISTANCE_DECAYED_HAZARD_PENALTY = "distance_decayed_hazard_penalty"
 
 
 # Numeric variant codes consumed by the C++ ``reward_batch`` / ``simulate_rollout``
 # kernels. Kept in lock-step with the C++ ``dangerous_area_contribution`` switch.
 _REWARD_VARIANT_CODES: Dict[RewardModelType, int] = {
-    RewardModelType.STANDARD: 0,
-    RewardModelType.HIGH_VARIANCE_STATES: 1,
-    RewardModelType.DECAYING_HIT_PROBABILITY: 2,
+    RewardModelType.CONSTANT_HAZARD_PENALTY: 0,
+    RewardModelType.ZERO_MEAN_HAZARD_SHOCK: 1,
+    RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY: 2,
 }
 
 
@@ -157,7 +157,7 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         name: str = "PacManPOMDP",
         output_dir: Optional[Path] = None,
         debug: bool = False,
-        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         penalty_decay: float = 1.0,
     ):
         """Initialize PacMan POMDP.
@@ -189,17 +189,17 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             name: Environment name. Defaults to "PacManPOMDP".
             output_dir: Output directory for logging. Defaults to None.
             debug: Enable debug logging. Defaults to False.
-            reward_model_type: Selects the reward variant. ``STANDARD`` (default)
+            reward_model_type: Selects the reward variant. ``CONSTANT_HAZARD_PENALTY`` (default)
                 deterministically subtracts ``dangerous_area_penalty`` whenever
                 PacMan's realised next position lies inside a hazard zone.
-                ``HIGH_VARIANCE_STATES`` emits ``±dangerous_area_penalty``
+                ``ZERO_MEAN_HAZARD_SHOCK`` emits ``±dangerous_area_penalty``
                 (50/50) on a zone hit (expected 0, high variance).
-                ``DECAYING_HIT_PROBABILITY`` applies ``-dangerous_area_penalty``
+                ``DISTANCE_DECAYED_HAZARD_PENALTY`` applies ``-dangerous_area_penalty``
                 with probability ``exp(-min_dist / penalty_decay)`` against
                 the nearest zone centre (no radius cutoff). Mirrors the
                 light-dark / laser-tag / rock-sample reward-model variants.
             penalty_decay: Decay length used by the
-                ``DECAYING_HIT_PROBABILITY`` reward model. Ignored by the other
+                ``DISTANCE_DECAYED_HAZARD_PENALTY`` reward model. Ignored by the other
                 variants. Must be strictly positive. Defaults to ``1.0``.
         """
         # Calculate reward range based on parameters. The dangerous-area
@@ -364,12 +364,12 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             "idx_terminal": self._idx_terminal,
             "neighbor_table_getter": self._get_neighbor_table,
         }
-        if reward_model_type == RewardModelType.STANDARD:
+        if reward_model_type == RewardModelType.CONSTANT_HAZARD_PENALTY:
             return PacManRewardModel(**common_kwargs)
-        if reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
-            return PacManHighVarianceStatesRewardModel(**common_kwargs)
-        if reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
-            return PacManDecayingHitProbabilityRewardModel(
+        if reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
+            return PacManZeroMeanHazardShockRewardModel(**common_kwargs)
+        if reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY:
+            return PacManDistanceDecayedHazardPenaltyRewardModel(
                 **common_kwargs, penalty_decay=penalty_decay
             )
         raise ValueError(f"Unknown reward model type: {reward_model_type}")

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/pacman_reward_models.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp_utils/pacman_reward_models.py
@@ -11,15 +11,15 @@ area scoring (step / collision / pellet / win) via the
 ``PacManRewardModel`` base; each variant only customises the dangerous-
 area contribution:
 
-* :class:`PacManRewardModel` (STANDARD): deterministic
+* :class:`PacManRewardModel` (CONSTANT_HAZARD_PENALTY): deterministic
   ``-dangerous_area_penalty`` whenever the realised next pacman position
   lies inside any configured circular hazard zone (squared-distance
   check against ``dangerous_area_radius``).
-* :class:`PacManHighVarianceStatesRewardModel` (HIGH_VARIANCE_STATES):
+* :class:`PacManZeroMeanHazardShockRewardModel` (ZERO_MEAN_HAZARD_SHOCK):
   ``±dangerous_area_penalty`` 50/50 in-zone — zero expected
   contribution, high variance.
-* :class:`PacManDecayingHitProbabilityRewardModel`
-  (DECAYING_HIT_PROBABILITY): ``-dangerous_area_penalty`` is applied
+* :class:`PacManDistanceDecayedHazardPenaltyRewardModel`
+  (DISTANCE_DECAYED_HAZARD_PENALTY): ``-dangerous_area_penalty`` is applied
   with probability ``exp(-min_dist / penalty_decay)`` based on the
   *closest* zone centre — no radius cutoff.
 
@@ -335,17 +335,17 @@ class PacManRewardModel(BasePacManRewardModel):
         return in_zone
 
 
-class PacManHighVarianceStatesRewardModel(PacManRewardModel):
-    """HIGH_VARIANCE_STATES variant.
+class PacManZeroMeanHazardShockRewardModel(PacManRewardModel):
+    """ZERO_MEAN_HAZARD_SHOCK variant.
 
     Replaces the deterministic in-zone penalty with a 50/50 split between
     ``+dangerous_area_penalty`` and ``-dangerous_area_penalty`` whenever
     the realised next pacman position is in any dangerous area. Expected
     contribution is ``0``; variance is ``dangerous_area_penalty**2``.
     Mirrors
-    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLDHighVarianceStatesRewardModel`
+    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLDZeroMeanHazardShockRewardModel`
     and
-    :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models.LaserTagHighVarianceStatesRewardModel`.
+    :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models.LaserTagZeroMeanHazardShockRewardModel`.
     All non-dangerous-area scoring (collision / pellet / win / step
     penalty) is identical to the standard model.
     """
@@ -404,8 +404,8 @@ class PacManHighVarianceStatesRewardModel(PacManRewardModel):
         return rewards
 
 
-class PacManDecayingHitProbabilityRewardModel(PacManRewardModel):
-    """DECAYING_HIT_PROBABILITY variant.
+class PacManDistanceDecayedHazardPenaltyRewardModel(PacManRewardModel):
+    """DISTANCE_DECAYED_HAZARD_PENALTY variant.
 
     Penalty is applied with probability
     ``exp(-min_dist / penalty_decay)`` where ``min_dist`` is the

--- a/POMDPPlanners/environments/push_pomdp/_cpp/continuous_push.cpp
+++ b/POMDPPlanners/environments/push_pomdp/_cpp/continuous_push.cpp
@@ -565,9 +565,9 @@ static inline bool discrete_collides(double px, double py,
 
 // Reward-variant codes shared between the standalone batch kernels and the
 // inline rollout reward paths. Mirrors the Python ``RewardModelType`` enum.
-constexpr int kRewardVariantStandard = 0;
+constexpr int kRewardVariantConstantHazardPenalty = 0;
 constexpr int kRewardVariantHighVar = 1;
-constexpr int kRewardVariantDecaying = 2;
+constexpr int kRewardVariantDistanceDecayedHazardPenalty = 2;
 
 // Squared Euclidean distance from (px, py) to the nearest dangerous-area
 // centre. Used by the Decaying variant to evaluate the exponential
@@ -588,15 +588,15 @@ static inline double dangerous_min_dist_sq(double px, double py_,
 }
 
 // Per-row dangerous-area reward contribution. Branches on ``variant_code``:
-// STANDARD (with optional Bernoulli), HIGH_VARIANCE_STATES (``±penalty``
-// 50/50 when in zone) and DECAYING_HIT_PROBABILITY (penalty fires with
+// CONSTANT_HAZARD_PENALTY (with optional Bernoulli), ZERO_MEAN_HAZARD_SHOCK (``±penalty``
+// 50/50 when in zone) and DISTANCE_DECAYED_HAZARD_PENALTY (penalty fires with
 // ``exp(-min_dist / penalty_decay)`` over every row, no radius cutoff).
 static inline double dangerous_contribution(int variant_code, bool in_zone,
                                             double penalty, double hit_prob,
                                             double min_dist_sq, double penalty_decay,
                                             pomdp_native::RNGState &rng) {
     std::uniform_real_distribution<double> uni(0.0, 1.0);
-    if (variant_code == kRewardVariantStandard) {
+    if (variant_code == kRewardVariantConstantHazardPenalty) {
         if (!in_zone) {
             return 0.0;
         }
@@ -665,7 +665,7 @@ static double discrete_step_reward(double nrx, double nry, double nox, double no
     if (!dangerous_areas.empty()) {
         const bool in_zone = point_in_dangerous_areas(nrx, nry, dangerous_areas,
                                                      cfg.dangerous_area_radius_sq);
-        const double min_sq = (cfg.reward_variant_code == kRewardVariantDecaying)
+        const double min_sq = (cfg.reward_variant_code == kRewardVariantDistanceDecayedHazardPenalty)
                                   ? dangerous_min_dist_sq(nrx, nry, dangerous_areas)
                                   : 0.0;
         reward += dangerous_contribution(cfg.reward_variant_code, in_zone,
@@ -1230,7 +1230,7 @@ static double cont_step_reward(const double *next_state,
         const bool in_zone = point_in_dangerous_areas(robot_after[0], robot_after[1],
                                                      dangerous_flat,
                                                      cfg.dangerous_area_radius_sq);
-        const double min_sq = (cfg.reward_variant_code == kRewardVariantDecaying)
+        const double min_sq = (cfg.reward_variant_code == kRewardVariantDistanceDecayedHazardPenalty)
                                   ? dangerous_min_dist_sq(robot_after[0], robot_after[1],
                                                           dangerous_flat)
                                   : 0.0;
@@ -1600,11 +1600,11 @@ py::array_t<double> push_observation_log_probability_step(
 //     circle-vs-AABB overlap (continuous) on the REALISED post-action robot
 //     position ``next_state[:2]`` with optional Bernoulli ``hit_probability``.
 //   * dangerous-area penalty: variant-driven.
-//        - reward_variant_code 0 (STANDARD): per-row penalty when in zone,
+//        - reward_variant_code 0 (CONSTANT_HAZARD_PENALTY): per-row penalty when in zone,
 //          optional Bernoulli ``dangerous_area_hit_probability``.
-//        - reward_variant_code 1 (HIGH_VARIANCE_STATES): ``±penalty`` 50/50
+//        - reward_variant_code 1 (ZERO_MEAN_HAZARD_SHOCK): ``±penalty`` 50/50
 //          when in zone; expectation is 0.
-//        - reward_variant_code 2 (DECAYING_HIT_PROBABILITY): penalty fires
+//        - reward_variant_code 2 (DISTANCE_DECAYED_HAZARD_PENALTY): penalty fires
 //          with probability ``exp(-min_dist / penalty_decay)`` over every
 //          row (no radius cutoff).
 // All RNG draws come from ``pomdp_native::default_rng()``. The variant
@@ -1670,7 +1670,7 @@ py::array_t<double> push_reward_batch(
         if (has_areas) {
             const bool in_zone =
                 point_in_dangerous_areas(rx, ry, areas_flat, area_r_sq);
-            const double min_sq = (reward_variant_code == kRewardVariantDecaying)
+            const double min_sq = (reward_variant_code == kRewardVariantDistanceDecayedHazardPenalty)
                                       ? dangerous_min_dist_sq(rx, ry, areas_flat)
                                       : 0.0;
             reward += dangerous_contribution(reward_variant_code, in_zone,
@@ -1748,7 +1748,7 @@ py::array_t<double> cont_push_reward_batch(
         if (has_areas) {
             const bool in_zone =
                 point_in_dangerous_areas(rx, ry, areas_flat, area_r_sq);
-            const double min_sq = (reward_variant_code == kRewardVariantDecaying)
+            const double min_sq = (reward_variant_code == kRewardVariantDistanceDecayedHazardPenalty)
                                       ? dangerous_min_dist_sq(rx, ry, areas_flat)
                                       : 0.0;
             reward += dangerous_contribution(reward_variant_code, in_zone,
@@ -1791,7 +1791,7 @@ PYBIND11_MODULE(_native, m) {
           "post-action robot position (next_state[:2]) for obstacle / danger "
           "tests, with Bernoulli ``*_hit_probability`` gating. "
           "``reward_variant_code`` selects the dangerous-area contract "
-          "(0=STANDARD, 1=HIGH_VARIANCE_STATES, 2=DECAYING_HIT_PROBABILITY); "
+          "(0=CONSTANT_HAZARD_PENALTY, 1=ZERO_MEAN_HAZARD_SHOCK, 2=DISTANCE_DECAYED_HAZARD_PENALTY); "
           "``penalty_decay`` is the decay length used by variant 2.");
 
     m.def("simulate_rollout_discrete", &simulate_rollout_discrete,
@@ -1812,7 +1812,7 @@ PYBIND11_MODULE(_native, m) {
           "consults the REALISED post-action robot position (next_state[:2]) "
           "for obstacle / danger tests, with Bernoulli ``*_hit_probability`` "
           "gating. ``reward_variant_code`` selects the dangerous-area contract "
-          "(0=STANDARD, 1=HIGH_VARIANCE_STATES, 2=DECAYING_HIT_PROBABILITY); "
+          "(0=CONSTANT_HAZARD_PENALTY, 1=ZERO_MEAN_HAZARD_SHOCK, 2=DISTANCE_DECAYED_HAZARD_PENALTY); "
           "``penalty_decay`` is the decay length used by variant 2.");
 
     m.def("belief_batch_transition_discrete", &belief_batch_transition_discrete,
@@ -1845,9 +1845,9 @@ PYBIND11_MODULE(_native, m) {
           py::arg("reward_variant_code"), py::arg("penalty_decay"),
           "Standalone variant-aware reward batch for PushPOMDP (discrete).\n\n"
           "Implements all three RewardModelType variants:\n"
-          "  0 = STANDARD: deterministic per-zone penalty (optional Bernoulli).\n"
-          "  1 = HIGH_VARIANCE_STATES: ±penalty 50/50 when in zone.\n"
-          "  2 = DECAYING_HIT_PROBABILITY: penalty fires with probability\n"
+          "  0 = CONSTANT_HAZARD_PENALTY: deterministic per-zone penalty (optional Bernoulli).\n"
+          "  1 = ZERO_MEAN_HAZARD_SHOCK: ±penalty 50/50 when in zone.\n"
+          "  2 = DISTANCE_DECAYED_HAZARD_PENALTY: penalty fires with probability\n"
           "      exp(-min_dist / penalty_decay) for every row (no radius cutoff).\n"
           "Obstacle penalty fires on next_state[:2] (realised position).");
 

--- a/POMDPPlanners/environments/push_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/push_pomdp/_native.pyi
@@ -47,8 +47,8 @@ def simulate_rollout_discrete(
     position (``next_state[:2]``) for obstacle and dangerous-area tests,
     with Bernoulli ``*_hit_probability`` gating.
     ``reward_variant_code`` selects the dangerous-area contract
-    (``0=STANDARD``, ``1=HIGH_VARIANCE_STATES``,
-    ``2=DECAYING_HIT_PROBABILITY``); ``penalty_decay`` is the decay
+    (``0=CONSTANT_HAZARD_PENALTY``, ``1=ZERO_MEAN_HAZARD_SHOCK``,
+    ``2=DISTANCE_DECAYED_HAZARD_PENALTY``); ``penalty_decay`` is the decay
     length used by variant 2.
     """
     ...
@@ -88,8 +88,8 @@ def cont_simulate_rollout(
     position (``next_state[:2]``) for obstacle and dangerous-area tests,
     with Bernoulli ``*_hit_probability`` gating.
     ``reward_variant_code`` selects the dangerous-area contract
-    (``0=STANDARD``, ``1=HIGH_VARIANCE_STATES``,
-    ``2=DECAYING_HIT_PROBABILITY``); ``penalty_decay`` is the decay
+    (``0=CONSTANT_HAZARD_PENALTY``, ``1=ZERO_MEAN_HAZARD_SHOCK``,
+    ``2=DISTANCE_DECAYED_HAZARD_PENALTY``); ``penalty_decay`` is the decay
     length used by variant 2.
     """
     ...
@@ -211,9 +211,9 @@ def push_reward_batch(
     """Standalone variant-aware reward-batch kernel for the discrete PushPOMDP.
 
     ``reward_variant_code`` selects the dangerous-area contract:
-        * 0 — STANDARD (deterministic / optional Bernoulli per zone).
-        * 1 — HIGH_VARIANCE_STATES (``±penalty`` 50/50 in zone).
-        * 2 — DECAYING_HIT_PROBABILITY (penalty fires with probability
+        * 0 — CONSTANT_HAZARD_PENALTY (deterministic / optional Bernoulli per zone).
+        * 1 — ZERO_MEAN_HAZARD_SHOCK (``±penalty`` 50/50 in zone).
+        * 2 — DISTANCE_DECAYED_HAZARD_PENALTY (penalty fires with probability
           ``exp(-min_dist / penalty_decay)``, no radius cutoff).
     Returns a ``(N,)`` float64 array of per-row rewards.
     """

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -42,8 +42,8 @@ from POMDPPlanners.environments.push_pomdp.continuous_push_geometry import (
 )
 from POMDPPlanners.environments.push_pomdp.push_pomdp_utils.push_reward_models import (
     BasePushRewardModel,
-    ContinuousPushDecayingHitProbabilityRewardModel,
-    ContinuousPushHighVarianceStatesRewardModel,
+    ContinuousPushDistanceDecayedHazardPenaltyRewardModel,
+    ContinuousPushZeroMeanHazardShockRewardModel,
     ContinuousPushRewardModel,
     RewardModelType,
 )
@@ -185,7 +185,7 @@ class ContinuousPushPOMDP(Environment):
         dangerous_area_radius: float = 0.5,
         dangerous_area_penalty: float = -10.0,
         dangerous_area_hit_probability: float = 1.0,
-        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         penalty_decay: float = 1.0,
         robot_radius: float = 0.3,
         state_transition_cov_matrix: np.ndarray = np.eye(2) * 0.1,
@@ -199,7 +199,10 @@ class ContinuousPushPOMDP(Environment):
             raise ValueError("obstacle_hit_probability must be between 0 and 1 (inclusive)")
         if not 0.0 <= dangerous_area_hit_probability <= 1.0:
             raise ValueError("dangerous_area_hit_probability must be between 0 and 1 (inclusive)")
-        if reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY and penalty_decay <= 0.0:
+        if (
+            reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY
+            and penalty_decay <= 0.0
+        ):
             raise ValueError("penalty_decay must be strictly positive")
 
         self.grid_size = grid_size
@@ -304,12 +307,12 @@ class ContinuousPushPOMDP(Environment):
             "dangerous_area_penalty": self.dangerous_area_penalty,
             "dangerous_area_hit_probability": self.dangerous_area_hit_probability,
         }
-        if self.reward_model_type == RewardModelType.STANDARD:
+        if self.reward_model_type == RewardModelType.CONSTANT_HAZARD_PENALTY:
             return ContinuousPushRewardModel(**common_kwargs)
-        if self.reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
-            return ContinuousPushHighVarianceStatesRewardModel(**common_kwargs)
-        if self.reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
-            return ContinuousPushDecayingHitProbabilityRewardModel(
+        if self.reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
+            return ContinuousPushZeroMeanHazardShockRewardModel(**common_kwargs)
+        if self.reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY:
+            return ContinuousPushDistanceDecayedHazardPenaltyRewardModel(
                 penalty_decay=self.penalty_decay, **common_kwargs
             )
         raise ValueError(f"Unknown reward model type: {self.reward_model_type}")
@@ -527,9 +530,9 @@ class ContinuousPushPOMDP(Environment):
         )
 
     def _reward_variant_native_params(self) -> Tuple[int, float]:
-        if self.reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+        if self.reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
             return 1, 0.0
-        if self.reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+        if self.reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY:
             return 2, float(getattr(self.reward_model, "penalty_decay", 1.0))
         return 0, 0.0
 
@@ -890,7 +893,7 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
         dangerous_area_radius: float = 0.5,
         dangerous_area_penalty: float = -10.0,
         dangerous_area_hit_probability: float = 1.0,
-        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         penalty_decay: float = 1.0,
         robot_radius: float = 0.3,
         state_transition_cov_matrix: np.ndarray = np.eye(2) * 0.1,

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -41,8 +41,8 @@ from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.environments.push_pomdp import _native
 from POMDPPlanners.environments.push_pomdp.push_pomdp_utils.push_reward_models import (
     BasePushRewardModel,
-    DiscretePushDecayingHitProbabilityRewardModel,
-    DiscretePushHighVarianceStatesRewardModel,
+    DiscretePushDistanceDecayedHazardPenaltyRewardModel,
+    DiscretePushZeroMeanHazardShockRewardModel,
     DiscretePushRewardModel,
     RewardModelType,
 )
@@ -223,7 +223,7 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         dangerous_area_radius: float = 0.5,
         dangerous_area_penalty: float = -10.0,
         dangerous_area_hit_probability: float = 1.0,
-        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         penalty_decay: float = 1.0,
         initial_state: Optional[np.ndarray] = None,
         transition_error_prob: float = 0.0,
@@ -236,7 +236,10 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             raise ValueError("obstacle_hit_probability must be between 0 and 1 (inclusive)")
         if not 0.0 <= dangerous_area_hit_probability <= 1.0:
             raise ValueError("dangerous_area_hit_probability must be between 0 and 1 (inclusive)")
-        if reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY and penalty_decay <= 0.0:
+        if (
+            reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY
+            and penalty_decay <= 0.0
+        ):
             raise ValueError("penalty_decay must be strictly positive")
 
         self.grid_size = grid_size
@@ -365,12 +368,12 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
             "dangerous_area_penalty": self.dangerous_area_penalty,
             "dangerous_area_hit_probability": self.dangerous_area_hit_probability,
         }
-        if self.reward_model_type == RewardModelType.STANDARD:
+        if self.reward_model_type == RewardModelType.CONSTANT_HAZARD_PENALTY:
             return DiscretePushRewardModel(**common_kwargs)
-        if self.reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
-            return DiscretePushHighVarianceStatesRewardModel(**common_kwargs)
-        if self.reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
-            return DiscretePushDecayingHitProbabilityRewardModel(
+        if self.reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
+            return DiscretePushZeroMeanHazardShockRewardModel(**common_kwargs)
+        if self.reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY:
+            return DiscretePushDistanceDecayedHazardPenaltyRewardModel(
                 penalty_decay=self.penalty_decay, **common_kwargs
             )
         raise ValueError(f"Unknown reward model type: {self.reward_model_type}")
@@ -736,7 +739,7 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         # penalties against the REALISED post-action robot position
         # (``next_state[:2]``), matching ``DiscretePushRewardModel``. Pass the
         # variant code + penalty decay so the C++ rollout dispatches
-        # STANDARD / HIGH_VARIANCE_STATES / DECAYING_HIT_PROBABILITY exactly
+        # CONSTANT_HAZARD_PENALTY / ZERO_MEAN_HAZARD_SHOCK / DISTANCE_DECAYED_HAZARD_PENALTY exactly
         # like the standalone ``push_reward_batch`` kernel.
         action_indices = np.random.randint(0, 4, size=remaining, dtype=np.int64)
         obs_arr = self._get_native_rollout_obstacles()
@@ -838,8 +841,8 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         already sampled the realised batch transition), it is used
         directly; otherwise N next states are drawn here via the cached
         ``PushVectorizedUpdater``. Per-particle rewards are computed in
-        the C++ ``push_reward_batch`` kernel (variant-aware: STANDARD,
-        HIGH_VARIANCE_STATES, DECAYING_HIT_PROBABILITY) so the batch
+        the C++ ``push_reward_batch`` kernel (variant-aware: CONSTANT_HAZARD_PENALTY,
+        ZERO_MEAN_HAZARD_SHOCK, DISTANCE_DECAYED_HAZARD_PENALTY) so the batch
         cost is a single round-trip into native code.
         """
         states_array = np.ascontiguousarray(np.asarray(states, dtype=float))
@@ -885,9 +888,9 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         )
 
     def _reward_variant_native_params(self) -> Tuple[int, float]:
-        if self.reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+        if self.reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
             return 1, 0.0
-        if self.reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+        if self.reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY:
             return 2, float(getattr(self.reward_model, "penalty_decay", 1.0))
         return 0, 0.0
 

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp_utils/push_reward_models.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp_utils/push_reward_models.py
@@ -14,16 +14,16 @@ observation paths and delegates ``reward()`` / ``reward_batch()`` to the
 model.
 
 Reward-model variants (selected via :class:`RewardModelType`):
-    * ``STANDARD`` — dangerous-area penalty fires deterministically (or
+    * ``CONSTANT_HAZARD_PENALTY`` — dangerous-area penalty fires deterministically (or
       with ``dangerous_area_hit_probability`` Bernoulli) whenever the
       realised post-action robot position lies inside any zone.
-    * ``HIGH_VARIANCE_STATES`` — dangerous-area penalty becomes
+    * ``ZERO_MEAN_HAZARD_SHOCK`` — dangerous-area penalty becomes
       ``±dangerous_area_penalty`` with 50/50 split when in zone; obstacle
       penalty is unchanged. Expected dangerous-area contribution is zero,
       variance is ``dangerous_area_penalty**2``. Useful for benchmarking
       risk-sensitive planners against expected-value MCTS on the same
       mean.
-    * ``DECAYING_HIT_PROBABILITY`` — dangerous-area penalty fires with
+    * ``DISTANCE_DECAYED_HAZARD_PENALTY`` — dangerous-area penalty fires with
       probability ``exp(-min_dist / penalty_decay)`` based on the
       Euclidean distance to the nearest dangerous-area centre, with no
       radius cutoff. Obstacle penalty is unchanged.
@@ -51,9 +51,9 @@ _scalar_random = np.random.random_sample  # pylint: disable=no-member
 class RewardModelType(Enum):
     """Reward model variants supported by the Push POMDP family."""
 
-    STANDARD = "standard"
-    HIGH_VARIANCE_STATES = "high_variance_states"
-    DECAYING_HIT_PROBABILITY = "decaying_hit_probability"
+    CONSTANT_HAZARD_PENALTY = "constant_hazard_penalty"
+    ZERO_MEAN_HAZARD_SHOCK = "zero_mean_hazard_shock"
+    DISTANCE_DECAYED_HAZARD_PENALTY = "distance_decayed_hazard_penalty"
 
 
 class BasePushRewardModel(ABC):
@@ -263,16 +263,16 @@ class DiscretePushRewardModel(BasePushRewardModel):
         return np.any(dist_sq <= self.dangerous_area_radius * self.dangerous_area_radius, axis=1)
 
 
-class DiscretePushHighVarianceStatesRewardModel(DiscretePushRewardModel):
+class DiscretePushZeroMeanHazardShockRewardModel(DiscretePushRewardModel):
     """High-variance dangerous-area contribution for :class:`PushPOMDP`.
 
     Dangerous-area hits emit ``+dangerous_area_penalty`` or
     ``-dangerous_area_penalty`` with equal probability — expected
     contribution is zero, variance is ``dangerous_area_penalty**2``.
     Obstacle penalty is unchanged. Mirrors
-    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLDHighVarianceStatesRewardModel`
+    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLDZeroMeanHazardShockRewardModel`
     and
-    :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models.LaserTagHighVarianceStatesRewardModel`.
+    :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models.LaserTagZeroMeanHazardShockRewardModel`.
     """
 
     def _dangerous_area_contribution_scalar(self, robot_x: float, robot_y: float) -> float:
@@ -298,7 +298,7 @@ class DiscretePushHighVarianceStatesRewardModel(DiscretePushRewardModel):
         return out
 
 
-class DiscretePushDecayingHitProbabilityRewardModel(DiscretePushRewardModel):
+class DiscretePushDistanceDecayedHazardPenaltyRewardModel(DiscretePushRewardModel):
     """Distance-decaying dangerous-area contribution for :class:`PushPOMDP`.
 
     Penalty fires with probability ``exp(-min_dist / penalty_decay)`` based
@@ -306,9 +306,9 @@ class DiscretePushDecayingHitProbabilityRewardModel(DiscretePushRewardModel):
     nearest dangerous-area centre. No radius cutoff — every position
     feels a (vanishingly small at large distance) penalty risk. Obstacle
     penalty is unchanged. Mirrors
-    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLightDarkDecayingHitProbabilityRewardModel`
+    :class:`~POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models.ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel`
     and
-    :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models.LaserTagDecayingHitProbabilityRewardModel`.
+    :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models.LaserTagDistanceDecayedHazardPenaltyRewardModel`.
     """
 
     def __init__(
@@ -493,7 +493,7 @@ class ContinuousPushRewardModel(BasePushRewardModel):
         return np.any(dist_sq < radius * radius, axis=1)
 
 
-class ContinuousPushHighVarianceStatesRewardModel(ContinuousPushRewardModel):
+class ContinuousPushZeroMeanHazardShockRewardModel(ContinuousPushRewardModel):
     """High-variance dangerous-area contribution for :class:`ContinuousPushPOMDP`."""
 
     def _dangerous_area_penalty_batch(self, next_states: np.ndarray) -> np.ndarray:
@@ -508,7 +508,7 @@ class ContinuousPushHighVarianceStatesRewardModel(ContinuousPushRewardModel):
         return out
 
 
-class ContinuousPushDecayingHitProbabilityRewardModel(ContinuousPushRewardModel):
+class ContinuousPushDistanceDecayedHazardPenaltyRewardModel(ContinuousPushRewardModel):
     """Distance-decaying dangerous-area contribution for :class:`ContinuousPushPOMDP`.
 
     Penalty fires with probability ``exp(-min_dist / penalty_decay)`` based

--- a/POMDPPlanners/environments/rock_sample_pomdp/_cpp/rock_sample.cpp
+++ b/POMDPPlanners/environments/rock_sample_pomdp/_cpp/rock_sample.cpp
@@ -633,13 +633,13 @@ class RockSampleObservationCpp {
 // Reward-variant codes mirror the Python ``RewardModelType`` enum used by
 // :class:`RockSamplePOMDP`:
 //
-//   0 -> STANDARD             (constant-probability dangerous-area penalty)
-//   1 -> HIGH_VARIANCE_STATES (+/- 50/50 dangerous-area perturbation)
-//   2 -> DECAYING_HIT_PROBABILITY (exp(-min_dist/decay) hit probability)
+//   0 -> CONSTANT_HAZARD_PENALTY             (constant-probability dangerous-area penalty)
+//   1 -> ZERO_MEAN_HAZARD_SHOCK (+/- 50/50 dangerous-area perturbation)
+//   2 -> DISTANCE_DECAYED_HAZARD_PENALTY (exp(-min_dist/decay) hit probability)
 // ---------------------------------------------------------------------------
-constexpr int kRewardVariantStandard = 0;
-constexpr int kRewardVariantHighVariance = 1;
-constexpr int kRewardVariantDecaying = 2;
+constexpr int kRewardVariantConstantHazardPenalty = 0;
+constexpr int kRewardVariantZeroMeanHazardShock = 1;
+constexpr int kRewardVariantDistanceDecayedHazardPenalty = 2;
 
 // Base reward shared across all variants: step / exit / sample / sense.
 // ``state_row`` is the current state row (length state_dim) so this
@@ -703,7 +703,7 @@ inline double dangerous_area_term(double next_row, double next_col,
     }
     pomdp_native::RNGState &rng = pomdp_native::default_rng();
     std::uniform_real_distribution<double> uniform(0.0, 1.0);
-    if (reward_variant_code == kRewardVariantDecaying) {
+    if (reward_variant_code == kRewardVariantDistanceDecayedHazardPenalty) {
         const double min_d = std::sqrt(min_dist_to_danger_sq(next_row, next_col, dangers, k));
         const double p = std::exp(-min_d / penalty_decay);
         return (uniform(rng.engine()) < p) ? dangerous_area_penalty : 0.0;
@@ -713,11 +713,11 @@ inline double dangerous_area_term(double next_row, double next_col,
     if (min_d2 > radius_sq) {
         return 0.0;
     }
-    if (reward_variant_code == kRewardVariantHighVariance) {
+    if (reward_variant_code == kRewardVariantZeroMeanHazardShock) {
         return (uniform(rng.engine()) < 0.5) ? dangerous_area_penalty
                                              : -dangerous_area_penalty;
     }
-    // STANDARD: constant-probability hit
+    // CONSTANT_HAZARD_PENALTY: constant-probability hit
     if (dangerous_area_hit_probability >= 1.0 ||
         uniform(rng.engine()) < dangerous_area_hit_probability) {
         return dangerous_area_penalty;
@@ -952,7 +952,7 @@ PYBIND11_MODULE(_native, m) {
           "action_indices must be a pre-drawn int32 array of length (max_depth-start_depth). "
           "rock_positions_flat is a 1-D int32 array [row0, col0, row1, col1, ...]. "
           "dangerous_areas is a (K, 2) float64 array (may be empty). "
-          "reward_variant_code: 0=STANDARD, 1=HIGH_VARIANCE_STATES, 2=DECAYING_HIT_PROBABILITY.");
+          "reward_variant_code: 0=CONSTANT_HAZARD_PENALTY, 1=ZERO_MEAN_HAZARD_SHOCK, 2=DISTANCE_DECAYED_HAZARD_PENALTY.");
 
     m.def("reward_batch", &reward_batch,
           py::arg("states"), py::arg("action"), py::arg("next_states"),
@@ -965,7 +965,7 @@ PYBIND11_MODULE(_native, m) {
           py::arg("reward_variant_code"), py::arg("penalty_decay"),
           "Variant-aware standalone batch reward kernel for RockSamplePOMDP. "
           "Returns a (N,) float64 array of rewards. "
-          "reward_variant_code: 0=STANDARD, 1=HIGH_VARIANCE_STATES, 2=DECAYING_HIT_PROBABILITY.");
+          "reward_variant_code: 0=CONSTANT_HAZARD_PENALTY, 1=ZERO_MEAN_HAZARD_SHOCK, 2=DISTANCE_DECAYED_HAZARD_PENALTY.");
 
     py::class_<RockSampleTransitionCpp>(m, "RockSampleTransitionCpp")
         .def(py::init<const py::object &, int, int, int, int,

--- a/POMDPPlanners/environments/rock_sample_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/rock_sample_pomdp/_native.pyi
@@ -50,7 +50,7 @@ def simulate_rollout_discrete(
     length ``max_depth - start_depth``. ``rock_positions_flat`` is a 1-D
     int32 array ``[row0, col0, row1, col1, …]``. ``dangerous_areas`` is a
     ``(K, 2)`` float64 array (may be empty). ``reward_variant_code``:
-    ``0=STANDARD``, ``1=HIGH_VARIANCE_STATES``, ``2=DECAYING_HIT_PROBABILITY``.
+    ``0=CONSTANT_HAZARD_PENALTY``, ``1=ZERO_MEAN_HAZARD_SHOCK``, ``2=DISTANCE_DECAYED_HAZARD_PENALTY``.
     """
     ...
 
@@ -76,9 +76,9 @@ def reward_batch(
     """Variant-aware standalone batch reward kernel for RockSamplePOMDP.
 
     Returns a ``(N,)`` float64 array of rewards. The dangerous-area term
-    is selected by ``reward_variant_code``: ``0=STANDARD`` (constant-
-    probability hit), ``1=HIGH_VARIANCE_STATES`` (50/50 ±penalty in zone),
-    ``2=DECAYING_HIT_PROBABILITY`` (hit with probability
+    is selected by ``reward_variant_code``: ``0=CONSTANT_HAZARD_PENALTY`` (constant-
+    probability hit), ``1=ZERO_MEAN_HAZARD_SHOCK`` (50/50 ±penalty in zone),
+    ``2=DISTANCE_DECAYED_HAZARD_PENALTY`` (hit with probability
     ``exp(-min_dist / penalty_decay)``).
     """
     ...

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -31,8 +31,8 @@ from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.environments.rock_sample_pomdp import _native
 from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_utils.rock_sample_reward_models import (
     BaseRockSampleRewardModel,
-    RockSampleDecayingHitProbabilityRewardModel,
-    RockSampleHighVarianceRewardModel,
+    RockSampleDistanceDecayedHazardPenaltyRewardModel,
+    RockSampleZeroMeanHazardShockRewardModel,
     RockSampleRewardModel,
 )
 from POMDPPlanners.utils.statistics_utils import confidence_interval
@@ -56,9 +56,9 @@ class RewardModelType(Enum):
     for the per-variant semantics.
     """
 
-    STANDARD = "standard"
-    DECAYING_HIT_PROBABILITY = "decaying_hit_probability"
-    HIGH_VARIANCE_STATES = "high_variance_states"
+    CONSTANT_HAZARD_PENALTY = "constant_hazard_penalty"
+    DISTANCE_DECAYED_HAZARD_PENALTY = "distance_decayed_hazard_penalty"
+    ZERO_MEAN_HAZARD_SHOCK = "zero_mean_hazard_shock"
 
 
 # Type alias for RockSampleState
@@ -195,7 +195,7 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         dangerous_area_radius: float = 1.0,
         dangerous_area_penalty: float = -5.0,
         dangerous_area_hit_probability: float = 1.0,
-        reward_model_type: RewardModelType = RewardModelType.STANDARD,
+        reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         penalty_decay: float = 1.0,
         discount_factor: float = 0.95,
         name: str = "RockSample",
@@ -230,21 +230,21 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
                 reward stochastic (per-call Bernoulli draw), useful for
                 risk-sensitive planning benchmarks. Note that this makes
                 ``reward(state, action)`` non-deterministic given a
-                state-action pair. Ignored by ``HIGH_VARIANCE_STATES``
-                and ``DECAYING_HIT_PROBABILITY`` reward models.
+                state-action pair. Ignored by ``ZERO_MEAN_HAZARD_SHOCK``
+                and ``DISTANCE_DECAYED_HAZARD_PENALTY`` reward models.
             reward_model_type: Which dangerous-area penalty model to use.
-                Defaults to ``RewardModelType.STANDARD`` (legacy
-                constant-probability behaviour). ``HIGH_VARIANCE_STATES``
+                Defaults to ``RewardModelType.CONSTANT_HAZARD_PENALTY`` (legacy
+                constant-probability behaviour). ``ZERO_MEAN_HAZARD_SHOCK``
                 applies ``±dangerous_area_penalty`` 50/50 in-zone (zero
                 expected contribution, high variance — useful for
                 risk-sensitive planner benchmarks).
-                ``DECAYING_HIT_PROBABILITY`` applies the penalty with
+                ``DISTANCE_DECAYED_HAZARD_PENALTY`` applies the penalty with
                 probability ``exp(-min_dist / penalty_decay)`` based on
                 distance to the closest dangerous-area centre (no radius
                 cutoff). See
                 :class:`~POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp.RewardModelType`.
             penalty_decay: Distance-decay constant for the
-                ``DECAYING_HIT_PROBABILITY`` reward model. Must be
+                ``DISTANCE_DECAYED_HAZARD_PENALTY`` reward model. Must be
                 positive. Ignored by other reward models. Defaults to
                 ``1.0``.
             discount_factor: Discount factor. Defaults to 0.95.
@@ -264,11 +264,11 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
                 stacklevel=2,
             )
 
-        # Calculate reward range based on parameters. HIGH_VARIANCE_STATES
+        # Calculate reward range based on parameters. ZERO_MEAN_HAZARD_SHOCK
         # can flip the sign of the dangerous-area contribution, so its
         # effective danger term spans ``[-|penalty|, +|penalty|]``.
         if dangerous_areas:
-            if reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
+            if reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
                 danger_term_min = -abs(dangerous_area_penalty)
                 danger_term_max = abs(dangerous_area_penalty)
             else:
@@ -340,9 +340,9 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         else:
             self._dangerous_areas_arr = np.empty((0, 2), dtype=np.float64)
         self._reward_variant_code: int = {
-            RewardModelType.STANDARD: 0,
-            RewardModelType.HIGH_VARIANCE_STATES: 1,
-            RewardModelType.DECAYING_HIT_PROBABILITY: 2,
+            RewardModelType.CONSTANT_HAZARD_PENALTY: 0,
+            RewardModelType.ZERO_MEAN_HAZARD_SHOCK: 1,
+            RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY: 2,
         }[self.reward_model_type]
 
         # Define actions: 0=sample, 1=north, 2=east, 3=south, 4=west, 5+=check_rock_i
@@ -381,12 +381,12 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
             "dangerous_area_penalty": self.dangerous_area_penalty,
             "dangerous_area_hit_probability": self.dangerous_area_hit_probability,
         }
-        if self.reward_model_type == RewardModelType.STANDARD:
+        if self.reward_model_type == RewardModelType.CONSTANT_HAZARD_PENALTY:
             return RockSampleRewardModel(**common_kwargs)
-        if self.reward_model_type == RewardModelType.HIGH_VARIANCE_STATES:
-            return RockSampleHighVarianceRewardModel(**common_kwargs)
-        if self.reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
-            return RockSampleDecayingHitProbabilityRewardModel(
+        if self.reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
+            return RockSampleZeroMeanHazardShockRewardModel(**common_kwargs)
+        if self.reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY:
+            return RockSampleDistanceDecayedHazardPenaltyRewardModel(
                 **common_kwargs, penalty_decay=self.penalty_decay
             )
         raise ValueError(f"Unknown reward model type: {self.reward_model_type}")

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_utils/rock_sample_reward_models.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_utils/rock_sample_reward_models.py
@@ -12,13 +12,13 @@ non-dangerous-area scoring (exit, sample, sense, step-penalty) via the
 ``RockSampleRewardModel`` base; each variant only customises the
 dangerous-area contribution:
 
-* :class:`RockSampleRewardModel` (STANDARD): constant-probability
+* :class:`RockSampleRewardModel` (CONSTANT_HAZARD_PENALTY): constant-probability
   penalty when the realised next position is in any dangerous area.
-* :class:`RockSampleHighVarianceRewardModel` (HIGH_VARIANCE_STATES):
+* :class:`RockSampleZeroMeanHazardShockRewardModel` (ZERO_MEAN_HAZARD_SHOCK):
   ``±dangerous_area_penalty`` 50/50 in-zone — zero expected
   contribution, high variance.
-* :class:`RockSampleDecayingHitProbabilityRewardModel`
-  (DECAYING_HIT_PROBABILITY): penalty applied with probability
+* :class:`RockSampleDistanceDecayedHazardPenaltyRewardModel`
+  (DISTANCE_DECAYED_HAZARD_PENALTY): penalty applied with probability
   ``exp(-min_dist / penalty_decay)`` based on the *closest* zone
   centre — no radius cutoff.
 """
@@ -299,8 +299,8 @@ class RockSampleRewardModel(BaseRockSampleRewardModel):
         return new_rows, new_cols
 
 
-class RockSampleHighVarianceRewardModel(RockSampleRewardModel):
-    """HIGH_VARIANCE_STATES variant.
+class RockSampleZeroMeanHazardShockRewardModel(RockSampleRewardModel):
+    """ZERO_MEAN_HAZARD_SHOCK variant.
 
     Replaces the constant-probability penalty with a 50/50 split between
     ``+dangerous_area_penalty`` and ``-dangerous_area_penalty`` whenever
@@ -335,8 +335,8 @@ class RockSampleHighVarianceRewardModel(RockSampleRewardModel):
         rewards[in_zone_indices] += signs * self.dangerous_area_penalty
 
 
-class RockSampleDecayingHitProbabilityRewardModel(RockSampleRewardModel):
-    """DECAYING_HIT_PROBABILITY variant.
+class RockSampleDistanceDecayedHazardPenaltyRewardModel(RockSampleRewardModel):
+    """DISTANCE_DECAYED_HAZARD_PENALTY variant.
 
     Penalty is applied with probability
     ``exp(-min_dist / penalty_decay)`` where ``min_dist`` is the

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/laser_tag_pomdp_utils/test_laser_tag_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/laser_tag_pomdp_utils/test_laser_tag_reward_cpp_parity.py
@@ -3,12 +3,12 @@
 Verifies that the native ``_native.lasertag_discrete_reward_batch`` C++
 kernel produces results that match the Python reward-model
 implementation across all three :class:`RewardModelType` variants —
-``STANDARD``, ``HIGH_VARIANCE_STATES`` and ``DECAYING_HIT_PROBABILITY``.
+``CONSTANT_HAZARD_PENALTY``, ``ZERO_MEAN_HAZARD_SHOCK`` and ``DISTANCE_DECAYED_HAZARD_PENALTY``.
 
 This is a TDD red-step test for Stage 2. The current native kernel does
 not accept a ``reward_variant_code`` / ``penalty_decay`` keyword pair,
 so today the calls below either raise ``TypeError`` (kwargs unknown)
-or — once the kernel grows the kwargs but still hard-codes STANDARD
+or — once the kernel grows the kwargs but still hard-codes CONSTANT_HAZARD_PENALTY
 semantics — produce values that fail the sample-mean parity check on
 the stochastic variants. The Stage 2 agent will teach the kernel about
 the variant code and decay length; this test will go green then.
@@ -38,11 +38,11 @@ _DANGEROUS_AREA_PENALTY = 5.0
 
 def _variant_code(rmt: RewardModelType) -> int:
     """Map a :class:`RewardModelType` to the integer code the C++ kernel expects."""
-    if rmt == RewardModelType.STANDARD:
+    if rmt == RewardModelType.CONSTANT_HAZARD_PENALTY:
         return 0
-    if rmt == RewardModelType.HIGH_VARIANCE_STATES:
+    if rmt == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
         return 1
-    if rmt == RewardModelType.DECAYING_HIT_PROBABILITY:
+    if rmt == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY:
         return 2
     raise ValueError(f"Unknown reward model type: {rmt}")
 
@@ -147,9 +147,9 @@ class TestLaserTagDiscreteRewardCppParity:
     @pytest.mark.parametrize(
         "rmt, penalty_decay",
         [
-            (RewardModelType.STANDARD, 0.0),
-            (RewardModelType.HIGH_VARIANCE_STATES, 0.0),
-            (RewardModelType.DECAYING_HIT_PROBABILITY, _PENALTY_DECAY),
+            (RewardModelType.CONSTANT_HAZARD_PENALTY, 0.0),
+            (RewardModelType.ZERO_MEAN_HAZARD_SHOCK, 0.0),
+            (RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY, _PENALTY_DECAY),
         ],
     )
     def test_cpp_matches_python_in_mean(self, rmt: RewardModelType, penalty_decay: float) -> None:
@@ -179,7 +179,7 @@ class TestLaserTagDiscreteRewardCppParity:
         Then: The two sample means agree within
             ``3 * py.std() / sqrt(N) + 1e-9``. Today this either raises
             ``TypeError`` (kernel lacks the kwargs) or fails the mean
-            check on HV / Decaying (kernel hard-codes STANDARD); both
+            check on HV / Decaying (kernel hard-codes CONSTANT_HAZARD_PENALTY); both
             failure modes confirm the kernel is not yet variant-aware.
 
         Test type: integration
@@ -211,14 +211,14 @@ class TestLaserTagDiscreteRewardCppParity:
         )
 
     def test_tag_action_path_is_also_covered(self) -> None:
-        """Tag-action (action=4) C++ mean matches Python mean for the STANDARD variant.
+        """Tag-action (action=4) C++ mean matches Python mean for the CONSTANT_HAZARD_PENALTY variant.
 
         Purpose: Ensures the tag-action branch is exercised on top of the
             movement-action branch covered by the parametrised test, so a
             kernel that handles tag rewards differently from movement
             rewards is caught.
 
-        Given: A STANDARD discrete LaserTag env with default walls and
+        Given: A CONSTANT_HAZARD_PENALTY discrete LaserTag env with default walls and
             dangerous areas, and a 2000-row state batch covering both
             danger-zone and clear cells.
         When: ``env.reward_model.compute_reward_batch`` and
@@ -230,7 +230,7 @@ class TestLaserTagDiscreteRewardCppParity:
         Test type: integration
         """
         np.random.seed(42)
-        env = _build_env(RewardModelType.STANDARD)
+        env = _build_env(RewardModelType.CONSTANT_HAZARD_PENALTY)
         states = _build_states_with_danger_and_clear(env, _BATCH_SIZE)
         action = 4
         next_states = env.sample_next_state_batch(states, action)
@@ -241,13 +241,13 @@ class TestLaserTagDiscreteRewardCppParity:
             states,
             action,
             next_states,
-            variant_code=_variant_code(RewardModelType.STANDARD),
+            variant_code=_variant_code(RewardModelType.CONSTANT_HAZARD_PENALTY),
             penalty_decay=0.0,
         )
 
         delta, tol = _sample_mean_parity(py_rewards, cpp_rewards)
         assert delta < tol, (
-            f"C++/Python reward mean mismatch for variant STANDARD (tag action): "
+            f"C++/Python reward mean mismatch for variant CONSTANT_HAZARD_PENALTY (tag action): "
             f"|py.mean - cpp.mean| = {delta:.6f} >= tol = {tol:.6f} "
             f"(py.mean={py_rewards.mean():.6f}, cpp.mean={cpp_rewards.mean():.6f}, "
             f"N={py_rewards.shape[0]})"

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/laser_tag_pomdp_utils/test_laser_tag_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/laser_tag_pomdp_utils/test_laser_tag_reward_models.py
@@ -16,8 +16,8 @@ from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import (
 )
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models import (
     BaseLaserTagRewardModel,
-    LaserTagDecayingHitProbabilityRewardModel,
-    LaserTagHighVarianceStatesRewardModel,
+    LaserTagDistanceDecayedHazardPenaltyRewardModel,
+    LaserTagZeroMeanHazardShockRewardModel,
     LaserTagRewardModel,
 )
 
@@ -51,8 +51,8 @@ _DEFAULT_ACTION_DIRS = {
 }
 
 
-def _make_hv_model() -> LaserTagHighVarianceStatesRewardModel:
-    return LaserTagHighVarianceStatesRewardModel(
+def _make_hv_model() -> LaserTagZeroMeanHazardShockRewardModel:
+    return LaserTagZeroMeanHazardShockRewardModel(
         floor_shape=_DEFAULT_FLOOR,
         walls=_DEFAULT_WALLS,
         dangerous_areas=_DEFAULT_DANGER_AREAS,
@@ -65,8 +65,10 @@ def _make_hv_model() -> LaserTagHighVarianceStatesRewardModel:
     )
 
 
-def _make_decay_model(penalty_decay: float = 1.0) -> LaserTagDecayingHitProbabilityRewardModel:
-    return LaserTagDecayingHitProbabilityRewardModel(
+def _make_decay_model(
+    penalty_decay: float = 1.0,
+) -> LaserTagDistanceDecayedHazardPenaltyRewardModel:
+    return LaserTagDistanceDecayedHazardPenaltyRewardModel(
         floor_shape=_DEFAULT_FLOOR,
         walls=_DEFAULT_WALLS,
         dangerous_areas=_DEFAULT_DANGER_AREAS,
@@ -80,7 +82,7 @@ def _make_decay_model(penalty_decay: float = 1.0) -> LaserTagDecayingHitProbabil
     )
 
 
-class TestLaserTagHighVarianceStatesRewardModel:
+class TestLaserTagZeroMeanHazardShockRewardModel:
     """Behavioural tests for the HV variant."""
 
     def test_subclass_inherits_base(self):
@@ -89,7 +91,7 @@ class TestLaserTagHighVarianceStatesRewardModel:
         Purpose: Validates the class hierarchy so callers that expect either
             base type can interchangeably use the HV variant.
 
-        Given: A constructed ``LaserTagHighVarianceStatesRewardModel``.
+        Given: A constructed ``LaserTagZeroMeanHazardShockRewardModel``.
         When: ``isinstance`` is checked against the abstract and concrete bases.
         Then: Both checks return True.
 
@@ -186,7 +188,7 @@ class TestLaserTagHighVarianceStatesRewardModel:
         assert abs(float(np.mean(contributions))) < 0.5
 
 
-class TestLaserTagDecayingHitProbabilityRewardModel:
+class TestLaserTagDistanceDecayedHazardPenaltyRewardModel:
     """Behavioural tests for the Decaying-Hit-Probability variant."""
 
     def test_rejects_non_positive_decay(self):
@@ -296,9 +298,12 @@ class TestLaserTagPOMDPRewardModelTypeWiring:
     @pytest.mark.parametrize(
         "rmt, expected_cls",
         [
-            (RewardModelType.STANDARD, LaserTagRewardModel),
-            (RewardModelType.HIGH_VARIANCE_STATES, LaserTagHighVarianceStatesRewardModel),
-            (RewardModelType.DECAYING_HIT_PROBABILITY, LaserTagDecayingHitProbabilityRewardModel),
+            (RewardModelType.CONSTANT_HAZARD_PENALTY, LaserTagRewardModel),
+            (RewardModelType.ZERO_MEAN_HAZARD_SHOCK, LaserTagZeroMeanHazardShockRewardModel),
+            (
+                RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
+                LaserTagDistanceDecayedHazardPenaltyRewardModel,
+            ),
         ],
     )
     def test_env_instantiates_correct_reward_model_subclass(self, rmt, expected_cls):

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -2305,19 +2305,19 @@ class TestNativeDiscreteRollout:
 
 class TestNativeDiscreteRolloutRewardVariantGating:
     """Native C++ rollout is variant-aware: the ``reward_variant_code`` /
-    ``penalty_decay`` parameters select the STANDARD / HIGH_VARIANCE_STATES /
-    DECAYING_HIT_PROBABILITY danger formulae inside the kernel, so dispatch
+    ``penalty_decay`` parameters select the CONSTANT_HAZARD_PENALTY / ZERO_MEAN_HAZARD_SHOCK /
+    DISTANCE_DECAYED_HAZARD_PENALTY danger formulae inside the kernel, so dispatch
     targets the native path for all three reward-model variants.
     """
 
     def test_native_kernel_used_for_standard_reward_model(self) -> None:
-        """STANDARD reward model dispatches to the native C++ kernel.
+        """CONSTANT_HAZARD_PENALTY reward model dispatches to the native C++ kernel.
 
-        Purpose: Guards against accidentally widening the fallback to STANDARD
+        Purpose: Guards against accidentally widening the fallback to CONSTANT_HAZARD_PENALTY
             (which would silently drop the perf optimisation for the default
             reward variant).
 
-        Given: A LaserTagPOMDP with default (STANDARD) reward_model_type.
+        Given: A LaserTagPOMDP with default (CONSTANT_HAZARD_PENALTY) reward_model_type.
         When: ``simulate_random_rollout`` is invoked.
         Then: The native ``simulate_rollout_discrete`` is called exactly once.
 
@@ -2333,7 +2333,7 @@ class TestNativeDiscreteRolloutRewardVariantGating:
 
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            reward_model_type=RewardModelType.STANDARD,
+            reward_model_type=RewardModelType.CONSTANT_HAZARD_PENALTY,
         )
         state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])
 
@@ -2348,19 +2348,19 @@ class TestNativeDiscreteRolloutRewardVariantGating:
                 discount_factor=0.95,
             )
             assert spy.call_count == 1, (
-                "STANDARD reward model must keep using the native rollout kernel; "
+                "CONSTANT_HAZARD_PENALTY reward model must keep using the native rollout kernel; "
                 f"got {spy.call_count} calls."
             )
 
     def test_native_kernel_used_for_high_variance_reward_model(self) -> None:
-        """HIGH_VARIANCE_STATES variant dispatches to the native rollout kernel.
+        """ZERO_MEAN_HAZARD_SHOCK variant dispatches to the native rollout kernel.
 
         Purpose: Regression for the variant-rollout integration — the C++
             kernel now implements the HV danger formula via
             ``reward_variant_code = 1``, so dispatch targets C++ instead of
             the Python loop.
 
-        Given: A LaserTagPOMDP configured with ``HIGH_VARIANCE_STATES``.
+        Given: A LaserTagPOMDP configured with ``ZERO_MEAN_HAZARD_SHOCK``.
         When: ``simulate_random_rollout`` is invoked.
         Then: ``_native.simulate_rollout_discrete`` is called exactly once with
             ``reward_variant_code = 1``.
@@ -2377,7 +2377,7 @@ class TestNativeDiscreteRolloutRewardVariantGating:
 
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            reward_model_type=RewardModelType.HIGH_VARIANCE_STATES,
+            reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
         )
         state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])
 
@@ -2396,14 +2396,14 @@ class TestNativeDiscreteRolloutRewardVariantGating:
             assert kwargs["reward_variant_code"] == 1
 
     def test_native_kernel_used_for_decaying_hit_reward_model(self) -> None:
-        """DECAYING_HIT_PROBABILITY variant dispatches to the native rollout kernel.
+        """DISTANCE_DECAYED_HAZARD_PENALTY variant dispatches to the native rollout kernel.
 
         Purpose: Regression for the variant-rollout integration — the C++
             kernel now implements the distance-decaying danger formula via
             ``reward_variant_code = 2`` and the ``penalty_decay`` argument,
             so dispatch targets C++ instead of the Python loop.
 
-        Given: A LaserTagPOMDP configured with ``DECAYING_HIT_PROBABILITY`` and
+        Given: A LaserTagPOMDP configured with ``DISTANCE_DECAYED_HAZARD_PENALTY`` and
             ``penalty_decay = 1.5``.
         When: ``simulate_random_rollout`` is invoked.
         Then: ``_native.simulate_rollout_discrete`` is called exactly once with
@@ -2421,7 +2421,7 @@ class TestNativeDiscreteRolloutRewardVariantGating:
 
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY,
+            reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
             penalty_decay=1.5,
         )
         state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/benchmark_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/benchmark_reward_models.py
@@ -5,8 +5,8 @@ Times the public Environment-API reward methods
 :meth:`ContinuousLightDarkPOMDP.reward_batch`) end-to-end so the numbers
 include the thin Python wrapper at ``continuous_light_dark_pomdp.py:637``
 on top of the reward model's ``compute_reward`` / ``compute_reward_batch``.
-Covers all three reward-model variants (Standard, HIGH_VARIANCE_STATES,
-DECAYING_HIT_PROBABILITY) on a fixed workload. Used to compare BEFORE vs
+Covers all three reward-model variants (Standard, ZERO_MEAN_HAZARD_SHOCK,
+DISTANCE_DECAYED_HAZARD_PENALTY) on a fixed workload. Used to compare BEFORE vs
 AFTER the dangerous-area generic-kernel refactor.
 
 Note: the C++ ``_native.simulate_rollout`` path is a separate hot path
@@ -73,19 +73,21 @@ def _build_envs() -> List[Tuple[str, ContinuousLightDarkPOMDP]]:
     }
     return [
         (
-            "Standard",
-            ContinuousLightDarkPOMDP(reward_model_type=RewardModelType.STANDARD, **common),
-        ),
-        (
-            "HighVariance",
+            "ConstantHazardPenalty",
             ContinuousLightDarkPOMDP(
-                reward_model_type=RewardModelType.HIGH_VARIANCE_STATES, **common
+                reward_model_type=RewardModelType.CONSTANT_HAZARD_PENALTY, **common
             ),
         ),
         (
-            "Decaying",
+            "ZeroMeanHazardShock",
             ContinuousLightDarkPOMDP(
-                reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY, **common
+                reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK, **common
+            ),
+        ),
+        (
+            "DistanceDecayedHazardPenalty",
+            ContinuousLightDarkPOMDP(
+                reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY, **common
             ),
         ),
     ]

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_cpp_parity.py
@@ -28,15 +28,15 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
 
 
 _REWARD_VARIANT_CODES = {
-    RewardModelType.STANDARD: 0,
-    RewardModelType.HIGH_VARIANCE_STATES: 1,
-    RewardModelType.DECAYING_HIT_PROBABILITY: 2,
+    RewardModelType.CONSTANT_HAZARD_PENALTY: 0,
+    RewardModelType.ZERO_MEAN_HAZARD_SHOCK: 1,
+    RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY: 2,
 }
 
 _PENALTY_DECAY_BY_VARIANT = {
-    RewardModelType.STANDARD: 0.0,
-    RewardModelType.HIGH_VARIANCE_STATES: 0.0,
-    RewardModelType.DECAYING_HIT_PROBABILITY: 1.5,
+    RewardModelType.CONSTANT_HAZARD_PENALTY: 0.0,
+    RewardModelType.ZERO_MEAN_HAZARD_SHOCK: 0.0,
+    RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY: 1.5,
 }
 
 
@@ -114,9 +114,9 @@ class TestLightDarkRewardCppParity:
     @pytest.mark.parametrize(
         "variant",
         [
-            RewardModelType.STANDARD,
-            RewardModelType.HIGH_VARIANCE_STATES,
-            RewardModelType.DECAYING_HIT_PROBABILITY,
+            RewardModelType.CONSTANT_HAZARD_PENALTY,
+            RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+            RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
         ],
     )
     def test_cpp_python_reward_means_match(self, variant: RewardModelType) -> None:

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_models.py
@@ -16,8 +16,8 @@ import pytest
 
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models import (
     BaseLightDarkRewardModel,
-    ContinuousLDHighVarianceStatesRewardModel,
-    ContinuousLightDarkDecayingHitProbabilityRewardModel,
+    ContinuousLDZeroMeanHazardShockRewardModel,
+    ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel,
     ContinuousLightDarkRewardModel,
 )
 
@@ -411,7 +411,7 @@ class TestContinuousLightDarkRewardModel:
             assert reward < -model_boundary.fuel_cost - np.linalg.norm(next_state - self.goal_state)
 
 
-class TestContinuousLDHighVarianceStatesRewardModel:
+class TestContinuousLDZeroMeanHazardShockRewardModel:
     """Test cases for high-variance states reward model."""
 
     def setup_method(self):
@@ -426,7 +426,7 @@ class TestContinuousLDHighVarianceStatesRewardModel:
         self.goal_reward = 100.0
         self.fuel_cost = 1.0
 
-        self.model = ContinuousLDHighVarianceStatesRewardModel(
+        self.model = ContinuousLDZeroMeanHazardShockRewardModel(
             goal_state=self.goal_state,
             obstacles=self.obstacles,
             goal_state_radius=self.goal_state_radius,
@@ -501,7 +501,7 @@ class TestContinuousLDHighVarianceStatesRewardModel:
         assert base_method != derived_method
 
 
-class TestContinuousLightDarkDecayingHitProbabilityRewardModel:
+class TestContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel:
     """Test cases for decaying hit probability reward model."""
 
     def setup_method(self):
@@ -517,7 +517,7 @@ class TestContinuousLightDarkDecayingHitProbabilityRewardModel:
         self.fuel_cost = 1.0
         self.penalty_decay = 2.0
 
-        self.model = ContinuousLightDarkDecayingHitProbabilityRewardModel(
+        self.model = ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel(
             goal_state=self.goal_state,
             obstacles=self.obstacles,
             goal_state_radius=self.goal_state_radius,
@@ -540,7 +540,7 @@ class TestContinuousLightDarkDecayingHitProbabilityRewardModel:
         inside ``np.exp(-d / penalty_decay)``.
 
         Given: The standard decaying-reward constructor kwargs
-        When: ``ContinuousLightDarkDecayingHitProbabilityRewardModel`` is instantiated
+        When: ``ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel`` is instantiated
             with ``penalty_decay`` equal to 0.0 or a negative value
         Then: ``ValueError`` is raised at construction; no instance is produced
 
@@ -548,7 +548,7 @@ class TestContinuousLightDarkDecayingHitProbabilityRewardModel:
         """
         for bad_decay in (0.0, -1.0):
             with pytest.raises(ValueError):
-                ContinuousLightDarkDecayingHitProbabilityRewardModel(
+                ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel(
                     goal_state=self.goal_state,
                     obstacles=self.obstacles,
                     goal_state_radius=self.goal_state_radius,
@@ -633,7 +633,7 @@ class TestContinuousLightDarkDecayingHitProbabilityRewardModel:
     def test_penalty_decay_parameter_effect(self):
         """Test that penalty_decay parameter affects probability decay rate."""
         # Create model with different decay rates
-        fast_decay_model = ContinuousLightDarkDecayingHitProbabilityRewardModel(
+        fast_decay_model = ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel(
             goal_state=self.goal_state,
             obstacles=self.obstacles,
             goal_state_radius=self.goal_state_radius,
@@ -646,7 +646,7 @@ class TestContinuousLightDarkDecayingHitProbabilityRewardModel:
             penalty_decay=1.0,  # Fast decay
         )
 
-        slow_decay_model = ContinuousLightDarkDecayingHitProbabilityRewardModel(
+        slow_decay_model = ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel(
             goal_state=self.goal_state,
             obstacles=self.obstacles,
             goal_state_radius=self.goal_state_radius,
@@ -785,7 +785,7 @@ class TestRewardModelBatch:
             fuel_cost=self.fuel_cost,
         )
 
-        self.high_variance_model = ContinuousLDHighVarianceStatesRewardModel(
+        self.high_variance_model = ContinuousLDZeroMeanHazardShockRewardModel(
             goal_state=self.goal_state,
             obstacles=self.obstacles,
             goal_state_radius=self.goal_state_radius,
@@ -797,7 +797,7 @@ class TestRewardModelBatch:
             fuel_cost=self.fuel_cost,
         )
 
-        self.decaying_model = ContinuousLightDarkDecayingHitProbabilityRewardModel(
+        self.decaying_model = ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel(
             goal_state=self.goal_state,
             obstacles=self.obstacles,
             goal_state_radius=self.goal_state_radius,
@@ -833,11 +833,11 @@ class TestRewardModelBatch:
         np.testing.assert_allclose(batch_rewards, expected)
 
     def test_high_variance_model_batch_matches_scalar(self):
-        """Test ContinuousLDHighVarianceStatesRewardModel batch matches scalar with same seed.
+        """Test ContinuousLDZeroMeanHazardShockRewardModel batch matches scalar with same seed.
 
         Purpose: Validates vectorized compute_reward_batch matches per-element compute_reward
 
-        Given: A ContinuousLDHighVarianceStatesRewardModel and 100 random states
+        Given: A ContinuousLDZeroMeanHazardShockRewardModel and 100 random states
         When: compute_reward_batch and scalar calls are made with same seed
         Then: Both produce identical reward arrays
 
@@ -857,11 +857,11 @@ class TestRewardModelBatch:
         np.testing.assert_allclose(batch_rewards, expected)
 
     def test_decaying_model_batch_matches_scalar(self):
-        """Test ContinuousLightDarkDecayingHitProbabilityRewardModel batch matches scalar with same seed.
+        """Test ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel batch matches scalar with same seed.
 
         Purpose: Validates vectorized compute_reward_batch matches per-element compute_reward
 
-        Given: A ContinuousLightDarkDecayingHitProbabilityRewardModel and 100 random states
+        Given: A ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel and 100 random states
         When: compute_reward_batch and scalar calls are made with same seed
         Then: Both produce identical reward arrays
 

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
@@ -40,8 +40,8 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
     RewardModelType,
 )
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models import (
-    ContinuousLightDarkDecayingHitProbabilityRewardModel,
-    ContinuousLDHighVarianceStatesRewardModel,
+    ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel,
+    ContinuousLDZeroMeanHazardShockRewardModel,
 )
 
 
@@ -404,7 +404,7 @@ def test_reward_range():
         grid_size=11,
     )
 
-    # Expected calculation for STANDARD reward model:
+    # Expected calculation for CONSTANT_HAZARD_PENALTY reward model:
     # Maximum distance to goal is diagonal of grid: sqrt(2) * grid_size
     max_distance_to_goal = np.sqrt(2) * 11  # grid_size=11
     # Min: -fuel_cost - max_distance + obstacle_reward
@@ -820,10 +820,10 @@ def test_decaying_hit_probability_reward_model():
         goal_state_radius=1.5,
         beacon_radius=1.0,
         obstacle_radius=1.5,
-        reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY,
+        reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
         penalty_decay=0.5,
     )
-    assert isinstance(env.reward_model, ContinuousLightDarkDecayingHitProbabilityRewardModel)
+    assert isinstance(env.reward_model, ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel)
 
 
 def test_high_variance_states_reward_model():
@@ -840,11 +840,11 @@ def test_high_variance_states_reward_model():
         goal_state_radius=1.5,
         beacon_radius=1.0,
         obstacle_radius=1.5,
-        reward_model_type=RewardModelType.HIGH_VARIANCE_STATES,
+        reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
     )
 
     # Test that the correct reward model is initialized
-    assert isinstance(env.reward_model, ContinuousLDHighVarianceStatesRewardModel)
+    assert isinstance(env.reward_model, ContinuousLDZeroMeanHazardShockRewardModel)
 
     # Test that the reward model produces both positive and negative rewards near obstacles
     state = np.array([4, 5])  # Near obstacle at (5, 5) - distance 1.0
@@ -2236,7 +2236,7 @@ def test_native_simulate_rollout_matches_python_rollout_seeded():
     np.random.seed(0)
     action_indices = np.random.randint(0, len(env.actions), size=max_depth, dtype=np.int32)
 
-    # Seed native C++ RNG; run native rollout (STANDARD variant: code 0)
+    # Seed native C++ RNG; run native rollout (CONSTANT_HAZARD_PENALTY variant: code 0)
     _native.set_seed(0)
     native_return = _native.simulate_rollout(  # pylint: disable=protected-access
         initial_state=np.ascontiguousarray(initial_state, dtype=np.float64),
@@ -2410,7 +2410,7 @@ def _empirical_pdf_relative_l1(samples: np.ndarray, log_pdf_fn: Any) -> float:
 def test_continuous_reward_at_goal_returns_goal_reward_minus_costs():
     """Reward at the goal equals goal_reward minus fuel_cost minus distance.
 
-    Purpose: Validates the goal branch of the STANDARD reward model: when
+    Purpose: Validates the goal branch of the CONSTANT_HAZARD_PENALTY reward model: when
         next_state lies inside the goal radius, reward equals
         ``goal_reward - fuel_cost - dist_to_goal`` deterministically (no
         stochastic obstacle draw is added on the goal branch).
@@ -2433,7 +2433,7 @@ def test_continuous_reward_at_goal_returns_goal_reward_minus_costs():
 def test_continuous_reward_outside_grid_returns_obstacle_reward_penalty():
     """Reward outside the grid adds the deterministic obstacle_reward penalty.
 
-    Purpose: Validates the out-of-grid branch of the STANDARD reward model:
+    Purpose: Validates the out-of-grid branch of the CONSTANT_HAZARD_PENALTY reward model:
         when next_state has any coordinate outside [0, grid_size] AND the
         state is not in the goal radius / obstacle range, reward equals
         ``-fuel_cost - dist_to_goal + obstacle_reward`` deterministically
@@ -2459,12 +2459,12 @@ def test_continuous_reward_outside_grid_returns_obstacle_reward_penalty():
 def test_continuous_reward_in_obstacle_zone_drifts_by_p_hit_times_obstacle_reward():
     """Obstacle-zone mean reward drifts by ``obstacle_reward * p_hit`` from the base.
 
-    Purpose: Validates the STANDARD obstacle branch contributes a stochastic
+    Purpose: Validates the CONSTANT_HAZARD_PENALTY obstacle branch contributes a stochastic
         drift to the reward mean equal to ``obstacle_reward * p_hit`` on top
         of the deterministic ``-fuel_cost - dist_to_goal`` base, and that a
         free cell yields a fully deterministic reward equal to the base.
 
-    Given: A STANDARD ContinuousLightDarkPOMDP with defaults
+    Given: A CONSTANT_HAZARD_PENALTY ContinuousLightDarkPOMDP with defaults
         (obstacle_hit_probability=0.2). Anchors ``in_obs=[5.0, 5.0]``
         (default obstacle position) and ``free=[8.0, 4.0]`` (free cell:
         distance to (5,5)=3.16 and to (3,7)=5.83, both >obstacle_radius=1.5;
@@ -2502,11 +2502,11 @@ def test_continuous_reward_in_obstacle_zone_drifts_by_p_hit_times_obstacle_rewar
 @pytest.mark.parametrize(
     "reward_model_type,expected_drift",
     [
-        (RewardModelType.STANDARD, -2.0),
-        (RewardModelType.DECAYING_HIT_PROBABILITY, -10.0),
-        (RewardModelType.HIGH_VARIANCE_STATES, 0.0),
+        (RewardModelType.CONSTANT_HAZARD_PENALTY, -2.0),
+        (RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY, -10.0),
+        (RewardModelType.ZERO_MEAN_HAZARD_SHOCK, 0.0),
     ],
-    ids=["STANDARD", "DECAYING_HIT_PROBABILITY", "HIGH_VARIANCE_STATES"],
+    ids=["CONSTANT_HAZARD_PENALTY", "DISTANCE_DECAYED_HAZARD_PENALTY", "ZERO_MEAN_HAZARD_SHOCK"],
 )
 def test_continuous_reward_in_obstacle_depends_on_reward_model_type(
     reward_model_type: RewardModelType, expected_drift: float
@@ -2514,9 +2514,9 @@ def test_continuous_reward_in_obstacle_depends_on_reward_model_type(
     """Each RewardModelType produces its documented obstacle-zone drift.
 
     Purpose: Validates that reward_model_type switches the obstacle-zone
-        contribution between ``obstacle_reward * p_hit`` (STANDARD),
-        ``obstacle_reward`` (DECAYING_HIT_PROBABILITY at d=0 since
-        hit_prob=exp(0)=1), and ``0`` (HIGH_VARIANCE_STATES, +/- obstacle_reward
+        contribution between ``obstacle_reward * p_hit`` (CONSTANT_HAZARD_PENALTY),
+        ``obstacle_reward`` (DISTANCE_DECAYED_HAZARD_PENALTY at d=0 since
+        hit_prob=exp(0)=1), and ``0`` (ZERO_MEAN_HAZARD_SHOCK, +/- obstacle_reward
         with p=0.5 averaging to zero).
 
     Given: state=[5,5] (default obstacle position) so min_dist_to_obstacle=0,
@@ -2541,14 +2541,14 @@ def test_continuous_reward_in_obstacle_depends_on_reward_model_type(
     base = -env.fuel_cost - float(np.linalg.norm(state - env.goal_state))
     empirical_drift = float(rewards.mean()) - base
 
-    if reward_model_type == RewardModelType.STANDARD:
+    if reward_model_type == RewardModelType.CONSTANT_HAZARD_PENALTY:
         sigma = abs(env.obstacle_reward) * np.sqrt(
             env.obstacle_hit_probability * (1.0 - env.obstacle_hit_probability)
         )
-    elif reward_model_type == RewardModelType.DECAYING_HIT_PROBABILITY:
+    elif reward_model_type == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY:
         # At d=0 the Bernoulli is degenerate (hit_prob=1) — zero variance.
         sigma = 0.0
-    else:  # HIGH_VARIANCE_STATES
+    else:  # ZERO_MEAN_HAZARD_SHOCK
         sigma = abs(env.obstacle_reward)
     sigma_mean = sigma / np.sqrt(n_samples)
     tolerance = max(3.0 * sigma_mean, 1e-9)
@@ -2559,14 +2559,14 @@ def test_continuous_reward_in_obstacle_depends_on_reward_model_type(
 
 
 def test_continuous_decaying_hit_probability_reward_decays_with_obstacle_distance():
-    """DECAYING_HIT_PROBABILITY mean reward follows -|r| * exp(-d/penalty_decay).
+    """DISTANCE_DECAYED_HAZARD_PENALTY mean reward follows -|r| * exp(-d/penalty_decay).
 
     Purpose: Validates the exp(-d/penalty_decay) decay formula in the
-        ContinuousLightDarkDecayingHitProbabilityRewardModel kernel — the
+        ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel kernel — the
         per-step drift relative to the deterministic fuel/distance base
         should track the documented exponential decay of the hit probability.
 
-    Given: A DECAYING_HIT_PROBABILITY env with penalty_decay=1.0 and the
+    Given: A DISTANCE_DECAYED_HAZARD_PENALTY env with penalty_decay=1.0 and the
         default obstacle (5, 5). Three anchor next_states with increasing
         min-distance to (5, 5): d=0.0, d=1.0, d=2.5; all in-grid and away
         from the goal (so the only stochastic component is the obstacle
@@ -2580,7 +2580,7 @@ def test_continuous_decaying_hit_probability_reward_decays_with_obstacle_distanc
     np.random.seed(55)
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY,
+        reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
         penalty_decay=1.0,
     )
     obstacle = np.array([5.0, 5.0])
@@ -3152,7 +3152,9 @@ class TestContinuousLightDarkRewardNextStateConsistency:
     """
 
     @staticmethod
-    def _make_env(obstacles, *, hit_probability=1.0, reward_model_type=RewardModelType.STANDARD):
+    def _make_env(
+        obstacles, *, hit_probability=1.0, reward_model_type=RewardModelType.CONSTANT_HAZARD_PENALTY
+    ):
         return ContinuousLightDarkPOMDP(
             discount_factor=0.95,
             state_transition_cov_matrix=np.eye(2) * 1e-12,
@@ -3360,7 +3362,7 @@ class TestContinuousLightDarkRewardNextStateConsistency:
         ``next_states = states + action``. Check it now consumes the
         threaded ``next_states``.
 
-        Given: An env with the DECAYING_HIT_PROBABILITY reward model and a
+        Given: An env with the DISTANCE_DECAYED_HAZARD_PENALTY reward model and a
             small ``penalty_decay`` so the hit probability is essentially 1
             at the obstacle and ~0 well away from it.
         When: ``env.reward_batch`` is called once with realised
@@ -3383,7 +3385,7 @@ class TestContinuousLightDarkRewardNextStateConsistency:
             goal_state_radius=1.0,
             beacon_radius=1.0,
             obstacle_radius=1.0,
-            reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY,
+            reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
             penalty_decay=0.1,
             is_obstacle_hit_terminal=False,
         )

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_utils/test_pacman_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_utils/test_pacman_reward_cpp_parity.py
@@ -4,7 +4,7 @@ Stage 1 (red step) of the upcoming native reward-kernel work. These
 tests assert that ``_native.reward_batch`` — the forthcoming standalone
 C++ reward kernel — produces sample means that agree with the Python
 reward-model implementations across all three reward variants
-(``STANDARD``, ``HIGH_VARIANCE_STATES``, ``DECAYING_HIT_PROBABILITY``).
+(``CONSTANT_HAZARD_PENALTY``, ``ZERO_MEAN_HAZARD_SHOCK``, ``DISTANCE_DECAYED_HAZARD_PENALTY``).
 
 The tests are expected to fail today: ``_native.reward_batch`` does not
 exist yet (reward is currently inlined inside ``_native.simulate_rollout``
@@ -40,9 +40,9 @@ _PENALTY_DECAY = 1.5
 _N_PARTICLES = 2000
 
 _VARIANT_CODES = {
-    RewardModelType.STANDARD: 0,
-    RewardModelType.HIGH_VARIANCE_STATES: 1,
-    RewardModelType.DECAYING_HIT_PROBABILITY: 2,
+    RewardModelType.CONSTANT_HAZARD_PENALTY: 0,
+    RewardModelType.ZERO_MEAN_HAZARD_SHOCK: 1,
+    RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY: 2,
 }
 
 
@@ -211,9 +211,9 @@ class TestPacManRewardCppParity:
     @pytest.mark.parametrize(
         "variant",
         [
-            RewardModelType.STANDARD,
-            RewardModelType.HIGH_VARIANCE_STATES,
-            RewardModelType.DECAYING_HIT_PROBABILITY,
+            RewardModelType.CONSTANT_HAZARD_PENALTY,
+            RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+            RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
         ],
     )
     def test_reward_batch_sample_mean_matches_python(self, variant: RewardModelType):
@@ -243,7 +243,7 @@ class TestPacManRewardCppParity:
         env = _make_env(variant)
         states = _seed_states(env, _N_PARTICLES)
         penalty_decay = (
-            env.penalty_decay if variant == RewardModelType.DECAYING_HIT_PROBABILITY else 0.0
+            env.penalty_decay if variant == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY else 0.0
         )
         py_rewards, cpp_rewards = _gather_rewards_across_actions(
             env,

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_utils/test_pacman_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_utils/test_pacman_reward_models.py
@@ -18,8 +18,8 @@ from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import (
 )
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.pacman_reward_models import (
     BasePacManRewardModel,
-    PacManDecayingHitProbabilityRewardModel,
-    PacManHighVarianceStatesRewardModel,
+    PacManDistanceDecayedHazardPenaltyRewardModel,
+    PacManZeroMeanHazardShockRewardModel,
     PacManRewardModel,
 )
 
@@ -67,7 +67,7 @@ def _state_with_pac(env: PacManPOMDP, pacman_pos: Tuple[int, int]) -> np.ndarray
     )
 
 
-class TestPacManHighVarianceStatesRewardModel:
+class TestPacManZeroMeanHazardShockRewardModel:
     """Behavioural tests for the HV variant."""
 
     def test_subclass_inherits_base(self):
@@ -82,10 +82,10 @@ class TestPacManHighVarianceStatesRewardModel:
 
         Test type: unit
         """
-        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        env = _make_env(RewardModelType.ZERO_MEAN_HAZARD_SHOCK)
         assert isinstance(env.reward_model, PacManRewardModel)
         assert isinstance(env.reward_model, BasePacManRewardModel)
-        assert isinstance(env.reward_model, PacManHighVarianceStatesRewardModel)
+        assert isinstance(env.reward_model, PacManZeroMeanHazardShockRewardModel)
 
     def test_outside_zone_matches_step_penalty(self):
         """Positions outside every zone score exactly the step penalty.
@@ -101,7 +101,7 @@ class TestPacManHighVarianceStatesRewardModel:
 
         Test type: unit
         """
-        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        env = _make_env(RewardModelType.ZERO_MEAN_HAZARD_SHOCK)
         state = _state_with_pac(env, (0, 0))
         next_state = _state_with_pac(env, (0, 1))
         reward = env.reward_model.compute_reward(state, action=1, next_state=next_state)
@@ -124,7 +124,7 @@ class TestPacManHighVarianceStatesRewardModel:
         Test type: unit
         """
         np.random.seed(42)
-        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        env = _make_env(RewardModelType.ZERO_MEAN_HAZARD_SHOCK)
         state = _state_with_pac(env, (3, 2))
         next_state = _state_with_pac(env, _DANGER_CENTRE)
         rewards = np.array(
@@ -154,7 +154,7 @@ class TestPacManHighVarianceStatesRewardModel:
         Test type: unit
         """
         np.random.seed(123)
-        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        env = _make_env(RewardModelType.ZERO_MEAN_HAZARD_SHOCK)
         n = 4000
         state = _state_with_pac(env, (3, 2))
         next_state = _state_with_pac(env, _DANGER_CENTRE)
@@ -179,7 +179,7 @@ class TestPacManHighVarianceStatesRewardModel:
         Test type: unit
         """
         np.random.seed(7)
-        env = _make_env(RewardModelType.HIGH_VARIANCE_STATES)
+        env = _make_env(RewardModelType.ZERO_MEAN_HAZARD_SHOCK)
         state = env.make_state(
             pacman_pos=(3, 3),
             ghost_positions=((6, 6),),
@@ -192,7 +192,7 @@ class TestPacManHighVarianceStatesRewardModel:
             assert env.reward_model.compute_reward(state, action=1, next_state=next_state) == 0.0
 
 
-class TestPacManDecayingHitProbabilityRewardModel:
+class TestPacManDistanceDecayedHazardPenaltyRewardModel:
     """Behavioural tests for the Decaying-Hit-Probability variant."""
 
     def test_rejects_non_positive_decay(self):
@@ -207,9 +207,9 @@ class TestPacManDecayingHitProbabilityRewardModel:
         Test type: unit
         """
         with pytest.raises(ValueError, match="penalty_decay"):
-            _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=0.0)
+            _make_env(RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY, penalty_decay=0.0)
         with pytest.raises(ValueError, match="penalty_decay"):
-            _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=-1.0)
+            _make_env(RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY, penalty_decay=-1.0)
 
     def test_at_centre_always_triggers_penalty(self):
         """When the realised position equals a centre, penalty fires every time.
@@ -225,7 +225,7 @@ class TestPacManDecayingHitProbabilityRewardModel:
         Test type: unit
         """
         np.random.seed(7)
-        env = _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=1.0)
+        env = _make_env(RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY, penalty_decay=1.0)
         state = _state_with_pac(env, (3, 2))
         next_state = _state_with_pac(env, _DANGER_CENTRE)
         for _ in range(50):
@@ -251,7 +251,7 @@ class TestPacManDecayingHitProbabilityRewardModel:
         """
         np.random.seed(99)
         decay = 2.0
-        env = _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=decay)
+        env = _make_env(RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY, penalty_decay=decay)
         n = 6000
         # Position (3, 1): nearest centre (3, 3) at distance 2.0. Use action 4
         # (stay) so the batch path's neighbor-table lookup keeps the realised
@@ -290,7 +290,7 @@ class TestPacManDecayingHitProbabilityRewardModel:
             ghost_collision_penalty=-100.0,
             pellet_reward=10.0,
             win_reward=100.0,
-            reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY,
+            reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
             penalty_decay=1.0,
         )
         state = _state_with_pac(env, (0, 0))
@@ -311,7 +311,7 @@ class TestPacManDecayingHitProbabilityRewardModel:
         Test type: unit
         """
         np.random.seed(7)
-        env = _make_env(RewardModelType.DECAYING_HIT_PROBABILITY, penalty_decay=1.0)
+        env = _make_env(RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY, penalty_decay=1.0)
         state = env.make_state(
             pacman_pos=(3, 3),
             ghost_positions=((6, 6),),
@@ -330,9 +330,12 @@ class TestPacManPOMDPRewardModelTypeWiring:
     @pytest.mark.parametrize(
         "rmt, expected_cls",
         [
-            (RewardModelType.STANDARD, PacManRewardModel),
-            (RewardModelType.HIGH_VARIANCE_STATES, PacManHighVarianceStatesRewardModel),
-            (RewardModelType.DECAYING_HIT_PROBABILITY, PacManDecayingHitProbabilityRewardModel),
+            (RewardModelType.CONSTANT_HAZARD_PENALTY, PacManRewardModel),
+            (RewardModelType.ZERO_MEAN_HAZARD_SHOCK, PacManZeroMeanHazardShockRewardModel),
+            (
+                RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
+                PacManDistanceDecayedHazardPenaltyRewardModel,
+            ),
         ],
     )
     def test_env_instantiates_correct_reward_model_subclass(self, rmt, expected_cls):
@@ -428,7 +431,7 @@ class TestPacManGhostSwapCollisionDetection:
 
         Test type: unit
         """
-        env = _make_env(RewardModelType.STANDARD)
+        env = _make_env(RewardModelType.CONSTANT_HAZARD_PENALTY)
         # Use cells well clear of the danger zone (centred at (3, 3), radius 1)
         # so the expected reward depends only on step + collision penalties.
         # Action 1 (east) moves pacman (0, 0) -> (0, 1); ghost (0, 1) -> (0, 0)
@@ -457,7 +460,7 @@ class TestPacManGhostSwapCollisionDetection:
 
         Test type: unit
         """
-        env = _make_env(RewardModelType.STANDARD)
+        env = _make_env(RewardModelType.CONSTANT_HAZARD_PENALTY)
         # Use cells well clear of the danger zone (centred at (3, 3), radius 1)
         # so the expected reward depends only on step + collision penalties.
         state = _make_swap_state(env, pacman_pos=(0, 0), ghost_pos=(0, 1))
@@ -482,7 +485,7 @@ class TestPacManGhostSwapCollisionDetection:
 
         Test type: unit
         """
-        env = _make_env(RewardModelType.STANDARD)
+        env = _make_env(RewardModelType.CONSTANT_HAZARD_PENALTY)
         # Use cells well clear of the danger zone (centred at (3, 3), radius 1)
         # so the expected reward depends only on step + collision penalties.
         state = _make_swap_state(env, pacman_pos=(0, 0), ghost_pos=(0, 1))

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/push_pomdp_utils/test_push_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/push_pomdp_utils/test_push_reward_cpp_parity.py
@@ -4,8 +4,8 @@ Verifies that the future native reward kernels
 ``_native.push_reward_batch`` (discrete) and
 ``_native.cont_push_reward_batch`` (continuous) reproduce — in
 expectation — the Python reward-model output across all three
-:class:`RewardModelType` variants: ``STANDARD``,
-``HIGH_VARIANCE_STATES`` and ``DECAYING_HIT_PROBABILITY``.
+:class:`RewardModelType` variants: ``CONSTANT_HAZARD_PENALTY``,
+``ZERO_MEAN_HAZARD_SHOCK`` and ``DISTANCE_DECAYED_HAZARD_PENALTY``.
 
 Today no standalone C++ reward kernel exists for the Push family —
 reward is inlined inside ``_native.simulate_rollout_discrete`` /
@@ -44,15 +44,15 @@ _DANGEROUS_AREAS_DISCRETE = [(3.0, 3.0), (6.0, 6.0), (8.0, 2.0)]
 _DANGEROUS_AREAS_CONTINUOUS = [(3.0, 3.0), (6.0, 6.0), (8.0, 2.0)]
 
 _REWARD_VARIANT_CODES = {
-    RewardModelType.STANDARD: 0,
-    RewardModelType.HIGH_VARIANCE_STATES: 1,
-    RewardModelType.DECAYING_HIT_PROBABILITY: 2,
+    RewardModelType.CONSTANT_HAZARD_PENALTY: 0,
+    RewardModelType.ZERO_MEAN_HAZARD_SHOCK: 1,
+    RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY: 2,
 }
 
 _PENALTY_DECAY_BY_VARIANT = {
-    RewardModelType.STANDARD: 0.0,
-    RewardModelType.HIGH_VARIANCE_STATES: 0.0,
-    RewardModelType.DECAYING_HIT_PROBABILITY: _PENALTY_DECAY,
+    RewardModelType.CONSTANT_HAZARD_PENALTY: 0.0,
+    RewardModelType.ZERO_MEAN_HAZARD_SHOCK: 0.0,
+    RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY: _PENALTY_DECAY,
 }
 
 
@@ -76,7 +76,7 @@ def _build_discrete_env(variant: RewardModelType) -> PushPOMDP:
         reward_model_type=variant,
         penalty_decay=(
             _PENALTY_DECAY_BY_VARIANT[variant]
-            if variant == RewardModelType.DECAYING_HIT_PROBABILITY
+            if variant == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY
             else 1.0
         ),
     )
@@ -94,7 +94,7 @@ def _build_continuous_env(variant: RewardModelType) -> ContinuousPushPOMDP:
         reward_model_type=variant,
         penalty_decay=(
             _PENALTY_DECAY_BY_VARIANT[variant]
-            if variant == RewardModelType.DECAYING_HIT_PROBABILITY
+            if variant == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY
             else 1.0
         ),
     )
@@ -211,9 +211,9 @@ class TestDiscretePushRewardCppParity:
     @pytest.mark.parametrize(
         "variant",
         [
-            RewardModelType.STANDARD,
-            RewardModelType.HIGH_VARIANCE_STATES,
-            RewardModelType.DECAYING_HIT_PROBABILITY,
+            RewardModelType.CONSTANT_HAZARD_PENALTY,
+            RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+            RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
         ],
     )
     def test_cpp_python_reward_means_match(self, variant: RewardModelType) -> None:
@@ -228,7 +228,7 @@ class TestDiscretePushRewardCppParity:
         Given: A discrete :class:`PushPOMDP` constructed with the chosen
             ``reward_model_type``, non-empty ``dangerous_areas``,
             ``dangerous_area_penalty = -10.0``,
-            ``dangerous_area_hit_probability = 1.0`` (so STANDARD is
+            ``dangerous_area_hit_probability = 1.0`` (so CONSTANT_HAZARD_PENALTY is
             deterministic) and (for the Decaying variant)
             ``penalty_decay = 1.5``. A seeded batch of ``N = 2000``
             states is generated mixing dangerous-area and clear cells,
@@ -275,9 +275,9 @@ class TestContinuousPushRewardCppParity:
     @pytest.mark.parametrize(
         "variant",
         [
-            RewardModelType.STANDARD,
-            RewardModelType.HIGH_VARIANCE_STATES,
-            RewardModelType.DECAYING_HIT_PROBABILITY,
+            RewardModelType.CONSTANT_HAZARD_PENALTY,
+            RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+            RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
         ],
     )
     def test_cpp_python_reward_means_match(self, variant: RewardModelType) -> None:

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/rock_sample_pomdp_utils/test_rock_sample_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/rock_sample_pomdp_utils/test_rock_sample_reward_cpp_parity.py
@@ -17,9 +17,9 @@ The contract being asserted here is:
   environment scoring parameters, plus ``reward_variant_code`` (int) and
   ``penalty_decay`` (float) selecting one of the three reward variants:
 
-  * ``reward_variant_code=0`` -> STANDARD
-  * ``reward_variant_code=1`` -> HIGH_VARIANCE_STATES
-  * ``reward_variant_code=2`` -> DECAYING_HIT_PROBABILITY
+  * ``reward_variant_code=0`` -> CONSTANT_HAZARD_PENALTY
+  * ``reward_variant_code=1`` -> ZERO_MEAN_HAZARD_SHOCK
+  * ``reward_variant_code=2`` -> DISTANCE_DECAYED_HAZARD_PENALTY
 
 * For each variant, the sample-mean of the C++ rewards over a seeded
   ``N=2000`` batch matches the sample-mean of the Python reward model
@@ -176,11 +176,11 @@ def _collect_py_rewards(
 @pytest.mark.parametrize(
     ("variant", "reward_variant_code", "penalty_decay"),
     [
-        (RewardModelType.STANDARD, 0, 0.0),
-        (RewardModelType.HIGH_VARIANCE_STATES, 1, 0.0),
-        (RewardModelType.DECAYING_HIT_PROBABILITY, 2, _PENALTY_DECAY_DECAYING_VARIANT),
+        (RewardModelType.CONSTANT_HAZARD_PENALTY, 0, 0.0),
+        (RewardModelType.ZERO_MEAN_HAZARD_SHOCK, 1, 0.0),
+        (RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY, 2, _PENALTY_DECAY_DECAYING_VARIANT),
     ],
-    ids=["standard", "high_variance_states", "decaying_hit_probability"],
+    ids=["constant_hazard_penalty", "zero_mean_hazard_shock", "distance_decayed_hazard_penalty"],
 )
 class TestRockSampleRewardCppParity:
     """C++ vs Python reward-mean parity across all RockSample reward variants."""

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/rock_sample_pomdp_utils/test_rock_sample_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/rock_sample_pomdp_utils/test_rock_sample_reward_models.py
@@ -1,7 +1,7 @@
-"""Tests for the RockSample HIGH_VARIANCE_STATES and DECAYING_HIT_PROBABILITY
+"""Tests for the RockSample ZERO_MEAN_HAZARD_SHOCK and DISTANCE_DECAYED_HAZARD_PENALTY
 reward-model variants.
 
-The STANDARD model is exercised by the env-level parity tests in
+The CONSTANT_HAZARD_PENALTY model is exercised by the env-level parity tests in
 ``test_rock_sample_pomdp.py`` / ``test_rock_sample_kernel_cache.py`` and
 is not re-tested here. These tests target only the new variants and
 their integration with :class:`RockSamplePOMDP` via the
@@ -19,8 +19,8 @@ from POMDPPlanners.environments.rock_sample_pomdp import (
     create_rock_sample_state,
 )
 from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_utils.rock_sample_reward_models import (
-    RockSampleDecayingHitProbabilityRewardModel,
-    RockSampleHighVarianceRewardModel,
+    RockSampleDistanceDecayedHazardPenaltyRewardModel,
+    RockSampleZeroMeanHazardShockRewardModel,
     RockSampleRewardModel,
 )
 
@@ -31,7 +31,7 @@ from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_utils.rock_s
 
 
 def test_env_builds_standard_reward_model_by_default():
-    """Default ``reward_model_type`` produces a STANDARD ``RockSampleRewardModel``.
+    """Default ``reward_model_type`` produces a CONSTANT_HAZARD_PENALTY ``RockSampleRewardModel``.
 
     Purpose: Validates the default dispatch path through ``_build_reward_model``.
 
@@ -47,14 +47,14 @@ def test_env_builds_standard_reward_model_by_default():
 
 
 def test_env_builds_high_variance_reward_model_on_request():
-    """HIGH_VARIANCE_STATES dispatch path constructs the right subclass.
+    """ZERO_MEAN_HAZARD_SHOCK dispatch path constructs the right subclass.
 
     Purpose: Validates that the env's reward-model factory picks the
         high-variance subclass when asked.
 
-    Given: A ``RockSamplePOMDP`` with ``reward_model_type=HIGH_VARIANCE_STATES``.
+    Given: A ``RockSamplePOMDP`` with ``reward_model_type=ZERO_MEAN_HAZARD_SHOCK``.
     When: The env is built.
-    Then: ``env.reward_model`` is a ``RockSampleHighVarianceRewardModel``
+    Then: ``env.reward_model`` is a ``RockSampleZeroMeanHazardShockRewardModel``
         and the env-level reward_range spans both signs of the penalty.
 
     Test type: unit
@@ -62,9 +62,9 @@ def test_env_builds_high_variance_reward_model_on_request():
     env = RockSamplePOMDP(
         dangerous_areas=[(2, 2)],
         dangerous_area_penalty=-5.0,
-        reward_model_type=RewardModelType.HIGH_VARIANCE_STATES,
+        reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
     )
-    assert isinstance(env.reward_model, RockSampleHighVarianceRewardModel)
+    assert isinstance(env.reward_model, RockSampleZeroMeanHazardShockRewardModel)
     # HIGH_VARIANCE flips the penalty sign with probability 0.5, so the
     # reward_range must include the positive sign too.
     assert env.reward_range is not None
@@ -74,25 +74,25 @@ def test_env_builds_high_variance_reward_model_on_request():
 
 
 def test_env_builds_decaying_reward_model_on_request():
-    """DECAYING_HIT_PROBABILITY dispatch path constructs the right subclass.
+    """DISTANCE_DECAYED_HAZARD_PENALTY dispatch path constructs the right subclass.
 
     Purpose: Validates the env's reward-model factory picks the
         decaying-probability subclass and threads ``penalty_decay`` through.
 
-    Given: A ``RockSamplePOMDP`` with reward_model_type=DECAYING_HIT_PROBABILITY
+    Given: A ``RockSamplePOMDP`` with reward_model_type=DISTANCE_DECAYED_HAZARD_PENALTY
         and penalty_decay=2.5.
     When: The env is built.
-    Then: ``env.reward_model`` is a ``RockSampleDecayingHitProbabilityRewardModel``
+    Then: ``env.reward_model`` is a ``RockSampleDistanceDecayedHazardPenaltyRewardModel``
         with ``penalty_decay`` 2.5.
 
     Test type: unit
     """
     env = RockSamplePOMDP(
         dangerous_areas=[(2, 2)],
-        reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY,
+        reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
         penalty_decay=2.5,
     )
-    assert isinstance(env.reward_model, RockSampleDecayingHitProbabilityRewardModel)
+    assert isinstance(env.reward_model, RockSampleDistanceDecayedHazardPenaltyRewardModel)
     assert env.reward_model.penalty_decay == 2.5
 
 
@@ -101,7 +101,7 @@ def test_decaying_model_rejects_non_positive_penalty_decay():
 
     Purpose: Validates the decaying-model constructor refuses zero / negative decay.
 
-    Given: A direct ``RockSampleDecayingHitProbabilityRewardModel`` build with
+    Given: A direct ``RockSampleDistanceDecayedHazardPenaltyRewardModel`` build with
         ``penalty_decay=0.0`` (and again with a negative value).
     When: The constructor is called.
     Then: ``ValueError`` is raised in both cases.
@@ -109,7 +109,7 @@ def test_decaying_model_rejects_non_positive_penalty_decay():
     Test type: unit
     """
     with pytest.raises(ValueError, match="penalty_decay must be positive"):
-        RockSampleDecayingHitProbabilityRewardModel(
+        RockSampleDistanceDecayedHazardPenaltyRewardModel(
             map_size=(5, 5),
             rock_positions=[(0, 0)],
             step_penalty=0.0,
@@ -124,7 +124,7 @@ def test_decaying_model_rejects_non_positive_penalty_decay():
             penalty_decay=0.0,
         )
     with pytest.raises(ValueError, match="penalty_decay must be positive"):
-        RockSampleDecayingHitProbabilityRewardModel(
+        RockSampleDistanceDecayedHazardPenaltyRewardModel(
             map_size=(5, 5),
             rock_positions=[(0, 0)],
             step_penalty=0.0,
@@ -141,7 +141,7 @@ def test_decaying_model_rejects_non_positive_penalty_decay():
 
 
 # ---------------------------------------------------------------------------
-# HIGH_VARIANCE_STATES semantics
+# ZERO_MEAN_HAZARD_SHOCK semantics
 # ---------------------------------------------------------------------------
 
 
@@ -151,7 +151,7 @@ def _make_high_variance_env() -> RockSamplePOMDP:
         rock_positions=[(0, 0), (2, 2), (3, 3), (5, 5)],
         dangerous_areas=[(2, 2), (4, 4)],
         dangerous_area_penalty=-5.0,
-        reward_model_type=RewardModelType.HIGH_VARIANCE_STATES,
+        reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
     )
 
 
@@ -252,7 +252,7 @@ def test_high_variance_batch_seeded_parity_with_scalar_loop():
 
 
 # ---------------------------------------------------------------------------
-# DECAYING_HIT_PROBABILITY semantics
+# DISTANCE_DECAYED_HAZARD_PENALTY semantics
 # ---------------------------------------------------------------------------
 
 
@@ -262,7 +262,7 @@ def _make_decaying_env(penalty_decay: float = 1.0) -> RockSamplePOMDP:
         rock_positions=[(0, 0), (2, 2), (3, 3), (5, 5)],
         dangerous_areas=[(3, 3)],
         dangerous_area_penalty=-5.0,
-        reward_model_type=RewardModelType.DECAYING_HIT_PROBABILITY,
+        reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
         penalty_decay=penalty_decay,
     )
 

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp_dpw.py
@@ -983,7 +983,7 @@ def test_numpy_array_observation_comparison():
         grid_size=2,
         goal_state_radius=0.5,
         beacon_radius=1.0,
-        reward_model_type=RewardModelType.STANDARD,
+        reward_model_type=RewardModelType.CONSTANT_HAZARD_PENALTY,
     )
 
     # Test that the environment's is_equal_observation method works correctly


### PR DESCRIPTION
## Summary

Mechanical rename of the shared three-variant reward-model taxonomy used by **light_dark**, **laser_tag**, **push**, **rock_sample**, and **pacman**. The new names describe what each variant actually computes:

| Before | After | What it does |
|---|---|---|
| ``STANDARD`` | ``CONSTANT_HAZARD_PENALTY`` | Fixed-probability Bernoulli penalty inside the hazard radius |
| ``HIGH_VARIANCE_STATES`` | ``ZERO_MEAN_HAZARD_SHOCK`` | Symmetric ±penalty (50/50 sign flip) inside the hazard radius; E[r]=0, Var=penalty² |
| ``DECAYING_HIT_PROBABILITY`` | ``DISTANCE_DECAYED_HAZARD_PENALTY`` | Penalty applied with probability ``exp(-d/penalty_decay)`` based on distance to nearest hazard centre |

"Shock" is the standard econ/finance term for a zero-mean random perturbation, which is exactly what variant 2 is.

## Scope of changes

Applied the rename consistently to:
- ``RewardModelType`` enum members **and** string values in all 5 envs
- Concrete reward-model class names (``*HighVarianceStatesRewardModel`` → ``*ZeroMeanHazardShockRewardModel``, ``*DecayingHitProbabilityRewardModel`` → ``*DistanceDecayedHazardPenaltyRewardModel``; rock_sample's odd ``RockSampleHighVarianceRewardModel`` aligned to the new ``RockSampleZeroMeanHazardShockRewardModel``)
- C++ kernel internal constants (``kVariantStandard`` → ``kVariantConstantHazardPenalty``, etc.) and surrounding comments
- Docstrings, ``.pyi`` stubs, and pytest parametrize IDs

## Intentionally **not** renamed

The pre-existing ``AVG_HIGH_VARIANCE_STATES_COUNTER`` metric counter in both light_dark variants is **deliberately left untouched** because it's a user-facing wire-name tied to analytics dashboards rather than to the reward-model taxonomy itself.

## Test plan

- [x] 1010/1010 pass across the 5 env test suites
- [x] Pyright clean on the whole tree (0 new errors, 0 new warnings)
- [x] Pylint on env sources: 9.97 → 9.98
- [x] All env enums importable; ``RewardModelType.<NEW_NAME>`` resolves correctly in all 5 envs
- [x] Pre-commit hooks (black, pylint, pyright) pass