### PR TITLE
feat(pacman): add dangerous-area step counter + total-danger-encounters aggregate

### DIFF
--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -53,6 +53,8 @@ class PacManPOMDPMetrics(Enum):
     AVG_EPISODE_LENGTH = "avg_episode_length"
     AVG_PACMAN_CLOSEST_GHOST_DISTANCE = "avg_pacman_closest_ghost_distance"
     AVG_COLLISION_ENCOUNTERS = "avg_collision_encounters"
+    AVG_DANGEROUS_AREA_STEPS = "avg_dangerous_area_steps"
+    AVG_ALL_DANGEROUS_ENCOUNTERS = "avg_all_dangerous_encounters"
 
 
 class RewardModelType(Enum):
@@ -1124,10 +1126,25 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         """Check if PacMan is at the same position as any ghost."""
         return pacman_pos in ghost_positions
 
-    def _collect_step_distances_and_collisions(self, history: History) -> Tuple[List[float], int]:
-        """Collect distances to closest ghost and collision count from episode history."""
+    def _is_in_dangerous_area(self, position: Tuple[int, int]) -> bool:
+        if not self.dangerous_areas:
+            return False
+        pos_row, pos_col = position
+        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
+        for danger_row, danger_col in self.dangerous_areas:
+            dr = pos_row - danger_row
+            dc = pos_col - danger_col
+            if dr * dr + dc * dc <= radius_sq:
+                return True
+        return False
+
+    def _collect_step_distances_and_collisions(
+        self, history: History
+    ) -> Tuple[List[float], int, int]:
+        """Collect distances, collision count, and danger-area step count from episode."""
         episode_distances = []
         episode_collisions = 0
+        episode_danger_steps = 0
 
         for step_data in history.history:
             state = step_data.state
@@ -1143,16 +1160,21 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             if self._is_collision(pacman_pos, ghost_positions):
                 episode_collisions += 1
 
-        return episode_distances, episode_collisions
+            if self._is_in_dangerous_area(pacman_pos):
+                episode_danger_steps += 1
+
+        return episode_distances, episode_collisions, episode_danger_steps
 
     def _process_episode_metrics(self, history: History) -> Dict[str, Any]:
         """Process metrics for a single episode."""
