### PR TITLE
feat(laser_tag): add EVADE_WHEN_SPOTTED opponent policy

### DIFF
--- a/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
@@ -221,6 +221,29 @@ void compute_laser_measurements(double robot_x, double robot_y, double opp_x, do
     }
 }
 
+// True iff the robot has line of sight to the opponent: some laser ray reaches
+// the opponent disc before any wall or the grid boundary. Mirrors the per-ray
+// comparison in compute_laser_measurements; used by the EVADE_WHEN_SPOTTED policy.
+bool opponent_visible(double robot_x, double robot_y, double opp_x, double opp_y,
+                      double opponent_radius, const std::vector<Wall> &walls, double grid_w,
+                      double grid_h) {
+    for (std::size_t d = 0; d < kObsDim; ++d) {
+        const double dx = kLaserDirections[d][0];
+        const double dy = kLaserDirections[d][1];
+        double occluder = ray_walls_distance(robot_x, robot_y, dx, dy, walls);
+        const double boundary = ray_grid_boundary_distance(robot_x, robot_y, dx, dy, grid_w, grid_h);
+        if (boundary < occluder) {
+            occluder = boundary;
+        }
+        const double opp_d =
+            ray_circle_distance(robot_x, robot_y, dx, dy, opp_x, opp_y, opponent_radius);
+        if (opp_d < occluder) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // Resolve collision between a circular entity at (x, y) with radius r and a
 // single wall AABB. Mirrors _resolve_single_wall in the Python geometry
 // module (circle-AABB minimum-translation-vector push-out).
@@ -274,6 +297,7 @@ void clamp_to_grid(double &x, double &y, double radius, double grid_w, double gr
 // post-move position). Mirrors OpponentPolicy.native_code in Python.
 constexpr int kPolicyEvade = 0;
 constexpr int kPolicyPursue = 1;
+constexpr int kPolicyEvadeWhenSpotted = 2;
 
 // Shared environment geometry / physics parameters used by both the
 // transition and observation models.
@@ -323,15 +347,22 @@ void sample_move(double mean_x, double mean_y, double radius,
     clamp_to_grid(out_x, out_y, radius, env.grid_w, env.grid_h);
 }
 
-// Compute the opponent's target mean: move ``move_speed`` away from (EVADE) or
-// toward (PURSUE) the robot, sampling a random unit vector when the two are
-// coincident. The caller chooses which robot position (pre- or post-move) to
-// pass per the policy's reference-position semantics.
+// Compute the opponent's target mean: move ``move_speed`` away from (EVADE-like)
+// or toward (PURSUE) the robot. When ``stay_in_place`` is set (EVADE_WHEN_SPOTTED
+// with no line of sight), the opponent holds its current position — only the
+// caller's Gaussian opponent noise then jitters it. A random unit vector is used
+// when the robot and opponent are coincident. The caller chooses which robot
+// position (pre- or post-move) to pass per the policy's reference-position semantics.
 void opponent_move_mean(double robot_x, double robot_y, double opp_x, double opp_y,
-                        double move_speed, int opponent_policy_code,
+                        double move_speed, int opponent_policy_code, bool stay_in_place,
                         pomdp_native::RNGState &rng, double &mean_x, double &mean_y) {
-    // EVADE flees (diff = opp - robot); PURSUE chases (diff = robot - opp).
-    const double sign = (opponent_policy_code == kPolicyEvade) ? 1.0 : -1.0;
+    if (stay_in_place) {
+        mean_x = opp_x;
+        mean_y = opp_y;
+        return;
+    }
+    // Only PURSUE chases (diff = robot - opp); every other policy flees (diff = opp - robot).
+    const double sign = (opponent_policy_code == kPolicyPursue) ? -1.0 : 1.0;
     const double diff_x = sign * (opp_x - robot_x);
     const double diff_y = sign * (opp_y - robot_y);
     const double dist = std::hypot(diff_x, diff_y);
@@ -500,8 +531,13 @@ class ContinuousLaserTagTransitionCpp {
             // (pre- and post-move robot coincide here).
             double mean_opp_x;
             double mean_opp_y;
+            const bool tag_stay_in_place =
+                env_.opponent_policy_code == kPolicyEvadeWhenSpotted &&
+                !opponent_visible(robot_x, robot_y, opp_x, opp_y, env_.opponent_radius, env_.walls,
+                                  env_.grid_w, env_.grid_h);
             opponent_move_mean(robot_x, robot_y, opp_x, opp_y, env_.evasion_speed,
-                               env_.opponent_policy_code, rng, mean_opp_x, mean_opp_y);
+                               env_.opponent_policy_code, tag_stay_in_place, rng, mean_opp_x,
+                               mean_opp_y);
             double new_opp_x;
             double new_opp_y;
             sample_move(mean_opp_x, mean_opp_y, env_.opponent_radius, opp_noise_, env_, rng,
@@ -522,13 +558,18 @@ class ContinuousLaserTagTransitionCpp {
 
         double mean_opp_x;
         double mean_opp_y;
-        // EVADE reacts to the robot's PRE-move position; PURSUE to its POST-move position.
+        // PURSUE reacts to the robot's POST-move position; EVADE / EVADE_WHEN_SPOTTED
+        // to its PRE-move position.
         const double ref_robot_x =
-            (env_.opponent_policy_code == kPolicyEvade) ? robot_x : new_robot_x;
+            (env_.opponent_policy_code == kPolicyPursue) ? new_robot_x : robot_x;
         const double ref_robot_y =
-            (env_.opponent_policy_code == kPolicyEvade) ? robot_y : new_robot_y;
+            (env_.opponent_policy_code == kPolicyPursue) ? new_robot_y : robot_y;
+        const bool stay_in_place =
+            env_.opponent_policy_code == kPolicyEvadeWhenSpotted &&
+            !opponent_visible(ref_robot_x, ref_robot_y, opp_x, opp_y, env_.opponent_radius,
+                              env_.walls, env_.grid_w, env_.grid_h);
         opponent_move_mean(ref_robot_x, ref_robot_y, opp_x, opp_y, env_.evasion_speed,
-                           env_.opponent_policy_code, rng, mean_opp_x, mean_opp_y);
+                           env_.opponent_policy_code, stay_in_place, rng, mean_opp_x, mean_opp_y);
         double new_opp_x;
         double new_opp_y;
         sample_move(mean_opp_x, mean_opp_y, env_.opponent_radius, opp_noise_, env_, rng, new_opp_x,
@@ -1204,8 +1245,13 @@ static bool cont_step_state(double *state, const double *action, const EnvParams
         // Robot stays; opponent moves per the policy (pre/post robot coincide).
         double mean_opp_x;
         double mean_opp_y;
+        const bool tag_stay_in_place =
+            env.opponent_policy_code == kPolicyEvadeWhenSpotted &&
+            !opponent_visible(robot_x, robot_y, opp_x, opp_y, env.opponent_radius, env.walls,
+                              env.grid_w, env.grid_h);
         opponent_move_mean(robot_x, robot_y, opp_x, opp_y, env.evasion_speed,
-                           env.opponent_policy_code, rng, mean_opp_x, mean_opp_y);
+                           env.opponent_policy_code, tag_stay_in_place, rng, mean_opp_x,
+                           mean_opp_y);
         double new_opp_x;
         double new_opp_y;
         sample_move(mean_opp_x, mean_opp_y, env.opponent_radius, opp_noise, env, rng, new_opp_x,
@@ -1223,11 +1269,16 @@ static bool cont_step_state(double *state, const double *action, const EnvParams
 
     double mean_opp_x;
     double mean_opp_y;
-    // EVADE reacts to the robot's PRE-move position; PURSUE to its POST-move position.
-    const double ref_robot_x = (env.opponent_policy_code == kPolicyEvade) ? robot_x : new_robot_x;
-    const double ref_robot_y = (env.opponent_policy_code == kPolicyEvade) ? robot_y : new_robot_y;
+    // PURSUE reacts to the robot's POST-move position; EVADE / EVADE_WHEN_SPOTTED to its
+    // PRE-move position.
+    const double ref_robot_x = (env.opponent_policy_code == kPolicyPursue) ? new_robot_x : robot_x;
+    const double ref_robot_y = (env.opponent_policy_code == kPolicyPursue) ? new_robot_y : robot_y;
+    const bool stay_in_place =
+        env.opponent_policy_code == kPolicyEvadeWhenSpotted &&
+        !opponent_visible(ref_robot_x, ref_robot_y, opp_x, opp_y, env.opponent_radius, env.walls,
+                          env.grid_w, env.grid_h);
     opponent_move_mean(ref_robot_x, ref_robot_y, opp_x, opp_y, env.evasion_speed,
-                       env.opponent_policy_code, rng, mean_opp_x, mean_opp_y);
+                       env.opponent_policy_code, stay_in_place, rng, mean_opp_x, mean_opp_y);
     double new_opp_x;
     double new_opp_y;
     sample_move(mean_opp_x, mean_opp_y, env.opponent_radius, opp_noise, env, rng, new_opp_x,
@@ -1570,6 +1621,35 @@ double disc_reward(const double *state, int action, const DiscreteEnvParams &env
     return base;
 }
 
+// 8 laser directions (N, NE, E, SE, S, SW, W, NW). Mirrors
+// LaserTagPOMDP._LASER_DIRECTIONS / kBeliefLaserDirections.
+static constexpr std::array<std::array<int, 2>, 8> kDiscLaserDirs = {{
+    {{-1, 0}}, {{-1, 1}}, {{0, 1}}, {{1, 1}}, {{1, 0}}, {{1, -1}}, {{0, -1}}, {{-1, -1}}}};
+
+// True iff the opponent lies on one of the robot's 8 unoccluded laser rays.
+// Mirrors LaserTagPOMDP._is_opponent_spotted: walks each ray from the robot and
+// returns true if the opponent cell is reached before a wall or the boundary.
+bool disc_opponent_spotted(int robot_r, int robot_c, int opp_r, int opp_c,
+                           const DiscreteEnvParams &env) {
+    for (std::size_t d = 0; d < 8; ++d) {
+        const int dr = kDiscLaserDirs[d][0];
+        const int dc = kDiscLaserDirs[d][1];
+        int r = robot_r;
+        int c = robot_c;
+        while (true) {
+            r += dr;
+            c += dc;
+            if (r == opp_r && c == opp_c) {
+                return true;
+            }
+            if (!disc_is_valid(r, c, env)) {  // wall or out of bounds
+                break;
+            }
+        }
+    }
+    return false;
+}
+
 std::pair<int, int> disc_sample_opponent_move(
     int opp_r, int opp_c, int robot_r, int robot_c,
     const DiscreteEnvParams &env, pomdp_native::RNGState &rng) {
@@ -1588,29 +1668,39 @@ std::pair<int, int> disc_sample_opponent_move(
         }
     };
 
-    // EVADE places the 0.4 directional mass on the distance-increasing (away)
-    // cell; PURSUE places it on the distance-decreasing (toward) cell. The
-    // aligned (robot == opponent) branch is policy-invariant.
-    const bool evade = (env.opponent_policy_code == kPolicyEvade);
-
-    // x-moves (column direction, fixed row = opp_r)
-    if (robot_c == opp_c) {
+    if (env.opponent_policy_code == kPolicyEvadeWhenSpotted &&
+        !disc_opponent_spotted(robot_r, robot_c, opp_r, opp_c, env)) {
+        // EVADE_WHEN_SPOTTED with no line of sight: uniform 0.2 on each valid
+        // cardinal neighbour; remainder (incl. blocked moves) falls through to stay.
+        add_cand(opp_r - 1, opp_c, 0.2);
+        add_cand(opp_r + 1, opp_c, 0.2);
         add_cand(opp_r, opp_c + 1, 0.2);
         add_cand(opp_r, opp_c - 1, 0.2);
     } else {
-        const int dir_c = (robot_c > opp_c) ? (evade ? opp_c - 1 : opp_c + 1)
-                                            : (evade ? opp_c + 1 : opp_c - 1);
-        add_cand(opp_r, dir_c, 0.4);
-    }
+        // Only PURSUE places the 0.4 directional mass on the distance-decreasing
+        // (toward) cell; every other policy flees to the away cell. The aligned
+        // (robot == opponent) branch is policy-invariant.
+        const bool evade = (env.opponent_policy_code != kPolicyPursue);
 
-    // y-moves (row direction, fixed col = opp_c)
-    if (robot_r == opp_r) {
-        add_cand(opp_r + 1, opp_c, 0.2);
-        add_cand(opp_r - 1, opp_c, 0.2);
-    } else {
-        const int dir_r = (robot_r > opp_r) ? (evade ? opp_r - 1 : opp_r + 1)
-                                            : (evade ? opp_r + 1 : opp_r - 1);
-        add_cand(dir_r, opp_c, 0.4);
+        // x-moves (column direction, fixed row = opp_r)
+        if (robot_c == opp_c) {
+            add_cand(opp_r, opp_c + 1, 0.2);
+            add_cand(opp_r, opp_c - 1, 0.2);
+        } else {
+            const int dir_c = (robot_c > opp_c) ? (evade ? opp_c - 1 : opp_c + 1)
+                                                : (evade ? opp_c + 1 : opp_c - 1);
+            add_cand(opp_r, dir_c, 0.4);
+        }
+
+        // y-moves (row direction, fixed col = opp_c)
+        if (robot_r == opp_r) {
+            add_cand(opp_r + 1, opp_c, 0.2);
+            add_cand(opp_r - 1, opp_c, 0.2);
+        } else {
+            const int dir_r = (robot_r > opp_r) ? (evade ? opp_r - 1 : opp_r + 1)
+                                                : (evade ? opp_r + 1 : opp_r - 1);
+            add_cand(dir_r, opp_c, 0.4);
+        }
     }
 
     // Compute actual_total including the base stay probability 0.2.
@@ -1742,12 +1832,12 @@ double simulate_rollout_discrete(
             break;
         }
 
-        // Sample opponent move. EVADE reacts to the robot's PRE-move position;
-        // PURSUE to its POST-move position.
+        // Sample opponent move. PURSUE reacts to the robot's POST-move position;
+        // EVADE / EVADE_WHEN_SPOTTED to its PRE-move position.
         const int ref_robot_r =
-            (env.opponent_policy_code == kPolicyEvade) ? robot_r : new_robot_r;
+            (env.opponent_policy_code == kPolicyPursue) ? new_robot_r : robot_r;
         const int ref_robot_c =
-            (env.opponent_policy_code == kPolicyEvade) ? robot_c : new_robot_c;
+            (env.opponent_policy_code == kPolicyPursue) ? new_robot_c : robot_c;
         auto [new_opp_r, new_opp_c] = disc_sample_opponent_move(
             opp_r, opp_c, ref_robot_r, ref_robot_c, env, rng);
 
@@ -1798,6 +1888,30 @@ inline bool belief_is_valid(int r, int c, int rows, int cols, const std::uint8_t
     return valid_cell[r * cols + c] != 0;
 }
 
+// True iff the opponent lies on one of the robot's 8 unoccluded laser rays
+// (over the belief ``valid_cell`` grid). Mirrors LaserTagPOMDP._is_opponent_spotted
+// / disc_opponent_spotted for the belief path.
+bool belief_opponent_spotted(int robot_r, int robot_c, int opp_r, int opp_c, int rows, int cols,
+                             const std::uint8_t *valid_cell) {
+    for (std::size_t d = 0; d < 8; ++d) {
+        const int dr = kBeliefLaserDirections[d][0];
+        const int dc = kBeliefLaserDirections[d][1];
+        int r = robot_r;
+        int c = robot_c;
+        while (true) {
+            r += dr;
+            c += dc;
+            if (r == opp_r && c == opp_c) {
+                return true;
+            }
+            if (!belief_is_valid(r, c, rows, cols, valid_cell)) {  // wall or out of bounds
+                break;
+            }
+        }
+    }
+    return false;
+}
+
 // Compute the opponent's next position by sampling from the 5-way
 // categorical distribution defined in
 // LaserTagVectorizedUpdater._batch_opponent_move, using a single uniform
@@ -1813,33 +1927,45 @@ void belief_sample_opponent_move(int robot_r, int robot_c, int opp_r, int opp_c,
 
     const bool same_col = (robot_c == opp_c);
     const bool same_row = (robot_r == opp_r);
-    // EVADE puts the 0.4 mass on the cell that increases distance to the robot;
-    // PURSUE on the cell that decreases it. The comparisons below flip per policy.
-    const bool evade = (opponent_policy_code == kPolicyEvade);
+    // Only PURSUE puts the 0.4 mass on the cell that decreases distance to the
+    // robot; every other policy flees to the cell that increases it.
+    const bool evade = (opponent_policy_code != kPolicyPursue);
+    // EVADE_WHEN_SPOTTED with no line of sight moves uniformly at random.
+    const bool move_randomly =
+        opponent_policy_code == kPolicyEvadeWhenSpotted &&
+        !belief_opponent_spotted(robot_r, robot_c, opp_r, opp_c, rows, cols, valid_cell);
 
     double right_prob = 0.0;
-    if (same_col && right_valid) {
-        right_prob = 0.2;
-    } else if ((evade ? (robot_c < opp_c) : (robot_c > opp_c)) && right_valid) {
-        right_prob = 0.4;
-    }
     double left_prob = 0.0;
-    if (same_col && left_valid) {
-        left_prob = 0.2;
-    } else if ((evade ? (robot_c > opp_c) : (robot_c < opp_c)) && left_valid) {
-        left_prob = 0.4;
-    }
     double up_prob = 0.0;
-    if (same_row && up_valid) {
-        up_prob = 0.2;
-    } else if ((evade ? (robot_r > opp_r) : (robot_r < opp_r)) && up_valid) {
-        up_prob = 0.4;
-    }
     double down_prob = 0.0;
-    if (same_row && down_valid) {
-        down_prob = 0.2;
-    } else if ((evade ? (robot_r < opp_r) : (robot_r > opp_r)) && down_valid) {
-        down_prob = 0.4;
+    if (move_randomly) {
+        // Uniform 0.2 on each valid neighbour; the remainder routes to "stay".
+        right_prob = right_valid ? 0.2 : 0.0;
+        left_prob = left_valid ? 0.2 : 0.0;
+        up_prob = up_valid ? 0.2 : 0.0;
+        down_prob = down_valid ? 0.2 : 0.0;
+    } else {
+        if (same_col && right_valid) {
+            right_prob = 0.2;
+        } else if ((evade ? (robot_c < opp_c) : (robot_c > opp_c)) && right_valid) {
+            right_prob = 0.4;
+        }
+        if (same_col && left_valid) {
+            left_prob = 0.2;
+        } else if ((evade ? (robot_c > opp_c) : (robot_c < opp_c)) && left_valid) {
+            left_prob = 0.4;
+        }
+        if (same_row && up_valid) {
+            up_prob = 0.2;
+        } else if ((evade ? (robot_r > opp_r) : (robot_r < opp_r)) && up_valid) {
+            up_prob = 0.4;
+        }
+        if (same_row && down_valid) {
+            down_prob = 0.2;
+        } else if ((evade ? (robot_r < opp_r) : (robot_r > opp_r)) && down_valid) {
+            down_prob = 0.4;
+        }
     }
 
     const double cum1 = right_prob;
@@ -1928,12 +2054,12 @@ void belief_apply_action(int action_idx, std::size_t n,
         const double u = uniform(rng.engine());
         int new_opp_r;
         int new_opp_c;
-        // EVADE reacts to the robot's PRE-move position; PURSUE to its POST-move
-        // position.
+        // PURSUE reacts to the robot's POST-move position; EVADE / EVADE_WHEN_SPOTTED
+        // to its PRE-move position.
         const int ref_robot_r =
-            (opponent_policy_code == kPolicyEvade) ? robot_r : new_robot_r;
+            (opponent_policy_code == kPolicyPursue) ? new_robot_r : robot_r;
         const int ref_robot_c =
-            (opponent_policy_code == kPolicyEvade) ? robot_c : new_robot_c;
+            (opponent_policy_code == kPolicyPursue) ? new_robot_c : robot_c;
         belief_sample_opponent_move(ref_robot_r, ref_robot_c, opp_r, opp_c,
                                      rows, cols, valid_cell, opponent_policy_code, u,
                                      &new_opp_r, &new_opp_c);
@@ -2230,12 +2356,6 @@ inline std::size_t cumulative_sample(const double *probs, std::size_t n, double 
     return n - 1;
 }
 
-// 8-direction laser distance scan from (robot_r, robot_c). Mirrors
-// LaserTagPOMDP._laser_distance_inline / _LASER_DIRECTIONS.
-// Output: out[0..7] in order N, NE, E, SE, S, SW, W, NW.
-static constexpr std::array<std::array<int, 2>, 8> kDiscLaserDirs = {{
-    {{-1, 0}}, {{-1, 1}}, {{0, 1}}, {{1, 1}}, {{1, 0}}, {{1, -1}}, {{0, -1}}, {{-1, -1}}}};
-
 void disc_laser_measurements(int robot_r, int robot_c, int opp_r, int opp_c,
                              const DiscreteEnvParams &env, double *out) {
     for (std::size_t d = 0; d < 8; ++d) {
@@ -2279,29 +2399,39 @@ std::size_t disc_opponent_move_table(int opp_r, int opp_c, int robot_r,
         }
     };
 
-    // EVADE places the 0.4 directional mass on the distance-increasing (away)
-    // cell; PURSUE on the distance-decreasing (toward) cell. The aligned branch
-    // is policy-invariant.
-    const bool evade = (env.opponent_policy_code == kPolicyEvade);
-
-    // x-moves (column direction, fixed row = opp_r)
-    if (robot_c == opp_c) {
+    if (env.opponent_policy_code == kPolicyEvadeWhenSpotted &&
+        !disc_opponent_spotted(robot_r, robot_c, opp_r, opp_c, env)) {
+        // EVADE_WHEN_SPOTTED with no line of sight: uniform 0.2 on each valid
+        // cardinal neighbour; remainder (incl. blocked moves) falls through to stay.
+        try_add(opp_r - 1, opp_c, 0.2);
+        try_add(opp_r + 1, opp_c, 0.2);
         try_add(opp_r, opp_c + 1, 0.2);
         try_add(opp_r, opp_c - 1, 0.2);
     } else {
-        const int dir_c = (robot_c > opp_c) ? (evade ? opp_c - 1 : opp_c + 1)
-                                            : (evade ? opp_c + 1 : opp_c - 1);
-        try_add(opp_r, dir_c, 0.4);
-    }
+        // Only PURSUE places the 0.4 directional mass on the distance-decreasing
+        // (toward) cell; every other policy flees to the away cell. The aligned
+        // branch is policy-invariant.
+        const bool evade = (env.opponent_policy_code != kPolicyPursue);
 
-    // y-moves (row direction, fixed col = opp_c)
-    if (robot_r == opp_r) {
-        try_add(opp_r + 1, opp_c, 0.2);
-        try_add(opp_r - 1, opp_c, 0.2);
-    } else {
-        const int dir_r = (robot_r > opp_r) ? (evade ? opp_r - 1 : opp_r + 1)
-                                            : (evade ? opp_r + 1 : opp_r - 1);
-        try_add(dir_r, opp_c, 0.4);
+        // x-moves (column direction, fixed row = opp_r)
+        if (robot_c == opp_c) {
+            try_add(opp_r, opp_c + 1, 0.2);
+            try_add(opp_r, opp_c - 1, 0.2);
+        } else {
+            const int dir_c = (robot_c > opp_c) ? (evade ? opp_c - 1 : opp_c + 1)
+                                                : (evade ? opp_c + 1 : opp_c - 1);
+            try_add(opp_r, dir_c, 0.4);
+        }
+
+        // y-moves (row direction, fixed col = opp_c)
+        if (robot_r == opp_r) {
+            try_add(opp_r + 1, opp_c, 0.2);
+            try_add(opp_r - 1, opp_c, 0.2);
+        } else {
+            const int dir_r = (robot_r > opp_r) ? (evade ? opp_r - 1 : opp_r + 1)
+                                                : (evade ? opp_r + 1 : opp_r - 1);
+            try_add(dir_r, opp_c, 0.4);
+        }
     }
 
     // Stay action probability: 0.2 + slack from invalid moves.
@@ -2393,11 +2523,12 @@ py::array_t<double> lasertag_sample_next_state_step(
     int opp_rows_buf[5];   // NOLINT(modernize-avoid-c-arrays)
     int opp_cols_buf[5];   // NOLINT(modernize-avoid-c-arrays)
     double opp_probs[5];   // NOLINT(modernize-avoid-c-arrays)
-    // EVADE reacts to the robot's PRE-move position; PURSUE to its POST-move position.
+    // PURSUE reacts to the robot's POST-move position; EVADE / EVADE_WHEN_SPOTTED to its
+    // PRE-move position.
     const int ref_robot_r =
-        (opponent_policy_code == kPolicyEvade) ? robot_r : robot_next_r;
+        (opponent_policy_code == kPolicyPursue) ? robot_next_r : robot_r;
     const int ref_robot_c =
-        (opponent_policy_code == kPolicyEvade) ? robot_c : robot_next_c;
+        (opponent_policy_code == kPolicyPursue) ? robot_next_c : robot_c;
     const std::size_t n_opp = disc_opponent_move_table(
         opp_r, opp_c, ref_robot_r, ref_robot_c, env, opp_rows_buf, opp_cols_buf, opp_probs);
     const std::size_t pick = cumulative_sample(opp_probs, n_opp, opp_uniform);
@@ -2626,7 +2757,8 @@ PYBIND11_MODULE(_native, m) {
         "Run a full random rollout for ContinuousLaserTagPOMDP in one C++ frame.\n\n"
         "``actions_buffer`` must be shape (N, 3) float64 with N >= max_depth - start_depth.\n"
         "``opponent_policy_code`` selects the opponent behaviour: 0 = EVADE (away from\n"
-        "the robot's pre-move position), 1 = PURSUE (toward its post-move position).\n"
+        "the robot's pre-move position), 1 = PURSUE (toward its post-move position),\n"
+        "2 = EVADE_WHEN_SPOTTED (evade while the robot has line of sight, else hold position).\n"
         "Returns the discounted sum of immediate rewards along the sampled trajectory.");
 
     // ── Discrete LaserTag native rollout binding ──────────────────────────────
@@ -2651,7 +2783,8 @@ PYBIND11_MODULE(_native, m) {
         "  2 = DISTANCE_DECAYED_HAZARD_PENALTY (wall always -penalty; danger -penalty\n"
         "      with probability exp(-min_dist / penalty_decay), no radius cutoff).\n"
         "``opponent_policy_code`` selects the opponent behaviour: 0 = EVADE (away from\n"
-        "the robot's pre-move position), 1 = PURSUE (toward its post-move position).\n"
+        "the robot's pre-move position), 1 = PURSUE (toward its post-move position),\n"
+        "2 = EVADE_WHEN_SPOTTED (evade while the robot has line of sight, else random).\n"
         "Returns the discounted sum of immediate rewards along the sampled trajectory.");
 
     // ── Discrete LaserTag belief-update kernels ─────────────────────────────
@@ -2664,7 +2797,8 @@ PYBIND11_MODULE(_native, m) {
         "Returns the (N, 5) float64 array of next particles.  Uses\n"
         "pomdp_native::default_rng(); seed via set_seed() for reproducibility.\n"
         "``opponent_policy_code`` selects the opponent behaviour: 0 = EVADE (away from\n"
-        "the robot's pre-move position), 1 = PURSUE (toward its post-move position).");
+        "the robot's pre-move position), 1 = PURSUE (toward its post-move position), "
+        "2 = EVADE_WHEN_SPOTTED (evade while the robot has line of sight, else random).");
 
     m.def(
         "belief_batch_obs_log_likelihood_discrete",
@@ -2688,7 +2822,8 @@ PYBIND11_MODULE(_native, m) {
         "used to pick the opponent move; must be drawn with np.random.random()\n"
         "for byte-identical reproducibility against the original Python path.\n"
         "``opponent_policy_code`` selects the opponent behaviour: 0 = EVADE (away from\n"
-        "the robot's pre-move position), 1 = PURSUE (toward its post-move position).\n"
+        "the robot's pre-move position), 1 = PURSUE (toward its post-move position),\n"
+        "2 = EVADE_WHEN_SPOTTED (evade while the robot has line of sight, else random).\n"
         "Returns a (5,) float64 ndarray.");
 
     m.def(

--- a/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
@@ -162,7 +162,8 @@ def simulate_rollout_discrete(
     ``2`` = DISTANCE_DECAYED_HAZARD_PENALTY. ``penalty_decay`` is consulted only by
     the ``DISTANCE_DECAYED_HAZARD_PENALTY`` variant. ``opponent_policy_code`` selects
     the opponent behaviour (``0`` = EVADE, away + pre-move robot reference;
-    ``1`` = PURSUE, toward + post-move robot reference). Returns the discounted sum of
+    ``1`` = PURSUE, toward + post-move robot reference; ``2`` = EVADE_WHEN_SPOTTED,
+    evade while the robot has line of sight else random). Returns the discounted sum of
     immediate rewards along the sampled trajectory.
     """
     ...
@@ -183,7 +184,8 @@ def belief_batch_transition_discrete(
     Returns the (N, 5) float64 array of next particles. Uses the module-level
     mt19937_64 RNG; seed via set_seed() before calling for reproducibility.
     ``opponent_policy_code`` selects the opponent behaviour (``0`` = EVADE,
-    away + pre-move robot reference; ``1`` = PURSUE, toward + post-move reference).
+    away + pre-move robot reference; ``1`` = PURSUE, toward + post-move reference;
+    ``2`` = EVADE_WHEN_SPOTTED, evade while the robot has line of sight else random).
     """
     ...
 
@@ -223,7 +225,8 @@ def sample_next_state_step(
     ``np.random.random()`` so byte-identical numpy RNG state is preserved
     across the original Python path and this native fast path.
     ``opponent_policy_code`` selects the opponent behaviour (``0`` = EVADE,
-    away + pre-move robot reference; ``1`` = PURSUE, toward + post-move reference).
+    away + pre-move robot reference; ``1`` = PURSUE, toward + post-move reference;
+    ``2`` = EVADE_WHEN_SPOTTED, evade while the robot has line of sight else random).
     """
     ...
 
@@ -283,7 +286,9 @@ def cont_simulate_rollout(
 
     ``actions_buffer`` must be shape (N, 3) float64 with N >= max_depth - start_depth.
     ``opponent_policy_code`` selects the opponent behaviour (``0`` = EVADE,
-    away + pre-move robot reference; ``1`` = PURSUE, toward + post-move reference).
+    away + pre-move robot reference; ``1`` = PURSUE, toward + post-move reference;
+    ``2`` = EVADE_WHEN_SPOTTED, evade while the robot has line of sight else hold
+    position).
     Returns the discounted sum of immediate rewards along the sampled trajectory.
     """
     ...

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -23,8 +23,10 @@ Observation:
 Opponent behaviour is selectable via ``opponent_policy`` (see
 :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.OpponentPolicy`):
 ``EVADE`` (default) flees the robot's pre-move position at ``evasion_speed``;
-``PURSUE`` chases the robot's post-move position. ``evasion_speed`` is a
-direction-neutral step magnitude under both policies.
+``PURSUE`` chases the robot's post-move position. ``EVADE_WHEN_SPOTTED`` flees
+only while the robot has line of sight to it and otherwise **holds its position**
+(in this continuous env; the discrete grid env moves randomly instead).
+``evasion_speed`` is a direction-neutral step magnitude under all policies.
 
 Classes:
     ContinuousLaserTagPOMDP: Continuous-action environment.

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -519,9 +519,42 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
     def _opponent_robot_reference(
         self, robot_current: Tuple[int, int], robot_next: Tuple[int, int]
     ) -> Tuple[int, int]:
-        # EVADE conditions the opponent move on the robot's pre-move cell; PURSUE on
-        # its post-move cell. Tag actions don't move the robot, so the two coincide.
-        return robot_current if self.opponent_policy is OpponentPolicy.EVADE else robot_next
+        # PURSUE conditions the opponent move on the robot's post-move cell; EVADE and
+        # EVADE_WHEN_SPOTTED on its pre-move cell. Tag actions don't move the robot, so
+        # the two coincide.
+        return robot_next if self.opponent_policy is OpponentPolicy.PURSUE else robot_current
+
+    def _is_opponent_spotted(self, robot_pos: Tuple[int, int], opp_pos: Tuple[int, int]) -> bool:
+        # True iff the opponent cell lies on one of the robot's 8 laser rays,
+        # unoccluded by a wall or the grid boundary. Mirrors the ray walk in
+        # _laser_distance_inline (and the C++ disc/belief spotted predicates) but
+        # returns whether the opponent — rather than a wall — is the first hit.
+        rows, cols = self.floor_shape
+        for dr, dc in _LASER_DIRECTIONS:
+            row, col = robot_pos
+            while True:
+                row += dr
+                col += dc
+                if row < 0 or row >= rows or col < 0 or col >= cols:
+                    break
+                if (row, col) == opp_pos:
+                    return True
+                if (row, col) in self.walls:
+                    break
+        return False
+
+    def _random_move_probabilities_inline(
+        self, current_opp: Tuple[int, int]
+    ) -> List[Tuple[Tuple[int, int], float]]:
+        # Uniform 0.2 on each valid cardinal neighbour; invalid neighbours are
+        # dropped and their mass falls through to "stay" via the shared slack tail.
+        moves: List[Tuple[Tuple[int, int], float]] = []
+        for action in (0, 1, 2, 3):  # North, South, East, West
+            dr, dc = self._action_directions[action]
+            cand = (current_opp[0] + dr, current_opp[1] + dc)
+            if self._is_valid_position_inline(cand):
+                moves.append((cand, 0.2))
+        return moves
 
     def _opponent_move_probabilities_inline(
         self, state: np.ndarray, robot_pos: Tuple[int, int]
@@ -532,10 +565,17 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         robot_row, robot_col = robot_pos
         opp_row, opp_col = current_opp
 
-        x_moves = self._directional_moves_inline(opp_col, robot_col, opp_row, True)
-        y_moves = self._directional_moves_inline(opp_row, robot_row, opp_col, False)
+        if (
+            self.opponent_policy is OpponentPolicy.EVADE_WHEN_SPOTTED
+            and not self._is_opponent_spotted(robot_pos, current_opp)
+        ):
+            directional_moves = self._random_move_probabilities_inline(current_opp)
+        else:
+            x_moves = self._directional_moves_inline(opp_col, robot_col, opp_row, True)
+            y_moves = self._directional_moves_inline(opp_row, robot_row, opp_col, False)
+            directional_moves = x_moves + y_moves
 
-        move_probs = x_moves + y_moves + [(current_opp, 0.2)]
+        move_probs = directional_moves + [(current_opp, 0.2)]
         actual_total = sum(prob for _, prob in move_probs if prob > 0)
         if actual_total < 1.0:
             stay_index = len(move_probs) - 1
@@ -546,13 +586,14 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
     def _directional_moves_inline(
         self, opponent_coord: int, robot_coord: int, fixed_coord: int, is_horizontal: bool
     ) -> List[Tuple[Tuple[int, int], float]]:
-        # Under EVADE the 0.4 directional mass goes on the away cell; under PURSUE it
-        # goes on the toward cell. The aligned (robot == opponent) case is policy-
-        # invariant and keeps its symmetric 0.2/0.2 split.
-        if self.opponent_policy is OpponentPolicy.EVADE:
-            directional_toward_prob, directional_away_prob = 0.0, 0.4
-        else:
+        # Only PURSUE puts the 0.4 directional mass on the toward cell; every other
+        # policy (EVADE, and EVADE_WHEN_SPOTTED on the spotted branch) flees to the
+        # away cell. The aligned (robot == opponent) case is policy-invariant and
+        # keeps its symmetric 0.2/0.2 split.
+        if self.opponent_policy is OpponentPolicy.PURSUE:
             directional_toward_prob, directional_away_prob = 0.4, 0.0
+        else:
+            directional_toward_prob, directional_away_prob = 0.0, 0.4
 
         if robot_coord > opponent_coord:
             toward_pos = (

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp_utils/__init__.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp_utils/__init__.py
@@ -3,7 +3,8 @@
 """Shared utilities for the LaserTag POMDP environments.
 
 Classes:
-    OpponentPolicy: Selectable opponent transition behaviour (evade vs pursue).
+    OpponentPolicy: Selectable opponent transition behaviour (evade, pursue, or
+        evade-when-spotted).
 """
 
 from enum import Enum
@@ -12,7 +13,7 @@ from enum import Enum
 class OpponentPolicy(Enum):
     """Opponent transition behaviour selectable on the LaserTag environments.
 
-    Two policies are offered:
+    Three policies are offered:
 
     - ``EVADE`` (default): the opponent flees the robot, placing its directional
       probability mass on the cell that *increases* distance, and reacts to the
@@ -20,15 +21,32 @@ class OpponentPolicy(Enum):
     - ``PURSUE``: the opponent chases the robot, placing its directional mass on
       the cell that *decreases* distance, and reacts to the robot's post-move
       position. This restores the behaviour used before the evader alignment fix.
+    - ``EVADE_WHEN_SPOTTED``: a partially-observed reactive opponent. When the
+      robot has a clear line of sight to the opponent (the opponent lies on one
+      of the robot's unoccluded laser rays, evaluated from the robot's pre-move
+      position), it behaves exactly like ``EVADE``. Otherwise the unspotted
+      behaviour is environment-specific: the discrete grid env moves randomly
+      (uniformly over the moves, with the usual stay/wall handling), while the
+      continuous env holds its position (only the Gaussian opponent noise jitters
+      it). The opponent is memoryless — visibility is recomputed each step from
+      the current state.
 
-    Both directional choices and reference-position choices are coupled per
-    policy, so ``PURSUE`` and ``EVADE`` are mutually exclusive opposites.
+    ``EVADE`` and ``PURSUE`` couple both the directional choice and the
+    reference-position choice, so they are mutually exclusive opposites.
     """
 
     EVADE = "evade"
     PURSUE = "pursue"
+    EVADE_WHEN_SPOTTED = "evade_when_spotted"
 
     @property
     def native_code(self) -> int:
-        """Integer code passed to the C++ kernels (``EVADE`` = 0, ``PURSUE`` = 1)."""
-        return 0 if self is OpponentPolicy.EVADE else 1
+        """Integer code passed to the C++ kernels.
+
+        ``EVADE`` = 0, ``PURSUE`` = 1, ``EVADE_WHEN_SPOTTED`` = 2.
+        """
+        return {
+            OpponentPolicy.EVADE: 0,
+            OpponentPolicy.PURSUE: 1,
+            OpponentPolicy.EVADE_WHEN_SPOTTED: 2,
+        }[self]

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
@@ -69,18 +69,19 @@ def test_continuous_opponent_policy_changes_config_id():
     """Distinct opponent policies produce distinct continuous env config IDs.
 
     Purpose: Validates the opponent_policy enum is captured by config_id so cached
-        results for EVADE and PURSUE continuous configs never collide
+        results for distinct continuous policies never collide
 
-    Given: Two ContinuousLaserTagPOMDPs identical except for opponent_policy
+    Given: ContinuousLaserTagPOMDPs identical except for opponent_policy
     When: config_id is computed for each
-    Then: The two IDs differ
+    Then: The three policy IDs are all distinct
 
     Test type: unit
     """
     common = {"discount_factor": 0.95, "walls": [], "dangerous_areas": []}
     evade = ContinuousLaserTagPOMDP(**common, opponent_policy=OpponentPolicy.EVADE)
     pursue = ContinuousLaserTagPOMDP(**common, opponent_policy=OpponentPolicy.PURSUE)
-    assert evade.config_id != pursue.config_id
+    spotted = ContinuousLaserTagPOMDP(**common, opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED)
+    assert len({evade.config_id, pursue.config_id, spotted.config_id}) == 3
 
 
 class TestContinuousLaserTagPOMDPInit:
@@ -324,6 +325,70 @@ class TestSampleNextState:
         assert (
             mean_opp_x > 5.6
         ), f"Expected opponent to chase +x toward post-move robot (>5.6), got {mean_opp_x}"
+
+    def test_evade_when_spotted_flees_when_visible(self):
+        """Continuous EVADE_WHEN_SPOTTED flees when the robot has line of sight.
+
+        Purpose: Validates that an opponent lying on one of the robot's laser rays flees
+            away (EVADE behaviour) under the spotted branch
+
+        Given: An EVADE_WHEN_SPOTTED env (no walls), robot at (5, 3) with the opponent due
+            +x at (8, 3) — on the robot's East ray, so visible
+        When: the robot holds position and many next states are sampled
+        Then: the opponent's mean x increases (it flees +x, away from the robot)
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        env = ContinuousLaserTagPOMDP(
+            discount_factor=0.95,
+            walls=[],
+            dangerous_areas=[],
+            opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED,
+        )
+        state = np.array([5.0, 3.0, 8.0, 3.0, 0.0])
+        action = np.array([0.0, 0.0, 0.0])  # robot holds position, no tag
+        samples = env.sample_next_state(state, action, n_samples=500)
+
+        mean_opp_x = float(np.mean([s[2] for s in samples]))
+        assert (
+            mean_opp_x > 8.1
+        ), f"Expected opponent to flee +x while spotted (>8.1), got {mean_opp_x}"
+
+    def test_evade_when_spotted_stays_when_not_visible(self):
+        """Continuous EVADE_WHEN_SPOTTED holds position when not visible.
+
+        Purpose: Validates that the continuous opponent stays in place (rather than taking a
+            directional step) when the robot has no line of sight — only the small Gaussian
+            transition noise jitters it
+
+        Given: An EVADE_WHEN_SPOTTED env (no walls), robot at (5, 3) and opponent at (8, 5)
+            — not aligned with any of the robot's 8 laser directions (so not visible)
+        When: the robot holds position and many next states are sampled
+        Then: the opponent stays near its start, and the per-step spread is just the Gaussian
+            opponent noise — well below a full evasion_speed (0.6) step
+
+        Test type: unit
+        """
+        np.random.seed(42)
+        env = ContinuousLaserTagPOMDP(
+            discount_factor=0.95,
+            walls=[],
+            dangerous_areas=[],
+            opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED,
+        )
+        state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        action = np.array([0.0, 0.0, 0.0])  # robot holds position, no tag
+        samples = env.sample_next_state(state, action, n_samples=600)
+
+        opp_x = np.array([s[2] for s in samples])
+        opp_y = np.array([s[3] for s in samples])
+        # The opponent holds its position (mean ~ start) ...
+        assert abs(float(np.mean(opp_x)) - 8.0) < 0.1, "Expected opponent to hold x"
+        assert abs(float(np.mean(opp_y)) - 5.0) < 0.1, "Expected opponent to hold y"
+        # ... with only the Gaussian opponent noise (std ~ sqrt(0.05) ~ 0.22), not a 0.6 step.
+        assert float(np.std(opp_x)) < 0.35, "Expected only noise-level spread in x (staying)"
+        assert float(np.std(opp_y)) < 0.35, "Expected only noise-level spread in y (staying)"
 
 
 class TestSampleObservation:

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -161,17 +161,18 @@ def test_opponent_policy_changes_config_id():
     """Distinct opponent policies produce distinct environment config IDs.
 
     Purpose: Validates the opponent_policy enum is captured by config_id so cached
-        results for EVADE and PURSUE configs never collide
+        results for distinct policies never collide
 
-    Given: Two LaserTagPOMDPs identical except for opponent_policy
+    Given: LaserTagPOMDPs identical except for opponent_policy
     When: config_id is computed for each
-    Then: The two IDs differ
+    Then: The three policy IDs are all distinct
 
     Test type: unit
     """
     evade = _make_env(opponent_policy=OpponentPolicy.EVADE)
     pursue = _make_env(opponent_policy=OpponentPolicy.PURSUE)
-    assert evade.config_id != pursue.config_id
+    spotted = _make_env(opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED)
+    assert len({evade.config_id, pursue.config_id, spotted.config_id}) == 3
 
 
 class TestLaserTagStateTransition:
@@ -361,6 +362,88 @@ class TestLaserTagStateTransition:
         assert (
             0.15 <= probs[1] <= 0.25
         ), f"Expected ~0.2 North from the post-move row-aligned split, got {probs[1]}"
+
+    def test_evade_when_spotted_flees_when_visible(self):
+        """EVADE_WHEN_SPOTTED behaves like EVADE when the robot has line of sight.
+
+        Purpose: Validates that an opponent on a clear laser ray from the robot flees
+            exactly as the EVADE policy would
+
+        Given: An EVADE_WHEN_SPOTTED env, robot at (2, 5) directly above the opponent at
+            (5, 5) on the same column (the opponent is on the robot's unoccluded South ray)
+        When: many transitions are sampled after the robot moves South
+        Then: the opponent flees to the away cell (6, 5) with >0.3 probability and rarely
+            takes the toward cell (4, 5), identical to EVADE
+
+        Test type: unit
+        """
+        env = _make_env(floor_shape=(7, 11), opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED)
+        state = np.array([2.0, 5.0, 5.0, 5.0, 0.0])
+
+        samples = env.sample_next_state(state, 1, n_samples=1000)
+        pos_counts = Counter((int(s[2]), int(s[3])) for s in samples)
+        total = len(samples)
+
+        away_prob = pos_counts.get((6, 5), 0) / total
+        toward_prob = pos_counts.get((4, 5), 0) / total
+        assert away_prob > 0.3, f"Expected >0.3 away (flee while spotted), got {away_prob}"
+        assert toward_prob < 0.1, f"Expected <0.1 toward while spotted, got {toward_prob}"
+
+    def test_evade_when_spotted_random_when_not_visible(self):
+        """EVADE_WHEN_SPOTTED moves uniformly at random when not on any laser ray.
+
+        Purpose: Validates the random fallback distribution (0.2 per move + 0.2 stay) when
+            the opponent is off all of the robot's rays
+
+        Given: An EVADE_WHEN_SPOTTED env, robot at (3, 5) and opponent at (5, 6) — not
+            collinear with any of the robot's 8 laser directions (so unspotted)
+        When: many transitions are sampled
+        Then: each of the four neighbour cells and the stay cell each get ~0.2 probability
+
+        Test type: unit
+        """
+        env = _make_env(floor_shape=(7, 11), opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED)
+        state = np.array([3.0, 5.0, 5.0, 6.0, 0.0])
+
+        samples = env.sample_next_state(state, 0, n_samples=4000)
+        pos_counts = Counter((int(s[2]), int(s[3])) for s in samples)
+        total = len(samples)
+
+        for cell in [(4, 6), (6, 6), (5, 7), (5, 5), (5, 6)]:  # N, S, E, W, stay
+            prob = pos_counts.get(cell, 0) / total
+            assert 0.15 <= prob <= 0.25, f"Expected ~0.2 for random cell {cell}, got {prob}"
+
+    def test_evade_when_spotted_occluded_is_random(self):
+        """A wall between robot and opponent breaks line of sight -> random moves.
+
+        Purpose: Validates that "spotted" uses true line of sight: an opponent on a ray but
+            occluded by a wall is treated as unspotted (random), not fleeing
+
+        Given: An EVADE_WHEN_SPOTTED env, robot at (1, 5) above the opponent at (5, 5) on the
+            same column, with a wall at (3, 5) between them occluding the South ray
+        When: many transitions are sampled
+        Then: the opponent moves randomly (toward cell (4, 5) gets ~0.2, not 0 as a spotted
+            evader would give)
+
+        Test type: unit
+        """
+        env = _make_env(
+            floor_shape=(7, 11),
+            walls={(3, 5)},
+            opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED,
+        )
+        state = np.array([1.0, 5.0, 5.0, 5.0, 0.0])
+
+        samples = env.sample_next_state(state, 2, n_samples=4000)
+        pos_counts = Counter((int(s[2]), int(s[3])) for s in samples)
+        total = len(samples)
+
+        toward_prob = pos_counts.get((4, 5), 0) / total
+        away_prob = pos_counts.get((6, 5), 0) / total
+        assert (
+            0.15 <= toward_prob <= 0.25
+        ), f"Expected ~0.2 toward cell (occluded -> random), got {toward_prob}"
+        assert 0.15 <= away_prob <= 0.25, f"Expected ~0.2 away cell (random), got {away_prob}"
 
     def test_successful_tagging(self):
         """Test successful tagging creates terminal state.
@@ -2262,7 +2345,10 @@ def _python_rollout(
 class TestNativeDiscreteRollout:
     """Tests for the native C++ discrete LaserTag rollout kernel."""
 
-    @pytest.mark.parametrize("opponent_policy", [OpponentPolicy.EVADE, OpponentPolicy.PURSUE])
+    @pytest.mark.parametrize(
+        "opponent_policy",
+        [OpponentPolicy.EVADE, OpponentPolicy.PURSUE, OpponentPolicy.EVADE_WHEN_SPOTTED],
+    )
     def test_lasertag_native_simulate_rollout_matches_python(self, opponent_policy) -> None:
         """Native C++ rollout produces the same return distribution as the Python loop.
 
@@ -2323,11 +2409,14 @@ class TestNativeDiscreteRollout:
             "implement different distributions."
         )
 
-    @pytest.mark.parametrize("opponent_policy", [OpponentPolicy.EVADE, OpponentPolicy.PURSUE])
+    @pytest.mark.parametrize(
+        "opponent_policy",
+        [OpponentPolicy.EVADE, OpponentPolicy.PURSUE, OpponentPolicy.EVADE_WHEN_SPOTTED],
+    )
     @pytest.mark.parametrize(
         "walls",
-        [set(), {(5, 6), (5, 4)}],
-        ids=["open", "wall_adjacent_slack"],
+        [set(), {(5, 6), (5, 4)}, {(3, 5)}],
+        ids=["open", "wall_adjacent_slack", "occluded_ray"],
     )
     def test_native_single_step_opponent_distribution_matches_python(
         self, opponent_policy, walls
@@ -2336,12 +2425,15 @@ class TestNativeDiscreteRollout:
 
         Purpose: Validates that the native ``sample_next_state_step`` opponent-move table
             (disc_opponent_move_table) reproduces the Python ``_python_sample_next_state``
-            distribution under BOTH opponent policies, including the wall-blocked
-            invalid-move -> stay slack path — guarding against a missed direction flip or
-            pre/post reference choice in the C++ single-step kernel.
+            distribution under ALL opponent policies, including the wall-blocked
+            invalid-move -> stay slack path and the occluded-ray case (which makes
+            EVADE_WHEN_SPOTTED fall back to random) — guarding against a missed direction
+            flip, pre/post reference choice, or spotted-predicate divergence in the C++
+            single-step kernel.
 
-        Given: A LaserTagPOMDP (open grid or walls blocking both opponent x-moves), robot
-            above the opponent, robot moving South, evaluated for EVADE and PURSUE.
+        Given: A LaserTagPOMDP (open grid, walls blocking both opponent x-moves, or a wall
+            on the robot-opponent ray), robot above the opponent, robot moving South,
+            evaluated for EVADE, PURSUE, and EVADE_WHEN_SPOTTED.
         When: 4000 single samples are drawn via the native path (n_samples == 1) and 4000
             via the Python batch path (n_samples > 1).
         Then: The per-cell opponent next-position probabilities agree within 0.05.

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_laser_tag_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_laser_tag_vectorized_updater.py
@@ -273,22 +273,28 @@ class TestBatchTransition:
         # Should see at least 2 different opponent positions
         assert len(seen_positions) >= 2
 
-    @pytest.mark.parametrize("opponent_policy", [OpponentPolicy.EVADE, OpponentPolicy.PURSUE])
+    @pytest.mark.parametrize(
+        "opponent_policy",
+        [OpponentPolicy.EVADE, OpponentPolicy.PURSUE, OpponentPolicy.EVADE_WHEN_SPOTTED],
+    )
     @pytest.mark.parametrize(
         "walls",
-        [set(), {(5, 6), (5, 4)}],
-        ids=["open", "wall_adjacent_slack"],
+        [set(), {(5, 6), (5, 4)}, {(3, 5)}],
+        ids=["open", "wall_adjacent_slack", "occluded_ray"],
     )
     def test_batch_transition_opponent_distribution_matches_env(self, opponent_policy, walls):
         """Native belief batch transition matches the env opponent distribution per policy.
 
         Purpose: Validates that the C++ belief kernel (belief_sample_opponent_move via
             belief_batch_transition_discrete) reproduces the env's Python opponent-move
-            distribution under BOTH policies, including the wall-blocked stay-slack path —
-            guarding against a missed direction flip / pre-move reference in the belief path.
+            distribution under ALL policies, including the wall-blocked stay-slack path and
+            the occluded-ray case (which makes EVADE_WHEN_SPOTTED fall back to random) —
+            guarding against a missed direction flip, pre-move reference, or spotted-predicate
+            divergence in the belief path.
 
-        Given: A LaserTagPOMDP (open grid or walls blocking both opponent x-moves), robot
-            above the opponent, action South, evaluated for EVADE and PURSUE.
+        Given: A LaserTagPOMDP (open grid, walls blocking both opponent x-moves, or a wall on
+            the robot-opponent ray), robot above the opponent, action South, evaluated for
+            EVADE, PURSUE, and EVADE_WHEN_SPOTTED.
         When: 4000 particles are pushed through updater.batch_transition and 4000 samples
             through the env's Python sample_next_state.
         Then: The per-cell opponent next-position probabilities agree within 0.05.


### PR DESCRIPTION
## Summary

Adds a third `OpponentPolicy`: **`EVADE_WHEN_SPOTTED`** — a memoryless, partially-observed reactive opponent that flees (the existing `EVADE` behaviour) **only while the robot has a clear line of sight to it**, and otherwise moves on its own.

- **Spotted** = true line-of-sight geometry: the opponent lies on one of the robot's 8 unoccluded laser rays, evaluated from the robot's **pre-move** position. Reuses the existing ray-walk (discrete) / ray-circle (continuous) code — no new geometry.
- **Unspotted behaviour is environment-specific:**
  - **Discrete** (`LaserTagPOMDP`): moves uniformly at random — 0.2 per cardinal + 0.2 stay, with the usual wall→stay slack.
  - **Continuous** (`ContinuousLaserTagPOMDP` / `…DiscreteActions`): **holds its position** (only the Gaussian opponent noise jitters it), so the robot can still corner it.
- **Memoryless:** visibility is recomputed each step from the current state — no new state dimension, stays Markov.

## Implementation

- Enum value `EVADE_WHEN_SPOTTED` (`native_code` 2) + C++ `kPolicyEvadeWhenSpotted`.
- A per-context spotted predicate gates the random/stay branch in front of the existing distribution: Python `_is_opponent_spotted`, C++ `disc_opponent_spotted` (over `wall_grid`), `belief_opponent_spotted` (over `valid_cell`), and `opponent_visible` (continuous laser geometry) — all the same 8-direction ray walk, kept in lock-step for parity.
- The direction and pre/post-move reference conditions now treat **PURSUE** as the special case, so `EVADE` and `EVADE_WHEN_SPOTTED` share the away + pre-move semantics.
- No updater/binding signature changes (they already forward the int code); `.pyi` + C++ binding docstrings document code 2.

## Compatibility

Additive — default `EVADE` is unchanged, so existing behaviour, tests, and golden GIFs are unaffected.

> **Note — stacked on #196.** This branch is based on `feat/lasertag-opponent-policy` (#196), so until that merges this PR's diff includes #196's EVADE/PURSUE commits. Merge #196 first and this diff collapses to just the EVADE_WHEN_SPOTTED commit.

## Test plan

- [x] `python setup.py build_ext --inplace` (C++ changed)
- [x] `pytest …/test_laser_tag_pomdp/` — 271 passed
- [x] Unit tests: flee-when-spotted, random/stay-when-unspotted, occluded-is-unspotted (discrete + continuous), config_id distinctness
- [x] Native-vs-Python parity tests extended to `EVADE_WHEN_SPOTTED` across spotted/unspotted/occluded configs for the single-step, rollout, and belief paths
- [x] `pyright POMDPPlanners/` — 0 new errors/warnings; `pylint --errors-only` clean on touched source + tests