### PR TITLE
ci(release): build sdist only — wheel has unportable platform tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,14 @@ jobs:
         python -m pip install --upgrade pip
         pip install build twine
 
-    - name: Build package
+    - name: Build sdist
+      # Build sdist only. Building a wheel here would produce a
+      # ``linux_x86_64``-tagged artifact which PyPI / TestPyPI reject
+      # (only ``manylinux*`` wheels are accepted). Portable wheels need
+      # a cibuildwheel-driven matrix that is out of scope for this
+      # workflow; users install from sdist and build locally.
       run: |
-        python -m build
+        python -m build --sdist
 
     - name: Check package
       run: |


### PR DESCRIPTION
## Summary
- ``python -m build`` on a vanilla GitHub runner produces a wheel tagged ``linux_x86_64``; PyPI / TestPyPI reject that with 403 (only ``manylinux*`` wheels are accepted).
- Twine uploads ``.tar.gz`` before ``.whl`` alphabetically, so historically the sdist slipped through before the wheel step failed. Verified via the PyPI JSON API: every prior release on PyPI is sdist-only.
- Switch the build step to ``python -m build --sdist`` so the run actually succeeds. Portable manylinux wheels would need a ``cibuildwheel`` matrix — out of scope here.

## Test plan
- [x] ``python -m build --sdist`` locally → ``pomdpplanners-0.4.0.tar.gz``
- [x] ``twine check dist/*`` → PASSED
- [ ] After merge, dispatch ``release.yml`` with ``test_pypi=true`` and confirm upload to TestPyPI completes