-        metrics_data = {
+        metrics_data: Dict[str, Any] = {
             "episode_length": len(history.history),
             "won": 0,
             "pellets_collected": 0,
             "avg_distance": None,
             "collisions": 0,
+            "dangerous_area_steps": 0,
+            "all_dangerous_encounters": 0,
         }
 
         if not history.history:
@@ -1167,13 +1189,17 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         metrics_data["won"] = self._check_episode_win_status(final_state)
         metrics_data["pellets_collected"] = self._count_pellets_collected(final_state)
 
-        # Collect distances and collisions from episode steps
-        episode_distances, episode_collisions = self._collect_step_distances_and_collisions(history)
+        # Collect distances, collisions, and danger-area steps from episode steps
+        episode_distances, episode_collisions, episode_danger_steps = (
+            self._collect_step_distances_and_collisions(history)
+        )
 
         if episode_distances:
             metrics_data["avg_distance"] = float(np.mean(episode_distances))
 
         metrics_data["collisions"] = episode_collisions
+        metrics_data["dangerous_area_steps"] = episode_danger_steps
+        metrics_data["all_dangerous_encounters"] = episode_collisions + episode_danger_steps
         return metrics_data
 
     def _create_metric_value(self, name: str, values: List[float]) -> Optional[MetricValue]:
@@ -1270,8 +1296,13 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         Returns:
             List containing metric names including standard metrics (win_rate,
             avg_pellets_collected, avg_episode_length, avg_pacman_closest_ghost_distance,
-            avg_collision_encounters) and dynamically generated per-ghost distance metrics
-            for multi-ghost scenarios (avg_pacman_ghost_0_distance, avg_pacman_ghost_1_distance, etc.)
+            avg_collision_encounters, avg_dangerous_area_steps,
+            avg_all_dangerous_encounters) and dynamically generated per-ghost
+            distance metrics for multi-ghost scenarios
+            (avg_pacman_ghost_0_distance, avg_pacman_ghost_1_distance, etc.).
+            ``avg_all_dangerous_encounters`` is the per-step sum of
+            ghost-collision and dangerous-area-step events; a step that is both
+            counts twice.
         """
         # Start with standard metrics
         metric_names = [metric.value for metric in PacManPOMDPMetrics]
@@ -1294,6 +1325,8 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         episode_lengths = []
         pacman_ghost_distances = []
         collision_encounters = []
+        dangerous_area_steps = []
+        all_dangerous_encounters = []
 
         for history in histories:
             episode_data = self._process_episode_metrics(history)
@@ -1301,6 +1334,8 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             wins.append(episode_data["won"])
             pellets_collected.append(episode_data["pellets_collected"])
             collision_encounters.append(episode_data["collisions"])
+            dangerous_area_steps.append(episode_data["dangerous_area_steps"])
+            all_dangerous_encounters.append(episode_data["all_dangerous_encounters"])
 
             if episode_data["avg_distance"] is not None:
                 pacman_ghost_distances.append(episode_data["avg_distance"])
@@ -1313,6 +1348,11 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             (PacManPOMDPMetrics.AVG_EPISODE_LENGTH.value, episode_lengths),
             (PacManPOMDPMetrics.AVG_PACMAN_CLOSEST_GHOST_DISTANCE.value, pacman_ghost_distances),
             (PacManPOMDPMetrics.AVG_COLLISION_ENCOUNTERS.value, collision_encounters),
+            (PacManPOMDPMetrics.AVG_DANGEROUS_AREA_STEPS.value, dangerous_area_steps),
+            (
+                PacManPOMDPMetrics.AVG_ALL_DANGEROUS_ENCOUNTERS.value,
+                all_dangerous_encounters,
+            ),
         ]
 
         for name, values in metric_definitions:

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
@@ -1539,6 +1539,166 @@ class TestPacManPOMDPMetrics:
         verify_return_shift_linearity(histories, self.pomdp, shift=1.5)
 
 
+class TestPacManPOMDPDangerMetrics:
+    """Test cases for PacMan dangerous-area step and aggregate metrics."""
+
+    def setup_method(self):
+        """Set up a PacMan env with a single danger zone at (3, 3) radius 1."""
+        self.pomdp = PacManPOMDP(
+            maze_size=(7, 7),
+            walls=set(),
+            initial_pellets=[(0, 6)],
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(6, 6)],
+            dangerous_areas={(3, 3)},
+            dangerous_area_radius=1.0,
+            dangerous_area_penalty=5.0,
+        )
+
+    def _make_state(
+        self, pac_pos: Tuple[int, int], ghost_pos: Tuple[int, int] = (6, 6)
+    ) -> np.ndarray:
+        return self.pomdp.make_state(
+            pacman_pos=pac_pos,
+            ghost_positions=(ghost_pos,),
+            pellets=((0, 6),),
+        )
+
+    def _make_history(self, states: list) -> History:
+        dummy_belief = WeightedParticleBelief(
+            particles=[None], log_weights=np.array([0.1]), resampling=False
+        )
+
+        def _step(state: np.ndarray, next_state: np.ndarray) -> StepData:
+            return StepData(
+                state=state,
+                action=None,
+                next_state=next_state,
+                observation=None,
+                reward=0,
+                belief=dummy_belief,
+            )
+
+        steps = [_step(states[i], states[i + 1]) for i in range(len(states) - 1)]
+        if not steps:
+            steps = [_step(states[0], states[0])]
+        return History(
+            history=steps,
+            discount_factor=0.95,
+            average_state_sampling_time=0.0,
+            average_action_time=0.0,
+            average_observation_time=0.0,
+            average_belief_update_time=0.0,
+            average_reward_time=0.0,
+            actual_num_steps=len(steps),
+            reach_terminal_state=False,
+            policy_run_data=[],
+        )
+
+    def test_compute_metrics_dangerous_area_steps_count(self):
+        """Counts each step whose state has PacMan inside any danger zone.
+
+        Purpose: Validates that ``avg_dangerous_area_steps`` totals one per
+            step whose recorded ``state`` places PacMan inside a configured
+            hazard zone, matching the LaserTag counting convention.
+
+        Given: Two episodes — episode A with 2 in-zone states and 1 outside,
+            episode B with 1 in-zone state and 1 outside.
+        When: ``compute_metrics`` is called.
+        Then: ``avg_dangerous_area_steps`` equals the per-episode mean
+            ``(2 + 1) / 2 = 1.5`` with finite confidence bounds.
+
+        Test type: unit
+        """
+        ep_a = self._make_history(
+            [
+                self._make_state((3, 3)),  # in zone
+                self._make_state((3, 4)),  # in zone (distance 1)
+                self._make_state((0, 0)),  # outside
+            ]
+        )
+        ep_b = self._make_history(
+            [
+                self._make_state((2, 3)),  # in zone
+                self._make_state((0, 1)),  # outside
+            ]
+        )
+
+        metrics = self.pomdp.compute_metrics([ep_a, ep_b])
+        danger_metric = next((m for m in metrics if m.name == "avg_dangerous_area_steps"), None)
+
+        assert danger_metric is not None
+        assert abs(danger_metric.value - 1.5) < 1e-9
+        assert danger_metric.lower_confidence_bound is not None
+        assert danger_metric.upper_confidence_bound is not None
+
+    def test_compute_metrics_all_dangerous_encounters_sums_collisions_and_zone_steps(self):
+        """Aggregate equals ghost-collision count plus danger-zone-step count.
+
+        Purpose: Validates that ``avg_all_dangerous_encounters`` is the sum
+            of ``avg_collision_encounters`` and ``avg_dangerous_area_steps``,
+            counting a step that is both a ghost collision and inside a
+            danger zone as two encounters (the LaserTag convention).
+
+        Given: Episode A with 2 danger-zone steps and 0 ghost collisions;
+            episode B with 1 step that is simultaneously in the zone and a
+            ghost collision plus 1 unrelated outside step.
+        When: ``compute_metrics`` is called.
+        Then: ``avg_collision_encounters`` is 0.5, ``avg_dangerous_area_steps``
+            is 1.5, and ``avg_all_dangerous_encounters`` is 2.0.
+
+        Test type: unit
+        """
+        ep_a = self._make_history(
+            [
+                self._make_state((3, 3), ghost_pos=(6, 6)),
+                self._make_state((3, 4), ghost_pos=(6, 6)),
+                self._make_state((0, 0), ghost_pos=(6, 6)),
+            ]
+        )
+        ep_b = self._make_history(
+            [
+                # Collision AND in-zone simultaneously
+                self._make_state((3, 3), ghost_pos=(3, 3)),
+                self._make_state((0, 1), ghost_pos=(6, 6)),
+            ]
+        )
+
+        metrics = self.pomdp.compute_metrics([ep_a, ep_b])
+        by_name = {m.name: m for m in metrics}
+
+        collisions = by_name.get("avg_collision_encounters")
+        danger_steps = by_name.get("avg_dangerous_area_steps")
+        aggregate = by_name.get("avg_all_dangerous_encounters")
+
+        assert collisions is not None
+        assert danger_steps is not None
+        assert aggregate is not None
+        assert abs(collisions.value - 0.5) < 1e-9
+        assert abs(danger_steps.value - 1.5) < 1e-9
+        assert abs(aggregate.value - (collisions.value + danger_steps.value)) < 1e-9
+        assert abs(aggregate.value - 2.0) < 1e-9
+
+    def test_get_metric_names_includes_danger_step_and_aggregate(self):
+        """``get_metric_names`` advertises both new metric keys.
+
+        Purpose: Validates that the public metric-name listing reports the
+            danger-step counter and the all-dangerous-encounters aggregate
+            so downstream tooling can discover them.
+
+        Given: A PacMan env with a danger zone configured.
+        When: ``get_metric_names`` is called.
+        Then: Both ``avg_dangerous_area_steps`` and
+            ``avg_all_dangerous_encounters`` appear in the returned list.
+
+        Test type: unit
+        """
+        names = self.pomdp.get_metric_names()
+        assert "avg_dangerous_area_steps" in names
+        assert "avg_all_dangerous_encounters" in names
+
+
 class TestCreateSimpleMazePacman:
     """Test cases for create_simple_maze_pacman function."""
 


### PR DESCRIPTION
## Summary

- Adds `avg_dangerous_area_steps` — per-step counter of states whose PacMan position lies inside any configured hazard zone, matching LaserTag's counting convention.
- Adds `avg_all_dangerous_encounters` — aggregate that sums ghost collisions and dangerous-area steps; a step that is both counts twice (LaserTag convention).
- Closes the gap audit: PacMan was the only env in the hazard family that silently penalised danger-zone steps without surfacing them in per-episode metrics. RockSample, LaserTag, and Push already report the danger-step counter; LaserTag also already has the matching aggregate.

## Implementation notes

- Introduces `_is_in_dangerous_area` (squared-distance check) — same algorithm as `LaserTagPOMDP._is_in_dangerous_area`.
- Threads the new counts through `_collect_step_distances_and_collisions` and `_process_episode_metrics`; aggregate is computed once per episode as `collisions + dangerous_area_steps`.
- Purely additive: no existing metric keys are renamed or removed. `experiment_configs.py` references to `avg_collision_encounters` remain valid.

## Test plan

- [x] New `TestPacManPOMDPDangerMetrics` class with three failing-first regression tests:
  - `test_compute_metrics_dangerous_area_steps_count` — 2 episodes, mean = 1.5
  - `test_compute_metrics_all_dangerous_encounters_sums_collisions_and_zone_steps` — verifies the aggregate equals collisions + danger-steps including the overlap case
  - `test_get_metric_names_includes_danger_step_and_aggregate` — public listing advertises both new keys
- [x] All 78 tests in `test_pacman_pomdp.py` pass (existing 75 + 3 new)
- [x] `pyright POMDPPlanners/` — 0 errors, 0 warnings (1 pre-existing warning in `core/environment/environment.py:345` is unrelated)
- [x] `pylint` on both files — source 9.95/10 (unchanged baseline), tests 9.64/10 (one extra W0201 from the standard `setup_method` pattern already accepted by every other test class in the file)