### PR TITLE
feat(laser_tag): add selectable OpponentPolicy (evade vs pursue)

### DIFF
--- a/POMDPPlanners/environments/laser_tag_pomdp/__init__.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/__init__.py
@@ -15,9 +15,13 @@ from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_pomdp impor
     ContinuousLaserTagPOMDP,
     ContinuousLaserTagPOMDPDiscreteActions,
 )
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils import (
+    OpponentPolicy,
+)
 
 __all__ = [
     "LaserTagPOMDP",
     "ContinuousLaserTagPOMDP",
     "ContinuousLaserTagPOMDPDiscreteActions",
+    "OpponentPolicy",
 ]

--- a/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
@@ -2625,6 +2625,8 @@ PYBIND11_MODULE(_native, m) {
         py::arg("dangerous_area_penalty"), py::arg("opponent_policy_code") = 0,
         "Run a full random rollout for ContinuousLaserTagPOMDP in one C++ frame.\n\n"
         "``actions_buffer`` must be shape (N, 3) float64 with N >= max_depth - start_depth.\n"
+        "``opponent_policy_code`` selects the opponent behaviour: 0 = EVADE (away from\n"
+        "the robot's pre-move position), 1 = PURSUE (toward its post-move position).\n"
         "Returns the discounted sum of immediate rewards along the sampled trajectory.");
 
     // ── Discrete LaserTag native rollout binding ──────────────────────────────
@@ -2648,6 +2650,8 @@ PYBIND11_MODULE(_native, m) {
         "  1 = ZERO_MEAN_HAZARD_SHOCK (wall always -penalty; danger +/-penalty 50/50);\n"
         "  2 = DISTANCE_DECAYED_HAZARD_PENALTY (wall always -penalty; danger -penalty\n"
         "      with probability exp(-min_dist / penalty_decay), no radius cutoff).\n"
+        "``opponent_policy_code`` selects the opponent behaviour: 0 = EVADE (away from\n"
+        "the robot's pre-move position), 1 = PURSUE (toward its post-move position).\n"
         "Returns the discounted sum of immediate rewards along the sampled trajectory.");
 
     // ── Discrete LaserTag belief-update kernels ─────────────────────────────
@@ -2658,7 +2662,9 @@ PYBIND11_MODULE(_native, m) {
         py::arg("opponent_policy_code") = 0,
         "Native port of LaserTagVectorizedUpdater.batch_transition.\n\n"
         "Returns the (N, 5) float64 array of next particles.  Uses\n"
-        "pomdp_native::default_rng(); seed via set_seed() for reproducibility.");
+        "pomdp_native::default_rng(); seed via set_seed() for reproducibility.\n"
+        "``opponent_policy_code`` selects the opponent behaviour: 0 = EVADE (away from\n"
+        "the robot's pre-move position), 1 = PURSUE (toward its post-move position).");
 
     m.def(
         "belief_batch_obs_log_likelihood_discrete",
@@ -2681,6 +2687,8 @@ PYBIND11_MODULE(_native, m) {
         "optional transition error). ``opp_uniform`` is a uniform [0,1) draw\n"
         "used to pick the opponent move; must be drawn with np.random.random()\n"
         "for byte-identical reproducibility against the original Python path.\n"
+        "``opponent_policy_code`` selects the opponent behaviour: 0 = EVADE (away from\n"
+        "the robot's pre-move position), 1 = PURSUE (toward its post-move position).\n"
         "Returns a (5,) float64 ndarray.");
 
     m.def(

--- a/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
@@ -268,6 +268,13 @@ void clamp_to_grid(double &x, double &y, double radius, double grid_w, double gr
     y = std::clamp(y, radius, grid_h - radius);
 }
 
+// Opponent transition policy. EVADE flees the robot (directional mass on the
+// distance-increasing move, reacting to the robot's pre-move position); PURSUE
+// chases (mass on the distance-decreasing move, reacting to the robot's
+// post-move position). Mirrors OpponentPolicy.native_code in Python.
+constexpr int kPolicyEvade = 0;
+constexpr int kPolicyPursue = 1;
+
 // Shared environment geometry / physics parameters used by both the
 // transition and observation models.
 struct EnvParams {
@@ -278,11 +285,13 @@ struct EnvParams {
     double opponent_radius;
     double tag_radius;
     double evasion_speed;
+    int opponent_policy_code = kPolicyEvade;
 };
 
 EnvParams make_env_params(const py::array_t<double> &walls_arr,
                           const py::array_t<double> &grid_size, double robot_radius,
-                          double opponent_radius, double tag_radius, double evasion_speed) {
+                          double opponent_radius, double tag_radius, double evasion_speed,
+                          int opponent_policy_code = kPolicyEvade) {
     if (grid_size.ndim() != 1 || grid_size.shape(0) != 2) {
         throw std::invalid_argument("grid_size must have shape (2,)");
     }
@@ -295,6 +304,7 @@ EnvParams make_env_params(const py::array_t<double> &walls_arr,
     p.opponent_radius = opponent_radius;
     p.tag_radius = tag_radius;
     p.evasion_speed = evasion_speed;
+    p.opponent_policy_code = opponent_policy_code;
     return p;
 }
 
@@ -313,13 +323,17 @@ void sample_move(double mean_x, double mean_y, double radius,
     clamp_to_grid(out_x, out_y, radius, env.grid_w, env.grid_h);
 }
 
-// Compute the evasion target for the opponent: move ``evasion_speed`` away from
-// the robot, sampling a random unit vector when the two are coincident.
-void opponent_evasion_mean(double robot_x, double robot_y, double opp_x, double opp_y,
-                           double evasion_speed, pomdp_native::RNGState &rng, double &mean_x,
-                           double &mean_y) {
-    const double diff_x = opp_x - robot_x;
-    const double diff_y = opp_y - robot_y;
+// Compute the opponent's target mean: move ``move_speed`` away from (EVADE) or
+// toward (PURSUE) the robot, sampling a random unit vector when the two are
+// coincident. The caller chooses which robot position (pre- or post-move) to
+// pass per the policy's reference-position semantics.
+void opponent_move_mean(double robot_x, double robot_y, double opp_x, double opp_y,
+                        double move_speed, int opponent_policy_code,
+                        pomdp_native::RNGState &rng, double &mean_x, double &mean_y) {
+    // EVADE flees (diff = opp - robot); PURSUE chases (diff = robot - opp).
+    const double sign = (opponent_policy_code == kPolicyEvade) ? 1.0 : -1.0;
+    const double diff_x = sign * (opp_x - robot_x);
+    const double diff_y = sign * (opp_y - robot_y);
     const double dist = std::hypot(diff_x, diff_y);
     double dir_x;
     double dir_y;
@@ -334,8 +348,8 @@ void opponent_evasion_mean(double robot_x, double robot_y, double opp_x, double 
         dir_x = diff_x / dist;
         dir_y = diff_y / dist;
     }
-    mean_x = opp_x + evasion_speed * dir_x;
-    mean_y = opp_y + evasion_speed * dir_y;
+    mean_x = opp_x + move_speed * dir_x;
+    mean_y = opp_y + move_speed * dir_y;
 }
 
 // Parse the 3-element action vector (dx, dy, tag_flag) from a Python object.
@@ -379,13 +393,14 @@ class ContinuousLaserTagTransitionCpp {
                                     const py::array_t<double> &opponent_cov, double evasion_speed,
                                     const py::array_t<double> &walls_arr,
                                     const py::array_t<double> &grid_size, double robot_radius,
-                                    double opponent_radius, double tag_radius)
+                                    double opponent_radius, double tag_radius,
+                                    int opponent_policy_code = kPolicyEvade)
         : state_(parse_state(state_obj)),
           action_(parse_action(action_obj)),
           robot_noise_(pomdp_native::GaussianND<2>::from_covariance(robot_cov)),
           opp_noise_(pomdp_native::GaussianND<2>::from_covariance(opponent_cov)),
           env_(make_env_params(walls_arr, grid_size, robot_radius, opponent_radius, tag_radius,
-                               evasion_speed)) {}
+                               evasion_speed, opponent_policy_code)) {}
 
     py::list sample(int n_samples) const {
         if (n_samples < 0) {
@@ -481,11 +496,12 @@ class ContinuousLaserTagTransitionCpp {
                 out[4] = 1.0;
                 return;
             }
-            // Robot does not move on a tag; opponent still evades.
+            // Robot does not move on a tag; opponent still moves per the policy
+            // (pre- and post-move robot coincide here).
             double mean_opp_x;
             double mean_opp_y;
-            opponent_evasion_mean(robot_x, robot_y, opp_x, opp_y, env_.evasion_speed, rng,
-                                  mean_opp_x, mean_opp_y);
+            opponent_move_mean(robot_x, robot_y, opp_x, opp_y, env_.evasion_speed,
+                               env_.opponent_policy_code, rng, mean_opp_x, mean_opp_y);
             double new_opp_x;
             double new_opp_y;
             sample_move(mean_opp_x, mean_opp_y, env_.opponent_radius, opp_noise_, env_, rng,
@@ -498,7 +514,7 @@ class ContinuousLaserTagTransitionCpp {
             return;
         }
 
-        // Non-tag action: apply robot Gaussian move then opponent evasion.
+        // Non-tag action: apply robot Gaussian move then the opponent move.
         double new_robot_x;
         double new_robot_y;
         sample_move(robot_x + action_[0], robot_y + action_[1], env_.robot_radius, robot_noise_,
@@ -506,10 +522,13 @@ class ContinuousLaserTagTransitionCpp {
 
         double mean_opp_x;
         double mean_opp_y;
-        // Opponent reacts to the robot's PRE-move position, consistent with the
-        // tag-action path and the discrete env.
-        opponent_evasion_mean(robot_x, robot_y, opp_x, opp_y, env_.evasion_speed, rng,
-                              mean_opp_x, mean_opp_y);
+        // EVADE reacts to the robot's PRE-move position; PURSUE to its POST-move position.
+        const double ref_robot_x =
+            (env_.opponent_policy_code == kPolicyEvade) ? robot_x : new_robot_x;
+        const double ref_robot_y =
+            (env_.opponent_policy_code == kPolicyEvade) ? robot_y : new_robot_y;
+        opponent_move_mean(ref_robot_x, ref_robot_y, opp_x, opp_y, env_.evasion_speed,
+                           env_.opponent_policy_code, rng, mean_opp_x, mean_opp_y);
         double new_opp_x;
         double new_opp_y;
         sample_move(mean_opp_x, mean_opp_y, env_.opponent_radius, opp_noise_, env_, rng, new_opp_x,
@@ -1182,11 +1201,11 @@ static bool cont_step_state(double *state, const double *action, const EnvParams
             state[4] = 1.0;
             return true;
         }
-        // Robot stays; opponent evades.
+        // Robot stays; opponent moves per the policy (pre/post robot coincide).
         double mean_opp_x;
         double mean_opp_y;
-        opponent_evasion_mean(robot_x, robot_y, opp_x, opp_y, env.evasion_speed, rng, mean_opp_x,
-                              mean_opp_y);
+        opponent_move_mean(robot_x, robot_y, opp_x, opp_y, env.evasion_speed,
+                           env.opponent_policy_code, rng, mean_opp_x, mean_opp_y);
         double new_opp_x;
         double new_opp_y;
         sample_move(mean_opp_x, mean_opp_y, env.opponent_radius, opp_noise, env, rng, new_opp_x,
@@ -1196,7 +1215,7 @@ static bool cont_step_state(double *state, const double *action, const EnvParams
         return false;
     }
 
-    // Non-tag: robot moves, then opponent evades.
+    // Non-tag: robot moves, then the opponent moves per the policy.
     double new_robot_x;
     double new_robot_y;
     sample_move(robot_x + action[0], robot_y + action[1], env.robot_radius, robot_noise, env, rng,
@@ -1204,10 +1223,11 @@ static bool cont_step_state(double *state, const double *action, const EnvParams
 
     double mean_opp_x;
     double mean_opp_y;
-    // Opponent reacts to the robot's PRE-move position, consistent with the
-    // tag-action path and the discrete env.
-    opponent_evasion_mean(robot_x, robot_y, opp_x, opp_y, env.evasion_speed, rng,
-                          mean_opp_x, mean_opp_y);
+    // EVADE reacts to the robot's PRE-move position; PURSUE to its POST-move position.
+    const double ref_robot_x = (env.opponent_policy_code == kPolicyEvade) ? robot_x : new_robot_x;
+    const double ref_robot_y = (env.opponent_policy_code == kPolicyEvade) ? robot_y : new_robot_y;
+    opponent_move_mean(ref_robot_x, ref_robot_y, opp_x, opp_y, env.evasion_speed,
+                       env.opponent_policy_code, rng, mean_opp_x, mean_opp_y);
     double new_opp_x;
     double new_opp_y;
     sample_move(mean_opp_x, mean_opp_y, env.opponent_radius, opp_noise, env, rng, new_opp_x,
@@ -1257,7 +1277,8 @@ double cont_simulate_rollout(
     double robot_radius, double opponent_radius, double tag_radius, double tag_reward,
     double tag_penalty, double step_cost,
     const py::array_t<double, py::array::c_style | py::array::forcecast> &dangerous_areas,
-    double dangerous_area_radius, double dangerous_area_penalty) {
+    double dangerous_area_radius, double dangerous_area_penalty,
+    int opponent_policy_code = kPolicyEvade) {
     // Validate shapes.
     if (initial_state.ndim() != 1 || initial_state.shape(0) != static_cast<py::ssize_t>(kStateDim)) {
         throw std::invalid_argument("initial_state must have shape (5,)");
@@ -1277,7 +1298,7 @@ double cont_simulate_rollout(
     // Build env params.
     py::array_t<double> grid_size_arr = grid_size;
     EnvParams env = make_env_params(walls, grid_size_arr, robot_radius, opponent_radius, tag_radius,
-                                    evasion_speed);
+                                    evasion_speed, opponent_policy_code);
 
     // Build Gaussian noise models.
     pomdp_native::GaussianND<2> robot_noise = pomdp_native::GaussianND<2>::from_covariance(robot_covariance);
@@ -1379,6 +1400,8 @@ struct DiscreteEnvParams {
     // Reward-variant fields (default to CONSTANT_HAZARD_PENALTY, penalty_decay=1.0).
     int reward_variant_code = kVariantConstantHazardPenalty;
     double penalty_decay = 1.0;
+    // Opponent transition policy (default EVADE).
+    int opponent_policy_code = kPolicyEvade;
 };
 
 DiscreteEnvParams make_discrete_env_params(
@@ -1389,7 +1412,8 @@ DiscreteEnvParams make_discrete_env_params(
     double tag_reward, double tag_penalty, double step_cost,
     double transition_error_prob,
     int reward_variant_code = kVariantConstantHazardPenalty,
-    double penalty_decay = 1.0) {
+    double penalty_decay = 1.0,
+    int opponent_policy_code = kPolicyEvade) {
 
     DiscreteEnvParams p;
     p.rows = rows;
@@ -1397,6 +1421,7 @@ DiscreteEnvParams make_discrete_env_params(
     p.wall_grid.assign(static_cast<std::size_t>(rows * cols), false);
     p.reward_variant_code = reward_variant_code;
     p.penalty_decay = penalty_decay;
+    p.opponent_policy_code = opponent_policy_code;
 
     // walls_flat: 1-D int64 array of length 2*M: [r0, c0, r1, c1, ...]
     if (walls_flat.ndim() != 1) {
@@ -1563,13 +1588,19 @@ std::pair<int, int> disc_sample_opponent_move(
         }
     };
 
+    // EVADE places the 0.4 directional mass on the distance-increasing (away)
+    // cell; PURSUE places it on the distance-decreasing (toward) cell. The
+    // aligned (robot == opponent) branch is policy-invariant.
+    const bool evade = (env.opponent_policy_code == kPolicyEvade);
+
     // x-moves (column direction, fixed row = opp_r)
     if (robot_c == opp_c) {
         add_cand(opp_r, opp_c + 1, 0.2);
         add_cand(opp_r, opp_c - 1, 0.2);
     } else {
-        const int away_c = (robot_c > opp_c) ? opp_c - 1 : opp_c + 1;
-        add_cand(opp_r, away_c, 0.4);
+        const int dir_c = (robot_c > opp_c) ? (evade ? opp_c - 1 : opp_c + 1)
+                                            : (evade ? opp_c + 1 : opp_c - 1);
+        add_cand(opp_r, dir_c, 0.4);
     }
 
     // y-moves (row direction, fixed col = opp_c)
@@ -1577,8 +1608,9 @@ std::pair<int, int> disc_sample_opponent_move(
         add_cand(opp_r + 1, opp_c, 0.2);
         add_cand(opp_r - 1, opp_c, 0.2);
     } else {
-        const int away_r = (robot_r > opp_r) ? opp_r - 1 : opp_r + 1;
-        add_cand(away_r, opp_c, 0.4);
+        const int dir_r = (robot_r > opp_r) ? (evade ? opp_r - 1 : opp_r + 1)
+                                            : (evade ? opp_r + 1 : opp_r - 1);
+        add_cand(dir_r, opp_c, 0.4);
     }
 
     // Compute actual_total including the base stay probability 0.2.
@@ -1631,7 +1663,8 @@ double simulate_rollout_discrete(
     double tag_reward, double tag_penalty, double step_cost,
     double transition_error_prob,
     int reward_variant_code,
-    double penalty_decay) {
+    double penalty_decay,
+    int opponent_policy_code = kPolicyEvade) {
 
     if (initial_state.ndim() != 1 || initial_state.shape(0) != 5) {
         throw std::invalid_argument("initial_state must have shape (5,)");
@@ -1645,7 +1678,7 @@ double simulate_rollout_discrete(
         rows, cols, walls_flat, dangerous_areas,
         dangerous_area_radius, dangerous_area_penalty,
         tag_reward, tag_penalty, step_cost, transition_error_prob,
-        reward_variant_code, penalty_decay);
+        reward_variant_code, penalty_decay, opponent_policy_code);
 
     pomdp_native::RNGState &rng = pomdp_native::default_rng();
     std::uniform_int_distribution<int> action_dist(0, 4);
@@ -1709,10 +1742,14 @@ double simulate_rollout_discrete(
             break;
         }
 
-        // Sample opponent move. The opponent reacts to the robot's PRE-move
-        // position (robot_r, robot_c), matching LaserTag.jl's transition.
+        // Sample opponent move. EVADE reacts to the robot's PRE-move position;
+        // PURSUE to its POST-move position.
+        const int ref_robot_r =
+            (env.opponent_policy_code == kPolicyEvade) ? robot_r : new_robot_r;
+        const int ref_robot_c =
+            (env.opponent_policy_code == kPolicyEvade) ? robot_c : new_robot_c;
         auto [new_opp_r, new_opp_c] = disc_sample_opponent_move(
-            opp_r, opp_c, robot_r, robot_c, env, rng);
+            opp_r, opp_c, ref_robot_r, ref_robot_c, env, rng);
 
         state[0] = static_cast<double>(new_robot_r);
         state[1] = static_cast<double>(new_robot_c);
@@ -1768,7 +1805,7 @@ inline bool belief_is_valid(int r, int c, int rows, int cols, const std::uint8_t
 // match the Python cumulative thresholds (cum1, cum2, cum3, cum4, 1.0).
 void belief_sample_opponent_move(int robot_r, int robot_c, int opp_r, int opp_c,
                                   int rows, int cols, const std::uint8_t *valid_cell,
-                                  double u, int *out_r, int *out_c) {
+                                  int opponent_policy_code, double u, int *out_r, int *out_c) {
     const bool right_valid = belief_is_valid(opp_r, opp_c + 1, rows, cols, valid_cell);
     const bool left_valid = belief_is_valid(opp_r, opp_c - 1, rows, cols, valid_cell);
     const bool up_valid = belief_is_valid(opp_r - 1, opp_c, rows, cols, valid_cell);
@@ -1776,29 +1813,32 @@ void belief_sample_opponent_move(int robot_r, int robot_c, int opp_r, int opp_c,
 
     const bool same_col = (robot_c == opp_c);
     const bool same_row = (robot_r == opp_r);
+    // EVADE puts the 0.4 mass on the cell that increases distance to the robot;
+    // PURSUE on the cell that decreases it. The comparisons below flip per policy.
+    const bool evade = (opponent_policy_code == kPolicyEvade);
 
     double right_prob = 0.0;
     if (same_col && right_valid) {
         right_prob = 0.2;
-    } else if (robot_c < opp_c && right_valid) {
+    } else if ((evade ? (robot_c < opp_c) : (robot_c > opp_c)) && right_valid) {
         right_prob = 0.4;
     }
     double left_prob = 0.0;
     if (same_col && left_valid) {
         left_prob = 0.2;
-    } else if (robot_c > opp_c && left_valid) {
+    } else if ((evade ? (robot_c > opp_c) : (robot_c < opp_c)) && left_valid) {
         left_prob = 0.4;
     }
     double up_prob = 0.0;
     if (same_row && up_valid) {
         up_prob = 0.2;
-    } else if (robot_r > opp_r && up_valid) {
+    } else if ((evade ? (robot_r > opp_r) : (robot_r < opp_r)) && up_valid) {
         up_prob = 0.4;
     }
     double down_prob = 0.0;
     if (same_row && down_valid) {
         down_prob = 0.2;
-    } else if (robot_r < opp_r && down_valid) {
+    } else if ((evade ? (robot_r < opp_r) : (robot_r > opp_r)) && down_valid) {
         down_prob = 0.4;
     }
 
@@ -1833,7 +1873,7 @@ void belief_sample_opponent_move(int robot_r, int robot_c, int opp_r, int opp_c,
 void belief_apply_action(int action_idx, std::size_t n,
                           const double *particles, double *out,
                           int rows, int cols, const std::uint8_t *valid_cell,
-                          pomdp_native::RNGState &rng) {
+                          int opponent_policy_code, pomdp_native::RNGState &rng) {
     std::uniform_real_distribution<double> uniform(0.0, 1.0);
     const int dr = kBeliefActionDirections[static_cast<std::size_t>(action_idx)][0];
     const int dc = kBeliefActionDirections[static_cast<std::size_t>(action_idx)][1];
@@ -1888,10 +1928,14 @@ void belief_apply_action(int action_idx, std::size_t n,
         const double u = uniform(rng.engine());
         int new_opp_r;
         int new_opp_c;
-        // Opponent reacts to the robot's PRE-move position (robot_r, robot_c),
-        // matching LaserTag.jl's transition.
-        belief_sample_opponent_move(robot_r, robot_c, opp_r, opp_c,
-                                     rows, cols, valid_cell, u,
+        // EVADE reacts to the robot's PRE-move position; PURSUE to its POST-move
+        // position.
+        const int ref_robot_r =
+            (opponent_policy_code == kPolicyEvade) ? robot_r : new_robot_r;
+        const int ref_robot_c =
+            (opponent_policy_code == kPolicyEvade) ? robot_c : new_robot_c;
+        belief_sample_opponent_move(ref_robot_r, ref_robot_c, opp_r, opp_c,
+                                     rows, cols, valid_cell, opponent_policy_code, u,
                                      &new_opp_r, &new_opp_c);
 
         out[off + 0] = static_cast<double>(new_robot_r);
@@ -1919,7 +1963,7 @@ py::array_t<double> belief_batch_transition_discrete(
     const py::array_t<double, py::array::c_style | py::array::forcecast> &particles,
     int action_idx, double transition_error_prob,
     const py::array_t<std::uint8_t, py::array::c_style | py::array::forcecast> &valid_cell_flat,
-    int rows, int cols) {
+    int rows, int cols, int opponent_policy_code = kPolicyEvade) {
     if (particles.ndim() != 2 || particles.shape(1) != 5) {
         throw std::invalid_argument("particles must have shape (N, 5)");
     }
@@ -1952,7 +1996,8 @@ py::array_t<double> belief_batch_transition_discrete(
 
     // Fast path: tag action or zero error probability → single dispatch.
     if (action_idx == 4 || transition_error_prob <= 0.0) {
-        belief_apply_action(action_idx, n, in_data, out_data, rows, cols, vc_data, rng);
+        belief_apply_action(action_idx, n, in_data, out_data, rows, cols, vc_data,
+                            opponent_policy_code, rng);
         // Suppress unused-variable warnings from unused views.
         (void)in_view;
         (void)out_view;
@@ -1967,7 +2012,7 @@ py::array_t<double> belief_batch_transition_discrete(
     for (int a = 0; a < 4; ++a) {
         candidates[static_cast<std::size_t>(a)].assign(n * 5, 0.0);
         belief_apply_action(a, n, in_data, candidates[static_cast<std::size_t>(a)].data(),
-                            rows, cols, vc_data, rng);
+                            rows, cols, vc_data, opponent_policy_code, rng);
     }
 
     // For each particle, decide which action was actually executed.
@@ -2234,13 +2279,19 @@ std::size_t disc_opponent_move_table(int opp_r, int opp_c, int robot_r,
         }
     };
 
+    // EVADE places the 0.4 directional mass on the distance-increasing (away)
+    // cell; PURSUE on the distance-decreasing (toward) cell. The aligned branch
+    // is policy-invariant.
+    const bool evade = (env.opponent_policy_code == kPolicyEvade);
+
     // x-moves (column direction, fixed row = opp_r)
     if (robot_c == opp_c) {
         try_add(opp_r, opp_c + 1, 0.2);
         try_add(opp_r, opp_c - 1, 0.2);
     } else {
-        const int away_c = (robot_c > opp_c) ? opp_c - 1 : opp_c + 1;
-        try_add(opp_r, away_c, 0.4);
+        const int dir_c = (robot_c > opp_c) ? (evade ? opp_c - 1 : opp_c + 1)
+                                            : (evade ? opp_c + 1 : opp_c - 1);
+        try_add(opp_r, dir_c, 0.4);
     }
 
     // y-moves (row direction, fixed col = opp_c)
@@ -2248,8 +2299,9 @@ std::size_t disc_opponent_move_table(int opp_r, int opp_c, int robot_r,
         try_add(opp_r + 1, opp_c, 0.2);
         try_add(opp_r - 1, opp_c, 0.2);
     } else {
-        const int away_r = (robot_r > opp_r) ? opp_r - 1 : opp_r + 1;
-        try_add(away_r, opp_c, 0.4);
+        const int dir_r = (robot_r > opp_r) ? (evade ? opp_r - 1 : opp_r + 1)
+                                            : (evade ? opp_r + 1 : opp_r - 1);
+        try_add(dir_r, opp_c, 0.4);
     }
 
     // Stay action probability: 0.2 + slack from invalid moves.
@@ -2274,7 +2326,8 @@ std::size_t disc_opponent_move_table(int opp_r, int opp_c, int robot_r,
 py::array_t<double> lasertag_sample_next_state_step(
     const py::array_t<double, py::array::c_style | py::array::forcecast> &state_arr,
     int actual_action, double opp_uniform, int rows, int cols,
-    const py::array_t<std::int64_t, py::array::c_style | py::array::forcecast> &walls_flat) {
+    const py::array_t<std::int64_t, py::array::c_style | py::array::forcecast> &walls_flat,
+    int opponent_policy_code = kPolicyEvade) {
     if (state_arr.ndim() != 1 || state_arr.shape(0) != 5) {
         throw std::invalid_argument("state must have shape (5,)");
     }
@@ -2287,6 +2340,7 @@ py::array_t<double> lasertag_sample_next_state_step(
     DiscreteEnvParams env;
     env.rows = rows;
     env.cols = cols;
+    env.opponent_policy_code = opponent_policy_code;
     env.wall_grid.assign(static_cast<std::size_t>(rows * cols), false);
     if (walls_flat.ndim() != 1) {
         throw std::invalid_argument("walls_flat must be 1-D");
@@ -2339,10 +2393,13 @@ py::array_t<double> lasertag_sample_next_state_step(
     int opp_rows_buf[5];   // NOLINT(modernize-avoid-c-arrays)
     int opp_cols_buf[5];   // NOLINT(modernize-avoid-c-arrays)
     double opp_probs[5];   // NOLINT(modernize-avoid-c-arrays)
-    // Opponent reacts to the robot's PRE-move position (robot_r, robot_c),
-    // matching LaserTag.jl's transition.
+    // EVADE reacts to the robot's PRE-move position; PURSUE to its POST-move position.
+    const int ref_robot_r =
+        (opponent_policy_code == kPolicyEvade) ? robot_r : robot_next_r;
+    const int ref_robot_c =
+        (opponent_policy_code == kPolicyEvade) ? robot_c : robot_next_c;
     const std::size_t n_opp = disc_opponent_move_table(
-        opp_r, opp_c, robot_r, robot_c, env, opp_rows_buf, opp_cols_buf, opp_probs);
+        opp_r, opp_c, ref_robot_r, ref_robot_c, env, opp_rows_buf, opp_cols_buf, opp_probs);
     const std::size_t pick = cumulative_sample(opp_probs, n_opp, opp_uniform);
 
     ov(0) = static_cast<double>(robot_next_r);
@@ -2527,11 +2584,11 @@ PYBIND11_MODULE(_native, m) {
     py::class_<ContinuousLaserTagTransitionCpp>(m, "ContinuousLaserTagTransitionCpp")
         .def(py::init<const py::object &, const py::object &, const py::array_t<double> &,
                       const py::array_t<double> &, double, const py::array_t<double> &,
-                      const py::array_t<double> &, double, double, double>(),
+                      const py::array_t<double> &, double, double, double, int>(),
              py::arg("state"), py::arg("action"), py::arg("robot_covariance"),
              py::arg("opponent_covariance"), py::arg("evasion_speed"), py::arg("walls"),
              py::arg("grid_size"), py::arg("robot_radius"), py::arg("opponent_radius"),
-             py::arg("tag_radius"))
+             py::arg("tag_radius"), py::arg("opponent_policy_code") = 0)
         .def("sample", &ContinuousLaserTagTransitionCpp::sample, py::arg("n_samples") = 1)
         .def("probability", &ContinuousLaserTagTransitionCpp::probability, py::arg("values"))
         .def("batch_sample", &ContinuousLaserTagTransitionCpp::batch_sample, py::arg("particles"))
@@ -2565,7 +2622,7 @@ PYBIND11_MODULE(_native, m) {
         py::arg("grid_size"), py::arg("robot_radius"), py::arg("opponent_radius"),
         py::arg("tag_radius"), py::arg("tag_reward"), py::arg("tag_penalty"),
         py::arg("step_cost"), py::arg("dangerous_areas"), py::arg("dangerous_area_radius"),
-        py::arg("dangerous_area_penalty"),
+        py::arg("dangerous_area_penalty"), py::arg("opponent_policy_code") = 0,
         "Run a full random rollout for ContinuousLaserTagPOMDP in one C++ frame.\n\n"
         "``actions_buffer`` must be shape (N, 3) float64 with N >= max_depth - start_depth.\n"
         "Returns the discounted sum of immediate rewards along the sampled trajectory.");
@@ -2582,6 +2639,7 @@ PYBIND11_MODULE(_native, m) {
         py::arg("transition_error_prob"),
         py::arg("reward_variant_code") = 0,
         py::arg("penalty_decay") = 1.0,
+        py::arg("opponent_policy_code") = 0,
         "Run a full random-action rollout for the discrete LaserTagPOMDP in one C++ frame.\n\n"
         "Actions are drawn uniformly from {0,1,2,3,4} using pomdp_native::default_rng().\n"
         "Seed via set_seed() before calling to obtain reproducible trajectories.\n"
@@ -2597,6 +2655,7 @@ PYBIND11_MODULE(_native, m) {
         "belief_batch_transition_discrete", &belief_batch_transition_discrete,
         py::arg("particles"), py::arg("action_idx"), py::arg("transition_error_prob"),
         py::arg("valid_cell_flat"), py::arg("rows"), py::arg("cols"),
+        py::arg("opponent_policy_code") = 0,
         "Native port of LaserTagVectorizedUpdater.batch_transition.\n\n"
         "Returns the (N, 5) float64 array of next particles.  Uses\n"
         "pomdp_native::default_rng(); seed via set_seed() for reproducibility.");
@@ -2616,6 +2675,7 @@ PYBIND11_MODULE(_native, m) {
         "sample_next_state_step", &lasertag_sample_next_state_step,
         py::arg("state"), py::arg("actual_action"), py::arg("opp_uniform"),
         py::arg("rows"), py::arg("cols"), py::arg("walls_flat"),
+        py::arg("opponent_policy_code") = 0,
         "Single-step transition for the discrete LaserTagPOMDP.\n\n"
         "Caller must resolve the actual_action via numpy (handling the\n"
         "optional transition error). ``opp_uniform`` is a uniform [0,1) draw\n"

--- a/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
@@ -160,7 +160,9 @@ def simulate_rollout_discrete(
     results. ``reward_variant_code`` selects the reward variant:
     ``0`` = CONSTANT_HAZARD_PENALTY, ``1`` = ZERO_MEAN_HAZARD_SHOCK,
     ``2`` = DISTANCE_DECAYED_HAZARD_PENALTY. ``penalty_decay`` is consulted only by
-    the ``DISTANCE_DECAYED_HAZARD_PENALTY`` variant. Returns the discounted sum of
+    the ``DISTANCE_DECAYED_HAZARD_PENALTY`` variant. ``opponent_policy_code`` selects
+    the opponent behaviour (``0`` = EVADE, away + pre-move robot reference;
+    ``1`` = PURSUE, toward + post-move robot reference). Returns the discounted sum of
     immediate rewards along the sampled trajectory.
     """
     ...
@@ -180,6 +182,8 @@ def belief_batch_transition_discrete(
 
     Returns the (N, 5) float64 array of next particles. Uses the module-level
     mt19937_64 RNG; seed via set_seed() before calling for reproducibility.
+    ``opponent_policy_code`` selects the opponent behaviour (``0`` = EVADE,
+    away + pre-move robot reference; ``1`` = PURSUE, toward + post-move reference).
     """
     ...
 
@@ -218,6 +222,8 @@ def sample_next_state_step(
     transition error in numpy) and pre-draws ``opp_uniform`` via
     ``np.random.random()`` so byte-identical numpy RNG state is preserved
     across the original Python path and this native fast path.
+    ``opponent_policy_code`` selects the opponent behaviour (``0`` = EVADE,
+    away + pre-move robot reference; ``1`` = PURSUE, toward + post-move reference).
     """
     ...
 
@@ -276,6 +282,8 @@ def cont_simulate_rollout(
     """Run a full random rollout for ContinuousLaserTagPOMDP in one C++ frame.
 
     ``actions_buffer`` must be shape (N, 3) float64 with N >= max_depth - start_depth.
+    ``opponent_policy_code`` selects the opponent behaviour (``0`` = EVADE,
+    away + pre-move robot reference; ``1`` = PURSUE, toward + post-move reference).
     Returns the discounted sum of immediate rewards along the sampled trajectory.
     """
     ...

--- a/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
@@ -84,6 +84,7 @@ class ContinuousLaserTagTransitionCpp:
         robot_radius: float,
         opponent_radius: float,
         tag_radius: float,
+        opponent_policy_code: int = ...,
     ) -> None: ...
     def sample(self, n_samples: int = 1) -> List[NDArray[np.float64]]: ...
     def probability(
@@ -150,6 +151,7 @@ def simulate_rollout_discrete(
     transition_error_prob: float,
     reward_variant_code: int = ...,
     penalty_decay: float = ...,
+    opponent_policy_code: int = ...,
 ) -> float:
     """Run a full random-action rollout for the discrete LaserTagPOMDP in one C++ frame.
 
@@ -172,6 +174,7 @@ def belief_batch_transition_discrete(
     valid_cell_flat: NDArray[np.unsignedinteger],
     rows: int,
     cols: int,
+    opponent_policy_code: int = ...,
 ) -> NDArray[np.float64]:
     """Native port of LaserTagVectorizedUpdater.batch_transition.
 
@@ -207,6 +210,7 @@ def sample_next_state_step(
     rows: int,
     cols: int,
     walls_flat: NDArray[np.integer],
+    opponent_policy_code: int = ...,
 ) -> NDArray[np.float64]:
     """Single-step transition for the discrete LaserTagPOMDP.
 
@@ -267,6 +271,7 @@ def cont_simulate_rollout(
     dangerous_areas: NDArray[np.floating],
     dangerous_area_radius: float,
     dangerous_area_penalty: float,
+    opponent_policy_code: int = ...,
 ) -> float:
     """Run a full random rollout for ContinuousLaserTagPOMDP in one C++ frame.
 

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -20,6 +20,12 @@ Observation:
     ``np.ndarray`` shape ``(8,)`` – noisy 8-direction laser range
     measurements.  Terminal observation is ``np.full(8, -1.0)``.
 
+Opponent behaviour is selectable via ``opponent_policy`` (see
+:class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.OpponentPolicy`):
+``EVADE`` (default) flees the robot's pre-move position at ``evasion_speed``;
+``PURSUE`` chases the robot's post-move position. ``evasion_speed`` is a
+direction-neutral step magnitude under both policies.
+
 Classes:
     ContinuousLaserTagPOMDP: Continuous-action environment.
     ContinuousLaserTagPOMDPDiscreteActions: Discrete-action variant.

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -45,6 +45,9 @@ from POMDPPlanners.core.environment import (
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.environments.laser_tag_pomdp import _native
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils import (
+    OpponentPolicy,
+)
 from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_visualizer import (
     ContinuousLaserTagVisualizer,
 )
@@ -171,6 +174,7 @@ class ContinuousLaserTagPOMDP(Environment):
         debug: bool = False,
         use_queue_logger: bool = False,
         initial_state: Optional[np.ndarray] = None,
+        opponent_policy: OpponentPolicy = OpponentPolicy.EVADE,
     ):
         """Initialize the Continuous LaserTag POMDP.
 
@@ -203,6 +207,12 @@ class ContinuousLaserTagPOMDP(Environment):
             debug: Enable debug logging.
             use_queue_logger: Use queue-based logger.
             initial_state: Fixed initial state (if provided).
+            opponent_policy: Selects the opponent transition behaviour.
+                ``EVADE`` (default) flees the robot at ``evasion_speed`` away from
+                its pre-move position; ``PURSUE`` chases toward its post-move
+                position. ``evasion_speed`` is a direction-neutral step magnitude
+                under both policies. See
+                :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.OpponentPolicy`.
         """
         if not 0.0 <= discount_factor <= 1.0:
             raise ValueError("discount_factor must be between 0 and 1 (inclusive)")
@@ -235,6 +245,7 @@ class ContinuousLaserTagPOMDP(Environment):
         self.step_cost = step_cost
         self.measurement_noise = measurement_noise
         self.evasion_speed = evasion_speed
+        self.opponent_policy = opponent_policy
         self.dangerous_areas: List[Tuple[float, float]] = (
             list(dangerous_areas) if dangerous_areas is not None else list(_DEFAULT_DANGEROUS_AREAS)
         )
@@ -284,6 +295,7 @@ class ContinuousLaserTagPOMDP(Environment):
             "dangerous_areas": self._dangerous_areas_arr,
             "dangerous_area_radius": self.dangerous_area_radius,
             "dangerous_area_penalty": self.dangerous_area_penalty,
+            "opponent_policy_code": self.opponent_policy.native_code,
         }
 
     # ------------------------------------------------------------------
@@ -315,6 +327,7 @@ class ContinuousLaserTagPOMDP(Environment):
                 robot_radius=self.robot_radius,
                 opponent_radius=self.opponent_radius,
                 tag_radius=self.tag_radius,
+                opponent_policy_code=self.opponent_policy.native_code,
             )
             self._trans_kernel_cache[key] = kernel
         if isinstance(action, np.ndarray):
@@ -999,6 +1012,7 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
         debug: bool = False,
         use_queue_logger: bool = False,
         initial_state: Optional[np.ndarray] = None,
+        opponent_policy: OpponentPolicy = OpponentPolicy.EVADE,
     ):
         super().__init__(
             discount_factor=discount_factor,
@@ -1023,6 +1037,7 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
             debug=debug,
             use_queue_logger=use_queue_logger,
             initial_state=initial_state,
+            opponent_policy=opponent_policy,
         )
 
         # Override space info to discrete actions

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -40,6 +40,9 @@ from POMDPPlanners.utils.statistics_utils import confidence_interval
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_visualizer import (  # pylint: disable=import-outside-toplevel
     LaserTagVisualizer,
 )
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils import (
+    OpponentPolicy,
+)
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models import (
     BaseLaserTagRewardModel,
     LaserTagDistanceDecayedHazardPenaltyRewardModel,
@@ -175,6 +178,7 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         transition_error_prob: float = 0.0,
         reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         penalty_decay: float = 1.0,
+        opponent_policy: OpponentPolicy = OpponentPolicy.EVADE,
     ):
         """Initialize the LaserTag POMDP environment.
 
@@ -214,6 +218,14 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             penalty_decay: Decay length used by the
                 ``DISTANCE_DECAYED_HAZARD_PENALTY`` reward model. Ignored by the other
                 variants. Must be strictly positive. Defaults to ``1.0``.
+            opponent_policy: Selects the opponent transition behaviour.
+                ``EVADE`` (default) makes the opponent flee the robot, placing its
+                directional mass on the distance-increasing cell and reacting to the
+                robot's pre-move position (matches JuliaPOMDP/LaserTag.jl). ``PURSUE``
+                makes the opponent chase the robot, placing its mass on the
+                distance-decreasing cell and reacting to the robot's post-move
+                position (restores the pre-evader-fix behaviour). See
+                :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.OpponentPolicy`.
 
         Raises:
             ValueError: If discount_factor is not in valid range [0, 1], if
@@ -255,6 +267,7 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         self.dangerous_area_penalty = dangerous_area_penalty
         self.initial_state = initial_state
         self.transition_error_prob = transition_error_prob
+        self.opponent_policy = opponent_policy
 
         # Action definitions
         self.actions = [0, 1, 2, 3, 4]  # North, South, East, West, Tag
@@ -413,6 +426,7 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             rows=rows,
             cols=cols,
             walls_flat=walls_flat,
+            opponent_policy_code=self.opponent_policy.native_code,
         )
 
     def _resolve_actual_action(self, action: int) -> int:
@@ -464,7 +478,9 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         # Regular transition: build opponent move distribution then draw indices
         # in a single np.random.choice call (matches the wrapper's RNG draw order
         # for any n_samples).
-        opp_moves = self._opponent_move_probabilities_inline(state, robot_current)
+        opp_moves = self._opponent_move_probabilities_inline(
+            state, self._opponent_robot_reference(robot_current, robot_next)
+        )
         positions, probabilities = zip(*opp_moves)
         opp_indices = np.random.choice(len(positions), size=n_samples, p=probabilities)
         if n_samples == 1:
@@ -494,6 +510,13 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             )
         return samples
 
+    def _opponent_robot_reference(
+        self, robot_current: Tuple[int, int], robot_next: Tuple[int, int]
+    ) -> Tuple[int, int]:
+        # EVADE conditions the opponent move on the robot's pre-move cell; PURSUE on
+        # its post-move cell. Tag actions don't move the robot, so the two coincide.
+        return robot_current if self.opponent_policy is OpponentPolicy.EVADE else robot_next
+
     def _opponent_move_probabilities_inline(
         self, state: np.ndarray, robot_pos: Tuple[int, int]
     ) -> List[Tuple[Tuple[int, int], float]]:
@@ -517,6 +540,14 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
     def _directional_moves_inline(
         self, opponent_coord: int, robot_coord: int, fixed_coord: int, is_horizontal: bool
     ) -> List[Tuple[Tuple[int, int], float]]:
+        # Under EVADE the 0.4 directional mass goes on the away cell; under PURSUE it
+        # goes on the toward cell. The aligned (robot == opponent) case is policy-
+        # invariant and keeps its symmetric 0.2/0.2 split.
+        if self.opponent_policy is OpponentPolicy.EVADE:
+            directional_toward_prob, directional_away_prob = 0.0, 0.4
+        else:
+            directional_toward_prob, directional_away_prob = 0.4, 0.0
+
         if robot_coord > opponent_coord:
             toward_pos = (
                 (fixed_coord, opponent_coord + 1)
@@ -528,7 +559,7 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
                 if is_horizontal
                 else (opponent_coord - 1, fixed_coord)
             )
-            toward_prob, away_prob = 0.0, 0.4
+            toward_prob, away_prob = directional_toward_prob, directional_away_prob
         elif robot_coord < opponent_coord:
             toward_pos = (
                 (fixed_coord, opponent_coord - 1)
@@ -540,7 +571,7 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
                 if is_horizontal
                 else (opponent_coord + 1, fixed_coord)
             )
-            toward_prob, away_prob = 0.0, 0.4
+            toward_prob, away_prob = directional_toward_prob, directional_away_prob
         else:
             toward_pos = (
                 (fixed_coord, opponent_coord + 1)
@@ -673,7 +704,9 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
 
         # Regular transition: opponent moves stochastically, terminal flag stays 0.
         if next_robot == robot_next and not next_terminal:
-            opp_moves = self._opponent_move_probabilities_inline(state, robot_current)
+            opp_moves = self._opponent_move_probabilities_inline(
+                state, self._opponent_robot_reference(robot_current, robot_next)
+            )
             for opp_pos, prob in opp_moves:
                 if next_opponent == opp_pos:
                     return prob
@@ -998,6 +1031,7 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
                     transition_error_prob=transition_error_prob,
                     reward_variant_code=self._native_reward_variant_code(),
                     penalty_decay=float(self.penalty_decay),
+                    opponent_policy_code=self.opponent_policy.native_code,
                 )
             )
 

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -14,12 +14,18 @@ The LaserTag problem features:
 - 8-directional laser range measurements with Gaussian noise
 - Positive reward for successful tagging, negative reward for failed tag attempts
 - Step cost for each movement action
-- Opponent moves with 0.4 prob away from robot in x-dir, 0.4 prob away from robot in y-dir, 0.2 prob stay
-- When aligned on an axis, the 0.4 budget is split equally (0.2/0.2) between both directions
+- Opponent moves with 0.4 prob in x-dir, 0.4 prob in y-dir, 0.2 prob stay; the
+  direction of the 0.4 mass is set by ``opponent_policy`` (see
+  :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.OpponentPolicy`):
+  ``EVADE`` (default) moves away from the robot's pre-move position, ``PURSUE``
+  moves toward the robot's post-move position
+- When aligned on an axis, the 0.4 budget is split equally (0.2/0.2) between both
+  directions, regardless of policy
 
 Classes:
     LaserTagState: State representation with robot and opponent positions
     LaserTagPOMDP: Main environment class implementing the LaserTag problem
+    OpponentPolicy: Selectable opponent transition behaviour (evade vs pursue)
 """
 
 from enum import Enum

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp_beliefs/continuous_laser_tag_vectorized_updater.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp_beliefs/continuous_laser_tag_vectorized_updater.py
@@ -31,6 +31,9 @@ from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
 )
 from POMDPPlanners.core.environment import SpaceType
 from POMDPPlanners.environments.laser_tag_pomdp import _native
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils import (
+    OpponentPolicy,
+)
 from POMDPPlanners.utils.config_to_id import config_to_id
 
 if TYPE_CHECKING:
@@ -93,6 +96,7 @@ class ContinuousLaserTagVectorizedUpdater(VectorizedParticleBeliefUpdater):
         robot_covariance: np.ndarray,
         opponent_covariance: np.ndarray,
         action_to_vector: Optional[Dict[str, np.ndarray]] = None,
+        opponent_policy: OpponentPolicy = OpponentPolicy.EVADE,
     ):
         """Initialize the vectorized updater.
 
@@ -102,13 +106,14 @@ class ContinuousLaserTagVectorizedUpdater(VectorizedParticleBeliefUpdater):
             robot_radius: Robot body radius.
             opponent_radius: Opponent body radius.
             tag_radius: Maximum tag distance.
-            evasion_speed: Mean opponent evasion step magnitude.
+            evasion_speed: Mean opponent step magnitude (direction set by policy).
             measurement_noise: Laser measurement noise std.
             robot_covariance: Robot transition noise covariance ``(2, 2)``.
             opponent_covariance: Opponent transition noise covariance
                 ``(2, 2)``.
             action_to_vector: Optional mapping from string actions to
                 3-D vectors (for discrete action variant).
+            opponent_policy: Opponent transition behaviour (EVADE or PURSUE).
         """
         self.walls = np.asarray(walls, dtype=float).reshape(-1, 4)
         self.grid_size = np.asarray(grid_size, dtype=float)
@@ -120,6 +125,7 @@ class ContinuousLaserTagVectorizedUpdater(VectorizedParticleBeliefUpdater):
         self.robot_covariance = np.asarray(robot_covariance, dtype=float)
         self.opponent_covariance = np.asarray(opponent_covariance, dtype=float)
         self._action_to_vector = action_to_vector
+        self.opponent_policy = opponent_policy
 
     @classmethod
     def from_environment(
@@ -142,6 +148,7 @@ class ContinuousLaserTagVectorizedUpdater(VectorizedParticleBeliefUpdater):
             robot_covariance=env.robot_transition_cov_matrix,
             opponent_covariance=env.opponent_transition_cov_matrix,
             action_to_vector=action_map,
+            opponent_policy=env.opponent_policy,
         )
 
     # ------------------------------------------------------------------
@@ -167,6 +174,7 @@ class ContinuousLaserTagVectorizedUpdater(VectorizedParticleBeliefUpdater):
             robot_radius=self.robot_radius,
             opponent_radius=self.opponent_radius,
             tag_radius=self.tag_radius,
+            opponent_policy_code=self.opponent_policy.native_code,
         )
         return transition.batch_sample(particles_arr)
 
@@ -203,6 +211,7 @@ class ContinuousLaserTagVectorizedUpdater(VectorizedParticleBeliefUpdater):
             "measurement_noise": self.measurement_noise,
             "robot_covariance": self.robot_covariance.tolist(),
             "opponent_covariance": self.opponent_covariance.tolist(),
+            "opponent_policy": self.opponent_policy.value,
         }
         if self._action_to_vector is not None:
             config_dict["action_to_vector"] = {

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp_beliefs/laser_tag_vectorized_updater.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp_beliefs/laser_tag_vectorized_updater.py
@@ -32,6 +32,9 @@ from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
     VectorizedParticleBeliefUpdater,
 )
 from POMDPPlanners.environments.laser_tag_pomdp import _native
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils import (
+    OpponentPolicy,
+)
 from POMDPPlanners.utils.config_to_id import config_to_id
 
 if TYPE_CHECKING:
@@ -120,6 +123,7 @@ class LaserTagVectorizedUpdater(VectorizedParticleBeliefUpdater):
         wall_dist_table: np.ndarray,
         measurement_noise: float,
         transition_error_prob: float,
+        opponent_policy: OpponentPolicy = OpponentPolicy.EVADE,
     ):
         """Initialize the vectorized updater.
 
@@ -129,12 +133,14 @@ class LaserTagVectorizedUpdater(VectorizedParticleBeliefUpdater):
             wall_dist_table: Integer array of shape (rows, cols, 8).
             measurement_noise: Standard deviation of laser noise.
             transition_error_prob: Probability of executing a random action.
+            opponent_policy: Opponent transition behaviour (EVADE or PURSUE).
         """
         self.floor_shape = floor_shape
         self.valid_cell = valid_cell
         self.wall_dist_table = wall_dist_table
         self.measurement_noise = measurement_noise
         self.transition_error_prob = transition_error_prob
+        self.opponent_policy = opponent_policy
 
         # Precompute observation constants
         self._variance = measurement_noise**2
@@ -170,6 +176,7 @@ class LaserTagVectorizedUpdater(VectorizedParticleBeliefUpdater):
             wall_dist_table=wall_dist_table,
             measurement_noise=env.measurement_noise,
             transition_error_prob=env.transition_error_prob,
+            opponent_policy=env.opponent_policy,
         )
 
     # ------------------------------------------------------------------
@@ -187,6 +194,7 @@ class LaserTagVectorizedUpdater(VectorizedParticleBeliefUpdater):
             valid_cell_flat=self._valid_cell_flat,
             rows=self._rows,
             cols=self._cols,
+            opponent_policy_code=self.opponent_policy.native_code,
         )
 
     def batch_observation_log_likelihood(
@@ -216,5 +224,6 @@ class LaserTagVectorizedUpdater(VectorizedParticleBeliefUpdater):
             "valid_cell": self.valid_cell.tolist(),
             "measurement_noise": self.measurement_noise,
             "transition_error_prob": self.transition_error_prob,
+            "opponent_policy": self.opponent_policy.value,
         }
         return config_to_id(config_dict)

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp_utils/__init__.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp_utils/__init__.py
@@ -1,1 +1,34 @@
 # SPDX-License-Identifier: MIT
+
+"""Shared utilities for the LaserTag POMDP environments.
+
+Classes:
+    OpponentPolicy: Selectable opponent transition behaviour (evade vs pursue).
+"""
+
+from enum import Enum
+
+
+class OpponentPolicy(Enum):
+    """Opponent transition behaviour selectable on the LaserTag environments.
+
+    Two policies are offered:
+
+    - ``EVADE`` (default): the opponent flees the robot, placing its directional
+      probability mass on the cell that *increases* distance, and reacts to the
+      robot's current (pre-move) position. This matches JuliaPOMDP/LaserTag.jl.
+    - ``PURSUE``: the opponent chases the robot, placing its directional mass on
+      the cell that *decreases* distance, and reacts to the robot's post-move
+      position. This restores the behaviour used before the evader alignment fix.
+
+    Both directional choices and reference-position choices are coupled per
+    policy, so ``PURSUE`` and ``EVADE`` are mutually exclusive opposites.
+    """
+
+    EVADE = "evade"
+    PURSUE = "pursue"
+
+    @property
+    def native_code(self) -> int:
+        """Integer code passed to the C++ kernels (``EVADE`` = 0, ``PURSUE`` = 1)."""
+        return 0 if self is OpponentPolicy.EVADE else 1

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
@@ -16,7 +16,7 @@ import pytest
 from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.core.policy import PolicyRunData
 from POMDPPlanners.core.simulation import History, StepData
-from POMDPPlanners.environments.laser_tag_pomdp import _native
+from POMDPPlanners.environments.laser_tag_pomdp import _native, OpponentPolicy
 from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_pomdp import (
     ContinuousLaserTagPOMDP,
     ContinuousLaserTagPOMDPDiscreteActions,
@@ -63,6 +63,24 @@ def env_default():
 def env_discrete_default():
     """Discrete-action environment with default configuration."""
     return ContinuousLaserTagPOMDPDiscreteActions(discount_factor=0.95)
+
+
+def test_continuous_opponent_policy_changes_config_id():
+    """Distinct opponent policies produce distinct continuous env config IDs.
+
+    Purpose: Validates the opponent_policy enum is captured by config_id so cached
+        results for EVADE and PURSUE continuous configs never collide
+
+    Given: Two ContinuousLaserTagPOMDPs identical except for opponent_policy
+    When: config_id is computed for each
+    Then: The two IDs differ
+
+    Test type: unit
+    """
+    common = {"discount_factor": 0.95, "walls": [], "dangerous_areas": []}
+    evade = ContinuousLaserTagPOMDP(**common, opponent_policy=OpponentPolicy.EVADE)
+    pursue = ContinuousLaserTagPOMDP(**common, opponent_policy=OpponentPolicy.PURSUE)
+    assert evade.config_id != pursue.config_id
 
 
 class TestContinuousLaserTagPOMDPInit:
@@ -245,6 +263,67 @@ class TestSampleNextState:
         assert (
             mean_opp_x > 5.6
         ), f"Expected opponent to flee +x from pre-move robot (>5.6), got {mean_opp_x}"
+
+    def test_opponent_pursues_toward_robot(self):
+        """Test the continuous opponent pursues by moving toward the robot under PURSUE.
+
+        Purpose: Validates the PURSUE policy restores the chaser: the opponent's mean step
+            decreases distance to the robot, the mirror image of the EVADE evasion
+
+        Given: A PURSUE env, robot at (5, 3) and opponent offset to +x/+y at (8, 5)
+        When: The robot holds position (no-op action) and many next states are sampled
+        Then: The mean opponent position moves inward toward the robot in both x and y
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        env = ContinuousLaserTagPOMDP(
+            discount_factor=0.95,
+            walls=[],
+            dangerous_areas=[],
+            opponent_policy=OpponentPolicy.PURSUE,
+        )
+        state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([0.0, 0.0, 0.0])  # robot holds position, no tag
+        samples = env.sample_next_state(state, action, n_samples=500)
+
+        mean_opp_x = float(np.mean([s[2] for s in samples]))
+        mean_opp_y = float(np.mean([s[3] for s in samples]))
+
+        assert mean_opp_x < 7.9, f"Expected opponent to chase in -x (<7.9), got {mean_opp_x}"
+        assert mean_opp_y < 4.9, f"Expected opponent to chase in -y (<4.9), got {mean_opp_y}"
+
+    def test_opponent_pursue_reacts_to_postmove_robot(self):
+        """Test the continuous PURSUE opponent reacts to the robot's POST-move position.
+
+        Purpose: Validates the opponent's pursuit direction on a movement action is computed
+            from the robot's post-move position (restoring the pre-evader-fix reference)
+
+        Given: A near-deterministic-robot PURSUE env, robot just left of the opponent on x
+            (robot x=5.0, opponent x=5.4, same y), and a +x action that carries the robot
+            across to the opponent's right (post-move x ~ 6.0)
+        When: many next states are sampled
+        Then: the opponent's mean next x increases (it chases +x toward the post-move robot
+            on its right); had it used the pre-move robot (5.0, on its left) it would chase -x
+
+        Test type: unit
+        """
+        np.random.seed(0)
+        env = ContinuousLaserTagPOMDP(
+            discount_factor=0.95,
+            walls=[],
+            dangerous_areas=[],
+            robot_transition_cov_matrix=np.eye(2) * 1e-9,
+            opponent_policy=OpponentPolicy.PURSUE,
+        )
+        state = np.array([5.0, 3.0, 5.4, 3.0, 0.0])
+        action = np.array([1.0, 0.0, 0.0])  # robot moves +x, crossing to the opponent's right
+        samples = env.sample_next_state(state, action, n_samples=400)
+
+        mean_opp_x = float(np.mean([s[2] for s in samples]))
+        assert (
+            mean_opp_x > 5.6
+        ), f"Expected opponent to chase +x toward post-move robot (>5.6), got {mean_opp_x}"
 
 
 class TestSampleObservation:

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -22,7 +22,7 @@ from POMDPPlanners.core.distributions import DiscreteDistribution
 from POMDPPlanners.core.environment import SpaceType
 from POMDPPlanners.core.policy import Policy, PolicyRunData, PolicySpaceInfo
 from POMDPPlanners.core.simulation import History, StepData
-from POMDPPlanners.environments.laser_tag_pomdp import LaserTagPOMDP
+from POMDPPlanners.environments.laser_tag_pomdp import LaserTagPOMDP, OpponentPolicy
 from POMDPPlanners.planners.planners_utils.dpw import ActionSampler
 from POMDPPlanners.simulations.episodes import run_episode
 from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
@@ -131,6 +131,7 @@ def _make_env(
     walls=None,
     transition_error_prob=0.0,
     measurement_noise=1.0,
+    opponent_policy=OpponentPolicy.EVADE,
 ):
     """Build a LaserTagPOMDP with empty dangerous areas for transition/observation tests."""
     return LaserTagPOMDP(
@@ -140,6 +141,7 @@ def _make_env(
         dangerous_areas=set(),
         measurement_noise=measurement_noise,
         transition_error_prob=transition_error_prob,
+        opponent_policy=opponent_policy,
     )
 
 
@@ -153,6 +155,23 @@ def _observation_probabilities(env, next_state, action, observations):
     """Convenience: env.observation_log_probability -> probability list."""
     log_probs = env.observation_log_probability(next_state, action, observations)
     return np.exp(log_probs)
+
+
+def test_opponent_policy_changes_config_id():
+    """Distinct opponent policies produce distinct environment config IDs.
+
+    Purpose: Validates the opponent_policy enum is captured by config_id so cached
+        results for EVADE and PURSUE configs never collide
+
+    Given: Two LaserTagPOMDPs identical except for opponent_policy
+    When: config_id is computed for each
+    Then: The two IDs differ
+
+    Test type: unit
+    """
+    evade = _make_env(opponent_policy=OpponentPolicy.EVADE)
+    pursue = _make_env(opponent_policy=OpponentPolicy.PURSUE)
+    assert evade.config_id != pursue.config_id
 
 
 class TestLaserTagStateTransition:
@@ -281,6 +300,67 @@ class TestLaserTagStateTransition:
             0.35 <= probs[0] <= 0.45
         ), f"Expected ~0.4 for opponent fleeing South (pre-move robot below), got {probs[0]}"
         assert probs[1] == 0.0, f"Expected 0.0 for the toward (North) cell, got {probs[1]}"
+
+    def test_opponent_pursues_toward_robot(self):
+        """Test opponent pursues by moving toward the robot under OpponentPolicy.PURSUE.
+
+        Purpose: Validates the PURSUE policy restores the pre-evader-fix chaser: the 0.4
+            directional mass lands on the cell that decreases distance to the robot
+
+        Given: A PURSUE env, robot above the opponent (robot row 2, opponent row 5, same column)
+        When: Many state transitions are sampled after the robot moves South
+        Then: Opponent prefers the toward cell (4, 5) and rarely takes the away cell (6, 5)
+
+        Test type: unit
+        """
+        env = _make_env(floor_shape=(7, 11), opponent_policy=OpponentPolicy.PURSUE)
+        state = np.array([2.0, 5.0, 5.0, 5.0, 0.0])
+
+        # Robot moves South (action 1) -> robot_next at (3, 5), still above opponent.
+        # PURSUE references the post-move robot (3, 5), so the opponent chases North.
+        samples = env.sample_next_state(state, 1, n_samples=1000)
+
+        opponent_positions = [(int(s[2]), int(s[3])) for s in samples]
+        pos_counts = Counter(opponent_positions)
+        total_samples = len(samples)
+
+        toward_prob = pos_counts.get((4, 5), 0) / total_samples
+        away_prob = pos_counts.get((6, 5), 0) / total_samples
+
+        assert toward_prob > 0.3, f"Expected >0.3 probability toward robot, got {toward_prob}"
+        assert away_prob < 0.1, f"Expected <0.1 probability away from robot, got {away_prob}"
+
+    def test_opponent_pursue_reacts_to_postmove_robot(self):
+        """Test the PURSUE opponent reacts to the robot's POST-move position.
+
+        Purpose: Validates the PURSUE move distribution is conditioned on the robot's
+            post-move cell (restoring the pre-evader-fix reference), the mirror image of
+            the EVADE pre-move semantics
+
+        Given: A PURSUE env, robot at (4, 5) one row above the opponent at (5, 5); the robot
+            moves South, landing on the opponent's cell at (5, 5)
+        When: transition_log_probability is evaluated for the opponent moving South (6, 5)
+            versus North (4, 5)
+        Then: Because the post-move robot (5, 5) is row-aligned with the opponent, the row
+            axis splits 0.2/0.2 between North and South — distinct from the EVADE pre-move
+            case (robot row 4 < 5) which would give 0.4 South / 0.0 North
+
+        Test type: unit
+        """
+        env = _make_env(floor_shape=(7, 11), opponent_policy=OpponentPolicy.PURSUE)
+        state = np.array([4.0, 5.0, 5.0, 5.0, 0.0])
+
+        next_state_south = np.array([5.0, 5.0, 6.0, 5.0, 0.0])  # opponent South
+        next_state_north = np.array([5.0, 5.0, 4.0, 5.0, 0.0])  # opponent North
+
+        probs = _transition_probabilities(env, state, 1, [next_state_south, next_state_north])
+
+        assert (
+            0.15 <= probs[0] <= 0.25
+        ), f"Expected ~0.2 South from the post-move row-aligned split, got {probs[0]}"
+        assert (
+            0.15 <= probs[1] <= 0.25
+        ), f"Expected ~0.2 North from the post-move row-aligned split, got {probs[1]}"
 
     def test_successful_tagging(self):
         """Test successful tagging creates terminal state.
@@ -2182,18 +2262,19 @@ def _python_rollout(
 class TestNativeDiscreteRollout:
     """Tests for the native C++ discrete LaserTag rollout kernel."""
 
-    def test_lasertag_native_simulate_rollout_matches_python(self) -> None:
+    @pytest.mark.parametrize("opponent_policy", [OpponentPolicy.EVADE, OpponentPolicy.PURSUE])
+    def test_lasertag_native_simulate_rollout_matches_python(self, opponent_policy) -> None:
         """Native C++ rollout produces the same return distribution as the Python loop.
 
         Purpose: Validates that simulate_rollout_discrete in the C++ extension implements
             the same stochastic transition / reward / terminal logic as the Python
-            ``Environment.simulate_random_rollout`` base-class loop, so that replacing
-            the Python loop with the C++ kernel does not change the algorithm's value
-            estimates in expectation.
+            ``Environment.simulate_random_rollout`` base-class loop under BOTH opponent
+            policies, so that the C++ and Python opponent-move kernels stay in lockstep
+            (the real hazard is C++-PURSUE diverging from Python-PURSUE).
 
         Given: A LaserTagPOMDP with default walls and dangerous areas, a fixed
             initial state, max_depth=15, discount=0.95, and 500 independent
-            rollout trials.
+            rollout trials, run once per opponent policy (EVADE, PURSUE).
         When: 500 trials are run with both the pure Python path (NumPy RNG) and
             the native C++ path (mt19937_64 RNG), each seeded independently before
             the batch.
@@ -2202,7 +2283,7 @@ class TestNativeDiscreteRollout:
 
         Test type: integration
         """
-        env = LaserTagPOMDP(discount_factor=0.95)
+        env = LaserTagPOMDP(discount_factor=0.95, opponent_policy=opponent_policy)
         state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])
         max_depth = 15
         discount = 0.95
@@ -2241,6 +2322,53 @@ class TestNativeDiscreteRollout:
             f"by {diff:.3f} (scale={scale:.3f}). C++ and Python rollout kernels "
             "implement different distributions."
         )
+
+    @pytest.mark.parametrize("opponent_policy", [OpponentPolicy.EVADE, OpponentPolicy.PURSUE])
+    @pytest.mark.parametrize(
+        "walls",
+        [set(), {(5, 6), (5, 4)}],
+        ids=["open", "wall_adjacent_slack"],
+    )
+    def test_native_single_step_opponent_distribution_matches_python(
+        self, opponent_policy, walls
+    ) -> None:
+        """Native single-step kernel matches the Python opponent distribution per policy.
+
+        Purpose: Validates that the native ``sample_next_state_step`` opponent-move table
+            (disc_opponent_move_table) reproduces the Python ``_python_sample_next_state``
+            distribution under BOTH opponent policies, including the wall-blocked
+            invalid-move -> stay slack path — guarding against a missed direction flip or
+            pre/post reference choice in the C++ single-step kernel.
+
+        Given: A LaserTagPOMDP (open grid or walls blocking both opponent x-moves), robot
+            above the opponent, robot moving South, evaluated for EVADE and PURSUE.
+        When: 4000 single samples are drawn via the native path (n_samples == 1) and 4000
+            via the Python batch path (n_samples > 1).
+        Then: The per-cell opponent next-position probabilities agree within 0.05.
+
+        Test type: integration
+        """
+        env = _make_env(floor_shape=(7, 11), walls=walls, opponent_policy=opponent_policy)
+        state = np.array([2.0, 5.0, 5.0, 5.0, 0.0])
+        action = 1  # robot moves South -> robot_next (3, 5), still above the opponent
+        n = 4000
+
+        np.random.seed(0)
+        native_counts = Counter(
+            (int(s[2]), int(s[3]))
+            for s in (env.sample_next_state(state, action, n_samples=1) for _ in range(n))
+        )
+        np.random.seed(0)
+        python_samples = env.sample_next_state(state, action, n_samples=n)
+        python_counts = Counter((int(s[2]), int(s[3])) for s in python_samples)
+
+        for cell in set(native_counts) | set(python_counts):
+            p_native = native_counts.get(cell, 0) / n
+            p_python = python_counts.get(cell, 0) / n
+            assert abs(p_native - p_python) < 0.05, (
+                f"policy={opponent_policy} cell={cell}: native {p_native:.3f} vs "
+                f"python {p_python:.3f} — C++ and Python single-step kernels diverge"
+            )
 
     def test_lasertag_native_rollout_returns_finite_float(self) -> None:
         """Native rollout returns a finite float from a valid initial state.

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_laser_tag_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_laser_tag_vectorized_updater.py
@@ -13,10 +13,12 @@ per-particle loop (one bulk ``np.random.random(K)`` vs sequential
 exact match while opponent positions are tested statistically.
 """
 
+from collections import Counter
+
 import numpy as np
 import pytest
 
-from POMDPPlanners.environments.laser_tag_pomdp import LaserTagPOMDP
+from POMDPPlanners.environments.laser_tag_pomdp import LaserTagPOMDP, OpponentPolicy
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_beliefs import (
     LaserTagVectorizedUpdater,
 )
@@ -270,6 +272,56 @@ class TestBatchTransition:
             seen_positions.add(opp)
         # Should see at least 2 different opponent positions
         assert len(seen_positions) >= 2
+
+    @pytest.mark.parametrize("opponent_policy", [OpponentPolicy.EVADE, OpponentPolicy.PURSUE])
+    @pytest.mark.parametrize(
+        "walls",
+        [set(), {(5, 6), (5, 4)}],
+        ids=["open", "wall_adjacent_slack"],
+    )
+    def test_batch_transition_opponent_distribution_matches_env(self, opponent_policy, walls):
+        """Native belief batch transition matches the env opponent distribution per policy.
+
+        Purpose: Validates that the C++ belief kernel (belief_sample_opponent_move via
+            belief_batch_transition_discrete) reproduces the env's Python opponent-move
+            distribution under BOTH policies, including the wall-blocked stay-slack path —
+            guarding against a missed direction flip / pre-move reference in the belief path.
+
+        Given: A LaserTagPOMDP (open grid or walls blocking both opponent x-moves), robot
+            above the opponent, action South, evaluated for EVADE and PURSUE.
+        When: 4000 particles are pushed through updater.batch_transition and 4000 samples
+            through the env's Python sample_next_state.
+        Then: The per-cell opponent next-position probabilities agree within 0.05.
+
+        Test type: integration
+        """
+        env = LaserTagPOMDP(
+            discount_factor=0.95,
+            floor_shape=(7, 11),
+            walls=walls,
+            dangerous_areas=set(),
+            opponent_policy=opponent_policy,
+        )
+        updater = LaserTagVectorizedUpdater.from_environment(env)
+        state = np.array([2.0, 5.0, 5.0, 5.0, 0.0])
+        action = 1  # robot moves South -> robot_next (3, 5), still above the opponent
+        n = 4000
+
+        np.random.seed(0)
+        out = updater.batch_transition(np.tile(state, (n, 1)), action=np.array(action))
+        belief_counts = Counter((int(r[2]), int(r[3])) for r in out)
+
+        np.random.seed(0)
+        env_samples = env.sample_next_state(state, action, n_samples=n)
+        env_counts = Counter((int(s[2]), int(s[3])) for s in env_samples)
+
+        for cell in set(belief_counts) | set(env_counts):
+            p_belief = belief_counts.get(cell, 0) / n
+            p_env = env_counts.get(cell, 0) / n
+            assert abs(p_belief - p_env) < 0.05, (
+                f"policy={opponent_policy} cell={cell}: belief {p_belief:.3f} vs "
+                f"env {p_env:.3f} — C++ belief and Python env kernels diverge"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR #195 switched the LaserTag opponent from a **pursuer** (moves toward the robot, post-move reference) to an **evader** (moves away, pre-move reference), removing the old behaviour entirely. This adds an `OpponentPolicy` enum so callers can pick either:

- **`EVADE`** (default) — current/post-#195 behaviour. No change for existing callers.
- **`PURSUE`** — restores the exact pre-#195 chaser, coupling **both** axes the fix changed: the toward-direction *and* the post-move robot reference.

Mirrors the existing `RewardModelType` → int-code pattern.

## What changed

- New `OpponentPolicy` enum in `laser_tag_pomdp_utils/` (exported from the package).
- `opponent_policy` kwarg on `LaserTagPOMDP`, `ContinuousLaserTagPOMDP`, `ContinuousLaserTagPOMDPDiscreteActions`, and both vectorized updaters (read via `from_environment`).
- C++ (`continuous_laser_tag.cpp`): `opponent_policy_code` carried in `DiscreteEnvParams` + the continuous `EnvParams`; the four opponent-move helpers flip direction per policy (non-aligned branches only); each caller selects the pre/post-move robot reference; the raw-int belief path is threaded; all 5 pybind bindings + `.pyi` stubs updated (default `kPolicyEvade` so omitting it is a no-op).
- `config_id` includes the policy on the envs (auto via `Enum` serialization) and both updaters, so `EVADE`/`PURSUE` configs never collide in the cache.

## Compatibility

Additive — default `EVADE` leaves existing behaviour, tests, and golden visualizations unchanged. Adding the attribute does change discrete-env `config_id`s (one-time cache invalidation), same class as #195's `pursuit_speed`→`evasion_speed` rename. The `evasion_speed` kwarg name is retained (direction-neutral step magnitude).

## Test plan

- [x] `python setup.py build_ext --inplace` (C++ changed)
- [x] `pytest POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/` — 255 passed
- [x] New PURSUE unit tests (discrete + continuous) + `config_id` distinctness
- [x] Native-vs-Python parity tests parametrized over `[EVADE, PURSUE]` for the single-step, rollout, and belief paths, incl. a wall-adjacent opponent (invalid-move→stay slack)
- [x] `python -m pyright POMDPPlanners/` — 0 new errors/warnings
- [x] `pylint --errors-only` (CI gate) clean on touched source + tests