### PR TITLE
Merge develop into master

### DIFF
--- a/POMDPPlanners/planners/mcts_planners/beta_zero/beta_zero.py
+++ b/POMDPPlanners/planners/mcts_planners/beta_zero/beta_zero.py
@@ -10,7 +10,7 @@ is orchestrated via :class:`~POMDPPlanners.training.PolicyTrainer`.
 References:
     Moss, R. J., Corso, A., Caers, J., & Kochenderfer, M. J. (2024). BetaZero:
     Belief-State Planning for Long-Horizon POMDPs using Learned Approximations.
-    arXiv:2306.00249. https://arxiv.org/abs/2306.00249
+    Reinforcement Learning Conference (RLC).
 
 Implementation note:
     Operates on the column-store arena
@@ -128,7 +128,7 @@ class BetaZero(ArenaDoubleProgressiveWideningMCTSPolicy, TrainablePolicy):
     References:
         Moss, R. J., Corso, A., Caers, J., & Kochenderfer, M. J. (2024).
         BetaZero: Belief-State Planning for Long-Horizon POMDPs using Learned
-        Approximations. arXiv:2306.00249. https://arxiv.org/abs/2306.00249
+        Approximations. Reinforcement Learning Conference (RLC).
     """
 
     def __init__(

--- a/POMDPPlanners/planners/mcts_planners/beta_zero/beta_zero.py
+++ b/POMDPPlanners/planners/mcts_planners/beta_zero/beta_zero.py
@@ -124,11 +124,6 @@ class BetaZero(ArenaDoubleProgressiveWideningMCTSPolicy, TrainablePolicy):
         >>> actions, run_data = planner.action(belief)
         >>> actions[0] in env.get_actions()
         True
-
-    References:
-        Moss, R. J., Corso, A., Caers, J., & Kochenderfer, M. J. (2024).
-        BetaZero: Belief-State Planning for Long-Horizon POMDPs using Learned
-        Approximations. Reinforcement Learning Conference (RLC).
     """
 
     def __init__(

--- a/POMDPPlanners/planners/mcts_planners/beta_zero/beta_zero.py
+++ b/POMDPPlanners/planners/mcts_planners/beta_zero/beta_zero.py
@@ -7,10 +7,10 @@ planning in belief space. It combines online MCTS with PUCT and neural network p
 for both action selection and leaf value estimation. Offline policy-iteration training
 is orchestrated via :class:`~POMDPPlanners.training.PolicyTrainer`.
 
-Reference:
+References:
     Moss, R. J., Corso, A., Caers, J., & Kochenderfer, M. J. (2024). BetaZero:
     Belief-State Planning for Long-Horizon POMDPs using Learned Approximations.
-    Reinforcement Learning Conference (RLC).
+    arXiv:2306.00249. https://arxiv.org/abs/2306.00249
 
 Implementation note:
     Operates on the column-store arena
@@ -124,6 +124,11 @@ class BetaZero(ArenaDoubleProgressiveWideningMCTSPolicy, TrainablePolicy):
         >>> actions, run_data = planner.action(belief)
         >>> actions[0] in env.get_actions()
         True
+
+    References:
+        Moss, R. J., Corso, A., Caers, J., & Kochenderfer, M. J. (2024).
+        BetaZero: Belief-State Planning for Long-Horizon POMDPs using Learned
+        Approximations. arXiv:2306.00249. https://arxiv.org/abs/2306.00249
     """
 
     def __init__(

--- a/POMDPPlanners/planners/mcts_planners/constrained_pft_dpw.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_pft_dpw.py
@@ -17,8 +17,9 @@ This is the PFT-DPW counterpart of
 
 References:
     Jamgochian, A., Corso, A., & Kochenderfer, M. J. (2023). Online Planning
-    for Constrained POMDPs with Continuous Spaces through Dual Ascent. AAAI.
-    arXiv:2212.12154.
+    for Constrained POMDPs with Continuous Spaces through Dual Ascent. Proceedings
+    of the International Conference on Automated Planning and Scheduling, 33(1),
+    198-202. https://doi.org/10.1609/icaps.v33i1.27195
     Lee, J., Kim, G.-H., Poupart, P., & Kim, K.-E. (2018). Monte-Carlo Tree
     Search for Constrained POMDPs. NeurIPS.
 

--- a/POMDPPlanners/planners/mcts_planners/constrained_pft_dpw.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_pft_dpw.py
@@ -20,8 +20,6 @@ References:
     for Constrained POMDPs with Continuous Spaces through Dual Ascent. Proceedings
     of the International Conference on Automated Planning and Scheduling, 33(1),
     198-202. https://doi.org/10.1609/icaps.v33i1.27195
-    Lee, J., Kim, G.-H., Poupart, P., & Kim, K.-E. (2018). Monte-Carlo Tree
-    Search for Constrained POMDPs. NeurIPS.
 
 Classes:
     CPFT_DPW: Constrained PFT-DPW planner.

--- a/POMDPPlanners/planners/mcts_planners/constrained_pomcpow.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_pomcpow.py
@@ -18,8 +18,6 @@ References:
     for Constrained POMDPs with Continuous Spaces through Dual Ascent. Proceedings
     of the International Conference on Automated Planning and Scheduling, 33(1),
     198-202. https://doi.org/10.1609/icaps.v33i1.27195
-    Lee, J., Kim, G.-H., Poupart, P., & Kim, K.-E. (2018). Monte-Carlo Tree
-    Search for Constrained POMDPs. NeurIPS.
 
 Classes:
     CPOMCPOW: Constrained POMCPOW planner.

--- a/POMDPPlanners/planners/mcts_planners/constrained_pomcpow.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_pomcpow.py
@@ -15,8 +15,9 @@ track and the optional minimal-cost propagation trick.
 
 References:
     Jamgochian, A., Corso, A., & Kochenderfer, M. J. (2023). Online Planning
-    for Constrained POMDPs with Continuous Spaces through Dual Ascent. AAAI.
-    arXiv:2212.12154.
+    for Constrained POMDPs with Continuous Spaces through Dual Ascent. Proceedings
+    of the International Conference on Automated Planning and Scheduling, 33(1),
+    198-202. https://doi.org/10.1609/icaps.v33i1.27195
     Lee, J., Kim, G.-H., Poupart, P., & Kim, K.-E. (2018). Monte-Carlo Tree
     Search for Constrained POMDPs. NeurIPS.
 

--- a/POMDPPlanners/planners/mcts_planners/constrained_zero/__init__.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_zero/__init__.py
@@ -10,8 +10,8 @@ References:
     Moss, R. J., Jamgochian, A., Fischer, J., Corso, A., & Kochenderfer, M. J. (2024).
     ConstrainedZero: Chance-Constrained POMDP Planning Using Learned Probabilistic Failure
     Surrogates and Adaptive Safety Constraints. Proceedings of the Thirty-Third International
-    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760. arXiv:2405.00644.
-    https://arxiv.org/abs/2405.00644
+    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760.
+    https://www.ijcai.org/proceedings/2024/746
 
 Classes:
     ConstrainedZero: Main planner extending BetaZero for CC-POMDPs

--- a/POMDPPlanners/planners/mcts_planners/constrained_zero/__init__.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_zero/__init__.py
@@ -6,12 +6,12 @@ This package implements the ConstrainedZero algorithm (Moss et al., IJCAI 2024),
 which extends BetaZero to solve CC-POMDPs by adding a failure probability head,
 safety-constrained PUCT, and adaptive failure threshold calibration.
 
-Reference:
+References:
     Moss, R. J., Jamgochian, A., Fischer, J., Corso, A., & Kochenderfer, M. J. (2024).
     ConstrainedZero: Chance-Constrained POMDP Planning Using Learned Probabilistic Failure
     Surrogates and Adaptive Safety Constraints. Proceedings of the Thirty-Third International
-    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760.
-    https://www.ijcai.org/proceedings/2024/746
+    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760. arXiv:2405.00644.
+    https://arxiv.org/abs/2405.00644
 
 Classes:
     ConstrainedZero: Main planner extending BetaZero for CC-POMDPs

--- a/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_puct.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_puct.py
@@ -5,12 +5,12 @@
 Implements the SPUCT selection rule that masks unsafe actions based on their
 estimated failure probability relative to an adaptive threshold Delta'.
 
-Reference:
+References:
     Moss, R. J., Jamgochian, A., Fischer, J., Corso, A., & Kochenderfer, M. J. (2024).
     ConstrainedZero: Chance-Constrained POMDP Planning Using Learned Probabilistic Failure
     Surrogates and Adaptive Safety Constraints. Proceedings of the Thirty-Third International
-    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760.
-    https://www.ijcai.org/proceedings/2024/746
+    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760. arXiv:2405.00644.
+    https://arxiv.org/abs/2405.00644
 
 Functions:
     spuct_selection: Select among existing children using safety-masked PUCT.

--- a/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_puct.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_puct.py
@@ -9,8 +9,8 @@ References:
     Moss, R. J., Jamgochian, A., Fischer, J., Corso, A., & Kochenderfer, M. J. (2024).
     ConstrainedZero: Chance-Constrained POMDP Planning Using Learned Probabilistic Failure
     Surrogates and Adaptive Safety Constraints. Proceedings of the Thirty-Third International
-    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760. arXiv:2405.00644.
-    https://arxiv.org/abs/2405.00644
+    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760.
+    https://www.ijcai.org/proceedings/2024/746
 
 Functions:
     spuct_selection: Select among existing children using safety-masked PUCT.

--- a/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_training.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_training.py
@@ -6,12 +6,12 @@ This module provides the loss function and training loop for the 3-head
 ConstrainedZero network. It extends the BetaZero training with an additional
 binary cross-entropy loss for the failure head.
 
-Reference:
+References:
     Moss, R. J., Jamgochian, A., Fischer, J., Corso, A., & Kochenderfer, M. J. (2024).
     ConstrainedZero: Chance-Constrained POMDP Planning Using Learned Probabilistic Failure
     Surrogates and Adaptive Safety Constraints. Proceedings of the Thirty-Third International
-    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760.
-    https://www.ijcai.org/proceedings/2024/746
+    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760. arXiv:2405.00644.
+    https://arxiv.org/abs/2405.00644
 
 Functions:
     compute_constrained_zero_loss: Combined value + policy + failure loss.

--- a/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_training.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_training.py
@@ -10,8 +10,8 @@ References:
     Moss, R. J., Jamgochian, A., Fischer, J., Corso, A., & Kochenderfer, M. J. (2024).
     ConstrainedZero: Chance-Constrained POMDP Planning Using Learned Probabilistic Failure
     Surrogates and Adaptive Safety Constraints. Proceedings of the Thirty-Third International
-    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760. arXiv:2405.00644.
-    https://arxiv.org/abs/2405.00644
+    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760.
+    https://www.ijcai.org/proceedings/2024/746
 
 Functions:
     compute_constrained_zero_loss: Combined value + policy + failure loss.

--- a/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_training_buffer.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_training_buffer.py
@@ -9,8 +9,8 @@ References:
     Moss, R. J., Jamgochian, A., Fischer, J., Corso, A., & Kochenderfer, M. J. (2024).
     ConstrainedZero: Chance-Constrained POMDP Planning Using Learned Probabilistic Failure
     Surrogates and Adaptive Safety Constraints. Proceedings of the Thirty-Third International
-    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760. arXiv:2405.00644.
-    https://arxiv.org/abs/2405.00644
+    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760.
+    https://www.ijcai.org/proceedings/2024/746
 
 Classes:
     ConstrainedTrainingExample: Training datum with failure target.

--- a/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_training_buffer.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_training_buffer.py
@@ -5,12 +5,12 @@
 This module extends the BetaZero training buffer with an additional failure
 target, used for training the 3-head ConstrainedZero network.
 
-Reference:
+References:
     Moss, R. J., Jamgochian, A., Fischer, J., Corso, A., & Kochenderfer, M. J. (2024).
     ConstrainedZero: Chance-Constrained POMDP Planning Using Learned Probabilistic Failure
     Surrogates and Adaptive Safety Constraints. Proceedings of the Thirty-Third International
-    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760.
-    https://www.ijcai.org/proceedings/2024/746
+    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760. arXiv:2405.00644.
+    https://arxiv.org/abs/2405.00644
 
 Classes:
     ConstrainedTrainingExample: Training datum with failure target.

--- a/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_zero.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_zero.py
@@ -7,12 +7,12 @@ CC-POMDPs. It adds a 3-head network with a failure probability head, safety-cons
 PUCT (SPUCT), adaptive failure threshold calibration via conformal inference, and
 constrained policy targets for training.
 
-Reference:
+References:
     Moss, R. J., Jamgochian, A., Fischer, J., Corso, A., & Kochenderfer, M. J. (2024).
     ConstrainedZero: Chance-Constrained POMDP Planning Using Learned Probabilistic Failure
     Surrogates and Adaptive Safety Constraints. Proceedings of the Thirty-Third International
-    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760.
-    https://www.ijcai.org/proceedings/2024/746
+    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760. arXiv:2405.00644.
+    https://arxiv.org/abs/2405.00644
 
 Implementation note:
     Operates on the column-store arena

--- a/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_zero.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_zero.py
@@ -11,8 +11,8 @@ References:
     Moss, R. J., Jamgochian, A., Fischer, J., Corso, A., & Kochenderfer, M. J. (2024).
     ConstrainedZero: Chance-Constrained POMDP Planning Using Learned Probabilistic Failure
     Surrogates and Adaptive Safety Constraints. Proceedings of the Thirty-Third International
-    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760. arXiv:2405.00644.
-    https://arxiv.org/abs/2405.00644
+    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760.
+    https://www.ijcai.org/proceedings/2024/746
 
 Implementation note:
     Operates on the column-store arena

--- a/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_zero_network.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_zero_network.py
@@ -10,8 +10,8 @@ References:
     Moss, R. J., Jamgochian, A., Fischer, J., Corso, A., & Kochenderfer, M. J. (2024).
     ConstrainedZero: Chance-Constrained POMDP Planning Using Learned Probabilistic Failure
     Surrogates and Adaptive Safety Constraints. Proceedings of the Thirty-Third International
-    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760. arXiv:2405.00644.
-    https://arxiv.org/abs/2405.00644
+    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760.
+    https://www.ijcai.org/proceedings/2024/746
 
 Classes:
     ConstrainedZeroNetwork: Shared-trunk network with policy, value, and failure heads.

--- a/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_zero_network.py
+++ b/POMDPPlanners/planners/mcts_planners/constrained_zero/constrained_zero_network.py
@@ -6,12 +6,12 @@ This module extends the BetaZero dual-head network with an additional failure
 probability head. The failure head outputs a raw logit; sigmoid is applied
 during prediction to produce a probability in [0, 1].
 
-Reference:
+References:
     Moss, R. J., Jamgochian, A., Fischer, J., Corso, A., & Kochenderfer, M. J. (2024).
     ConstrainedZero: Chance-Constrained POMDP Planning Using Learned Probabilistic Failure
     Surrogates and Adaptive Safety Constraints. Proceedings of the Thirty-Third International
-    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760.
-    https://www.ijcai.org/proceedings/2024/746
+    Joint Conference on Artificial Intelligence (IJCAI), 6752-6760. arXiv:2405.00644.
+    https://arxiv.org/abs/2405.00644
 
 Classes:
     ConstrainedZeroNetwork: Shared-trunk network with policy, value, and failure heads.

--- a/POMDPPlanners/planners/mcts_planners/icvar_pft_dpw.py
+++ b/POMDPPlanners/planners/mcts_planners/icvar_pft_dpw.py
@@ -6,10 +6,9 @@ This module implements a risk-sensitive variant of PFT-DPW that uses the Iterate
 Value at Risk (ICVaR) for value backups instead of the expected value. This makes the planner
 focus on the worst-alpha fraction of outcomes, enabling risk-averse planning in POMDPs.
 
-Reference:
+References:
     Pariente, Y., & Indelman, V. (2026). Online Risk-Averse Planning in POMDPs Using
-    Iterated CVaR Value Function. arXiv preprint arXiv:2601.20554.
-    https://arxiv.org/abs/2601.20554
+    Iterated CVaR Value Function. arXiv:2601.20554. https://arxiv.org/abs/2601.20554
 
 Implementation note:
     Operates on the column-store arena

--- a/POMDPPlanners/planners/mcts_planners/icvar_pomcpow.py
+++ b/POMDPPlanners/planners/mcts_planners/icvar_pomcpow.py
@@ -7,10 +7,9 @@ Value at Risk (ICVaR) for value backups instead of the expected value. This make
 focus on the worst-alpha fraction of outcomes, enabling risk-averse planning in POMDPs with
 continuous state, action, and observation spaces.
 
-Reference:
+References:
     Pariente, Y., & Indelman, V. (2026). Online Risk-Averse Planning in POMDPs Using
-    Iterated CVaR Value Function. arXiv preprint arXiv:2601.20554.
-    https://arxiv.org/abs/2601.20554
+    Iterated CVaR Value Function. arXiv:2601.20554. https://arxiv.org/abs/2601.20554
 
 Implementation note:
     Operates on the column-store arena

--- a/POMDPPlanners/planners/mcts_planners/pft_dpw.py
+++ b/POMDPPlanners/planners/mcts_planners/pft_dpw.py
@@ -19,11 +19,11 @@ The algorithm progressively expands the tree by:
 3. Balancing exploration of new actions with exploitation of promising ones
 4. Performing random rollouts from leaf nodes for value estimation
 
-Reference:
+References:
     Sunberg, Z. N., & Kochenderfer, M. J. (2018). Online Algorithms for POMDPs with
     Continuous State, Action, and Observation Spaces. Proceedings of the International
     Conference on Automated Planning and Scheduling, 28(1), 259-263.
-    https://ojs.aaai.org/index.php/ICAPS/article/view/13882
+    arXiv:1709.06196. https://arxiv.org/abs/1709.06196
 
 Implementation note:
     This implementation operates on the column-store arena

--- a/POMDPPlanners/planners/mcts_planners/pft_dpw.py
+++ b/POMDPPlanners/planners/mcts_planners/pft_dpw.py
@@ -23,7 +23,7 @@ References:
     Sunberg, Z. N., & Kochenderfer, M. J. (2018). Online Algorithms for POMDPs with
     Continuous State, Action, and Observation Spaces. Proceedings of the International
     Conference on Automated Planning and Scheduling, 28(1), 259-263.
-    arXiv:1709.06196. https://arxiv.org/abs/1709.06196
+    https://ojs.aaai.org/index.php/ICAPS/article/view/13882
 
 Implementation note:
     This implementation operates on the column-store arena

--- a/POMDPPlanners/planners/mcts_planners/pomcp.py
+++ b/POMDPPlanners/planners/mcts_planners/pomcp.py
@@ -18,7 +18,7 @@ Key features:
 - Can be configured with time limits or simulation count limits
 - Provides theoretical convergence guarantees to optimal policy
 
-Reference:
+References:
     Silver, D., & Veness, J. (2010). Monte-Carlo Planning in Large POMDPs.
     Advances in Neural Information Processing Systems, 23.
     https://papers.nips.cc/paper_files/paper/2010/hash/edfbe1afcf9246bb0d40eb4d8027d90f-Abstract.html

--- a/POMDPPlanners/planners/mcts_planners/pomcp_dpw.py
+++ b/POMDPPlanners/planners/mcts_planners/pomcp_dpw.py
@@ -18,7 +18,7 @@ References:
     Sunberg, Z. N., & Kochenderfer, M. J. (2018). Online Algorithms for POMDPs with
     Continuous State, Action, and Observation Spaces. Proceedings of the International
     Conference on Automated Planning and Scheduling, 28(1), 259-263.
-    arXiv:1709.06196. https://arxiv.org/abs/1709.06196
+    https://ojs.aaai.org/index.php/ICAPS/article/view/13882
 
 Implementation note:
     This implementation operates on the column-store arena

--- a/POMDPPlanners/planners/mcts_planners/pomcp_dpw.py
+++ b/POMDPPlanners/planners/mcts_planners/pomcp_dpw.py
@@ -14,11 +14,11 @@ Key features:
 - Handles continuous and discrete action spaces
 - Adaptive observation node expansion
 
-Reference:
+References:
     Sunberg, Z. N., & Kochenderfer, M. J. (2018). Online Algorithms for POMDPs with
     Continuous State, Action, and Observation Spaces. Proceedings of the International
     Conference on Automated Planning and Scheduling, 28(1), 259-263.
-    https://ojs.aaai.org/index.php/ICAPS/article/view/13882
+    arXiv:1709.06196. https://arxiv.org/abs/1709.06196
 
 Implementation note:
     This implementation operates on the column-store arena

--- a/POMDPPlanners/planners/mcts_planners/pomcpow.py
+++ b/POMDPPlanners/planners/mcts_planners/pomcpow.py
@@ -21,11 +21,11 @@ The algorithm progressively expands the tree by:
 4. Balancing exploration of new actions with exploitation of promising ones
 5. Performing random rollouts from leaf nodes for value estimation
 
-Reference:
+References:
     Sunberg, Z. N., & Kochenderfer, M. J. (2018). Online Algorithms for POMDPs with
     Continuous State, Action, and Observation Spaces. Proceedings of the International
     Conference on Automated Planning and Scheduling, 28(1), 259-263.
-    https://ojs.aaai.org/index.php/ICAPS/article/view/13882
+    arXiv:1709.06196. https://arxiv.org/abs/1709.06196
 
 Implementation note:
     This implementation operates on the column-store arena

--- a/POMDPPlanners/planners/mcts_planners/pomcpow.py
+++ b/POMDPPlanners/planners/mcts_planners/pomcpow.py
@@ -25,7 +25,7 @@ References:
     Sunberg, Z. N., & Kochenderfer, M. J. (2018). Online Algorithms for POMDPs with
     Continuous State, Action, and Observation Spaces. Proceedings of the International
     Conference on Automated Planning and Scheduling, 28(1), 259-263.
-    arXiv:1709.06196. https://arxiv.org/abs/1709.06196
+    https://ojs.aaai.org/index.php/ICAPS/article/view/13882
 
 Implementation note:
     This implementation operates on the column-store arena

--- a/POMDPPlanners/planners/sparse_sampling_planners/icvar_sparse_sampling.py
+++ b/POMDPPlanners/planners/sparse_sampling_planners/icvar_sparse_sampling.py
@@ -7,10 +7,9 @@ for POMDP planning. Instead of using the expected value (mean) for Bellman backu
 it uses the Conditional Value at Risk (CVaR) to focus on the worst-alpha fraction
 of outcomes.
 
-Reference:
+References:
     Pariente, Y., & Indelman, V. (2026). Online Risk-Averse Planning in POMDPs Using
-    Iterated CVaR Value Function. arXiv preprint arXiv:2601.20554.
-    https://arxiv.org/abs/2601.20554
+    Iterated CVaR Value Function. arXiv:2601.20554. https://arxiv.org/abs/2601.20554
 
 Classes:
     ICVaRSparseSampling: Risk-sensitive sparse sampling with CVaR-based value updates

--- a/POMDPPlanners/planners/sparse_sampling_planners/sparse_sampling.py
+++ b/POMDPPlanners/planners/sparse_sampling_planners/sparse_sampling.py
@@ -12,10 +12,10 @@ The sparse sampling approach works by:
 3. Computing value estimates using dynamic programming
 4. Selecting the action with the best estimated value
 
-Reference:
+References:
     Kearns, M., Mansour, Y., & Ng, A. Y. (2002). A Sparse Sampling Algorithm for
-    Near-Optimal Planning in Large Markov Decision Processes. Machine Learning, 49, 193-208.
-    https://link.springer.com/article/10.1023/A:1017932429737
+    Near-Optimal Planning in Large Markov Decision Processes. Machine Learning, 49(2),
+    193-208. https://link.springer.com/article/10.1023/A:1017932429737
 
 Classes:
     BaseSparseSamplingDiscreteActionsPlanner: Abstract base class for sparse sampling algorithms

--- a/POMDPPlanners/tests/benchmarks/conftest.py
+++ b/POMDPPlanners/tests/benchmarks/conftest.py
@@ -25,6 +25,13 @@ from POMDPPlanners.planners.mcts_planners.pomcp import POMCP
 from POMDPPlanners.planners.mcts_planners.pomcp_dpw import POMCP_DPW
 from POMDPPlanners.planners.mcts_planners.pomcpow import POMCPOW
 from POMDPPlanners.planners.mcts_planners.sparse_pft import SparsePFT
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+    discrete_light_dark_pinned_kwargs,
+    laser_tag_pinned_kwargs,
+    mountain_car_pinned_kwargs,
+    rock_sample_pinned_kwargs,
+)
 from POMDPPlanners.utils.action_samplers import DiscreteActionSampler
 
 DISCOUNT_FACTOR = 0.95
@@ -48,31 +55,36 @@ def tiger_env():
 @pytest.fixture
 def discrete_ld_env():
     """DiscreteLightDarkPOMDP environment for benchmarking."""
-    return DiscreteLightDarkPOMDP(discount_factor=DISCOUNT_FACTOR)
+    return DiscreteLightDarkPOMDP(
+        discount_factor=DISCOUNT_FACTOR, **discrete_light_dark_pinned_kwargs()
+    )
 
 
 @pytest.fixture
 def continuous_ld_env():
     """ContinuousLightDarkPOMDPDiscreteActions environment for benchmarking."""
-    return ContinuousLightDarkPOMDPDiscreteActions(discount_factor=DISCOUNT_FACTOR)
+    return ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=DISCOUNT_FACTOR,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(),
+    )
 
 
 @pytest.fixture
 def rock_sample_env():
     """RockSamplePOMDP environment for benchmarking."""
-    return RockSamplePOMDP(discount_factor=DISCOUNT_FACTOR)
+    return RockSamplePOMDP(discount_factor=DISCOUNT_FACTOR, **rock_sample_pinned_kwargs())
 
 
 @pytest.fixture
 def laser_tag_env():
     """LaserTagPOMDP environment for benchmarking."""
-    return LaserTagPOMDP(discount_factor=DISCOUNT_FACTOR)
+    return LaserTagPOMDP(discount_factor=DISCOUNT_FACTOR, **laser_tag_pinned_kwargs())
 
 
 @pytest.fixture
 def mountain_car_env():
     """MountainCarPOMDP environment for benchmarking."""
-    return MountainCarPOMDP(discount_factor=DISCOUNT_FACTOR)
+    return MountainCarPOMDP(discount_factor=DISCOUNT_FACTOR, **mountain_car_pinned_kwargs())
 
 
 # ---------------------------------------------------------------------------

--- a/POMDPPlanners/tests/benchmarks/test_benchmark_combined.py
+++ b/POMDPPlanners/tests/benchmarks/test_benchmark_combined.py
@@ -22,6 +22,10 @@ from POMDPPlanners.planners.mcts_planners.pomcp import POMCP
 from POMDPPlanners.planners.mcts_planners.pomcp_dpw import POMCP_DPW
 from POMDPPlanners.planners.mcts_planners.pomcpow import POMCPOW
 from POMDPPlanners.planners.mcts_planners.sparse_pft import SparsePFT
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    discrete_light_dark_pinned_kwargs,
+    rock_sample_pinned_kwargs,
+)
 from POMDPPlanners.utils.action_samplers import DiscreteActionSampler
 
 DISCOUNT = 0.95
@@ -78,7 +82,7 @@ def test_bench_pomcp_rocksample(benchmark):
 
     Test type: performance
     """
-    env = RockSamplePOMDP(discount_factor=DISCOUNT)
+    env = RockSamplePOMDP(discount_factor=DISCOUNT, **rock_sample_pinned_kwargs())
     planner = POMCP(
         environment=env,
         discount_factor=DISCOUNT,
@@ -102,7 +106,7 @@ def test_bench_pomcp_discrete_ld(benchmark):
 
     Test type: performance
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=DISCOUNT)
+    env = DiscreteLightDarkPOMDP(discount_factor=DISCOUNT, **discrete_light_dark_pinned_kwargs())
     planner = POMCP(
         environment=env,
         discount_factor=DISCOUNT,
@@ -157,7 +161,7 @@ def test_bench_sparse_pft_discrete_ld(benchmark):
 
     Test type: performance
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=DISCOUNT)
+    env = DiscreteLightDarkPOMDP(discount_factor=DISCOUNT, **discrete_light_dark_pinned_kwargs())
     planner = SparsePFT(
         environment=env,
         discount_factor=DISCOUNT,
@@ -188,7 +192,7 @@ def test_bench_pft_dpw_discrete_ld(benchmark):
 
     Test type: performance
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=DISCOUNT)
+    env = DiscreteLightDarkPOMDP(discount_factor=DISCOUNT, **discrete_light_dark_pinned_kwargs())
     actions = env.get_actions()
     planner = PFT_DPW(
         environment=env,
@@ -218,7 +222,7 @@ def test_bench_pomcpow_discrete_ld(benchmark):
 
     Test type: performance
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=DISCOUNT)
+    env = DiscreteLightDarkPOMDP(discount_factor=DISCOUNT, **discrete_light_dark_pinned_kwargs())
     actions = env.get_actions()
     planner = POMCPOW(
         environment=env,
@@ -248,7 +252,7 @@ def test_bench_pomcp_dpw_discrete_ld(benchmark):
 
     Test type: performance
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=DISCOUNT)
+    env = DiscreteLightDarkPOMDP(discount_factor=DISCOUNT, **discrete_light_dark_pinned_kwargs())
     actions = env.get_actions()
     planner = POMCP_DPW(
         environment=env,

--- a/POMDPPlanners/tests/test_configs/test_experiment_configs.py
+++ b/POMDPPlanners/tests/test_configs/test_experiment_configs.py
@@ -60,6 +60,10 @@ from POMDPPlanners.environments.laser_tag_pomdp import (
     ContinuousLaserTagPOMDPDiscreteActions,
 )
 from POMDPPlanners.environments.pacman_pomdp import PacManPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_laser_tag_discrete_actions_pinned_kwargs,
+    continuous_laser_tag_pinned_kwargs,
+)
 
 # Set random seeds for reproducible tests
 np.random.seed(42)
@@ -1428,9 +1432,13 @@ class TestAverageReturnParameterToOptimizeMapper:
         Test type: unit
         """
         envs = [
-            ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[]),
+            ContinuousLaserTagPOMDP(
+                discount_factor=0.95,
+                **continuous_laser_tag_pinned_kwargs(walls=[], dangerous_areas=[]),
+            ),
             ContinuousLaserTagPOMDPDiscreteActions(
-                discount_factor=0.95, walls=[], dangerous_areas=[]
+                discount_factor=0.95,
+                **continuous_laser_tag_discrete_actions_pinned_kwargs(walls=[], dangerous_areas=[]),
             ),
         ]
         for env in envs:
@@ -1530,9 +1538,13 @@ class TestRiskAverseParameterToOptimizeMapper:
         Test type: unit
         """
         envs = [
-            ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[]),
+            ContinuousLaserTagPOMDP(
+                discount_factor=0.95,
+                **continuous_laser_tag_pinned_kwargs(walls=[], dangerous_areas=[]),
+            ),
             ContinuousLaserTagPOMDPDiscreteActions(
-                discount_factor=0.95, walls=[], dangerous_areas=[]
+                discount_factor=0.95,
+                **continuous_laser_tag_discrete_actions_pinned_kwargs(walls=[], dangerous_areas=[]),
             ),
         ]
         for env in envs:

--- a/POMDPPlanners/tests/test_configs/test_planners_hyperparam_configs.py
+++ b/POMDPPlanners/tests/test_configs/test_planners_hyperparam_configs.py
@@ -20,6 +20,9 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
     ContinuousLightDarkPOMDP,
 )
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_pinned_kwargs,
+)
 from POMDPPlanners.utils.action_samplers import DiscreteActionSampler, UnitCircleActionSampler
 from POMDPPlanners.planners.mcts_planners.pft_dpw import PFT_DPW
 from POMDPPlanners.planners.mcts_planners.pomcp import POMCP
@@ -539,7 +542,9 @@ class TestPlannersHyperparamConfigs:
 
         Test type: unit
         """
-        env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+        env = ContinuousLightDarkPOMDP(
+            discount_factor=0.95, **continuous_light_dark_pinned_kwargs()
+        )
         planners = self.config_api.get_compatible_planners(env)
 
         # Should return 3 planners for continuous/continuous environment
@@ -606,7 +611,9 @@ class TestPlannersHyperparamConfigs:
 
         Test type: unit
         """
-        env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+        env = ContinuousLightDarkPOMDP(
+            discount_factor=0.95, **continuous_light_dark_pinned_kwargs()
+        )
         action_sampler = self.config_api._get_action_sampler_for_environment(env)
 
         assert isinstance(action_sampler, UnitCircleActionSampler)

--- a/POMDPPlanners/tests/test_core/test_belief/test_base.py
+++ b/POMDPPlanners/tests/test_core/test_belief/test_base.py
@@ -19,6 +19,7 @@ from POMDPPlanners.core.belief import (
 )
 from POMDPPlanners.core.config_types import BeliefConfig
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import tiger_pinned_kwargs
 from POMDPPlanners.utils.weighted_particle_beliefs import (
     WeightedParticleBeliefContinuousLightDarkFullCoverage,
     WeightedParticleBeliefDiscreteLightDark,
@@ -283,7 +284,7 @@ def test_create_belief_from_config_basic():
         class_name="WeightedParticleBelief",
         params={"n_particles": 5, "resampling": True, "ess_factor": 0.5},
     )
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = create_belief(env, config)
     assert isinstance(belief, WeightedParticleBelief)
     assert len(belief.particles) == 5
@@ -300,7 +301,7 @@ def test_create_belief_particles_and_weights():
         class_name="WeightedParticleBelief",
         params={"n_particles": 3, "resampling": False, "ess_factor": 0.1},
     )
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = create_belief(env, config)
     assert len(belief.particles) == 3
     assert all(p in env.states for p in belief.particles)
@@ -321,7 +322,7 @@ def test_reinvigoration_discrete_light_dark():
             "reinvigoration_fraction": 0.2,
         },
     )
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = create_belief(env, config)
     assert isinstance(belief, WeightedParticleBeliefDiscreteLightDark)
     # Call reinvigorate with dummy action and observation
@@ -336,7 +337,7 @@ def test_reinvigoration_discrete_light_dark_full_coverage():
         class_name="WeightedParticleBeliefDiscreteLightDarkFullCoverage",
         params={"n_particles": 5, "ess_factor": 0.5, "reinvigoration_fraction": 0.05},
     )
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = create_belief(env, config)
     assert isinstance(belief, WeightedParticleBeliefDiscreteLightDarkFullCoverage)
     # Call reinvigorate with dummy action and observation
@@ -356,7 +357,7 @@ def test_reinvigoration_continuous_light_dark_full_coverage():
             "reinvigoration_cov_matrix": np.eye(2),
         },
     )
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = create_belief(env, config)
     assert isinstance(belief, WeightedParticleBeliefContinuousLightDarkFullCoverage)
     # Call reinvigorate with dummy action and observation
@@ -376,7 +377,7 @@ def test_reinvigoration_sanity_pomdp():
             "reinvigoration_fraction": 0.2,
         },
     )
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = create_belief(env, config)
     assert isinstance(belief, WeightedParticleBeliefSanityPOMDP)
     # Call reinvigorate with dummy action and observation

--- a/POMDPPlanners/tests/test_core/test_belief/test_belief_environment_integration.py
+++ b/POMDPPlanners/tests/test_core/test_belief/test_belief_environment_integration.py
@@ -45,6 +45,16 @@ from POMDPPlanners.environments import (
 )
 from POMDPPlanners.environments.pacman_pomdp import create_simple_maze_pacman
 from POMDPPlanners.environments.rock_sample_pomdp import create_random_rock_sample
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    cartpole_pinned_kwargs,
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+    discrete_light_dark_pinned_kwargs,
+    laser_tag_pinned_kwargs,
+    mountain_car_pinned_kwargs,
+    push_pinned_kwargs,
+    safety_ant_velocity_pinned_kwargs,
+    tiger_pinned_kwargs,
+)
 from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_belief_invariants,
 )
@@ -54,7 +64,7 @@ NUM_STATE_UPDATE_PARTICLES = 3
 
 
 def _make_tiger():
-    return TigerPOMDP(discount_factor=0.95)
+    return TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
 
 def _make_sanity():
@@ -62,27 +72,32 @@ def _make_sanity():
 
 
 def _make_cartpole():
-    return CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1)
+    return CartPolePOMDP(
+        discount_factor=0.95, noise_cov=np.eye(4) * 0.1, **cartpole_pinned_kwargs()
+    )
 
 
 def _make_mountain_car():
-    return MountainCarPOMDP(discount_factor=0.95)
+    return MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
 
 
 def _make_continuous_light_dark():
-    return ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    return ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(),
+    )
 
 
 def _make_discrete_light_dark():
-    return DiscreteLightDarkPOMDP(discount_factor=0.95)
+    return DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
 
 
 def _make_push():
-    return PushPOMDP(discount_factor=0.95)
+    return PushPOMDP(discount_factor=0.95, **push_pinned_kwargs())
 
 
 def _make_laser_tag():
-    return LaserTagPOMDP(discount_factor=0.95)
+    return LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
 
 def _make_pacman():
@@ -94,7 +109,7 @@ def _make_rock_sample():
 
 
 def _make_safe_ant_velocity():
-    return SafeAntVelocityPOMDP(discount_factor=0.95)
+    return SafeAntVelocityPOMDP(discount_factor=0.95, **safety_ant_velocity_pinned_kwargs())
 
 
 ENV_FACTORIES = [
@@ -288,8 +303,10 @@ def _make_continuous_light_dark_with_cov():
     R = 0.1 * np.eye(2)
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        state_transition_cov_matrix=Q,
-        observation_cov_matrix=R,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            state_transition_cov_matrix=Q,
+            observation_cov_matrix=R,
+        ),
     )
     return env, Q, R
 

--- a/POMDPPlanners/tests/test_core/test_belief/test_belief_utils.py
+++ b/POMDPPlanners/tests/test_core/test_belief/test_belief_utils.py
@@ -22,6 +22,11 @@ from POMDPPlanners.core.belief import (
 from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
 from POMDPPlanners.environments.laser_tag_pomdp import LaserTagPOMDP
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    cartpole_pinned_kwargs,
+    laser_tag_pinned_kwargs,
+    tiger_pinned_kwargs,
+)
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -32,7 +37,7 @@ random.seed(42)
 def test_is_terminal_belief_all_terminal_particles():
     """Test is_terminal_belief returns True when all particles are terminal."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Create terminal states
     terminal_state1 = np.array([0.0, 0.0, 1.0, 1.0, 1.0])
@@ -54,7 +59,7 @@ def test_is_terminal_belief_all_terminal_particles():
 def test_is_terminal_belief_no_terminal_particles():
     """Test is_terminal_belief returns False when no particles are terminal."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Create non-terminal states
     non_terminal_state1 = np.array([0.0, 0.0, 1.0, 1.0, 0.0])
@@ -76,7 +81,7 @@ def test_is_terminal_belief_no_terminal_particles():
 def test_is_terminal_belief_mixed_particles():
     """Test is_terminal_belief returns False when some particles are terminal."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Create mixed states (some terminal, some not)
     terminal_state = np.array([0.0, 0.0, 1.0, 1.0, 1.0])
@@ -98,7 +103,7 @@ def test_is_terminal_belief_mixed_particles():
 def test_is_terminal_belief_single_terminal_particle():
     """Test is_terminal_belief with single terminal particle."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Create single terminal state
     terminal_state = np.array([0.0, 0.0, 1.0, 1.0, 1.0])
@@ -118,7 +123,7 @@ def test_is_terminal_belief_single_terminal_particle():
 def test_is_terminal_belief_single_non_terminal_particle():
     """Test is_terminal_belief with single non-terminal particle."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Create single non-terminal state
     non_terminal_state = np.array([0.0, 0.0, 1.0, 1.0, 0.0])
@@ -138,7 +143,7 @@ def test_is_terminal_belief_single_non_terminal_particle():
 def test_is_terminal_belief_empty_belief():
     """Test is_terminal_belief with empty belief."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Create empty belief using WeightedParticleBeliefStateUpdate (which allows empty)
     belief = WeightedParticleBeliefStateUpdate(particles=[], weights=[])
@@ -153,7 +158,7 @@ def test_is_terminal_belief_empty_belief():
 def test_is_terminal_belief_with_weighted_particle_belief_state_update():
     """Test is_terminal_belief with WeightedParticleBeliefStateUpdate."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Create terminal and non-terminal states
     terminal_state = np.array([0.0, 0.0, 1.0, 1.0, 1.0])
@@ -174,7 +179,7 @@ def test_is_terminal_belief_with_weighted_particle_belief_state_update():
 def test_is_terminal_belief_with_unweighted_particle_belief_state_update():
     """Test is_terminal_belief with UnweightedParticleBeliefStateUpdate."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Create all terminal states
     terminal_state1 = np.array([0.0, 0.0, 1.0, 1.0, 1.0])
@@ -194,8 +199,8 @@ def test_is_terminal_belief_with_unweighted_particle_belief_state_update():
 def test_is_terminal_belief_with_different_environments():
     """Test is_terminal_belief with different environment types."""
     # ARRANGE: Create different environments
-    laser_tag_env = LaserTagPOMDP(discount_factor=0.95)
-    tiger_env = TigerPOMDP(discount_factor=0.95)
+    laser_tag_env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
+    tiger_env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
     # Create LaserTag terminal state
     laser_tag_terminal = np.array([0.0, 0.0, 1.0, 1.0, 1.0])
@@ -219,7 +224,7 @@ def test_is_terminal_belief_with_different_environments():
 def test_is_terminal_belief_large_particle_set():
     """Test is_terminal_belief with large number of particles."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Create large set of terminal particles
     particles = []
@@ -242,7 +247,7 @@ def test_is_terminal_belief_large_particle_set():
 def test_is_terminal_belief_large_mixed_particle_set():
     """Test is_terminal_belief with large mixed particle set."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Create large set of mixed particles (alternating terminal/non-terminal)
     particles = []
@@ -272,7 +277,7 @@ def test_is_terminal_belief_large_mixed_particle_set():
 def test_is_terminal_belief_edge_case_all_false():
     """Test is_terminal_belief edge case with all False terminal flags."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Create states with explicit False terminal flags
     state1 = np.array([0.0, 0.0, 1.0, 1.0, 0.0])
@@ -293,7 +298,7 @@ def test_is_terminal_belief_edge_case_all_false():
 def test_is_terminal_belief_edge_case_all_true():
     """Test is_terminal_belief edge case with all True terminal flags."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Create states with explicit True terminal flags
     state1 = np.array([0.0, 0.0, 1.0, 1.0, 1.0])
@@ -314,7 +319,7 @@ def test_is_terminal_belief_edge_case_all_true():
 def test_is_terminal_belief_comprehensive_scenarios():
     """Test is_terminal_belief with comprehensive scenarios."""
     # ARRANGE: Create LaserTag environment
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
     # Scenario 1: All terminal
     all_terminal_particles = [
@@ -378,7 +383,7 @@ def test_weighted_particle_belief_update_normalized_weights_sum_to_one_cartpole(
     """
     # ARRANGE: Create CartPole POMDP environment
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    env = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
     # Create initial states for CartPole (4D continuous states)
     particles = [

--- a/POMDPPlanners/tests/test_core/test_belief/test_particle_beliefs.py
+++ b/POMDPPlanners/tests/test_core/test_belief/test_particle_beliefs.py
@@ -28,6 +28,11 @@ from POMDPPlanners.core.tree import ActionNode, BeliefNode
 from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
 from POMDPPlanners.environments.sanity_pomdp import SanityPOMDP
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    cartpole_pinned_kwargs,
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+    tiger_pinned_kwargs,
+)
 from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_belief_invariants,
 )
@@ -666,7 +671,7 @@ def test_get_unique_support_preserves_original_types():
 def test_belief_update_basic():
     """Test basic belief update functionality."""
     # Create a simple environment and belief
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     particles = [0, 1, 0, 1]  # Mix of states
     log_weights = np.array([0.1, 0.1, 0.1, 0.1])  # Non-zero weights
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights, resampling=False)
@@ -691,7 +696,7 @@ def test_belief_update_basic():
 
 def test_belief_update_with_resampling():
     """Test belief update with resampling enabled."""
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     particles = [0, 1, 0, 1]
     log_weights = np.array([0.1, 0.1, 0.1, 0.1])  # Non-zero weights
     belief = WeightedParticleBelief(
@@ -718,7 +723,7 @@ def test_belief_update_with_resampling():
 def test_belief_update_state_transitions():
     """Test that belief update correctly handles state transitions."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     particles = [0, 0, 0]  # All particles start in state 0
     log_weights = np.array([0.1, 0.1, 0.1])  # Non-zero weights
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights, resampling=False)
@@ -735,7 +740,7 @@ def test_belief_update_state_transitions():
 def test_belief_update_observation_probabilities():
     """Test that belief update correctly computes observation probabilities."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     particles = [0, 1, 0, 1]
     log_weights = np.array([0.1, 0.1, 0.1, 0.1])  # Non-zero weights
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights, resampling=False)
@@ -751,7 +756,7 @@ def test_belief_update_observation_probabilities():
 
 def test_belief_update_with_tiger_pomdp():
     """Test belief update with TigerPOMDP environment."""
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     particles = ["tiger_left", "tiger_right", "tiger_left"]
     log_weights = np.array([0.1, 0.1, 0.1])  # Non-zero weights
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights, resampling=False)
@@ -772,7 +777,7 @@ def test_belief_update_with_tiger_pomdp():
 def test_belief_update_preserves_particle_count():
     """Test that belief update preserves the number of particles."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     n_particles = 10
     particles = [0] * n_particles
     log_weights = np.ones(n_particles) * 0.1  # Non-zero weights
@@ -789,7 +794,7 @@ def test_belief_update_preserves_particle_count():
 def test_belief_update_weight_normalization():
     """Test that belief update properly handles weight normalization."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     particles = [0, 1, 0, 1]
     log_weights = np.array([1.0, 2.0, 3.0, 4.0])  # Unequal weights
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights, resampling=False)
@@ -808,7 +813,7 @@ def test_belief_update_weight_normalization():
 def test_belief_update_with_extreme_weights():
     """Test belief update with extreme weight values."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     particles = [0, 1, 0, 1]
     log_weights = np.array([-1000.0, -1000.0, -1000.0, -1000.0])  # Very small weights
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights, resampling=False)
@@ -851,7 +856,10 @@ def test_update_weights_skips_asarray_round_trip_on_native_path():
         ContinuousLightDarkPOMDPDiscreteActions,
     )
 
-    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(),
+    )
 
     np.random.seed(123)
     init_particles = env.initial_state_dist().sample(n_samples=8)
@@ -908,7 +916,7 @@ def test_update_weights_preserves_list_path_for_non_native_envs():
     Test type: unit
     """
     # pylint: disable=protected-access
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     particles = ["tiger_left", "tiger_right", "tiger_left"]
     log_weights = np.array([0.1, 0.1, 0.1])
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights, resampling=False)
@@ -926,7 +934,7 @@ def test_update_weights_preserves_list_path_for_non_native_envs():
 def test_belief_update_consistency():
     """Test that belief update produces consistent results."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     particles = [0, 1, 0, 1]
     log_weights = np.array([0.1, 0.1, 0.1, 0.1])  # Non-zero weights
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights, resampling=False)
@@ -946,7 +954,7 @@ def test_belief_update_consistency():
 def test_belief_update_with_different_actions():
     """Test that belief update behaves differently for different actions."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     particles = [0, 1, 0, 1]
     log_weights = np.array([0.1, 0.1, 0.1, 0.1])  # Non-zero weights
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights, resampling=False)
@@ -1026,7 +1034,7 @@ def test_weighted_particle_belief_state_update_initialization_weight_sum():
 def test_weighted_particle_belief_state_update_inplace_update():
     """Test inplace_update method adds state and weight correctly."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     belief = WeightedParticleBeliefStateUpdate(particles=[0], weights=[0.5])
     initial_sum = belief.weights_sum
 
@@ -1050,7 +1058,7 @@ def test_weighted_particle_belief_state_update_inplace_update():
 def test_weighted_particle_belief_state_update_inplace_update_observation_probability():
     """Test that inplace_update correctly computes observation probability."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     belief = WeightedParticleBeliefStateUpdate()
 
     state = 0
@@ -1070,7 +1078,7 @@ def test_weighted_particle_belief_state_update_inplace_update_observation_probab
 def test_weighted_particle_belief_state_update_multiple_inplace_updates():
     """Test multiple inplace_updates accumulate correctly."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     belief = WeightedParticleBeliefStateUpdate(particles=[], weights=[])
 
     states = [0, 1, 0]
@@ -1089,7 +1097,7 @@ def test_weighted_particle_belief_state_update_multiple_inplace_updates():
 def test_weighted_particle_belief_state_update_update_returns_new_instance():
     """Test that update method returns a new instance."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     original_belief = WeightedParticleBeliefStateUpdate(particles=[0], weights=[0.5])
 
     action = 0
@@ -1116,7 +1124,7 @@ def test_weighted_particle_belief_state_update_update_returns_new_instance():
 def test_weighted_particle_belief_state_update_update_preserves_original_data():
     """Test that update method preserves original particles and weights."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     original_particles = [0, 1]
     original_weights = [0.3, 0.7]
     original_belief = WeightedParticleBeliefStateUpdate(
@@ -1144,7 +1152,7 @@ def test_weighted_particle_belief_state_update_update_preserves_original_data():
 def test_weighted_particle_belief_state_update_inplace_vs_update_comparison():
     """Test that inplace_update modifies the belief in-place while update returns a new belief."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
 
     # Test 1: inplace_update modifies the original belief
     belief1 = WeightedParticleBeliefStateUpdate(particles=[0], weights=[0.5])
@@ -1327,7 +1335,7 @@ def test_weighted_particle_belief_state_update_sample_normalization():
 
 def test_weighted_particle_belief_state_update_with_tiger_pomdp():
     """Test WeightedParticleBeliefStateUpdate integration with TigerPOMDP."""
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
     # Start with empty belief
     belief = WeightedParticleBeliefStateUpdate([], [])
@@ -1354,7 +1362,7 @@ def test_weighted_particle_belief_state_update_with_tiger_pomdp():
 
 def test_weighted_particle_belief_state_update_with_tiger_pomdp_different_observations():
     """Test WeightedParticleBeliefStateUpdate with different observations in TigerPOMDP."""
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
     # Create two beliefs with different observations
     belief1 = WeightedParticleBeliefStateUpdate([], [])
@@ -1627,7 +1635,7 @@ def test_weighted_particle_belief_state_update_hashable():
 def test_weighted_particle_belief_state_update_edge_cases():
     """Test edge cases for WeightedParticleBeliefStateUpdate."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
 
     # Test with very small weights
     belief = WeightedParticleBeliefStateUpdate(particles=[0], weights=[1e-10])
@@ -1655,7 +1663,7 @@ def test_weighted_particle_belief_state_update_comprehensive_usage_example():
     """Test the comprehensive WeightedParticleBeliefStateUpdate usage example from the class docstring."""
 
     # Create environment and empty belief (from docstring)
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = WeightedParticleBeliefStateUpdate(particles=[], weights=[])
 
     # Add states incrementally with observations (from docstring)
@@ -1692,7 +1700,7 @@ def test_weighted_particle_belief_state_update_update_method_example():
     """Test the update method usage example from WeightedParticleBeliefStateUpdate docstring."""
 
     # Create a mock environment for testing
-    environment = TigerPOMDP(discount_factor=0.95)
+    environment = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
     # Original belief with 2 particles (from docstring)
     belief = WeightedParticleBeliefStateUpdate(
@@ -1721,7 +1729,7 @@ def test_weighted_particle_belief_state_update_update_method_example():
 def test_weighted_particle_belief_state_update_inplace_update_example():
     """Test the inplace_update method usage example from WeightedParticleBeliefStateUpdate docstring."""
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = WeightedParticleBeliefStateUpdate([], [])
 
     # Add particles one by one (from docstring)
@@ -1801,7 +1809,7 @@ def test_unweighted_particle_belief_state_update_initialization_weight_sum():
 def test_unweighted_particle_belief_state_update_inplace_update():
     """Test inplace_update method adds state correctly."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     belief = UnweightedParticleBeliefStateUpdate(particles=[0])
     initial_sum = belief.weights_sum
 
@@ -1824,7 +1832,7 @@ def test_unweighted_particle_belief_state_update_inplace_update():
 def test_unweighted_particle_belief_state_update_inplace_update_ignores_observation():
     """Test that inplace_update doesn't use observation probability (unweighted)."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     belief = UnweightedParticleBeliefStateUpdate()
 
     state = 0
@@ -1842,7 +1850,7 @@ def test_unweighted_particle_belief_state_update_inplace_update_ignores_observat
 def test_unweighted_particle_belief_state_update_multiple_inplace_updates():
     """Test multiple inplace_updates accumulate correctly."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     belief = UnweightedParticleBeliefStateUpdate(particles=[])
 
     states = [0, 1, 0, 2]
@@ -1860,7 +1868,7 @@ def test_unweighted_particle_belief_state_update_multiple_inplace_updates():
 def test_unweighted_particle_belief_state_update_update_returns_new_instance():
     """Test that update method returns a new instance."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     original_belief = UnweightedParticleBeliefStateUpdate(particles=[0])
 
     action = 0
@@ -1887,7 +1895,7 @@ def test_unweighted_particle_belief_state_update_update_returns_new_instance():
 def test_unweighted_particle_belief_state_update_update_preserves_original_data():
     """Test that update method preserves original particles."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
     original_particles = [0, 1]
     original_belief = UnweightedParticleBeliefStateUpdate(particles=original_particles)
 
@@ -1911,7 +1919,7 @@ def test_unweighted_particle_belief_state_update_update_preserves_original_data(
 def test_unweighted_particle_belief_state_update_inplace_vs_update_comparison():
     """Test that inplace_update modifies the belief in-place while update returns a new belief."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
 
     # Test 1: inplace_update modifies the original belief
     belief1 = UnweightedParticleBeliefStateUpdate(particles=[0])
@@ -2027,7 +2035,7 @@ def test_unweighted_particle_belief_state_update_sample_empty_belief_raises_erro
 
 def test_unweighted_particle_belief_state_update_with_tiger_pomdp():
     """Test UnweightedParticleBeliefStateUpdate integration with TigerPOMDP."""
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
     # Start with empty belief
     belief = UnweightedParticleBeliefStateUpdate([])
@@ -2268,7 +2276,7 @@ def test_unweighted_particle_belief_state_update_hashable():
 def test_unweighted_particle_belief_state_update_edge_cases():
     """Test edge cases for UnweightedParticleBeliefStateUpdate."""
 
-    env = SanityPOMDP()
+    env = SanityPOMDP(discount_factor=0.95)
 
     # Test with None state
     belief = UnweightedParticleBeliefStateUpdate(particles=[0])
@@ -2287,7 +2295,7 @@ def test_unweighted_particle_belief_state_update_comprehensive_usage_example():
     """Test comprehensive usage example similar to the weighted version."""
 
     # Create environment and empty belief
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = UnweightedParticleBeliefStateUpdate(particles=[])
 
     # Add states incrementally (observations are ignored in unweighted version)
@@ -2320,7 +2328,7 @@ def test_unweighted_particle_belief_state_update_comprehensive_usage_example():
 def test_unweighted_particle_belief_state_update_differences_from_weighted():
     """Test that UnweightedParticleBeliefStateUpdate behaves differently from WeightedParticleBeliefStateUpdate."""
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
     # Create both types of beliefs
     unweighted_belief = UnweightedParticleBeliefStateUpdate([])
@@ -2395,7 +2403,7 @@ def test_weighted_particle_belief_basic_incremental_construction_usage_example()
     """Test the basic incremental belief construction usage example from WeightedParticleBeliefStateUpdate docstring."""
 
     # Create environment and empty belief (from docstring)
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = WeightedParticleBeliefStateUpdate(particles=[], weights=[])
 
     # Add states incrementally with observations (from docstring)
@@ -2424,7 +2432,7 @@ def test_weighted_particle_belief_immutable_updates_usage_example():
 
     # Create continuous state environment (from docstring)
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    env = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
     # Start with single particle (from docstring)
     initial_state = np.array([0.0, 0.0, 0.1, 0.0])  # [x, x_dot, theta, theta_dot]
@@ -2498,7 +2506,7 @@ def test_weighted_particle_belief_update_strategies_comparison_usage_example():
 def test_weighted_particle_belief_mcts_integration_usage_example():
     """Test the Monte Carlo Tree Search integration usage example from WeightedParticleBeliefStateUpdate docstring."""
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
     # Root belief node with initial particles (from docstring)
     root_belief = WeightedParticleBeliefStateUpdate(
@@ -2542,7 +2550,7 @@ def test_weighted_particle_belief_mcts_integration_usage_example():
 def test_weighted_particle_belief_weighted_sampling_usage_example():
     """Test the weighted sampling and state estimation usage example from WeightedParticleBeliefStateUpdate docstring."""
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = WeightedParticleBeliefStateUpdate([], [])
 
     # Add strongly biased evidence for tiger_left (from docstring)
@@ -2603,7 +2611,7 @@ def test_weighted_particle_belief_custom_particle_types_usage_example():
 
     # Works with any particle type - numpy arrays, custom objects, etc. (from docstring)
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    env = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
     # Numpy array particles (from docstring)
     particles = [
@@ -2643,7 +2651,7 @@ def test_unweighted_particle_belief_state_update_basic_uniform_belief_constructi
     """Test the basic uniform belief construction usage example from UnweightedParticleBeliefStateUpdate docstring."""
 
     # Create environment and empty uniform belief
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = UnweightedParticleBeliefStateUpdate(particles=[])
 
     # Add states uniformly (all have equal probability)
@@ -2729,7 +2737,7 @@ def test_unweighted_particle_belief_state_update_comparing_weighted_vs_unweighte
 def test_unweighted_particle_belief_state_update_discrete_observation_filtering_usage_example():
     """Test the discrete observation filtering usage example from UnweightedParticleBeliefStateUpdate docstring."""
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = UnweightedParticleBeliefStateUpdate([])
 
     # Simulate multiple observations (discrete: hear_left or hear_right)
@@ -2767,7 +2775,7 @@ def test_unweighted_particle_belief_state_update_immutable_belief_trees_usage_ex
 
     # Create continuous state environment
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    env = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
     # Start with uniform belief over multiple initial states
     initial_states = [
@@ -2851,7 +2859,7 @@ def test_unweighted_particle_belief_state_update_configuration_caching_usage_exa
 def test_unweighted_particle_belief_state_update_large_scale_accumulation_usage_example():
     """Test the large-scale particle accumulation usage example from UnweightedParticleBeliefStateUpdate docstring."""
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     belief = UnweightedParticleBeliefStateUpdate([])
 
     # Time large-scale particle addition (reduced scale for testing)

--- a/POMDPPlanners/tests/test_core/test_cost.py
+++ b/POMDPPlanners/tests/test_core/test_cost.py
@@ -31,6 +31,10 @@ from POMDPPlanners.core.cost import (
     belief_expectation_reward_particle_belief,
 )
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    cartpole_pinned_kwargs,
+    tiger_pinned_kwargs,
+)
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -93,7 +97,7 @@ def tiger_env():
 
     Test type: unit
     """
-    return TigerPOMDP(discount_factor=0.95)
+    return TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
 
 def test_belief_expectation_cost_particle_belief_uniform_weights(
@@ -155,7 +159,7 @@ def test_belief_expectation_cost_particle_belief_varying_rewards():
     log_weights = np.log(np.array([0.7, 0.3]))
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights)
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     action = "open_left"
     cost = belief_expectation_cost_particle_belief(belief=belief, action=action, env=env)
 
@@ -181,7 +185,7 @@ def test_belief_expectation_cost_entropy_penalty():
     log_weights = np.log(np.ones(2) / 2)
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights)
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     action = "listen"
     entropy_weight = 0.1
 
@@ -296,7 +300,7 @@ def test_belief_expectation_cost_belief_information_gain():
     log_weights_next = np.log(np.array([0.9, 0.1]))
     belief_next = WeightedParticleBelief(particles=particles_next, log_weights=log_weights_next)
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     action = "listen"
     entropy_weight = 0.1
 
@@ -474,7 +478,7 @@ def test_belief_expectation_cost_belief_information_gain_with_weighted_particle_
     log_weights_next = np.log(np.array([0.9, 0.1]))
     belief_next = WeightedParticleBelief(particles=particles_next, log_weights=log_weights_next)
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     action = "listen"
     entropy_weight = 0.1
 
@@ -562,7 +566,7 @@ def test_belief_expectation_cost_single_particle():
     log_weights = np.array([1e-10])
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights)
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
     action = "open_right"  # Opening right door when tiger is left gives +10 reward
     cost = belief_expectation_cost_particle_belief(belief=belief, action=action, env=env)
@@ -597,7 +601,7 @@ def test_belief_expectation_cost_entropy_penalty_maximum_uncertainty():
         particles=particles_concentrated, log_weights=log_weights_concentrated
     )
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     action = "listen"
     entropy_weight = 0.5
 
@@ -646,7 +650,7 @@ def test_belief_expectation_cost_weights_normalization():
     log_weights = np.log(np.array([0.5, 0.5]))  # Will be normalized to [0.5, 0.5]
     belief = WeightedParticleBelief(particles=particles, log_weights=log_weights)
 
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     action = "open_left"  # This gives different rewards: -100 for tiger_left, 10 for tiger_right
 
     cost = belief_expectation_cost_particle_belief(belief=belief, action=action, env=env)
@@ -680,7 +684,9 @@ class TestVectorizedBeliefCost:
         )
         from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
 
-        env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.diag([0.1] * 4))
+        env = CartPolePOMDP(
+            discount_factor=0.95, noise_cov=np.diag([0.1] * 4), **cartpole_pinned_kwargs()
+        )
         np.random.seed(42)
         particles_arr = np.random.randn(50, 4)
         weights = np.random.dirichlet(np.ones(50))
@@ -715,7 +721,7 @@ class TestVectorizedBeliefCost:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         particles = ["tiger_left", "tiger_right"]
         weights = np.array([0.7, 0.3])
         log_weights = np.log(weights)

--- a/POMDPPlanners/tests/test_core/test_environment/test_environment.py
+++ b/POMDPPlanners/tests/test_core/test_environment/test_environment.py
@@ -23,6 +23,7 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import tiger_pinned_kwargs
 from POMDPPlanners.utils.logger import reset_logger_state
 
 # Set seeds for reproducible tests
@@ -281,7 +282,7 @@ def test_attribute_presence(base_environment: MockEnvironment, attr_name: str, a
 @pytest.fixture
 def base_tiger_environment() -> TigerPOMDP:
     """Fixture providing a base TigerPOMDP environment for comparison."""
-    return TigerPOMDP(discount_factor=0.95)
+    return TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
 
 @pytest.fixture(autouse=True)
@@ -377,11 +378,11 @@ class TestEnvironmentConfigId:
         Test type: configuration
         """
         # Same configuration should have same ID
-        other_env = TigerPOMDP(discount_factor=0.95)
+        other_env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         assert base_tiger_environment.config_id == other_env.config_id
 
         # Different configuration should have different ID
-        different_env = TigerPOMDP(discount_factor=0.8)
+        different_env = TigerPOMDP(discount_factor=0.8, **tiger_pinned_kwargs())
         assert base_tiger_environment.config_id != different_env.config_id
 
     def test_config_id_format(self, base_environment: MockEnvironment):

--- a/POMDPPlanners/tests/test_core/test_hash_action_contract.py
+++ b/POMDPPlanners/tests/test_core/test_hash_action_contract.py
@@ -42,6 +42,22 @@ from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_po
 )
 from POMDPPlanners.environments.sanity_pomdp import SanityPOMDP
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    cartpole_pinned_kwargs,
+    continuous_laser_tag_discrete_actions_pinned_kwargs,
+    continuous_laser_tag_pinned_kwargs,
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+    continuous_light_dark_pinned_kwargs,
+    continuous_push_pinned_kwargs,
+    discrete_light_dark_pinned_kwargs,
+    laser_tag_pinned_kwargs,
+    mountain_car_pinned_kwargs,
+    pacman_pinned_kwargs,
+    push_pinned_kwargs,
+    rock_sample_pinned_kwargs,
+    safety_ant_velocity_pinned_kwargs,
+    tiger_pinned_kwargs,
+)
 from POMDPPlanners.planners.mcts_planners.pft_dpw import PFT_DPW
 from POMDPPlanners.planners.mcts_planners.pomcpow import POMCPOW
 from POMDPPlanners.planners.planners_utils.dpw import ActionSampler
@@ -60,75 +76,97 @@ random.seed(42)
 
 
 def _continuous_light_dark_factory():
-    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
     actions = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
     return env, actions
 
 
 def _continuous_light_dark_discrete_factory():
-    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(),
+    )
     return env, env.get_actions()
 
 
 def _discrete_light_dark_factory():
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
     return env, env.get_actions()
 
 
 def _continuous_laser_tag_factory():
-    env = ContinuousLaserTagPOMDP(discount_factor=0.95)
+    env = ContinuousLaserTagPOMDP(discount_factor=0.95, **continuous_laser_tag_pinned_kwargs())
     actions = [np.array([1.0, 0.0, 0.0]), np.array([0.0, 1.0, 0.0])]
     return env, actions
 
 
 def _continuous_laser_tag_discrete_factory():
-    env = ContinuousLaserTagPOMDPDiscreteActions(discount_factor=0.95)
+    env = ContinuousLaserTagPOMDPDiscreteActions(
+        discount_factor=0.95,
+        **continuous_laser_tag_discrete_actions_pinned_kwargs(),
+    )
     return env, env.get_actions()
 
 
 def _laser_tag_factory():
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
     return env, env.get_actions()
 
 
 def _continuous_push_factory():
-    env = ContinuousPushPOMDP(discount_factor=0.95)
+    env = ContinuousPushPOMDP(discount_factor=0.95, **continuous_push_pinned_kwargs())
     actions = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
     return env, actions
 
 
 def _push_factory():
-    env = PushPOMDP(discount_factor=0.95)
+    env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs())
     return env, env.get_actions()
 
 
 def _cartpole_factory():
-    env = CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    env = CartPolePOMDP(
+        discount_factor=0.99,
+        noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]),
+        **cartpole_pinned_kwargs(),
+    )
     return env, env.get_actions()
 
 
 def _mountain_car_factory():
-    env = MountainCarPOMDP(discount_factor=0.99)
+    env = MountainCarPOMDP(discount_factor=0.99, **mountain_car_pinned_kwargs())
     return env, env.get_actions()
 
 
 def _pacman_factory():
-    env = PacManPOMDP(maze_size=(5, 5), walls=set(), initial_pellets=[(2, 2)])
+    env = PacManPOMDP(
+        discount_factor=0.95,
+        **pacman_pinned_kwargs(
+            maze_size=(5, 5),
+            walls=set(),
+            initial_pellets=[(2, 2)],
+            initial_ghost_positions=None,
+            ghost_strategies=None,
+        ),
+    )
     return env, env.get_actions()
 
 
 def _rock_sample_factory():
-    env = RockSamplePOMDP(map_size=(5, 5), rock_positions=[(0, 0), (2, 2)])
+    env = RockSamplePOMDP(
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(map_size=(5, 5), rock_positions=[(0, 0), (2, 2)]),
+    )
     return env, env.get_actions()
 
 
 def _safety_ant_factory():
-    env = SafeAntVelocityPOMDP(discount_factor=0.95)
+    env = SafeAntVelocityPOMDP(discount_factor=0.95, **safety_ant_velocity_pinned_kwargs())
     return env, env.get_actions()
 
 
 def _tiger_factory():
-    env = TigerPOMDP(discount_factor=0.95)
+    env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
     return env, env.get_actions()
 
 
@@ -302,7 +340,7 @@ class _FixedNDArrayActionSampler(ActionSampler):
 
 
 def _run_pomcpow_continuous_light_dark():
-    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
     sampler = _FixedNDArrayActionSampler(
         [np.array([1.0, 0.0]), np.array([0.0, 1.0]), np.array([-1.0, 0.0])]
     )
@@ -325,7 +363,7 @@ def _run_pomcpow_continuous_light_dark():
 
 
 def _run_pft_dpw_continuous_light_dark():
-    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
     sampler = _FixedNDArrayActionSampler(
         [np.array([1.0, 0.0]), np.array([0.0, 1.0]), np.array([-1.0, 0.0])]
     )
@@ -454,7 +492,7 @@ def test_action_child_lookup_distinguishes_distinct_ndarray_actions():
 
     Test type: integration
     """
-    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
     belief = get_initial_belief(pomdp=env, n_particles=4, resampling=True)
     tree = Tree()
     root_id = tree.add_belief_node(belief=belief)

--- a/POMDPPlanners/tests/test_core/test_hash_observation_contract.py
+++ b/POMDPPlanners/tests/test_core/test_hash_observation_contract.py
@@ -26,6 +26,12 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
 from POMDPPlanners.environments.push_pomdp.push_pomdp import PushPOMDP
 from POMDPPlanners.planners.mcts_planners.pomcpow import POMCPOW
 from POMDPPlanners.planners.planners_utils.dpw import ActionSampler
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_laser_tag_discrete_actions_pinned_kwargs,
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+    laser_tag_pinned_kwargs,
+    push_pinned_kwargs,
+)
 
 
 np.random.seed(42)
@@ -46,19 +52,25 @@ class _DiscreteActionSampler(ActionSampler):
 
 
 def _make_continuous_light_dark():
-    return ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    return ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(),
+    )
 
 
 def _make_continuous_laser_tag():
-    return ContinuousLaserTagPOMDPDiscreteActions(discount_factor=0.95)
+    return ContinuousLaserTagPOMDPDiscreteActions(
+        discount_factor=0.95,
+        **continuous_laser_tag_discrete_actions_pinned_kwargs(),
+    )
 
 
 def _make_laser_tag():
-    return LaserTagPOMDP(discount_factor=0.95)
+    return LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
 
 def _make_push():
-    return PushPOMDP(discount_factor=0.95)
+    return PushPOMDP(discount_factor=0.95, **push_pinned_kwargs())
 
 
 # ---------------------------------------------------------------------------

--- a/POMDPPlanners/tests/test_core/test_simulation_configs.py
+++ b/POMDPPlanners/tests/test_core/test_simulation_configs.py
@@ -6,6 +6,7 @@ import pytest
 
 from POMDPPlanners.core.simulation.simulation_configs import EnvironmentRunParams
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import tiger_pinned_kwargs
 from POMDPPlanners.core.belief import get_initial_belief
 from POMDPPlanners.planners.open_loop_planners.discrete_action_sequences_planner import (
     DiscreteActionSequencesPlanner,
@@ -26,7 +27,7 @@ class TestEnvironmentRunParamsConfigId:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -53,8 +54,8 @@ class TestEnvironmentRunParamsConfigId:
 
         Test type: unit
         """
-        env1 = TigerPOMDP(discount_factor=0.95)
-        env2 = TigerPOMDP(discount_factor=0.90)
+        env1 = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
+        env2 = TigerPOMDP(discount_factor=0.90, **tiger_pinned_kwargs())
 
         belief1 = get_initial_belief(env1, n_particles=100)
         belief2 = get_initial_belief(env2, n_particles=100)
@@ -95,7 +96,7 @@ class TestEnvironmentRunParamsConfigId:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
         belief1 = get_initial_belief(env, n_particles=100)
         belief2 = get_initial_belief(env, n_particles=200)
@@ -125,7 +126,7 @@ class TestEnvironmentRunParamsConfigId:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
 
         policy1 = DiscreteActionSequencesPlanner(
@@ -164,7 +165,7 @@ class TestEnvironmentRunParamsConfigId:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -191,7 +192,7 @@ class TestEnvironmentRunParamsConfigId:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -218,7 +219,7 @@ class TestEnvironmentRunParamsConfigId:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
 
         policy1 = DiscreteActionSequencesPlanner(
@@ -269,7 +270,7 @@ class TestEnvironmentRunParamsHashAndEquality:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -296,7 +297,7 @@ class TestEnvironmentRunParamsHashAndEquality:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -323,7 +324,7 @@ class TestEnvironmentRunParamsHashAndEquality:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -350,7 +351,7 @@ class TestEnvironmentRunParamsHashAndEquality:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -375,7 +376,7 @@ class TestEnvironmentRunParamsHashAndEquality:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -407,7 +408,7 @@ class TestEnvironmentRunParamsHashAndEquality:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -442,7 +443,7 @@ class TestEnvironmentRunParamsInputValidation:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -477,7 +478,7 @@ class TestEnvironmentRunParamsInputValidation:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -512,7 +513,7 @@ class TestEnvironmentRunParamsInputValidation:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -539,7 +540,7 @@ class TestEnvironmentRunParamsInputValidation:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -566,7 +567,7 @@ class TestEnvironmentRunParamsInputValidation:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -601,7 +602,7 @@ class TestEnvironmentRunParamsInputValidation:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -636,7 +637,7 @@ class TestEnvironmentRunParamsInputValidation:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
 
         with pytest.raises(ValueError, match="policies list cannot be empty"):
@@ -655,7 +656,7 @@ class TestEnvironmentRunParamsInputValidation:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10
@@ -690,7 +691,7 @@ class TestEnvironmentRunParamsInputValidation:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=100)
         policy = DiscreteActionSequencesPlanner(
             environment=env, discount_factor=0.95, name="test_planner", depth=5, n_return_samples=10

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
@@ -23,6 +23,7 @@ from POMDPPlanners.environments.cartpole_pomdp import (
     CartPolePOMDP,
     _native,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import cartpole_pinned_kwargs
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -33,7 +34,7 @@ random.seed(42)
 def base_cartpole_environment() -> CartPolePOMDP:
     """Fixture providing a base CartPolePOMDP environment for comparison."""
     noise_cov = np.eye(4) * 0.1
-    return CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
+    return CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
 
 class TestCartPolePOMDPEquality:
@@ -51,7 +52,9 @@ class TestCartPolePOMDPEquality:
         Test type: unit
         """
         other_env = CartPolePOMDP(
-            discount_factor=0.95, noise_cov=base_cartpole_environment.noise_cov
+            discount_factor=0.95,
+            noise_cov=base_cartpole_environment.noise_cov,
+            **cartpole_pinned_kwargs(),
         )
         assert base_cartpole_environment == other_env
         assert other_env == base_cartpole_environment  # Test symmetry
@@ -68,7 +71,9 @@ class TestCartPolePOMDPEquality:
         Test type: unit
         """
         other_env = CartPolePOMDP(
-            discount_factor=0.8, noise_cov=base_cartpole_environment.noise_cov
+            discount_factor=0.8,
+            noise_cov=base_cartpole_environment.noise_cov,
+            **cartpole_pinned_kwargs(),
         )
         assert base_cartpole_environment != other_env
         assert other_env != base_cartpole_environment  # Test symmetry
@@ -85,8 +90,7 @@ class TestCartPolePOMDPEquality:
         Test type: unit
         """
         other_env = CartPolePOMDP(
-            discount_factor=0.95,
-            noise_cov=np.eye(4) * 0.2,  # Different noise covariance
+            discount_factor=0.95, noise_cov=np.eye(4) * 0.2, **cartpole_pinned_kwargs()
         )
         assert base_cartpole_environment != other_env
         assert other_env != base_cartpole_environment  # Test symmetry
@@ -103,13 +107,17 @@ class TestCartPolePOMDPEquality:
         Test type: unit
         """
         other_env = CartPolePOMDP(
-            discount_factor=0.95, noise_cov=base_cartpole_environment.noise_cov
+            discount_factor=0.95,
+            noise_cov=base_cartpole_environment.noise_cov,
+            **cartpole_pinned_kwargs(),
         )
         other_env.gravity = 10.0  # Different gravity
         assert base_cartpole_environment != other_env
 
         other_env = CartPolePOMDP(
-            discount_factor=0.95, noise_cov=base_cartpole_environment.noise_cov
+            discount_factor=0.95,
+            noise_cov=base_cartpole_environment.noise_cov,
+            **cartpole_pinned_kwargs(),
         )
         other_env.masscart = 2.0  # Different cart mass
         assert base_cartpole_environment != other_env
@@ -141,13 +149,17 @@ class TestCartPolePOMDPEquality:
         Test type: unit
         """
         other_env = CartPolePOMDP(
-            discount_factor=0.95, noise_cov=base_cartpole_environment.noise_cov
+            discount_factor=0.95,
+            noise_cov=base_cartpole_environment.noise_cov,
+            **cartpole_pinned_kwargs(),
         )
         delattr(other_env, "gravity")
         assert base_cartpole_environment != other_env
 
         other_env = CartPolePOMDP(
-            discount_factor=0.95, noise_cov=base_cartpole_environment.noise_cov
+            discount_factor=0.95,
+            noise_cov=base_cartpole_environment.noise_cov,
+            **cartpole_pinned_kwargs(),
         )
         delattr(other_env, "masscart")
         assert base_cartpole_environment != other_env
@@ -183,7 +195,9 @@ class TestCartPolePOMDPConfigId:
         Test type: configuration
         """
         other_env = CartPolePOMDP(
-            discount_factor=0.95, noise_cov=base_cartpole_environment.noise_cov
+            discount_factor=0.95,
+            noise_cov=base_cartpole_environment.noise_cov,
+            **cartpole_pinned_kwargs(),
         )
         assert base_cartpole_environment.config_id == other_env.config_id
 
@@ -199,7 +213,9 @@ class TestCartPolePOMDPConfigId:
         Test type: configuration
         """
         other_env = CartPolePOMDP(
-            discount_factor=0.8, noise_cov=base_cartpole_environment.noise_cov
+            discount_factor=0.8,
+            noise_cov=base_cartpole_environment.noise_cov,
+            **cartpole_pinned_kwargs(),
         )
         assert base_cartpole_environment.config_id != other_env.config_id
 
@@ -215,8 +231,7 @@ class TestCartPolePOMDPConfigId:
         Test type: configuration
         """
         other_env = CartPolePOMDP(
-            discount_factor=0.95,
-            noise_cov=np.eye(4) * 0.2,  # Different noise covariance
+            discount_factor=0.95, noise_cov=np.eye(4) * 0.2, **cartpole_pinned_kwargs()
         )
         assert base_cartpole_environment.config_id != other_env.config_id
 
@@ -234,13 +249,17 @@ class TestCartPolePOMDPConfigId:
         Test type: configuration
         """
         other_env = CartPolePOMDP(
-            discount_factor=0.95, noise_cov=base_cartpole_environment.noise_cov
+            discount_factor=0.95,
+            noise_cov=base_cartpole_environment.noise_cov,
+            **cartpole_pinned_kwargs(),
         )
         other_env.gravity = 10.0  # Different gravity
         assert base_cartpole_environment.config_id != other_env.config_id
 
         other_env = CartPolePOMDP(
-            discount_factor=0.95, noise_cov=base_cartpole_environment.noise_cov
+            discount_factor=0.95,
+            noise_cov=base_cartpole_environment.noise_cov,
+            **cartpole_pinned_kwargs(),
         )
         other_env.masscart = 2.0  # Different cart mass
         assert base_cartpole_environment.config_id != other_env.config_id
@@ -379,7 +398,7 @@ def test_state_transition_default_covariance():
 
     Test type: unit
     """
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1, **cartpole_pinned_kwargs())
     np.testing.assert_array_equal(
         env.state_transition_cov, CartPolePOMDP.DEFAULT_STATE_TRANSITION_COV
     )
@@ -401,7 +420,7 @@ def test_state_transition_custom_covariance():
     env = CartPolePOMDP(
         discount_factor=0.95,
         noise_cov=np.eye(4) * 0.1,
-        state_transition_cov=custom_cov,
+        **cartpole_pinned_kwargs(state_transition_cov=custom_cov),
     )
     np.testing.assert_array_equal(env.state_transition_cov, custom_cov)
 
@@ -457,7 +476,7 @@ def test_cartpole_pomdp_initialization():
     # Test POMDP initialization
     noise_cov = np.eye(4) * 0.1
 
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
     # Verify parameters
     assert np.array_equal(env.noise_cov, noise_cov)
@@ -479,7 +498,7 @@ def test_cartpole_pomdp_reward():
     Test type: unit
     """
     # Test reward function
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1, **cartpole_pinned_kwargs())
 
     # Test non-terminal state
     state = np.array([0.0, 0.0, 0.0, 0.0])
@@ -505,7 +524,7 @@ def test_cartpole_pomdp_terminal():
     Test type: unit
     """
     # Test terminal state detection
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1, **cartpole_pinned_kwargs())
 
     # Test non-terminal state
     state = np.array([0.0, 0.0, 0.0, 0.0])
@@ -535,7 +554,7 @@ def test_cartpole_pomdp_models():
 
     Test type: unit
     """
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1, **cartpole_pinned_kwargs())
     state = np.array([0.0, 0.0, 0.0, 0.0])
     action = 0
 
@@ -573,7 +592,7 @@ def test_cartpole_observation_model_probability_shape_single_observation():
     true_state = np.array([0.1, 0.05, 0.02, -0.1])
     action = 1
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
     # Create single observation
     observation = np.array([0.12, 0.06, 0.025, -0.09])
@@ -611,7 +630,7 @@ def test_cartpole_observation_model_probability_shape_multiple_observations():
     true_state = np.array([0.1, 0.05, 0.02, -0.1])
     action = 1
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
     # Create multiple observations
     observations = [
@@ -658,7 +677,7 @@ def test_cartpole_observation_model_probability_empty_list():
     true_state = np.array([0.1, 0.05, 0.02, -0.1])
     action = 1
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
     # ACT: Get probability for empty list via env-level API
     probs = np.exp(
@@ -688,7 +707,7 @@ def test_cartpole_observation_model_probability_values_reasonable():
     true_state = np.array([0.1, 0.05, 0.02, -0.1])
     action = 1
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
     # Create observations: one close to true state, one far
     close_obs = true_state + np.array([0.01, 0.01, 0.01, 0.01])  # Small deviation
@@ -721,7 +740,7 @@ def test_get_metric_names():
     Test type: unit
     """
     noise_cov = np.eye(4) * 0.1
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov, **cartpole_pinned_kwargs())
     metric_names = env.get_metric_names()
     assert "goal_reaching_rate" in metric_names
     assert len(metric_names) == 1
@@ -742,7 +761,7 @@ def test_compute_metrics_goal_reaching():
     from POMDPPlanners.core.simulation import History, StepData
 
     noise_cov = np.eye(4) * 0.1
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
     # Create a simple belief for testing
     def create_test_belief(state):
@@ -869,9 +888,7 @@ def test_compute_metrics_values_within_confidence_intervals():
     from POMDPPlanners.core.belief import (  # pylint: disable=import-outside-toplevel
         WeightedParticleBelief,
     )
-    from POMDPPlanners.core.policy import (  # pylint: disable=import-outside-toplevel
-        PolicyRunData,
-    )
+    from POMDPPlanners.core.policy import PolicyRunData  # pylint: disable=import-outside-toplevel
     from POMDPPlanners.core.simulation import (  # pylint: disable=import-outside-toplevel
         History,
         StepData,
@@ -886,7 +903,7 @@ def test_compute_metrics_values_within_confidence_intervals():
     )
 
     noise_cov = np.eye(4) * 0.1
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
     def _make_belief(state: np.ndarray) -> WeightedParticleBelief:
         return WeightedParticleBelief(
@@ -1004,7 +1021,9 @@ def test_reward_batch_matches_scalar_reward():
 
     Test type: unit
     """
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    env = CartPolePOMDP(
+        discount_factor=0.95, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]), **cartpole_pinned_kwargs()
+    )
     np.random.seed(42)
     states = np.random.randn(100, 4)
     action = 1
@@ -1047,7 +1066,9 @@ def test_simulate_random_rollout_native_matches_base_class_python() -> None:
         python_random_rollout,
     )  # pylint: disable=import-outside-toplevel
 
-    env = CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    env = CartPolePOMDP(
+        discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]), **cartpole_pinned_kwargs()
+    )
     state = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float64)
     max_depth = 10
     gamma = 0.95
@@ -1123,7 +1144,9 @@ def test_scalar_obs_log_prob_un_floored_matches_batch_after_fix() -> None:
 
     Test type: unit
     """
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.01)
+    env = CartPolePOMDP(
+        discount_factor=0.95, noise_cov=np.eye(4) * 0.01, **cartpole_pinned_kwargs()
+    )
     next_state = np.zeros(4)
     action = 0
     observation = np.array([1.87, 1.87, 1.87, 1.87])
@@ -1162,7 +1185,7 @@ def test_initial_observation_dist_applies_obs_noise() -> None:
     """
     np.random.seed(0)
     noise_cov = np.eye(4) * 0.04
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
     samples = np.asarray(env.initial_observation_dist().sample(n_samples=5000))
 
@@ -1191,7 +1214,7 @@ def test_is_equal_observation_tolerates_float_roundoff() -> None:
 
     Test type: unit
     """
-    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1)
+    env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1, **cartpole_pinned_kwargs())
     a = np.array([0.1, -0.2, 0.03, -0.04])
     a_copy = a.copy()
     a_eps = a + 1e-12

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_belief_factory.py
@@ -15,12 +15,15 @@ from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
 )
 from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
 from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp_beliefs import create_cartpole_belief
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import cartpole_pinned_kwargs
 from POMDPPlanners.utils.belief_factory import BeliefType
 
 
 @pytest.fixture
 def env():
-    return CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    return CartPolePOMDP(
+        discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]), **cartpole_pinned_kwargs()
+    )
 
 
 class TestCreateCartpoleBelief:

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_beliefs.py
@@ -29,6 +29,7 @@ from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils imp
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import cartpole_pinned_kwargs
 
 
 def _make_aligned_beliefs(updater, n_particles=60):
@@ -60,7 +61,7 @@ def _make_aligned_beliefs(updater, n_particles=60):
 @pytest.fixture
 def env():
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    return CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
+    return CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
 
 @pytest.fixture

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_gaussian_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_gaussian_beliefs.py
@@ -19,6 +19,7 @@ from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp_gaussian_beliefs i
     GaussianBeliefUpdaterType,
     create_cartpole_gaussian_belief,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import cartpole_pinned_kwargs
 
 
 def _deterministic_next_state(env: CartPolePOMDP, state: np.ndarray, action: int) -> np.ndarray:
@@ -53,7 +54,7 @@ def _deterministic_next_state(env: CartPolePOMDP, state: np.ndarray, action: int
 @pytest.fixture
 def env():
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    return CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
+    return CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
 
 @pytest.fixture

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_kernel_cache.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_kernel_cache.py
@@ -17,13 +17,14 @@ import pytest
 
 from POMDPPlanners.environments.cartpole_pomdp import _native
 from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp import CartPolePOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import cartpole_pinned_kwargs
 
 _NOISE_COV = np.diag([0.1, 0.1, 0.1, 0.1])
 _STATE_DIM = 4
 
 
 def _make_env() -> CartPolePOMDP:
-    return CartPolePOMDP(discount_factor=0.95, noise_cov=_NOISE_COV)
+    return CartPolePOMDP(discount_factor=0.95, noise_cov=_NOISE_COV, **cartpole_pinned_kwargs())
 
 
 def _all_actions() -> List[int]:

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_native_equivalence.py
@@ -16,13 +16,14 @@ import pytest
 
 from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP, _native
 from POMDPPlanners.tests.test_environments import _native_parity
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import cartpole_pinned_kwargs
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 
 
 @pytest.fixture(name="env")
 def _env_fixture():
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    return CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
+    return CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
 
 def _build_transition(env: CartPolePOMDP, state: np.ndarray, action: int):

--- a/POMDPPlanners/tests/test_environments/test_env_api_conformance.py
+++ b/POMDPPlanners/tests/test_environments/test_env_api_conformance.py
@@ -56,73 +56,99 @@ from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import RockS
 from POMDPPlanners.environments.safety_ant_velocity_pomdp import SafeAntVelocityPOMDP
 from POMDPPlanners.environments.sanity_pomdp import SanityPOMDP
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    cartpole_pinned_kwargs,
+    continuous_laser_tag_discrete_actions_pinned_kwargs,
+    continuous_laser_tag_pinned_kwargs,
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+    continuous_light_dark_pinned_kwargs,
+    continuous_push_discrete_actions_pinned_kwargs,
+    continuous_push_pinned_kwargs,
+    discrete_light_dark_pinned_kwargs,
+    laser_tag_pinned_kwargs,
+    mountain_car_pinned_kwargs,
+    pacman_pinned_kwargs,
+    push_pinned_kwargs,
+    rock_sample_pinned_kwargs,
+    safety_ant_velocity_pinned_kwargs,
+    sanity_pinned_kwargs,
+    tiger_pinned_kwargs,
+)
 
 
 EnvBuilder = Callable[[], Environment]
 
 
 def _build_tiger() -> TigerPOMDP:
-    return TigerPOMDP(discount_factor=0.95)
+    return TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
 
 
 def _build_sanity() -> SanityPOMDP:
-    return SanityPOMDP(discount_factor=0.95)
+    return SanityPOMDP(discount_factor=0.95, **sanity_pinned_kwargs())
 
 
 def _build_cartpole() -> CartPolePOMDP:
-    return CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1)
+    return CartPolePOMDP(
+        discount_factor=0.95, noise_cov=np.eye(4) * 0.1, **cartpole_pinned_kwargs()
+    )
 
 
 def _build_mountain_car() -> MountainCarPOMDP:
-    return MountainCarPOMDP(discount_factor=0.95)
+    return MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
 
 
 def _build_push() -> PushPOMDP:
-    return PushPOMDP(discount_factor=0.95)
+    return PushPOMDP(discount_factor=0.95, **push_pinned_kwargs())
 
 
 def _build_continuous_push() -> ContinuousPushPOMDP:
-    return ContinuousPushPOMDP(discount_factor=0.95)
+    return ContinuousPushPOMDP(discount_factor=0.95, **continuous_push_pinned_kwargs())
 
 
 def _build_continuous_push_discrete() -> ContinuousPushPOMDPDiscreteActions:
-    return ContinuousPushPOMDPDiscreteActions(discount_factor=0.95)
+    return ContinuousPushPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_push_discrete_actions_pinned_kwargs()
+    )
 
 
 def _build_rock_sample() -> RockSamplePOMDP:
-    return RockSamplePOMDP(discount_factor=0.95)
+    return RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
 
 
 def _build_discrete_light_dark() -> DiscreteLightDarkPOMDP:
-    return DiscreteLightDarkPOMDP(discount_factor=0.95)
+    return DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
 
 
 def _build_continuous_light_dark() -> ContinuousLightDarkPOMDP:
-    return ContinuousLightDarkPOMDP(discount_factor=0.95)
+    return ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
 
 
 def _build_continuous_light_dark_discrete() -> ContinuousLightDarkPOMDPDiscreteActions:
-    return ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    return ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_light_dark_discrete_actions_pinned_kwargs()
+    )
 
 
 def _build_pacman() -> PacManPOMDP:
-    return PacManPOMDP(discount_factor=0.95)
+    return PacManPOMDP(discount_factor=0.95, **pacman_pinned_kwargs())
 
 
 def _build_laser_tag() -> LaserTagPOMDP:
-    return LaserTagPOMDP(discount_factor=0.95)
+    return LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
 
 
 def _build_continuous_laser_tag() -> ContinuousLaserTagPOMDP:
-    return ContinuousLaserTagPOMDP(discount_factor=0.95)
+    return ContinuousLaserTagPOMDP(discount_factor=0.95, **continuous_laser_tag_pinned_kwargs())
 
 
 def _build_continuous_laser_tag_discrete() -> ContinuousLaserTagPOMDPDiscreteActions:
-    return ContinuousLaserTagPOMDPDiscreteActions(discount_factor=0.95)
+    return ContinuousLaserTagPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_laser_tag_discrete_actions_pinned_kwargs()
+    )
 
 
 def _build_safety_ant() -> SafeAntVelocityPOMDP:
-    return SafeAntVelocityPOMDP(discount_factor=0.95)
+    return SafeAntVelocityPOMDP(discount_factor=0.95, **safety_ant_velocity_pinned_kwargs())
 
 
 # Registry of (env_id, builder). New envs added here are automatically

--- a/POMDPPlanners/tests/test_environments/test_environment_serialization.py
+++ b/POMDPPlanners/tests/test_environments/test_environment_serialization.py
@@ -30,6 +30,14 @@ from POMDPPlanners.environments import (
     SanityPOMDP,
     TigerPOMDP,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_pinned_kwargs,
+    discrete_light_dark_pinned_kwargs,
+    pacman_pinned_kwargs,
+    rock_sample_pinned_kwargs,
+    sanity_pinned_kwargs,
+    tiger_pinned_kwargs,
+)
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -263,7 +271,7 @@ class TestEnvironmentStateSerialization:
 
         Test type: unit
         """
-        env = TigerPOMDP(discount_factor=0.95)
+        env = TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs())
         state = env.initial_state_dist().sample()[0]
 
         pickled_state = pickle.dumps(state)
@@ -282,7 +290,7 @@ class TestEnvironmentStateSerialization:
 
         Test type: unit
         """
-        env = PacManPOMDP(discount_factor=0.95)
+        env = PacManPOMDP(discount_factor=0.95, **pacman_pinned_kwargs())
         state = env.initial_state_dist().sample()[0]
 
         pickled_state = pickle.dumps(state)
@@ -302,7 +310,7 @@ class TestEnvironmentStateSerialization:
 
         Test type: unit
         """
-        env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+        env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
         state = env.initial_state_dist().sample()[0]
 
         pickled_state = pickle.dumps(state)
@@ -322,7 +330,7 @@ class TestEnvironmentStateSerialization:
 
         Test type: unit
         """
-        env = RockSamplePOMDP(discount_factor=0.95, map_size=(5, 5))
+        env = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs(map_size=(5, 5)))
         state = env.initial_state_dist().sample()[0]
 
         pickled_state = pickle.dumps(state)
@@ -401,10 +409,10 @@ class TestEnvironmentSerializationRoundTrip:
         Test type: integration
         """
         environments = [
-            TigerPOMDP(discount_factor=0.95),
-            SanityPOMDP(discount_factor=0.95),
-            PacManPOMDP(discount_factor=0.95),
-            DiscreteLightDarkPOMDP(discount_factor=0.95),
+            TigerPOMDP(discount_factor=0.95, **tiger_pinned_kwargs()),
+            SanityPOMDP(discount_factor=0.95, **sanity_pinned_kwargs()),
+            PacManPOMDP(discount_factor=0.95, **pacman_pinned_kwargs()),
+            DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs()),
         ]
 
         for env in environments:
@@ -445,7 +453,9 @@ class TestEnvironmentSerializationRoundTrip:
         Test type: unit
         """
         # Test continuous environments that use numpy arrays
-        env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+        env = ContinuousLightDarkPOMDP(
+            discount_factor=0.95, **continuous_light_dark_pinned_kwargs()
+        )
 
         # Sample state
         state = env.initial_state_dist().sample()[0]

--- a/POMDPPlanners/tests/test_environments/test_environment_visualizations_golden_files.py
+++ b/POMDPPlanners/tests/test_environments/test_environment_visualizations_golden_files.py
@@ -78,6 +78,16 @@ from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_po
 from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_visualizer import (
     SafeAntVelocityVisualizer,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_laser_tag_pinned_kwargs,
+    continuous_light_dark_pinned_kwargs,
+    continuous_push_pinned_kwargs,
+    laser_tag_pinned_kwargs,
+    pacman_pinned_kwargs,
+    push_pinned_kwargs,
+    rock_sample_pinned_kwargs,
+    safety_ant_velocity_pinned_kwargs,
+)
 
 
 # Golden files directory
@@ -189,11 +199,13 @@ def create_deterministic_rock_sample_episode(seed: int = 42) -> List[StepData]:
     """
     np.random.seed(seed)
     env = RockSamplePOMDP(
-        map_size=(5, 5),
-        rock_positions=[(1, 1), (2, 3), (4, 2)],
-        dangerous_areas=[(2, 2)],
-        dangerous_area_radius=1.0,
         discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=(5, 5),
+            rock_positions=[(1, 1), (2, 3), (4, 2)],
+            dangerous_areas=[(2, 2)],
+            dangerous_area_radius=1.0,
+        ),
     )
 
     state = env.initial_state_dist().sample()[0]
@@ -251,9 +263,13 @@ def create_deterministic_pacman_episode(seed: int = 42) -> List[StepData]:
     # the episode deterministic end-to-end.
     _pacman_native.set_seed(seed)
     env = PacManPOMDP(
-        maze_size=(7, 7),
-        num_ghosts=2,
         discount_factor=0.95,
+        **pacman_pinned_kwargs(
+            maze_size=(7, 7),
+            num_ghosts=2,
+            initial_ghost_positions=None,
+            ghost_strategies=None,
+        ),
     )
 
     state = env.initial_state_dist().sample()[0]
@@ -312,6 +328,7 @@ def create_deterministic_light_dark_episode(seed: int = 42) -> List[StepData]:
     _ld_native.set_seed(seed)
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
+        **continuous_light_dark_pinned_kwargs(),
     )
 
     state = env.initial_state_dist().sample()[0]
@@ -372,8 +389,10 @@ def create_deterministic_push_episode(seed: int = 42) -> List[StepData]:
     np.random.seed(seed)
     env = PushPOMDP(
         discount_factor=0.95,
-        grid_size=8,
-        transition_error_prob=0.0,  # Explicitly set for deterministic behavior
+        **push_pinned_kwargs(
+            grid_size=8,
+            transition_error_prob=0.0,  # Explicitly set for deterministic behavior
+        ),
     )
 
     state = env.initial_state_dist().sample()[0]
@@ -426,7 +445,9 @@ def create_deterministic_laser_tag_episode(seed: int = 42) -> List[StepData]:
     np.random.seed(seed)
     env = LaserTagPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.0,  # Explicitly set for deterministic behavior
+        **laser_tag_pinned_kwargs(
+            transition_error_prob=0.0,  # Explicitly set for deterministic behavior
+        ),
     )
 
     state = env.initial_state_dist().sample()[0]
@@ -485,6 +506,7 @@ def create_deterministic_safety_ant_velocity_episode(seed: int = 42) -> List[Ste
     _sa_native.set_seed(seed)
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
+        **safety_ant_velocity_pinned_kwargs(),
     )
 
     state = env.initial_state_dist().sample()[0]
@@ -540,8 +562,10 @@ def create_deterministic_continuous_laser_tag_episode(seed: int = 42) -> List[St
     _laser_tag_native.set_seed(seed)
     env = ContinuousLaserTagPOMDP(
         discount_factor=0.95,
-        robot_transition_cov_matrix=np.eye(2) * 0.01,
-        opponent_transition_cov_matrix=np.eye(2) * 0.01,
+        **continuous_laser_tag_pinned_kwargs(
+            robot_transition_cov_matrix=np.eye(2) * 0.01,
+            opponent_transition_cov_matrix=np.eye(2) * 0.01,
+        ),
     )
 
     state = env.initial_state_dist().sample()[0]
@@ -607,9 +631,11 @@ def create_deterministic_continuous_push_episode(seed: int = 42) -> List[StepDat
     _push_native.set_seed(seed)
     env = ContinuousPushPOMDP(
         discount_factor=0.99,
-        grid_size=10,
-        obstacles=[(3.0, 3.0, 0.5), (6.0, 6.0, 0.5)],
-        state_transition_cov_matrix=np.eye(2) * 0.01,
+        **continuous_push_pinned_kwargs(
+            grid_size=10,
+            obstacles=[(3.0, 3.0, 0.5), (6.0, 6.0, 0.5)],
+            state_transition_cov_matrix=np.eye(2) * 0.01,
+        ),
     )
 
     state = env.initial_state_dist().sample()[0]
@@ -700,11 +726,13 @@ class TestVisualizationConsistency:
 
         # Create environment and visualizer
         env = RockSamplePOMDP(
-            map_size=(5, 5),
-            rock_positions=[(1, 1), (2, 3), (4, 2)],
-            dangerous_areas=[(2, 2)],
-            dangerous_area_radius=1.0,
             discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                map_size=(5, 5),
+                rock_positions=[(1, 1), (2, 3), (4, 2)],
+                dangerous_areas=[(2, 2)],
+                dangerous_area_radius=1.0,
+            ),
         )
         visualizer = RockSampleVisualizer(env)
 
@@ -735,9 +763,13 @@ class TestVisualizationConsistency:
 
         # Create environment and visualizer
         env = PacManPOMDP(
-            maze_size=(7, 7),
-            num_ghosts=2,
             discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(7, 7),
+                num_ghosts=2,
+                initial_ghost_positions=None,
+                ghost_strategies=None,
+            ),
         )
         visualizer = PacManVisualizer(env)
 
@@ -769,6 +801,7 @@ class TestVisualizationConsistency:
         # Create environment and visualizer
         env = ContinuousLightDarkPOMDP(
             discount_factor=0.95,
+            **continuous_light_dark_pinned_kwargs(),
         )
         visualizer = LightDarkPOMDPVisualizer(env)
 
@@ -800,8 +833,10 @@ class TestVisualizationConsistency:
         # Create environment and visualizer
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=8,
-            transition_error_prob=0.0,  # Explicitly set for deterministic behavior
+            **push_pinned_kwargs(
+                grid_size=8,
+                transition_error_prob=0.0,  # Explicitly set for deterministic behavior
+            ),
         )
         visualizer = PushPOMDPVisualizer(env)
 
@@ -833,7 +868,9 @@ class TestVisualizationConsistency:
         # Create environment and visualizer
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.0,  # Explicitly set for deterministic behavior
+            **laser_tag_pinned_kwargs(
+                transition_error_prob=0.0,  # Explicitly set for deterministic behavior
+            ),
         )
         visualizer = LaserTagVisualizer(
             floor_shape=env.floor_shape,
@@ -870,8 +907,10 @@ class TestVisualizationConsistency:
         # Create environment and visualizer
         env = ContinuousLaserTagPOMDP(
             discount_factor=0.95,
-            robot_transition_cov_matrix=np.eye(2) * 0.01,
-            opponent_transition_cov_matrix=np.eye(2) * 0.01,
+            **continuous_laser_tag_pinned_kwargs(
+                robot_transition_cov_matrix=np.eye(2) * 0.01,
+                opponent_transition_cov_matrix=np.eye(2) * 0.01,
+            ),
         )
         visualizer = ContinuousLaserTagVisualizer(
             grid_size=env.grid_size,
@@ -910,9 +949,11 @@ class TestVisualizationConsistency:
         # Create environment and visualizer
         env = ContinuousPushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            obstacles=[(3.0, 3.0, 0.5), (6.0, 6.0, 0.5)],
-            state_transition_cov_matrix=np.eye(2) * 0.01,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                obstacles=[(3.0, 3.0, 0.5), (6.0, 6.0, 0.5)],
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+            ),
         )
         visualizer = ContinuousPushPOMDPVisualizer(env)
 
@@ -944,6 +985,7 @@ class TestVisualizationConsistency:
         # Create environment and visualizer
         env = SafeAntVelocityPOMDP(
             discount_factor=0.95,
+            **safety_ant_velocity_pinned_kwargs(),
         )
         visualizer = SafeAntVelocityVisualizer(env)
 
@@ -978,11 +1020,13 @@ class TestVisualizationDeterminism:
 
         # Create environment and visualizer
         env = RockSamplePOMDP(
-            map_size=(5, 5),
-            rock_positions=[(1, 1), (2, 3), (4, 2)],
-            dangerous_areas=[(2, 2)],
-            dangerous_area_radius=1.0,
             discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                map_size=(5, 5),
+                rock_positions=[(1, 1), (2, 3), (4, 2)],
+                dangerous_areas=[(2, 2)],
+                dangerous_area_radius=1.0,
+            ),
         )
         visualizer = RockSampleVisualizer(env)
 

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/laser_tag_pomdp_utils/test_laser_tag_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/laser_tag_pomdp_utils/test_laser_tag_reward_cpp_parity.py
@@ -30,6 +30,9 @@ from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import (
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models import (
     LaserTagRewardModel,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    laser_tag_pinned_kwargs as _lt_pinned_kwargs,
+)
 
 
 _BATCH_SIZE = 2000
@@ -53,10 +56,12 @@ def _build_env(rmt: RewardModelType) -> LaserTagPOMDP:
     """Build a discrete LaserTag env with non-empty danger zones and the chosen variant."""
     return LaserTagPOMDP(
         discount_factor=0.95,
-        dangerous_areas=_DANGEROUS_AREAS,
-        dangerous_area_penalty=_DANGEROUS_AREA_PENALTY,
-        reward_model_type=rmt,
-        penalty_decay=_PENALTY_DECAY,
+        **_lt_pinned_kwargs(
+            dangerous_areas=_DANGEROUS_AREAS,
+            dangerous_area_penalty=_DANGEROUS_AREA_PENALTY,
+            reward_model_type=rmt,
+            penalty_decay=_PENALTY_DECAY,
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/laser_tag_pomdp_utils/test_laser_tag_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/laser_tag_pomdp_utils/test_laser_tag_reward_models.py
@@ -22,6 +22,9 @@ from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_
     LaserTagZeroMeanHazardShockRewardModel,
     LaserTagRewardModel,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    laser_tag_pinned_kwargs as _lt_pinned_kwargs,
+)
 
 
 # Default ``LaserTagPOMDP`` walls / danger areas / radii — referenced by the
@@ -320,7 +323,10 @@ class TestLaserTagPOMDPRewardModelTypeWiring:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95, reward_model_type=rmt, penalty_decay=2.0)
+        env = LaserTagPOMDP(
+            discount_factor=0.95,
+            **_lt_pinned_kwargs(reward_model_type=rmt, penalty_decay=2.0),
+        )
         assert isinstance(env.reward_model, expected_cls)
 
     def test_env_default_reward_model_is_standard(self):
@@ -337,7 +343,7 @@ class TestLaserTagPOMDPRewardModelTypeWiring:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
         assert (
             type(env.reward_model) is LaserTagRewardModel
         )  # pylint: disable=unidiomatic-typecheck

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_native_equivalence.py
@@ -22,6 +22,9 @@ from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_pomdp impor
     ContinuousLaserTagPOMDP,
 )
 from POMDPPlanners.tests.test_environments import _native_parity
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_laser_tag_pinned_kwargs as _cont_lt_pinned_kwargs,
+)
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 
 
@@ -29,7 +32,7 @@ from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMulti
 def _env_fixture():
     # Use an empty-walls environment so the geometry is purely grid-bounded;
     # per-test fixtures below cover the populated-walls case separately.
-    return ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[])
+    return ContinuousLaserTagPOMDP(discount_factor=0.95, **_cont_lt_pinned_kwargs(walls=[]))
 
 
 def _build_transition_kernel(

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
@@ -26,6 +26,9 @@ from POMDPPlanners.planners.planners_utils.rollout import python_random_rollout
 from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
     verify_metrics_within_confidence_intervals,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_laser_tag_pinned_kwargs as _cont_lt_pinned_kwargs,
+)
 from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_history_returns_bounded,
     verify_metric_sanity,
@@ -38,8 +41,7 @@ def env():
     """Continuous-action environment with no walls for simpler testing."""
     return ContinuousLaserTagPOMDP(
         discount_factor=0.95,
-        walls=[],
-        dangerous_areas=[],
+        **_cont_lt_pinned_kwargs(walls=[], dangerous_areas=[]),
     )
 
 
@@ -48,21 +50,20 @@ def env_discrete():
     """Discrete-action environment with no walls for simpler testing."""
     return ContinuousLaserTagPOMDPDiscreteActions(
         discount_factor=0.95,
-        walls=[],
-        dangerous_areas=[],
+        **_cont_lt_pinned_kwargs(walls=[], dangerous_areas=[]),
     )
 
 
 @pytest.fixture
 def env_default():
     """Environment with default configuration (includes walls)."""
-    return ContinuousLaserTagPOMDP(discount_factor=0.95)
+    return ContinuousLaserTagPOMDP(discount_factor=0.95, **_cont_lt_pinned_kwargs())
 
 
 @pytest.fixture
 def env_discrete_default():
     """Discrete-action environment with default configuration."""
-    return ContinuousLaserTagPOMDPDiscreteActions(discount_factor=0.95)
+    return ContinuousLaserTagPOMDPDiscreteActions(discount_factor=0.95, **_cont_lt_pinned_kwargs())
 
 
 def test_continuous_opponent_policy_changes_config_id():
@@ -77,10 +78,24 @@ def test_continuous_opponent_policy_changes_config_id():
 
     Test type: unit
     """
-    common = {"discount_factor": 0.95, "walls": [], "dangerous_areas": []}
-    evade = ContinuousLaserTagPOMDP(**common, opponent_policy=OpponentPolicy.EVADE)
-    pursue = ContinuousLaserTagPOMDP(**common, opponent_policy=OpponentPolicy.PURSUE)
-    spotted = ContinuousLaserTagPOMDP(**common, opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED)
+    evade = ContinuousLaserTagPOMDP(
+        discount_factor=0.95,
+        **_cont_lt_pinned_kwargs(
+            walls=[], dangerous_areas=[], opponent_policy=OpponentPolicy.EVADE
+        ),
+    )
+    pursue = ContinuousLaserTagPOMDP(
+        discount_factor=0.95,
+        **_cont_lt_pinned_kwargs(
+            walls=[], dangerous_areas=[], opponent_policy=OpponentPolicy.PURSUE
+        ),
+    )
+    spotted = ContinuousLaserTagPOMDP(
+        discount_factor=0.95,
+        **_cont_lt_pinned_kwargs(
+            walls=[], dangerous_areas=[], opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED
+        ),
+    )
     assert len({evade.config_id, pursue.config_id, spotted.config_id}) == 3
 
 
@@ -116,7 +131,7 @@ class TestContinuousLaserTagPOMDPInit:
         Test type: unit
         """
         with pytest.raises(ValueError, match="discount_factor"):
-            ContinuousLaserTagPOMDP(discount_factor=1.5)
+            ContinuousLaserTagPOMDP(discount_factor=1.5, **_cont_lt_pinned_kwargs())
 
     def test_default_walls(self, env_default):
         """Test that default walls are loaded.
@@ -252,9 +267,11 @@ class TestSampleNextState:
         np.random.seed(0)
         env = ContinuousLaserTagPOMDP(
             discount_factor=0.95,
-            walls=[],
-            dangerous_areas=[],
-            robot_transition_cov_matrix=np.eye(2) * 1e-9,
+            **_cont_lt_pinned_kwargs(
+                walls=[],
+                dangerous_areas=[],
+                robot_transition_cov_matrix=np.eye(2) * 1e-9,
+            ),
         )
         state = np.array([5.0, 3.0, 5.4, 3.0, 0.0])
         action = np.array([1.0, 0.0, 0.0])  # robot moves +x, crossing to the opponent's right
@@ -280,9 +297,11 @@ class TestSampleNextState:
         np.random.seed(42)
         env = ContinuousLaserTagPOMDP(
             discount_factor=0.95,
-            walls=[],
-            dangerous_areas=[],
-            opponent_policy=OpponentPolicy.PURSUE,
+            **_cont_lt_pinned_kwargs(
+                walls=[],
+                dangerous_areas=[],
+                opponent_policy=OpponentPolicy.PURSUE,
+            ),
         )
         state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
         action = np.array([0.0, 0.0, 0.0])  # robot holds position, no tag
@@ -312,10 +331,12 @@ class TestSampleNextState:
         np.random.seed(0)
         env = ContinuousLaserTagPOMDP(
             discount_factor=0.95,
-            walls=[],
-            dangerous_areas=[],
-            robot_transition_cov_matrix=np.eye(2) * 1e-9,
-            opponent_policy=OpponentPolicy.PURSUE,
+            **_cont_lt_pinned_kwargs(
+                walls=[],
+                dangerous_areas=[],
+                robot_transition_cov_matrix=np.eye(2) * 1e-9,
+                opponent_policy=OpponentPolicy.PURSUE,
+            ),
         )
         state = np.array([5.0, 3.0, 5.4, 3.0, 0.0])
         action = np.array([1.0, 0.0, 0.0])  # robot moves +x, crossing to the opponent's right
@@ -342,9 +363,11 @@ class TestSampleNextState:
         np.random.seed(42)
         env = ContinuousLaserTagPOMDP(
             discount_factor=0.95,
-            walls=[],
-            dangerous_areas=[],
-            opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED,
+            **_cont_lt_pinned_kwargs(
+                walls=[],
+                dangerous_areas=[],
+                opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED,
+            ),
         )
         state = np.array([5.0, 3.0, 8.0, 3.0, 0.0])
         action = np.array([0.0, 0.0, 0.0])  # robot holds position, no tag
@@ -373,9 +396,11 @@ class TestSampleNextState:
         np.random.seed(42)
         env = ContinuousLaserTagPOMDP(
             discount_factor=0.95,
-            walls=[],
-            dangerous_areas=[],
-            opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED,
+            **_cont_lt_pinned_kwargs(
+                walls=[],
+                dangerous_areas=[],
+                opponent_policy=OpponentPolicy.EVADE_WHEN_SPOTTED,
+            ),
         )
         state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
         action = np.array([0.0, 0.0, 0.0])  # robot holds position, no tag
@@ -463,7 +488,8 @@ class TestSampleObservation:
         """
         np.random.seed(0)
         env = ContinuousLaserTagPOMDP(
-            discount_factor=0.95, walls=[], dangerous_areas=[], measurement_noise=1e-6
+            discount_factor=0.95,
+            **_cont_lt_pinned_kwargs(walls=[], dangerous_areas=[], measurement_noise=1e-6),
         )
         state = np.array([5.0, 3.0, 8.0, 3.0, 0.0])
         obs = np.asarray(env.sample_observation(state, np.array([0.0, 0.0, 0.0]), n_samples=1))
@@ -552,10 +578,12 @@ class TestReward:
         """
         env = ContinuousLaserTagPOMDP(
             discount_factor=0.95,
-            walls=[],
-            dangerous_areas=[(5.0, 3.0)],
-            dangerous_area_radius=1.0,
-            dangerous_area_penalty=5.0,
+            **_cont_lt_pinned_kwargs(
+                walls=[],
+                dangerous_areas=[(5.0, 3.0)],
+                dangerous_area_radius=1.0,
+                dangerous_area_penalty=5.0,
+            ),
         )
         state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
         action = np.array([1.0, 0.0, 0.0])
@@ -570,11 +598,13 @@ class TestStochasticDangerousAreaPenalty:
     def _stochastic_env(hit_probability: float, penalty: float = 5.0) -> ContinuousLaserTagPOMDP:
         return ContinuousLaserTagPOMDP(
             discount_factor=0.95,
-            walls=[],
-            dangerous_areas=[(5.0, 3.0)],
-            dangerous_area_radius=1.0,
-            dangerous_area_penalty=penalty,
-            dangerous_area_hit_probability=hit_probability,
+            **_cont_lt_pinned_kwargs(
+                walls=[],
+                dangerous_areas=[(5.0, 3.0)],
+                dangerous_area_radius=1.0,
+                dangerous_area_penalty=penalty,
+                dangerous_area_hit_probability=hit_probability,
+            ),
         )
 
     def test_default_hit_probability_is_one(self, env_default):
@@ -716,7 +746,7 @@ class TestStochasticDangerousAreaPenalty:
         with pytest.raises(ValueError, match="dangerous_area_hit_probability"):
             ContinuousLaserTagPOMDP(
                 discount_factor=0.95,
-                dangerous_area_hit_probability=bad_value,
+                **_cont_lt_pinned_kwargs(dangerous_area_hit_probability=bad_value),
             )
 
     def test_discrete_actions_wrapper_forwards_hit_probability(self):
@@ -736,11 +766,13 @@ class TestStochasticDangerousAreaPenalty:
         """
         env = ContinuousLaserTagPOMDPDiscreteActions(
             discount_factor=0.95,
-            walls=[],
-            dangerous_areas=[(5.0, 3.0)],
-            dangerous_area_radius=1.0,
-            dangerous_area_penalty=5.0,
-            dangerous_area_hit_probability=0.0,
+            **_cont_lt_pinned_kwargs(
+                walls=[],
+                dangerous_areas=[(5.0, 3.0)],
+                dangerous_area_radius=1.0,
+                dangerous_area_penalty=5.0,
+                dangerous_area_hit_probability=0.0,
+            ),
         )
         assert env.dangerous_area_hit_probability == 0.0
         state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
@@ -763,11 +795,13 @@ class TestContinuousLaserTagRewardNextStateConsistency:
     def _danger_env(hit_probability: float = 1.0) -> ContinuousLaserTagPOMDP:
         return ContinuousLaserTagPOMDP(
             discount_factor=0.95,
-            walls=[],
-            dangerous_areas=[(5.0, 3.0)],
-            dangerous_area_radius=1.0,
-            dangerous_area_penalty=5.0,
-            dangerous_area_hit_probability=hit_probability,
+            **_cont_lt_pinned_kwargs(
+                walls=[],
+                dangerous_areas=[(5.0, 3.0)],
+                dangerous_area_radius=1.0,
+                dangerous_area_penalty=5.0,
+                dangerous_area_hit_probability=hit_probability,
+            ),
         )
 
     def test_reward_penalty_uses_realised_next_state(self):
@@ -960,8 +994,7 @@ class TestInitialStateDist:
         fixed = np.array([2.0, 3.0, 8.0, 5.0, 0.0])
         env = ContinuousLaserTagPOMDP(
             discount_factor=0.95,
-            walls=[],
-            initial_state=fixed,
+            **_cont_lt_pinned_kwargs(walls=[], initial_state=fixed),
         )
         dist = env.initial_state_dist()
         samples = dist.sample(n_samples=5)
@@ -1347,10 +1380,12 @@ class TestMetrics:
         np.random.seed(42)
         env = ContinuousLaserTagPOMDP(
             discount_factor=0.95,
-            walls=[],
-            dangerous_areas=[(5.0, 3.0)],
-            dangerous_area_radius=1.0,
-            dangerous_area_penalty=5.0,
+            **_cont_lt_pinned_kwargs(
+                walls=[],
+                dangerous_areas=[(5.0, 3.0)],
+                dangerous_area_radius=1.0,
+                dangerous_area_penalty=5.0,
+            ),
         )
         dummy_belief = WeightedParticleBelief(
             particles=[np.array([5.0, 3.0, 8.0, 5.0, 0.0])],
@@ -1574,7 +1609,9 @@ class TestObservationLogProbabilityTerminal:
 
         Test type: unit
         """
-        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        env = ContinuousLaserTagPOMDP(
+            discount_factor=0.95, **_cont_lt_pinned_kwargs(walls=[], dangerous_areas=[])
+        )
         terminal_state = np.array([3.0, 3.0, 8.0, 5.0, 1.0])
         action = np.array([0.0, 0.0, 1.0])
         terminal_obs = np.full(8, -1.0)
@@ -1607,7 +1644,9 @@ class TestObservationLogProbabilityScalarBatchTerminalParity:
     """
 
     def _build_env(self) -> ContinuousLaserTagPOMDP:
-        return ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        return ContinuousLaserTagPOMDP(
+            discount_factor=0.95, **_cont_lt_pinned_kwargs(walls=[], dangerous_areas=[])
+        )
 
     def test_scalar_matches_batch_nonterminal_state_terminal_obs(self) -> None:
         """Non-terminal next_state with terminal-sentinel obs returns -inf on both paths.
@@ -1728,8 +1767,7 @@ class TestContinuousLaserTagNativeRollout:
         """
         env = ContinuousLaserTagPOMDP(
             discount_factor=0.95,
-            walls=[],
-            dangerous_areas=[],
+            **_cont_lt_pinned_kwargs(walls=[], dangerous_areas=[]),
         )
         state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
         max_depth = 10
@@ -1797,7 +1835,9 @@ class TestContinuousLaserTagNativeRollout:
             def sample(self, belief_node=None):  # pylint: disable=unused-argument
                 return np.array([1.0, 0.0, 0.0])
 
-        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        env = ContinuousLaserTagPOMDP(
+            discount_factor=0.95, **_cont_lt_pinned_kwargs(walls=[], dangerous_areas=[])
+        )
         terminal_state = np.array([5.0, 3.0, 5.0, 3.0, 1.0])
         result = env.simulate_random_rollout(
             state=terminal_state,
@@ -1824,7 +1864,9 @@ class TestContinuousLaserTagNativeRollout:
             def sample(self, belief_node=None):  # pylint: disable=unused-argument
                 return np.array([1.0, 0.0, 0.0])
 
-        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        env = ContinuousLaserTagPOMDP(
+            discount_factor=0.95, **_cont_lt_pinned_kwargs(walls=[], dangerous_areas=[])
+        )
         state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
         result = env.simulate_random_rollout(
             state=state,
@@ -1851,8 +1893,7 @@ class TestContinuousLaserTagNativeRollout:
         """
         env = ContinuousLaserTagPOMDPDiscreteActions(
             discount_factor=0.95,
-            walls=[],
-            dangerous_areas=[],
+            **_cont_lt_pinned_kwargs(walls=[], dangerous_areas=[]),
         )
         state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
         max_depth = 8
@@ -1926,7 +1967,9 @@ class TestObservationLogProbabilityLowDensityB1:
 
         Test type: unit
         """
-        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        env = ContinuousLaserTagPOMDP(
+            discount_factor=0.95, **_cont_lt_pinned_kwargs(walls=[], dangerous_areas=[])
+        )
         action = np.array([1.0, 0.0, 0.0])
         next_state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
 
@@ -1975,7 +2018,9 @@ class TestObservationLogProbabilityLowDensityB1:
 
         Test type: unit
         """
-        env = ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[], dangerous_areas=[])
+        env = ContinuousLaserTagPOMDP(
+            discount_factor=0.95, **_cont_lt_pinned_kwargs(walls=[], dangerous_areas=[])
+        )
         action = np.array([1.0, 0.0, 0.0])
         next_state = np.array([3.0, 3.0, 8.0, 5.0, 0.0])
 

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -23,10 +23,14 @@ from POMDPPlanners.core.environment import SpaceType
 from POMDPPlanners.core.policy import Policy, PolicyRunData, PolicySpaceInfo
 from POMDPPlanners.core.simulation import History, StepData
 from POMDPPlanners.environments.laser_tag_pomdp import LaserTagPOMDP, OpponentPolicy
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import RewardModelType
 from POMDPPlanners.planners.planners_utils.dpw import ActionSampler
 from POMDPPlanners.simulations.episodes import run_episode
 from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
     verify_metrics_within_confidence_intervals,
+)
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    laser_tag_pinned_kwargs as _lt_pinned_kwargs,
 )
 from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_history_returns_bounded,
@@ -136,12 +140,14 @@ def _make_env(
     """Build a LaserTagPOMDP with empty dangerous areas for transition/observation tests."""
     return LaserTagPOMDP(
         discount_factor=0.95,
-        floor_shape=floor_shape,
-        walls=walls if walls is not None else set(),
-        dangerous_areas=set(),
-        measurement_noise=measurement_noise,
-        transition_error_prob=transition_error_prob,
-        opponent_policy=opponent_policy,
+        **_lt_pinned_kwargs(
+            floor_shape=floor_shape,
+            walls=walls if walls is not None else set(),
+            dangerous_areas=set(),
+            measurement_noise=measurement_noise,
+            transition_error_prob=transition_error_prob,
+            opponent_policy=opponent_policy,
+        ),
     )
 
 
@@ -960,16 +966,16 @@ class TestLaserTagPOMDPTransitionError:
         """
         # Test negative value
         with pytest.raises(ValueError, match="transition_error_prob must be between 0 and 1"):
-            LaserTagPOMDP(discount_factor=0.95, transition_error_prob=-0.1)
+            LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs(transition_error_prob=-0.1))
 
         # Test value > 1.0
         with pytest.raises(ValueError, match="transition_error_prob must be between 0 and 1"):
-            LaserTagPOMDP(discount_factor=0.95, transition_error_prob=1.1)
+            LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs(transition_error_prob=1.1))
 
         # Test valid values should not raise
-        LaserTagPOMDP(discount_factor=0.95, transition_error_prob=0.0)
-        LaserTagPOMDP(discount_factor=0.95, transition_error_prob=0.5)
-        LaserTagPOMDP(discount_factor=0.95, transition_error_prob=1.0)
+        LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs(transition_error_prob=0.0))
+        LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs(transition_error_prob=0.5))
+        LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs(transition_error_prob=1.0))
 
     def test_transition_error_probability_stored_on_environment(self):
         """Test that transition_error_prob is stored on the environment.
@@ -982,7 +988,7 @@ class TestLaserTagPOMDPTransitionError:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95, transition_error_prob=0.3)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs(transition_error_prob=0.3))
         assert env.transition_error_prob == 0.3
 
     def test_transition_error_probability_default_zero(self):
@@ -997,7 +1003,7 @@ class TestLaserTagPOMDPTransitionError:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95, dangerous_areas=set())
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs(dangerous_areas=set()))
         assert env.transition_error_prob == 0.0, "Default transition_error_prob should be 0.0"
 
         np.random.seed(42)
@@ -1021,7 +1027,7 @@ class TestLaserTagPOMDPTransitionError:
         Test type: integration
         """
         np.random.seed(42)  # For reproducibility
-        env = LaserTagPOMDP(discount_factor=0.95, transition_error_prob=0.7)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs(transition_error_prob=0.7))
         state = np.array([3.0, 5.0, 1.0, 1.0, 0.0])
 
         # Sample many transitions with North action (0) via the env-level API.
@@ -1326,7 +1332,7 @@ class TestLaserTagPOMDP:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
 
         assert env.discount_factor == 0.95
         assert env.floor_shape == (11, 7)
@@ -1360,7 +1366,7 @@ class TestLaserTagPOMDP:
         Test type: unit
         """
         walls = {(3, 3), (4, 4)}
-        env = LaserTagPOMDP(discount_factor=0.95, walls=walls)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs(walls=walls))
 
         assert env.walls == walls
 
@@ -1376,7 +1382,7 @@ class TestLaserTagPOMDP:
         Test type: unit
         """
         # Create environment with no dangerous areas to get deterministic rewards
-        env = LaserTagPOMDP(discount_factor=0.95, dangerous_areas=set())
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs(dangerous_areas=set()))
 
         # Test successful tag - using position (1, 1) which is not in default dangerous areas
         same_pos_state = np.array([1.0, 1.0, 1.0, 1.0, 0.0])
@@ -1408,7 +1414,7 @@ class TestLaserTagPOMDP:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
 
         non_terminal = np.array([3.0, 5.0, 2.0, 4.0, 0.0])
         terminal = np.array([3.0, 5.0, 3.0, 5.0, 1.0])
@@ -1427,7 +1433,10 @@ class TestLaserTagPOMDP:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95, tag_reward=15.0, tag_penalty=20.0, step_cost=2.0)
+        env = LaserTagPOMDP(
+            discount_factor=0.95,
+            **_lt_pinned_kwargs(tag_reward=15.0, tag_penalty=20.0, step_cost=2.0),
+        )
 
         # Expected calculation from LaserTagPOMDP constructor:
         # reward_range=(-tag_penalty, tag_reward) = (-20.0, 15.0)
@@ -1438,7 +1447,8 @@ class TestLaserTagPOMDP:
 
         # Test with different parameters
         env2 = LaserTagPOMDP(
-            discount_factor=0.95, tag_reward=50.0, tag_penalty=100.0, step_cost=1.0
+            discount_factor=0.95,
+            **_lt_pinned_kwargs(tag_reward=50.0, tag_penalty=100.0, step_cost=1.0),
         )
 
         expected_min2 = -100.0  # Failed tag penalty
@@ -1457,7 +1467,7 @@ class TestLaserTagPOMDP:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
         initial_dist = env.initial_state_dist()
 
         # Sample several initial states
@@ -1483,7 +1493,7 @@ class TestLaserTagPOMDP:
         Test type: unit
         """
         # Test 1: When initial_state is None (default), should return uniform distribution
-        env_default = LaserTagPOMDP(discount_factor=0.95)
+        env_default = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
         assert env_default.initial_state is None
 
         initial_dist_default = env_default.initial_state_dist()
@@ -1499,7 +1509,9 @@ class TestLaserTagPOMDP:
 
         # Test 2: When initial_state is set, should return that state with probability 1.0
         start_state = np.array([2.0, 3.0, 5.0, 6.0, 0.0])
-        env_custom = LaserTagPOMDP(discount_factor=0.95, initial_state=start_state)
+        env_custom = LaserTagPOMDP(
+            discount_factor=0.95, **_lt_pinned_kwargs(initial_state=start_state)
+        )
         assert env_custom.initial_state is not None
         assert np.array_equal(env_custom.initial_state, start_state)
 
@@ -1546,7 +1558,7 @@ class TestLaserTagPOMDP:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
 
         obs1 = (2.0, 4.0, 1.5, 3.2, 2.8, 1.1, 0.9, 2.5)
         obs2 = (2.0, 4.0, 1.5, 3.2, 2.8, 1.1, 0.9, 2.5)
@@ -1567,7 +1579,7 @@ class TestLaserTagPOMDP:
         Test type: unit
         """
         walls = {(3, 3)}
-        env = LaserTagPOMDP(discount_factor=0.95, walls=walls)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs(walls=walls))
 
         # Create mock history with wall collision
         # Create a simple belief for testing
@@ -1682,7 +1694,8 @@ class TestLaserTagPOMDP:
         """
         walls = {(3, 3)}
         env = LaserTagPOMDP(
-            discount_factor=0.95, walls=walls, dangerous_area_penalty=5.0, step_cost=1.0
+            discount_factor=0.95,
+            **_lt_pinned_kwargs(walls=walls, dangerous_area_penalty=5.0, step_cost=1.0),
         )
 
         # Robot at (3, 2); attempted East move into wall at (3, 3).
@@ -1724,7 +1737,8 @@ class TestLaserTagPOMDP:
         """
         walls = {(3, 3)}
         env = LaserTagPOMDP(
-            discount_factor=0.95, walls=walls, dangerous_area_penalty=5.0, step_cost=1.0
+            discount_factor=0.95,
+            **_lt_pinned_kwargs(walls=walls, dangerous_area_penalty=5.0, step_cost=1.0),
         )
 
         # Will-collide: robot at (3, 2) attempting East move into wall
@@ -1766,11 +1780,13 @@ class TestLaserTagPOMDP:
         # Create LaserTag environment with known configuration
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            tag_reward=10.0,
-            tag_penalty=10.0,
-            step_cost=1.0,
-            measurement_noise=0.1,
-            dangerous_areas={(3, 3), (4, 4)},  # Add some dangerous areas
+            **_lt_pinned_kwargs(
+                tag_reward=10.0,
+                tag_penalty=10.0,
+                step_cost=1.0,
+                measurement_noise=0.1,
+                dangerous_areas={(3, 3), (4, 4)},  # Add some dangerous areas
+            ),
         )
 
         # Generate realistic episode histories by running environment simulation
@@ -1914,7 +1930,7 @@ class TestLaserTagPOMDP:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
 
         # Create test belief
         dummy_particles = [np.array([3.0, 5.0, 2.0, 4.0, 0.0])]
@@ -2037,9 +2053,11 @@ def test_metrics_confidence_intervals():
     # Create a LaserTagPOMDP environment with smaller grid for faster testing
     env = LaserTagPOMDP(
         discount_factor=0.95,
-        floor_shape=(7, 7),  # Smaller grid for faster episodes
-        walls={(2, 2), (3, 4), (5, 1)},  # Some walls for variety
-        dangerous_areas={(1, 3), (4, 4)},  # Some dangerous areas
+        **_lt_pinned_kwargs(
+            floor_shape=(7, 7),  # Smaller grid for faster episodes
+            walls={(2, 2), (3, 4), (5, 1)},  # Some walls for variety
+            dangerous_areas={(1, 3), (4, 4)},  # Some dangerous areas
+        ),
     )
 
     # Create random policy and initial belief
@@ -2105,7 +2123,7 @@ class TestLaserTagRewardBatch:
     """
 
     def _make_env(self) -> LaserTagPOMDP:
-        return LaserTagPOMDP(discount_factor=0.95)
+        return LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
 
     def _sample_states(self, env: LaserTagPOMDP, n: int, seed: int = 0) -> np.ndarray:
         np.random.seed(seed)
@@ -2239,11 +2257,13 @@ class TestLaserTagRewardNextStateConsistency:
         """
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            walls=set(),
-            dangerous_areas={(5, 5)},
-            dangerous_area_radius=0.0,
-            dangerous_area_penalty=5.0,
-            step_cost=1.0,
+            **_lt_pinned_kwargs(
+                walls=set(),
+                dangerous_areas={(5, 5)},
+                dangerous_area_radius=0.0,
+                dangerous_area_penalty=5.0,
+                step_cost=1.0,
+            ),
         )
         state = np.array([4.0, 5.0, 0.0, 0.0, 0.0])  # robot at (4, 5)
         # Realised next_state: robot landed at (5, 5) (the danger cell).
@@ -2280,11 +2300,13 @@ class TestLaserTagRewardNextStateConsistency:
         """
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            walls={(3, 3)},
-            dangerous_areas={(3, 3)},
-            dangerous_area_radius=0.0,
-            dangerous_area_penalty=5.0,
-            step_cost=1.0,
+            **_lt_pinned_kwargs(
+                walls={(3, 3)},
+                dangerous_areas={(3, 3)},
+                dangerous_area_radius=0.0,
+                dangerous_area_penalty=5.0,
+                step_cost=1.0,
+            ),
         )
         state = np.array([3.0, 2.0, 0.0, 0.0, 0.0])
         # Realised next_state: robot stayed at (3, 2) (wall blocked the East move).
@@ -2322,12 +2344,14 @@ class TestLaserTagRewardNextStateConsistency:
         """
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            walls={(3, 3), (4, 5)},
-            dangerous_areas={(2, 5), (5, 3)},
-            dangerous_area_radius=1.0,
-            dangerous_area_penalty=5.0,
-            step_cost=1.0,
-            transition_error_prob=0.5,
+            **_lt_pinned_kwargs(
+                walls={(3, 3), (4, 5)},
+                dangerous_areas={(2, 5), (5, 3)},
+                dangerous_area_radius=1.0,
+                dangerous_area_penalty=5.0,
+                step_cost=1.0,
+                transition_error_prob=0.5,
+            ),
         )
         np.random.seed(0)
         state = np.array([3.0, 4.0, 1.0, 1.0, 0.0])
@@ -2365,11 +2389,13 @@ class TestLaserTagRewardNextStateConsistency:
         """
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            walls={(3, 3)},
-            dangerous_areas={(5, 5)},
-            dangerous_area_radius=0.0,
-            dangerous_area_penalty=5.0,
-            step_cost=1.0,
+            **_lt_pinned_kwargs(
+                walls={(3, 3)},
+                dangerous_areas={(5, 5)},
+                dangerous_area_radius=0.0,
+                dangerous_area_penalty=5.0,
+                step_cost=1.0,
+            ),
         )
         states = np.array(
             [
@@ -2456,7 +2482,9 @@ class TestNativeDiscreteRollout:
 
         Test type: integration
         """
-        env = LaserTagPOMDP(discount_factor=0.95, opponent_policy=opponent_policy)
+        env = LaserTagPOMDP(
+            discount_factor=0.95, **_lt_pinned_kwargs(opponent_policy=opponent_policy)
+        )
         state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])
         max_depth = 15
         discount = 0.95
@@ -2561,7 +2589,7 @@ class TestNativeDiscreteRollout:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
         state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])
         from POMDPPlanners.environments.laser_tag_pomdp import (
             _native,
@@ -2589,7 +2617,7 @@ class TestNativeDiscreteRollout:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
         terminal_state = np.array([3.0, 2.0, 3.0, 2.0, 1.0])
         from POMDPPlanners.environments.laser_tag_pomdp import (
             _native,
@@ -2619,10 +2647,12 @@ class TestNativeDiscreteRollout:
         """
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            tag_reward=10.0,
-            tag_penalty=10.0,
-            step_cost=1.0,
-            dangerous_area_penalty=5.0,
+            **_lt_pinned_kwargs(
+                tag_reward=10.0,
+                tag_penalty=10.0,
+                step_cost=1.0,
+                dangerous_area_penalty=5.0,
+            ),
         )
         state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])
         max_depth = 5
@@ -2671,7 +2701,7 @@ class TestNativeDiscreteRolloutRewardVariantGating:
 
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            reward_model_type=RewardModelType.CONSTANT_HAZARD_PENALTY,
+            **_lt_pinned_kwargs(reward_model_type=RewardModelType.CONSTANT_HAZARD_PENALTY),
         )
         state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])
 
@@ -2715,7 +2745,7 @@ class TestNativeDiscreteRolloutRewardVariantGating:
 
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+            **_lt_pinned_kwargs(reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK),
         )
         state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])
 
@@ -2759,8 +2789,10 @@ class TestNativeDiscreteRolloutRewardVariantGating:
 
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
-            penalty_decay=1.5,
+            **_lt_pinned_kwargs(
+                reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
+                penalty_decay=1.5,
+            ),
         )
         state = np.array([0.0, 0.0, 6.0, 5.0, 0.0])
 

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -1215,6 +1215,93 @@ class TestLaserTagObservation:
 
         assert all(p > 0 for p in probs), f"All probabilities should be positive, got {probs}"
 
+    def test_observation_discriminates_opponent_on_laser_ray(self):
+        """Test the observation model detects an opponent that sits on a laser ray.
+
+        Purpose: Validates that when the opponent lies on one of the robot's 8 laser
+            rays, the in-sight laser reading is far more likely under the in-sight
+            state than under a state where the opponent has left that ray
+
+        Given: A wall-free 7x11 grid, robot fixed at (3, 3); the in-sight state places
+            the opponent 3 cells East at (3, 6) (blocking the East beam at reading
+            distance-1 = 2), and the out-of-sight state moves the opponent off every
+            ray to (4, 6) so the East beam runs to the grid edge (reading 7)
+        When: env.observation_log_probability scores the noiseless in-sight laser
+            reading (3, 3, 2, 3, 3, 3, 3, 3) against both states
+        Then: the in-sight likelihood equals the analytic Gaussian maximum and is more
+            than 1000x larger than the out-of-sight likelihood (East beam differs by 5
+            cells with sigma=1)
+
+        Test type: unit
+        """
+        env = _make_env(floor_shape=(7, 11), walls=set(), measurement_noise=1.0)
+
+        state_in_sight = np.array([3.0, 3.0, 3.0, 6.0, 0.0])
+        state_out_of_sight = np.array([3.0, 3.0, 4.0, 6.0, 0.0])
+
+        # Noiseless true laser ranges for the in-sight state: the opponent blocks the
+        # East beam (reading distance-1 = 2); every other beam runs to the grid edge,
+        # 3 cells from the centre cell (3, 3).
+        in_sight_measurement = (3.0, 3.0, 2.0, 3.0, 3.0, 3.0, 3.0, 3.0)
+
+        p_in = _observation_probabilities(env, state_in_sight, 0, [in_sight_measurement])[0]
+        p_out = _observation_probabilities(env, state_out_of_sight, 0, [in_sight_measurement])[0]
+
+        # All 8 diffs are zero under the in-sight state, so the likelihood is the
+        # product of 8 Gaussian peaks. This also confirms the hardcoded reading is
+        # exactly the true range vector.
+        expected_max = (1.0 / np.sqrt(2 * np.pi)) ** 8
+        assert np.isclose(
+            p_in, expected_max
+        ), f"In-sight reading should be the max-likelihood observation, got {p_in}"
+        assert p_in > p_out, f"Expected in-sight > out-of-sight, got {p_in} vs {p_out}"
+        assert (
+            p_out < p_in * 1e-3
+        ), f"Out-of-sight likelihood should be far smaller, got {p_out} vs {p_in}"
+
+    def test_observation_blind_to_off_ray_opponent_position(self):
+        """Test the observation model carries no information for off-ray opponents.
+
+        Purpose: Demonstrates the LaserTag blindspot: when the opponent is off all 8
+            laser rays, the observation likelihood is identical regardless of where the
+            opponent actually is, so the laser cannot localise it
+
+        Given: A wall-free 7x11 grid, robot fixed at (3, 3), and two states whose
+            opponents sit at different off-ray cells (4, 6) and (1, 2) at different
+            Euclidean distances from the robot
+        When: env.observation_log_probability scores the same observations (the free
+            ranges (3, 3, 7, 3, 3, 3, 3, 3) and an arbitrary noisy vector) against both
+            states
+        Then: the two states yield identical log-likelihoods for every observation, and
+            the free-range vector is the max-likelihood observation for both, proving
+            the opponent's position leaves no imprint on the observation
+
+        Test type: unit
+        """
+        env = _make_env(floor_shape=(7, 11), walls=set(), measurement_noise=1.0)
+
+        state_opp_a = np.array([3.0, 3.0, 4.0, 6.0, 0.0])  # opponent at (4, 6)
+        state_opp_b = np.array([3.0, 3.0, 1.0, 2.0, 0.0])  # opponent at (1, 2)
+
+        # With no opponent on any ray, every beam runs to the grid edge, so both states
+        # share the same true ranges: 7 cells East, 3 cells in every other direction.
+        free_ranges = (3.0, 3.0, 7.0, 3.0, 3.0, 3.0, 3.0, 3.0)
+        noisy_obs = (2.4, 3.1, 6.5, 2.9, 3.3, 2.7, 3.0, 3.2)
+
+        for obs in (free_ranges, noisy_obs):
+            log_a = env.observation_log_probability(state_opp_a, 0, [obs])
+            log_b = env.observation_log_probability(state_opp_b, 0, [obs])
+            assert np.allclose(log_a, log_b), (
+                "Observation likelihood must be identical for the two off-ray opponent "
+                f"positions, but got {log_a} vs {log_b}"
+            )
+
+        expected_max = (1.0 / np.sqrt(2 * np.pi)) ** 8
+        p_free = _observation_probabilities(env, state_opp_a, 0, [free_ranges])[0]
+        assert np.isclose(
+            p_free, expected_max
+        ), f"Free ranges should be the max-likelihood observation, got {p_free}"
+
 
 class TestLaserTagPOMDP:
     """Test main LaserTag POMDP environment functionality.

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_continuous_laser_tag_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_continuous_laser_tag_belief_factory.py
@@ -16,19 +16,28 @@ from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_pomdp impor
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_beliefs.continuous_laser_tag_belief_factory import (
     create_continuous_laser_tag_belief,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_laser_tag_discrete_actions_pinned_kwargs,
+    continuous_laser_tag_pinned_kwargs,
+)
 from POMDPPlanners.utils.belief_factory import BeliefType, create_environment_belief
 
 
 @pytest.fixture
 def env():
     np.random.seed(42)
-    return ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[])
+    return ContinuousLaserTagPOMDP(
+        discount_factor=0.95, **continuous_laser_tag_pinned_kwargs(walls=[])
+    )
 
 
 @pytest.fixture
 def env_discrete():
     np.random.seed(42)
-    return ContinuousLaserTagPOMDPDiscreteActions(discount_factor=0.95, walls=[])
+    return ContinuousLaserTagPOMDPDiscreteActions(
+        discount_factor=0.95,
+        **continuous_laser_tag_discrete_actions_pinned_kwargs(walls=[]),
+    )
 
 
 class TestCreateContinuousLaserTagBelief:

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_continuous_laser_tag_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_continuous_laser_tag_vectorized_updater.py
@@ -27,6 +27,10 @@ from POMDPPlanners.tests.test_core.test_belief.belief_equivalence_utils import (
 from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
     assert_batch_obs_log_likelihood_matches_loop,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_laser_tag_discrete_actions_pinned_kwargs,
+    continuous_laser_tag_pinned_kwargs,
+)
 
 
 def _make_aligned_beliefs(updater, n_particles=20):
@@ -60,12 +64,17 @@ def _make_aligned_beliefs(updater, n_particles=20):
 
 @pytest.fixture
 def env():
-    return ContinuousLaserTagPOMDP(discount_factor=0.95, walls=[])
+    return ContinuousLaserTagPOMDP(
+        discount_factor=0.95, **continuous_laser_tag_pinned_kwargs(walls=[])
+    )
 
 
 @pytest.fixture
 def env_discrete():
-    return ContinuousLaserTagPOMDPDiscreteActions(discount_factor=0.95, walls=[])
+    return ContinuousLaserTagPOMDPDiscreteActions(
+        discount_factor=0.95,
+        **continuous_laser_tag_discrete_actions_pinned_kwargs(walls=[]),
+    )
 
 
 @pytest.fixture

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_laser_tag_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_laser_tag_belief_factory.py
@@ -17,12 +17,15 @@ from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import LaserTagP
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_beliefs import (
     create_laser_tag_belief,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    laser_tag_pinned_kwargs as _lt_pinned_kwargs,
+)
 from POMDPPlanners.utils.belief_factory import BeliefType
 
 
 @pytest.fixture
 def env():
-    return LaserTagPOMDP(discount_factor=0.95)
+    return LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
 
 
 class TestCreateLaserTagBelief:

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_laser_tag_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_laser_tag_vectorized_updater.py
@@ -18,6 +18,9 @@ from collections import Counter
 import numpy as np
 import pytest
 
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
 from POMDPPlanners.environments.laser_tag_pomdp import LaserTagPOMDP, OpponentPolicy
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_beliefs import (
     LaserTagVectorizedUpdater,
@@ -656,3 +659,133 @@ class TestEquivalenceWithPerParticleLoop:
         assert result[1] == 0.0  # terminal
         assert result[2] == -np.inf  # non-terminal
         assert result[3] == 0.0  # terminal
+
+
+# ---------------------------------------------------------------------------
+# Belief filtering: ESS-gated resampling drops off-sight particles
+# ---------------------------------------------------------------------------
+
+# Open 7x15 grid scenario shared by the resampling tests.
+_ROBOT = (3, 5)
+_TRUE_OPP = (3, 8)  # 3 cells East of the robot, on the East laser ray (in sight)
+_FAR_OFF_RAY = (0, 12)  # far from the robot and off all 8 laser rays (never spotted)
+_NEAR_THRESHOLD = 2.0  # opponent within this many cells of _TRUE_OPP counts as "relevant"
+
+# Noiseless laser reading for robot (3, 5), opponent (3, 8) on an open 7x15 grid:
+# the opponent blocks the East beam (reading distance-1 = 2); West runs 5 cells to
+# the edge; every other beam runs 3 cells to the edge. The no-opponent reading would
+# show East = 9, so this observation is informative about the opponent's location.
+_IN_SIGHT_OBS = np.array([3.0, 3.0, 2.0, 3.0, 3.0, 3.0, 5.0, 3.0])
+
+
+def _make_open_env() -> LaserTagPOMDP:
+    """Build a wall-free 7x15 LaserTag env with unit measurement noise."""
+    return LaserTagPOMDP(
+        discount_factor=0.95,
+        floor_shape=(7, 15),
+        walls=set(),
+        dangerous_areas=set(),
+        measurement_noise=1.0,
+    )
+
+
+def _mixed_belief(
+    n_relevant: int, n_irrelevant: int, ess_factor: float
+) -> VectorizedWeightedParticleBelief:
+    """Build a uniform-weight belief mixing near-true and far off-ray particles."""
+    relevant = np.tile(np.array([*_ROBOT, *_TRUE_OPP, 0.0], dtype=float), (n_relevant, 1))
+    irrelevant = np.tile(np.array([*_ROBOT, *_FAR_OFF_RAY, 0.0], dtype=float), (n_irrelevant, 1))
+    particles = np.vstack([relevant, irrelevant])
+    log_weights = np.full(len(particles), -np.log(len(particles)))
+    updater = LaserTagVectorizedUpdater.from_environment(_make_open_env())
+    return VectorizedWeightedParticleBelief(
+        particles, log_weights, updater, resampling=True, ess_factor=ess_factor
+    )
+
+
+def _opp_distance_from_true(belief: VectorizedWeightedParticleBelief) -> np.ndarray:
+    """Euclidean distance of each particle's opponent cell from _TRUE_OPP."""
+    opp = belief.particles[:, 2:4]
+    return np.sqrt(((opp - np.array(_TRUE_OPP, dtype=float)) ** 2).sum(axis=1))
+
+
+class TestLaserTagBeliefResamplingFiltering:
+    """Test ESS-gated resampling filters off-sight particles in the LaserTag belief.
+
+    Purpose: Validates that the dedicated LaserTag belief, driven by
+        LaserTagVectorizedUpdater, removes particles whose opponent is far and out of
+        the laser's line of sight once an in-sight observation collapses their weights
+
+    Given: A VectorizedWeightedParticleBelief mixing a minority of near-true particles
+        with a majority of far off-ray particles
+    When: The belief is updated with an in-sight laser observation
+    Then: Resampling fires (or is gated off) according to the ESS threshold
+
+    Test type: integration
+    """
+
+    def test_resampling_filters_off_sight_particles(self):
+        """Test an in-sight observation filters out far off-ray particles via resampling.
+
+        Purpose: Validates that the ESS-gated resample step removes irrelevant particles
+            (opponent far and off the laser line of sight) when the observation strongly
+            favours the minority near the true opponent location
+
+        Given: A 200-particle belief (40 near the true opponent at (3, 8), 160 far
+            off-ray at (0, 12)) with resampling enabled and ess_factor=0.5, so the
+            threshold is 100 effective particles
+        When: The belief is updated with the in-sight observation (East beam blocked at
+            reading 2); the post-reweight ESS (~20) falls below the threshold
+        Then: Resampling fires (weights reset to uniform) and every surviving particle
+            places the opponent within 2 cells of the true location — all 160 far
+            off-ray particles are filtered out
+
+        Test type: integration
+        """
+        np.random.seed(0)
+        belief = _mixed_belief(n_relevant=40, n_irrelevant=160, ess_factor=0.5)
+
+        assert belief.n_particles == 200
+        assert int((_opp_distance_from_true(belief) > _NEAR_THRESHOLD).sum()) == 160
+
+        updated = belief.update(action=4, observation=_IN_SIGHT_OBS)
+
+        assert updated.n_particles == 200
+        assert np.allclose(
+            updated.log_weights, updated.log_weights[0]
+        ), "Resampling should have fired and reset weights to uniform"
+        assert (
+            int((_opp_distance_from_true(updated) > _NEAR_THRESHOLD).sum()) == 0
+        ), "All far off-sight particles should have been filtered out"
+
+    def test_resampling_gated_off_keeps_irrelevant_particles(self):
+        """Test irrelevant particles survive when ESS stays above the resample threshold.
+
+        Purpose: Locks in that the filtering is ESS-gated, not automatic: with the same
+            degenerate weights but a threshold below the ESS, the resample step does not
+            fire and the far off-sight particles remain in the belief
+
+        Given: The identical 200-particle mix (40 near-true, 160 far off-ray) and the
+            same in-sight observation, but ess_factor=0.05 so the threshold is only 10
+            effective particles — below the post-reweight ESS (~20)
+        When: The belief is updated
+        Then: Resampling does not fire (weights stay non-uniform), all 160 far off-ray
+            particles survive, yet they carry essentially zero normalized weight — the
+            reweight captured the information, only the gated resample step removes them
+
+        Test type: integration
+        """
+        np.random.seed(0)
+        belief = _mixed_belief(n_relevant=40, n_irrelevant=160, ess_factor=0.05)
+
+        updated = belief.update(action=4, observation=_IN_SIGHT_OBS)
+
+        assert not np.allclose(
+            updated.log_weights, updated.log_weights[0]
+        ), "Resampling should not have fired, so weights should remain non-uniform"
+
+        far_mask = _opp_distance_from_true(updated) > _NEAR_THRESHOLD
+        assert int(far_mask.sum()) == 160, "Far off-sight particles should not be filtered out"
+        assert (
+            updated.normalized_weights[far_mask].sum() < 1e-6
+        ), "Surviving far particles should carry essentially zero weight"

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_laser_tag_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp_beliefs/test_laser_tag_vectorized_updater.py
@@ -28,6 +28,9 @@ from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_beliefs import (
 from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
     assert_batch_obs_log_likelihood_matches_loop,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    laser_tag_pinned_kwargs as _lt_pinned_kwargs,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -39,9 +42,11 @@ from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils imp
 def env():
     return LaserTagPOMDP(
         discount_factor=0.95,
-        floor_shape=(11, 7),
-        walls={(1, 2), (3, 0), (3, 4), (5, 0), (6, 4), (9, 1), (9, 4), (10, 6)},
-        measurement_noise=1.0,
+        **_lt_pinned_kwargs(
+            floor_shape=(11, 7),
+            walls={(1, 2), (3, 0), (3, 4), (5, 0), (6, 4), (9, 1), (9, 4), (10, 6)},
+            measurement_noise=1.0,
+        ),
     )
 
 
@@ -49,9 +54,11 @@ def env():
 def env_no_walls():
     return LaserTagPOMDP(
         discount_factor=0.95,
-        floor_shape=(5, 5),
-        walls=set(),
-        measurement_noise=1.0,
+        **_lt_pinned_kwargs(
+            floor_shape=(5, 5),
+            walls=set(),
+            measurement_noise=1.0,
+        ),
     )
 
 
@@ -306,10 +313,12 @@ class TestBatchTransition:
         """
         env = LaserTagPOMDP(
             discount_factor=0.95,
-            floor_shape=(7, 11),
-            walls=walls,
-            dangerous_areas=set(),
-            opponent_policy=opponent_policy,
+            **_lt_pinned_kwargs(
+                floor_shape=(7, 11),
+                walls=walls,
+                dangerous_areas=set(),
+                opponent_policy=opponent_policy,
+            ),
         )
         updater = LaserTagVectorizedUpdater.from_environment(env)
         state = np.array([2.0, 5.0, 5.0, 5.0, 0.0])
@@ -499,9 +508,11 @@ class TestConfigId:
 
         env2 = LaserTagPOMDP(
             discount_factor=0.95,
-            floor_shape=env.floor_shape,
-            walls=env.walls,
-            measurement_noise=env.measurement_noise * 2,
+            **_lt_pinned_kwargs(
+                floor_shape=env.floor_shape,
+                walls=env.walls,
+                measurement_noise=env.measurement_noise * 2,
+            ),
         )
         u2 = LaserTagVectorizedUpdater.from_environment(env2)
         assert u1.config_id != u2.config_id
@@ -682,10 +693,12 @@ def _make_open_env() -> LaserTagPOMDP:
     """Build a wall-free 7x15 LaserTag env with unit measurement noise."""
     return LaserTagPOMDP(
         discount_factor=0.95,
-        floor_shape=(7, 15),
-        walls=set(),
-        dangerous_areas=set(),
-        measurement_noise=1.0,
+        **_lt_pinned_kwargs(
+            floor_shape=(7, 15),
+            walls=set(),
+            dangerous_areas=set(),
+            measurement_noise=1.0,
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_reward_native.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_reward_native.py
@@ -30,6 +30,9 @@ from POMDPPlanners.environments.laser_tag_pomdp import _native
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils.laser_tag_reward_models import (
     LaserTagRewardModel,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    laser_tag_pinned_kwargs as _lt_pinned_kwargs,
+)
 
 
 def _reference_reward_batch_python(
@@ -97,7 +100,7 @@ def _build_state_batch() -> np.ndarray:
 @pytest.fixture(name="default_env")
 def _default_env_fixture() -> LaserTagPOMDP:
     """Default LaserTag env (uses the built-in dangerous_areas + walls)."""
-    return LaserTagPOMDP(discount_factor=0.95)
+    return LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
 
 
 @pytest.fixture(name="explicit_env")
@@ -105,7 +108,7 @@ def _explicit_env_fixture() -> LaserTagPOMDP:
     """LaserTag env with an explicit dangerous_areas set ({(2,3),(5,5)})."""
     return LaserTagPOMDP(
         discount_factor=0.95,
-        dangerous_areas={(2, 3), (5, 5)},
+        **_lt_pinned_kwargs(dangerous_areas={(2, 3), (5, 5)}),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_visualizer.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_visualizer.py
@@ -18,6 +18,9 @@ from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.core.policy import PolicyRunData
 from POMDPPlanners.core.simulation import History, StepData
 from POMDPPlanners.environments.laser_tag_pomdp import LaserTagPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    laser_tag_pinned_kwargs as _lt_pinned_kwargs,
+)
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -47,7 +50,7 @@ class TestLaserTagVisualization:
 
         Test type: integration
         """
-        env = LaserTagPOMDP(discount_factor=0.95)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
 
         # Create simple test history
 
@@ -117,7 +120,7 @@ class TestLaserTagVisualization:
 
         Test type: unit
         """
-        env = LaserTagPOMDP(discount_factor=0.95)
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
 
         # Create dummy history for testing
         dummy_history = History(

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/benchmark_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/benchmark_reward_models.py
@@ -30,6 +30,7 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
     ContinuousLightDarkPOMDP,
     RewardModelType,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import continuous_light_dark_pinned_kwargs
 
 # Fixed workload: 4 obstacles on a 10x10 grid, goal at (8, 8).
 GOAL_STATE = np.array([8.0, 8.0])
@@ -61,7 +62,6 @@ def _time_fn(fn: Callable[[], Any], n_runs: int) -> Tuple[float, float]:
 
 def _build_envs() -> List[Tuple[str, ContinuousLightDarkPOMDP]]:
     common = {
-        "discount_factor": 0.95,
         "goal_state": GOAL_STATE,
         "obstacles": OBSTACLES_LIST,
         "goal_state_radius": GOAL_RADIUS,
@@ -77,19 +77,31 @@ def _build_envs() -> List[Tuple[str, ContinuousLightDarkPOMDP]]:
         (
             "ConstantHazardPenalty",
             ContinuousLightDarkPOMDP(
-                reward_model_type=RewardModelType.CONSTANT_HAZARD_PENALTY, **common
+                discount_factor=0.95,
+                **continuous_light_dark_pinned_kwargs(
+                    **common,
+                    reward_model_type=RewardModelType.CONSTANT_HAZARD_PENALTY,
+                ),
             ),
         ),
         (
             "ZeroMeanHazardShock",
             ContinuousLightDarkPOMDP(
-                reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK, **common
+                discount_factor=0.95,
+                **continuous_light_dark_pinned_kwargs(
+                    **common,
+                    reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+                ),
             ),
         ),
         (
             "DistanceDecayedHazardPenalty",
             ContinuousLightDarkPOMDP(
-                reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY, **common
+                discount_factor=0.95,
+                **continuous_light_dark_pinned_kwargs(
+                    **common,
+                    reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
+                ),
             ),
         ),
     ]

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/light_dark_pomdp_utils/test_light_dark_reward_cpp_parity.py
@@ -20,14 +20,12 @@ from typing import Tuple
 import numpy as np
 import pytest
 
-from POMDPPlanners.environments.light_dark_pomdp import (
-    _native,  # pylint: disable=no-name-in-module
-)
+from POMDPPlanners.environments.light_dark_pomdp import _native  # pylint: disable=no-name-in-module
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDP,
     RewardModelType,
 )
-
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import continuous_light_dark_pinned_kwargs
 
 _REWARD_VARIANT_CODES = {
     RewardModelType.CONSTANT_HAZARD_PENALTY: 0,
@@ -48,9 +46,11 @@ def _build_env(variant: RewardModelType) -> ContinuousLightDarkPOMDP:
     # consumed by the DECAYING variant but is harmless elsewhere.
     return ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        obstacles=[(3.0, 3.0), (6.0, 6.0), (8.0, 2.0)],
-        reward_model_type=variant,
-        penalty_decay=_PENALTY_DECAY_BY_VARIANT[variant],
+        **continuous_light_dark_pinned_kwargs(
+            obstacles=[(3.0, 3.0), (6.0, 6.0), (8.0, 2.0)],
+            reward_model_type=variant,
+            penalty_decay=_PENALTY_DECAY_BY_VARIANT[variant],
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
@@ -19,21 +19,11 @@ import numpy as np
 import pytest
 from scipy.stats import multivariate_normal
 
-from POMDPPlanners.configs.environment_configs import (
-    RiskAverseEnvironmentConfigsAPI,
-)
+from POMDPPlanners.configs.environment_configs import RiskAverseEnvironmentConfigsAPI
 from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.core.distributions import DiscreteDistribution
 from POMDPPlanners.core.policy import PolicyRunData
 from POMDPPlanners.core.simulation import History, StepData
-from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
-    verify_metrics_within_confidence_intervals,
-)
-from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
-    verify_history_returns_bounded,
-    verify_metric_sanity,
-    verify_return_shift_linearity,
-)
 from POMDPPlanners.environments.light_dark_pomdp import _native
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDP,
@@ -42,10 +32,21 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
     RewardModelType,
 )
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_utils.light_dark_reward_models import (
-    ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel,
     ContinuousLDZeroMeanHazardShockRewardModel,
+    ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel,
 )
-
+from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
+    verify_metrics_within_confidence_intervals,
+)
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+    continuous_light_dark_pinned_kwargs,
+)
+from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
+    verify_history_returns_bounded,
+    verify_metric_sanity,
+    verify_return_shift_linearity,
+)
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -57,16 +58,18 @@ def base_light_dark_environment() -> ContinuousLightDarkPOMDPDiscreteActions:
     """Fixture providing a base ContinuousLightDarkPOMDP environment for comparison."""
     return ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2),
-        observation_cov_matrix=np.eye(2),
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        goal_state_radius=1.5,
-        beacon_radius=1.0,
-        obstacle_radius=1.5,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2),
+            observation_cov_matrix=np.eye(2),
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            goal_state_radius=1.5,
+            beacon_radius=1.0,
+            obstacle_radius=1.5,
+        ),
     )
 
 
@@ -74,16 +77,18 @@ def base_light_dark_environment() -> ContinuousLightDarkPOMDPDiscreteActions:
 def base_continuous_light_dark_pomdp() -> ContinuousLightDarkPOMDP:
     return ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2),
-        observation_cov_matrix=np.eye(2),
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        goal_state_radius=1.5,
-        beacon_radius=1.0,
-        obstacle_radius=1.5,
+        **continuous_light_dark_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2),
+            observation_cov_matrix=np.eye(2),
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            goal_state_radius=1.5,
+            beacon_radius=1.0,
+            obstacle_radius=1.5,
+        ),
     )
 
 
@@ -91,16 +96,18 @@ def base_continuous_light_dark_pomdp() -> ContinuousLightDarkPOMDP:
 def pomdp():
     return ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2),
-        observation_cov_matrix=np.eye(2),
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        goal_state_radius=1.5,
-        beacon_radius=1.0,
-        obstacle_radius=1.5,
+        **continuous_light_dark_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2),
+            observation_cov_matrix=np.eye(2),
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            goal_state_radius=1.5,
+            beacon_radius=1.0,
+            obstacle_radius=1.5,
+        ),
     )
 
 
@@ -113,16 +120,18 @@ class TestContinuousLightDarkPOMDPEquality:
         """Test that ContinuousLightDarkPOMDPs with same discount factor are equal."""
         other_env = ContinuousLightDarkPOMDPDiscreteActions(
             discount_factor=0.95,
-            state_transition_cov_matrix=np.eye(2),
-            observation_cov_matrix=np.eye(2),
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            goal_state_radius=1.5,
-            beacon_radius=1.0,
-            obstacle_radius=1.5,
+            **continuous_light_dark_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2),
+                observation_cov_matrix=np.eye(2),
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                goal_state_radius=1.5,
+                beacon_radius=1.0,
+                obstacle_radius=1.5,
+            ),
         )
         assert base_light_dark_environment == other_env
         assert other_env == base_light_dark_environment  # Test symmetry
@@ -133,16 +142,18 @@ class TestContinuousLightDarkPOMDPEquality:
         """Test that ContinuousLightDarkPOMDPs with different discount factors are not equal."""
         other_env = ContinuousLightDarkPOMDPDiscreteActions(
             discount_factor=0.8,
-            state_transition_cov_matrix=np.eye(2),
-            observation_cov_matrix=np.eye(2),
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            goal_state_radius=1.5,
-            beacon_radius=1.0,
-            obstacle_radius=1.5,
+            **continuous_light_dark_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2),
+                observation_cov_matrix=np.eye(2),
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                goal_state_radius=1.5,
+                beacon_radius=1.0,
+                obstacle_radius=1.5,
+            ),
         )
         assert base_light_dark_environment != other_env
         assert other_env != base_light_dark_environment  # Test symmetry
@@ -153,31 +164,35 @@ class TestContinuousLightDarkPOMDPEquality:
         """Test that ContinuousLightDarkPOMDPs with different covariance matrices are not equal."""
         other_env = ContinuousLightDarkPOMDPDiscreteActions(
             discount_factor=0.95,
-            state_transition_cov_matrix=2 * np.eye(2),  # Different state transition covariance
-            observation_cov_matrix=np.eye(2),
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            goal_state_radius=1.5,
-            beacon_radius=1.0,
-            obstacle_radius=1.5,
+            **continuous_light_dark_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=2 * np.eye(2),
+                observation_cov_matrix=np.eye(2),
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                goal_state_radius=1.5,
+                beacon_radius=1.0,
+                obstacle_radius=1.5,
+            ),
         )
         assert base_light_dark_environment != other_env
 
         other_env = ContinuousLightDarkPOMDPDiscreteActions(
             discount_factor=0.95,
-            state_transition_cov_matrix=np.eye(2),
-            observation_cov_matrix=2 * np.eye(2),  # Different observation covariance
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            goal_state_radius=1.5,
-            beacon_radius=1.0,
-            obstacle_radius=1.5,
+            **continuous_light_dark_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2),
+                observation_cov_matrix=2 * np.eye(2),
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                goal_state_radius=1.5,
+                beacon_radius=1.0,
+                obstacle_radius=1.5,
+            ),
         )
         assert base_light_dark_environment != other_env
 
@@ -187,46 +202,52 @@ class TestContinuousLightDarkPOMDPEquality:
         """Test that ContinuousLightDarkPOMDPs with different radii are not equal."""
         other_env = ContinuousLightDarkPOMDPDiscreteActions(
             discount_factor=0.95,
-            state_transition_cov_matrix=np.eye(2),
-            observation_cov_matrix=np.eye(2),
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            goal_state_radius=2.0,  # Different goal radius
-            beacon_radius=1.0,
-            obstacle_radius=1.5,
+            **continuous_light_dark_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2),
+                observation_cov_matrix=np.eye(2),
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                goal_state_radius=2.0,
+                beacon_radius=1.0,
+                obstacle_radius=1.5,
+            ),
         )
         assert base_light_dark_environment != other_env
 
         other_env = ContinuousLightDarkPOMDPDiscreteActions(
             discount_factor=0.95,
-            state_transition_cov_matrix=np.eye(2),
-            observation_cov_matrix=np.eye(2),
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            goal_state_radius=1.5,
-            beacon_radius=2.0,  # Different beacon radius
-            obstacle_radius=1.5,
+            **continuous_light_dark_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2),
+                observation_cov_matrix=np.eye(2),
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                goal_state_radius=1.5,
+                beacon_radius=2.0,
+                obstacle_radius=1.5,
+            ),
         )
         assert base_light_dark_environment != other_env
 
         other_env = ContinuousLightDarkPOMDPDiscreteActions(
             discount_factor=0.95,
-            state_transition_cov_matrix=np.eye(2),
-            observation_cov_matrix=np.eye(2),
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            goal_state_radius=1.5,
-            beacon_radius=1.0,
-            obstacle_radius=2.0,  # Different obstacle radius
+            **continuous_light_dark_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2),
+                observation_cov_matrix=np.eye(2),
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                goal_state_radius=1.5,
+                beacon_radius=1.0,
+                obstacle_radius=2.0,
+            ),
         )
         assert base_light_dark_environment != other_env
 
@@ -235,16 +256,18 @@ def test_initialization():
     """Test initialization with default parameters"""
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2),
-        observation_cov_matrix=np.eye(2),
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        goal_state_radius=1.5,
-        beacon_radius=1.0,
-        obstacle_radius=1.5,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2),
+            observation_cov_matrix=np.eye(2),
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            goal_state_radius=1.5,
+            beacon_radius=1.0,
+            obstacle_radius=1.5,
+        ),
     )
 
     # Check default parameters
@@ -276,16 +299,18 @@ def test_beacons_and_obstacles_array_structure():
     """Test that beacons and obstacles are numpy arrays with correct shapes after initialization."""
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2),
-        observation_cov_matrix=np.eye(2),
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        goal_state_radius=1.5,
-        beacon_radius=1.0,
-        obstacle_radius=1.5,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2),
+            observation_cov_matrix=np.eye(2),
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            goal_state_radius=1.5,
+            beacon_radius=1.0,
+            obstacle_radius=1.5,
+        ),
     )
 
     # Test beacons structure
@@ -344,9 +369,9 @@ def test_reward_function():
     """Test reward function"""
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        obstacle_hit_probability=1.0,
-        goal_state_radius=1.5,
-        obstacle_radius=1.5,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            obstacle_hit_probability=1.0, goal_state_radius=1.5, obstacle_radius=1.5
+        ),
     )
 
     # Test goal state reward (state within goal radius)
@@ -368,7 +393,10 @@ def test_reward_function():
 def test_is_terminal():
     """Test terminal state detection"""
     env = ContinuousLightDarkPOMDPDiscreteActions(
-        discount_factor=0.95, goal_state_radius=1.5, obstacle_radius=1.5
+        discount_factor=0.95,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state_radius=1.5, obstacle_radius=1.5
+        ),
     )
 
     # Test goal state (within radius)
@@ -400,10 +428,9 @@ def test_reward_range():
     """
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        obstacle_reward=-15.0,
-        goal_reward=25.0,
-        fuel_cost=2.0,
-        grid_size=11,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            obstacle_reward=-15.0, goal_reward=25.0, fuel_cost=2.0, grid_size=11
+        ),
     )
 
     # Expected calculation for CONSTANT_HAZARD_PENALTY reward model:
@@ -420,10 +447,9 @@ def test_reward_range():
     # Test with another environment instance with different parameters
     env2 = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.99,
-        obstacle_reward=-50.0,
-        goal_reward=100.0,
-        fuel_cost=3.0,
-        grid_size=15,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            obstacle_reward=-50.0, goal_reward=100.0, fuel_cost=3.0, grid_size=15
+        ),
     )
 
     # Calculate expected range for different parameters
@@ -438,7 +464,10 @@ def test_reward_range():
 def test_compute_metrics():
     """Test computation of metrics for different simulation histories"""
     env = ContinuousLightDarkPOMDPDiscreteActions(
-        discount_factor=0.95, goal_state_radius=1.5, obstacle_radius=1.5
+        discount_factor=0.95,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state_radius=1.5, obstacle_radius=1.5
+        ),
     )
 
     # Create test histories
@@ -549,7 +578,10 @@ def test_compute_metrics_values_within_confidence_intervals():
     Test type: integration
     """
     env = ContinuousLightDarkPOMDPDiscreteActions(
-        discount_factor=0.95, goal_state_radius=1.5, obstacle_radius=1.5
+        discount_factor=0.95,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state_radius=1.5, obstacle_radius=1.5
+        ),
     )
 
     def _make_belief(state: np.ndarray) -> WeightedParticleBelief:
@@ -812,18 +844,20 @@ def test_decaying_hit_probability_reward_model():
     """Test that the environment uses the decaying hit probability reward model when specified."""
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2),
-        observation_cov_matrix=np.eye(2),
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        goal_state_radius=1.5,
-        beacon_radius=1.0,
-        obstacle_radius=1.5,
-        reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
-        penalty_decay=0.5,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2),
+            observation_cov_matrix=np.eye(2),
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            goal_state_radius=1.5,
+            beacon_radius=1.0,
+            obstacle_radius=1.5,
+            reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
+            penalty_decay=0.5,
+        ),
     )
     assert isinstance(env.reward_model, ContinuousLightDarkDistanceDecayedHazardPenaltyRewardModel)
 
@@ -832,17 +866,19 @@ def test_high_variance_states_reward_model():
     """Test that the environment uses the high-variance states reward model when specified."""
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2),
-        observation_cov_matrix=np.eye(2),
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        goal_state_radius=1.5,
-        beacon_radius=1.0,
-        obstacle_radius=1.5,
-        reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2),
+            observation_cov_matrix=np.eye(2),
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            goal_state_radius=1.5,
+            beacon_radius=1.0,
+            obstacle_radius=1.5,
+            reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+        ),
     )
 
     # Test that the correct reward model is initialized
@@ -883,17 +919,19 @@ def test_single_obstacle_reward_behavior():
 
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2),
-        observation_cov_matrix=np.eye(2),
-        obstacle_hit_probability=1.0,  # Always hit obstacle when in range
-        obstacle_reward=-15.0,  # High negative reward for obstacle hits
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        goal_state_radius=1.5,
-        beacon_radius=1.0,
-        obstacle_radius=1.0,  # Radius of 1.0
-        obstacles=single_obstacle,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2),
+            observation_cov_matrix=np.eye(2),
+            obstacle_hit_probability=1.0,
+            obstacle_reward=-15.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            goal_state_radius=1.5,
+            beacon_radius=1.0,
+            obstacle_radius=1.0,
+            obstacles=single_obstacle,
+        ),
     )
 
     # Test state exactly at obstacle center (5, 5)
@@ -1416,9 +1454,11 @@ def test_beacon_proximity_observation_covariance_changes():
     """
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2) * 4.0,
-        beacons=[(0.0, 0.0), (5.0, 5.0), (10.0, 10.0)],
-        beacon_radius=1.0,
+        **continuous_light_dark_pinned_kwargs(
+            observation_cov_matrix=np.eye(2) * 4.0,
+            beacons=[(0.0, 0.0), (5.0, 5.0), (10.0, 10.0)],
+            beacon_radius=1.0,
+        ),
     )
     action = np.array([0.0, 0.0])
 
@@ -1456,9 +1496,11 @@ def test_beacon_proximity_with_multiple_beacons():
     """
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2) * 2.0,
-        beacons=[(0.0, 0.0), (5.0, 5.0), (10.0, 10.0)],
-        beacon_radius=1.5,
+        **continuous_light_dark_pinned_kwargs(
+            observation_cov_matrix=np.eye(2) * 2.0,
+            beacons=[(0.0, 0.0), (5.0, 5.0), (10.0, 10.0)],
+            beacon_radius=1.5,
+        ),
     )
 
     near_first_beacon = np.array([1.0, 1.0])  # Distance sqrt(2) ≈ 1.41 < 1.5 from (0,0)
@@ -1493,9 +1535,11 @@ def test_observation_model_probability_function():
     observation_cov_matrix = np.eye(2) * 0.25
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_cov_matrix=observation_cov_matrix,
-        beacons=[(0.0, 0.0), (10.0, 10.0)],
-        beacon_radius=1.0,
+        **continuous_light_dark_pinned_kwargs(
+            observation_cov_matrix=observation_cov_matrix,
+            beacons=[(0.0, 0.0), (10.0, 10.0)],
+            beacon_radius=1.0,
+        ),
     )
 
     # Single value at the mean.
@@ -1551,9 +1595,9 @@ def test_observation_model_probability_with_beacon_proximity():
     """
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2),
-        beacons=[(0.0, 0.0), (5.0, 5.0)],
-        beacon_radius=1.0,
+        **continuous_light_dark_pinned_kwargs(
+            observation_cov_matrix=np.eye(2), beacons=[(0.0, 0.0), (5.0, 5.0)], beacon_radius=1.0
+        ),
     )
     action = np.array([0.0, 0.0])
     near_state = np.array([0.5, 0.5])
@@ -1582,9 +1626,11 @@ def test_observation_model_probability_edge_cases():
     action = np.array([0.0, 0.0])
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2) * 0.1,
-        beacons=[(2.0, 2.0), (8.0, 8.0)],
-        beacon_radius=1.0,
+        **continuous_light_dark_pinned_kwargs(
+            observation_cov_matrix=np.eye(2) * 0.1,
+            beacons=[(2.0, 2.0), (8.0, 8.0)],
+            beacon_radius=1.0,
+        ),
     )
 
     # Single observation at the mean.
@@ -1607,9 +1653,11 @@ def test_observation_model_probability_edge_cases():
     # Very small covariance — density at the mean is much higher than off.
     small_env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2) * 1e-6,
-        beacons=[(2.0, 2.0), (8.0, 8.0)],
-        beacon_radius=1.0,
+        **continuous_light_dark_pinned_kwargs(
+            observation_cov_matrix=np.eye(2) * 1e-6,
+            beacons=[(2.0, 2.0), (8.0, 8.0)],
+            beacon_radius=1.0,
+        ),
     )
     exact_log = small_env.observation_log_probability(next_state, action, [next_state])[0]
     offset_log = small_env.observation_log_probability(
@@ -1632,16 +1680,18 @@ def test_start_state_not_in_obstacle_radius():
     # Test default environment configuration
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2),
-        observation_cov_matrix=np.eye(2),
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        goal_state_radius=1.5,
-        beacon_radius=1.0,
-        obstacle_radius=1.5,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2),
+            observation_cov_matrix=np.eye(2),
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            goal_state_radius=1.5,
+            beacon_radius=1.0,
+            obstacle_radius=1.5,
+        ),
     )
 
     # Check that start state is not terminal (not in obstacle radius)
@@ -1740,20 +1790,22 @@ def test_environment_configuration_obstacle_placement():
     for config in test_configs:
         env = ContinuousLightDarkPOMDPDiscreteActions(
             discount_factor=0.95,
-            state_transition_cov_matrix=np.eye(2),
-            observation_cov_matrix=np.eye(2),
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=config["grid_size"],
-            goal_state_radius=1.5,
-            beacon_radius=1.0,
-            obstacle_radius=1.5,
-            start_state=config["start_state"],
-            goal_state=config["goal_state"],
-            beacons=config["beacons"],
-            obstacles=config["obstacles"],
+            **continuous_light_dark_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2),
+                observation_cov_matrix=np.eye(2),
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=config["grid_size"],
+                goal_state_radius=1.5,
+                beacon_radius=1.0,
+                obstacle_radius=1.5,
+                start_state=config["start_state"],
+                goal_state=config["goal_state"],
+                beacons=config["beacons"],
+                obstacles=config["obstacles"],
+            ),
         )
 
         # Basic sanity checks
@@ -1794,7 +1846,7 @@ def test_continuous_light_dark_sample_next_state_shapes_and_distribution():
     """
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2) * 0.1,
+        **continuous_light_dark_pinned_kwargs(state_transition_cov_matrix=np.eye(2) * 0.1),
     )
     state = np.array([2.0, 3.0])
     action = np.array([1.0, -0.5])
@@ -1835,7 +1887,9 @@ def test_normal_noise_observation_model():
     """
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.NORMAL_NOISE,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            observation_model_type=ObservationModelType.NORMAL_NOISE
+        ),
     )
     assert env.observation_model_type == ObservationModelType.NORMAL_NOISE
 
@@ -1864,7 +1918,9 @@ def test_normal_noise_no_obs_in_dark_observation_model():
     """
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK
+        ),
     )
     assert env.observation_model_type == ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK
     action = "up"
@@ -1893,7 +1949,9 @@ def test_default_observation_model_type():
 
     Test type: unit
     """
-    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_light_dark_discrete_actions_pinned_kwargs()
+    )
     assert env.observation_model_type == ObservationModelType.NORMAL_NOISE
 
     obs = env.sample_observation(np.array([5.0, 5.0]), "up", n_samples=1)
@@ -1905,18 +1963,24 @@ def test_observation_model_type_equality():
     """Test that environments with different observation model types are not equal."""
     env1 = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.NORMAL_NOISE,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            observation_model_type=ObservationModelType.NORMAL_NOISE
+        ),
     )
     env2 = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK
+        ),
     )
     assert env1 != env2, "Environments with different observation model types should not be equal"
 
     # Test distance-based vs others
     env3 = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            observation_model_type=ObservationModelType.DISTANCE_BASED
+        ),
     )
     assert env1 != env3, "Distance-based should not equal normal noise"
     assert env2 != env3, "Distance-based should not equal no obs in dark"
@@ -1937,7 +2001,9 @@ def test_continuous_light_dark_pomdp_observation_model_type():
     """
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK,
+        **continuous_light_dark_pinned_kwargs(
+            observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK
+        ),
     )
     assert env.observation_model_type == ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK
 
@@ -1967,7 +2033,9 @@ def test_distance_based_observation_model():
     """
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            observation_model_type=ObservationModelType.DISTANCE_BASED
+        ),
     )
     assert env.observation_model_type == ObservationModelType.DISTANCE_BASED
     action = "up"
@@ -2010,10 +2078,12 @@ def test_distance_based_observation_model_binary_selection():
     """
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2) * 2.0,
-        beacon_radius=2.0,
-        beacons=[(0.0, 0.0)],
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            observation_cov_matrix=np.eye(2) * 2.0,
+            beacon_radius=2.0,
+            beacons=[(0.0, 0.0)],
+            observation_model_type=ObservationModelType.DISTANCE_BASED,
+        ),
     )
     action = "up"
 
@@ -2049,8 +2119,9 @@ def test_distance_based_observation_model_probability():
     """
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        beacon_radius=1.0,
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            beacon_radius=1.0, observation_model_type=ObservationModelType.DISTANCE_BASED
+        ),
     )
     action = "up"
 
@@ -2138,7 +2209,7 @@ def test_continuous_sample_next_state_n_samples_shapes(n_samples):
 
     Test type: unit
     """
-    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
     state = np.array([3.0, 4.0])
     action = np.array([1.0, 0.5])
 
@@ -2166,7 +2237,7 @@ def test_continuous_sample_observation_n_samples_shapes(n_samples):
 
     Test type: unit
     """
-    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
     next_state = np.array([5.0, 5.0])  # near beacon
     action = np.array([0.0, 0.0])
 
@@ -2200,7 +2271,7 @@ def test_continuous_sample_observation_n_samples_for_non_normal_noise():
     ):
         env = ContinuousLightDarkPOMDP(
             discount_factor=0.95,
-            observation_model_type=obs_type,
+            **continuous_light_dark_pinned_kwargs(observation_model_type=obs_type),
         )
         next_state = np.array([5.0, 5.0])
         action = np.array([0.0, 0.0])
@@ -2227,9 +2298,11 @@ def test_native_simulate_rollout_matches_python_rollout_seeded():
     """
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        obstacle_hit_probability=0.0,  # Deterministic rewards — no stochastic obstacle draw
-        state_transition_cov_matrix=np.eye(2) * 0.01,
-        observation_cov_matrix=np.eye(2),
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            obstacle_hit_probability=0.0,
+            state_transition_cov_matrix=np.eye(2) * 0.01,
+            observation_cov_matrix=np.eye(2),
+        ),
     )
     initial_state = np.array([1.0, 2.0])
     max_depth = 8
@@ -2297,7 +2370,9 @@ def test_native_simulate_rollout_terminal_short_circuit():
 
     Test type: unit
     """
-    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_light_dark_discrete_actions_pinned_kwargs()
+    )
 
     # Place initial state exactly at goal — is_terminal must return True
     terminal_state = env.goal_state.astype(np.float64).copy()
@@ -2347,7 +2422,7 @@ def test_continuous_light_dark_reward_batch_matches_scalar():
     """
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        obstacle_hit_probability=0.0,  # Deterministic rewards
+        **continuous_light_dark_discrete_actions_pinned_kwargs(obstacle_hit_probability=0.0),
     )
 
     np.random.seed(7)
@@ -2425,7 +2500,7 @@ def test_continuous_reward_at_goal_returns_goal_reward_minus_costs():
 
     Test type: unit
     """
-    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
     state = np.array([8.5, 5.0])
     action = np.array([1.0, 0.0])
     expected = -env.fuel_cost - 0.5 + env.goal_reward
@@ -2450,7 +2525,7 @@ def test_continuous_reward_outside_grid_returns_obstacle_reward_penalty():
 
     Test type: unit
     """
-    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
     state = np.array([5.0, 12.5])
     action = np.array([0.0, 0.0])
     dist_to_goal = float(np.linalg.norm(state - env.goal_state))
@@ -2480,7 +2555,7 @@ def test_continuous_reward_in_obstacle_zone_drifts_by_p_hit_times_obstacle_rewar
     Test type: unit
     """
     np.random.seed(2024)
-    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
     in_obs = np.array([5.0, 5.0])
     free = np.array([8.0, 4.0])
     action = np.array([0.0, 0.0])
@@ -2532,8 +2607,9 @@ def test_continuous_reward_in_obstacle_depends_on_reward_model_type(
     np.random.seed(31)
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        reward_model_type=reward_model_type,
-        penalty_decay=1.0,
+        **continuous_light_dark_pinned_kwargs(
+            reward_model_type=reward_model_type, penalty_decay=1.0
+        ),
     )
     state = np.array([5.0, 5.0])
     action = np.array([0.0, 0.0])
@@ -2582,8 +2658,9 @@ def test_continuous_decaying_hit_probability_reward_decays_with_obstacle_distanc
     np.random.seed(55)
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
-        penalty_decay=1.0,
+        **continuous_light_dark_pinned_kwargs(
+            reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY, penalty_decay=1.0
+        ),
     )
     obstacle = np.array([5.0, 5.0])
     action = np.array([0.0, 0.0])
@@ -2634,7 +2711,7 @@ def test_continuous_sample_next_state_density_matches_transition_log_probability
     np.random.seed(42)
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2) * 0.05,
+        **continuous_light_dark_pinned_kwargs(state_transition_cov_matrix=np.eye(2) * 0.05),
     )
     state = np.array([2.0, 5.0])
     action = np.array([1.0, 0.0])
@@ -2668,8 +2745,10 @@ def test_continuous_sample_observation_density_matches_log_prob_normal_noise():
     """
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2) * 0.05,
-        observation_model_type=ObservationModelType.NORMAL_NOISE,
+        **continuous_light_dark_pinned_kwargs(
+            observation_cov_matrix=np.eye(2) * 0.05,
+            observation_model_type=ObservationModelType.NORMAL_NOISE,
+        ),
     )
     action = np.array([0.0, 0.0])
     n_samples = 20_000
@@ -2710,8 +2789,10 @@ def test_continuous_sample_observation_consistency_no_obs_in_dark():
     """
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2) * 0.05,
-        observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK,
+        **continuous_light_dark_pinned_kwargs(
+            observation_cov_matrix=np.eye(2) * 0.05,
+            observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK,
+        ),
     )
     action = np.array([0.0, 0.0])
     n_samples = 20_000
@@ -2762,8 +2843,10 @@ def test_continuous_sample_observation_consistency_distance_based():
     """
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2) * 0.05,
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **continuous_light_dark_pinned_kwargs(
+            observation_cov_matrix=np.eye(2) * 0.05,
+            observation_model_type=ObservationModelType.DISTANCE_BASED,
+        ),
     )
     action = np.array([0.0, 0.0])
     n_samples = 20_000
@@ -2807,7 +2890,7 @@ def test_continuous_is_terminal_inside_goal_radius_boundary_is_true():
 
     Test type: unit
     """
-    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
     state = env.goal_state.astype(np.float64) + np.array([env.goal_state_radius - 1e-9, 0.0])
     assert env.is_terminal(state) is True
 
@@ -2824,7 +2907,7 @@ def test_continuous_is_terminal_outside_goal_radius_boundary_is_false():
 
     Test type: unit
     """
-    env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
     state = env.goal_state.astype(np.float64) + np.array([env.goal_state_radius + 1e-6, 0.0])
     assert env.is_terminal(state) is False
 
@@ -2845,8 +2928,12 @@ def test_continuous_is_obstacle_hit_terminal_flag_controls_obstacle_termination(
     Test type: unit
     """
     state = np.array([5.0, 5.0])
-    env_term = ContinuousLightDarkPOMDP(discount_factor=0.95, is_obstacle_hit_terminal=True)
-    env_continue = ContinuousLightDarkPOMDP(discount_factor=0.95, is_obstacle_hit_terminal=False)
+    env_term = ContinuousLightDarkPOMDP(
+        discount_factor=0.95, **continuous_light_dark_pinned_kwargs(is_obstacle_hit_terminal=True)
+    )
+    env_continue = ContinuousLightDarkPOMDP(
+        discount_factor=0.95, **continuous_light_dark_pinned_kwargs(is_obstacle_hit_terminal=False)
+    )
     assert env_term.is_terminal(state) is True
     assert env_continue.is_terminal(state) is False
 
@@ -2882,9 +2969,11 @@ def test_continuous_sample_outputs_finite_and_in_grid(
     np.random.seed(101)
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2) * 0.05,
-        observation_cov_matrix=np.eye(2) * 0.05,
-        observation_model_type=observation_model_type,
+        **continuous_light_dark_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2) * 0.05,
+            observation_cov_matrix=np.eye(2) * 0.05,
+            observation_model_type=observation_model_type,
+        ),
     )
     state = np.array([5.5, 5.5])
     action = np.array([0.0, 0.0])
@@ -2931,7 +3020,7 @@ def test_continuous_sample_next_state_batch_matches_looped_sample():
     """
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2) * 0.05,
+        **continuous_light_dark_pinned_kwargs(state_transition_cov_matrix=np.eye(2) * 0.05),
     )
     rng = np.random.RandomState(7)
     states = rng.uniform(0.0, env.grid_size, size=(32, 2))
@@ -2975,8 +3064,10 @@ def test_continuous_observation_log_probability_per_state_matches_scalar_normal_
     """
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2) * 0.05,
-        observation_model_type=ObservationModelType.NORMAL_NOISE,
+        **continuous_light_dark_pinned_kwargs(
+            observation_cov_matrix=np.eye(2) * 0.05,
+            observation_model_type=ObservationModelType.NORMAL_NOISE,
+        ),
     )
     rng = np.random.RandomState(13)
     next_states = rng.uniform(4.0, 6.0, size=(64, 2))
@@ -3030,8 +3121,10 @@ def test_scalar_obs_log_prob_un_floored_matches_batch_after_fix():
     """
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2) * 0.05,
-        observation_model_type=ObservationModelType.NORMAL_NOISE,
+        **continuous_light_dark_pinned_kwargs(
+            observation_cov_matrix=np.eye(2) * 0.05,
+            observation_model_type=ObservationModelType.NORMAL_NOISE,
+        ),
     )
     next_state = np.array([5.0, 5.0])
     action = np.array([0.0, 0.0])
@@ -3076,8 +3169,10 @@ def test_scalar_and_batch_obs_log_prob_share_symmetric_floor_in_deep_underflow()
     """
     env = ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2) * 0.01,
-        observation_model_type=ObservationModelType.NORMAL_NOISE,
+        **continuous_light_dark_pinned_kwargs(
+            observation_cov_matrix=np.eye(2) * 0.01,
+            observation_model_type=ObservationModelType.NORMAL_NOISE,
+        ),
     )
     next_state = np.array([5.0, 5.0])
     action = np.array([0.0, 0.0])
@@ -3129,8 +3224,9 @@ def test_observation_sampler_unbiased_near_grid_edge(obs_type: ObservationModelT
 
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        observation_cov_matrix=np.eye(2),
-        observation_model_type=obs_type,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            observation_cov_matrix=np.eye(2), observation_model_type=obs_type
+        ),
     )
     observations = env.sample_observation(next_state, "up", n_samples=n_samples)
     observations_arr = np.asarray(observations, dtype=float)
@@ -3159,20 +3255,22 @@ class TestContinuousLightDarkRewardNextStateConsistency:
     ):
         return ContinuousLightDarkPOMDP(
             discount_factor=0.95,
-            state_transition_cov_matrix=np.eye(2) * 1e-12,
-            observation_cov_matrix=np.eye(2),
-            obstacles=obstacles,
-            obstacle_hit_probability=hit_probability,
-            obstacle_reward=-25.0,
-            goal_reward=10.0,
-            fuel_cost=1.0,
-            grid_size=20,
-            goal_state=np.array([18, 5]),
-            goal_state_radius=1.0,
-            beacon_radius=1.0,
-            obstacle_radius=1.0,
-            reward_model_type=reward_model_type,
-            is_obstacle_hit_terminal=False,
+            **continuous_light_dark_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 1e-12,
+                observation_cov_matrix=np.eye(2),
+                obstacles=obstacles,
+                obstacle_hit_probability=hit_probability,
+                obstacle_reward=-25.0,
+                goal_reward=10.0,
+                fuel_cost=1.0,
+                grid_size=20,
+                goal_state=np.array([18, 5]),
+                goal_state_radius=1.0,
+                beacon_radius=1.0,
+                obstacle_radius=1.0,
+                reward_model_type=reward_model_type,
+                is_obstacle_hit_terminal=False,
+            ),
         )
 
     def test_reward_obstacle_penalty_uses_realised_next_state(self):
@@ -3270,17 +3368,19 @@ class TestContinuousLightDarkRewardNextStateConsistency:
         # rewards rather than a single value.
         env = ContinuousLightDarkPOMDP(
             discount_factor=0.95,
-            state_transition_cov_matrix=np.eye(2) * 4.0,
-            observation_cov_matrix=np.eye(2),
-            obstacles=[(5.0, 5.0)],
-            obstacle_hit_probability=1.0,
-            obstacle_reward=-50.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            goal_state_radius=1.5,
-            obstacle_radius=0.5,
-            is_obstacle_hit_terminal=False,
+            **continuous_light_dark_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 4.0,
+                observation_cov_matrix=np.eye(2),
+                obstacles=[(5.0, 5.0)],
+                obstacle_hit_probability=1.0,
+                obstacle_reward=-50.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                goal_state_radius=1.5,
+                obstacle_radius=0.5,
+                is_obstacle_hit_terminal=False,
+            ),
         )
         state = np.array([4.0, 5.0])
         action = np.array([1.0, 0.0])  # state+action == (5,5) — the obstacle
@@ -3376,20 +3476,22 @@ class TestContinuousLightDarkRewardNextStateConsistency:
         """
         env = ContinuousLightDarkPOMDP(
             discount_factor=0.95,
-            state_transition_cov_matrix=np.eye(2) * 1e-12,
-            observation_cov_matrix=np.eye(2),
-            obstacles=[(8.0, 5.0)],
-            obstacle_reward=-25.0,
-            goal_reward=10.0,
-            fuel_cost=1.0,
-            grid_size=20,
-            goal_state=np.array([18, 5]),
-            goal_state_radius=1.0,
-            beacon_radius=1.0,
-            obstacle_radius=1.0,
-            reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
-            penalty_decay=0.1,
-            is_obstacle_hit_terminal=False,
+            **continuous_light_dark_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 1e-12,
+                observation_cov_matrix=np.eye(2),
+                obstacles=[(8.0, 5.0)],
+                obstacle_reward=-25.0,
+                goal_reward=10.0,
+                fuel_cost=1.0,
+                grid_size=20,
+                goal_state=np.array([18, 5]),
+                goal_state_radius=1.0,
+                beacon_radius=1.0,
+                obstacle_radius=1.0,
+                reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
+                penalty_decay=0.1,
+                is_obstacle_hit_terminal=False,
+            ),
         )
         states = np.array([[4.0, 5.0], [4.0, 5.0], [4.0, 5.0], [4.0, 5.0]])
         action = np.array([1.0, 0.0])
@@ -3425,18 +3527,20 @@ class TestContinuousLightDarkRewardNextStateConsistency:
         """
         env = ContinuousLightDarkPOMDPDiscreteActions(
             discount_factor=0.95,
-            state_transition_cov_matrix=np.eye(2) * 1e-12,
-            observation_cov_matrix=np.eye(2),
-            obstacles=[(8.0, 5.0)],
-            obstacle_hit_probability=1.0,
-            obstacle_reward=-25.0,
-            goal_reward=10.0,
-            fuel_cost=1.0,
-            grid_size=20,
-            goal_state=np.array([18, 5]),
-            goal_state_radius=1.0,
-            obstacle_radius=1.0,
-            is_obstacle_hit_terminal=False,
+            **continuous_light_dark_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 1e-12,
+                observation_cov_matrix=np.eye(2),
+                obstacles=[(8.0, 5.0)],
+                obstacle_hit_probability=1.0,
+                obstacle_reward=-25.0,
+                goal_reward=10.0,
+                fuel_cost=1.0,
+                grid_size=20,
+                goal_state=np.array([18, 5]),
+                goal_state_radius=1.0,
+                obstacle_radius=1.0,
+                is_obstacle_hit_terminal=False,
+            ),
         )
         state = np.array([4.0, 5.0])
         clean = np.array([5.0, 5.0])

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_native_step.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_native_step.py
@@ -23,21 +23,22 @@ from typing import Any, List, Tuple
 import numpy as np
 import pytest
 
-from POMDPPlanners.environments.light_dark_pomdp import (
-    _native,  # pylint: disable=no-name-in-module
-)
+from POMDPPlanners.environments.light_dark_pomdp import _native  # pylint: disable=no-name-in-module
 from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
     DiscreteLightDarkPOMDP,
     ObservationModelType,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import discrete_light_dark_pinned_kwargs
 
 
 def _make_env() -> DiscreteLightDarkPOMDP:
     return DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        beacons=[(0, 0), (5, 5)],
-        beacon_radius=1.5,
-        observation_model_type=ObservationModelType.NORMAL,
+        **discrete_light_dark_pinned_kwargs(
+            beacons=[(0, 0), (5, 5)],
+            beacon_radius=1.5,
+            observation_model_type=ObservationModelType.NORMAL,
+        ),
     )
 
 
@@ -150,9 +151,11 @@ def test_native_sample_next_state_empirical_distribution_matches_cumprobs() -> N
     """
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.1,
-        beacons=[(0, 0)],
-        observation_model_type=ObservationModelType.NORMAL,
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.1,
+            beacons=[(0, 0)],
+            observation_model_type=ObservationModelType.NORMAL,
+        ),
     )
     state = np.array([3, 4])
     success_offset = env.action_to_vector["up"]
@@ -192,10 +195,12 @@ def test_native_sample_observation_empirical_distribution_matches_cumprobs() -> 
     """
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        observation_error_prob=0.2,
-        beacons=[(5, 5)],
-        beacon_radius=1.5,
-        observation_model_type=ObservationModelType.NORMAL,
+        **discrete_light_dark_pinned_kwargs(
+            observation_error_prob=0.2,
+            beacons=[(5, 5)],
+            beacon_radius=1.5,
+            observation_model_type=ObservationModelType.NORMAL,
+        ),
     )
     next_state = np.array([5, 5])
     no_noise_outcome = (5.0, 5.0)

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_pomdp.py
@@ -21,17 +21,18 @@ from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.core.distributions import DiscreteDistribution
 from POMDPPlanners.core.policy import PolicyRunData
 from POMDPPlanners.core.simulation import History, StepData
+from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
+    DiscreteLightDarkPOMDP,
+    ObservationModelType,
+)
 from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
     verify_metrics_within_confidence_intervals,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import discrete_light_dark_pinned_kwargs
 from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_history_returns_bounded,
     verify_metric_sanity,
     verify_return_shift_linearity,
-)
-from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
-    DiscreteLightDarkPOMDP,
-    ObservationModelType,
 )
 
 # Set seeds for reproducible tests
@@ -44,14 +45,16 @@ def base_light_dark_environment() -> DiscreteLightDarkPOMDP:
     """Fixture providing a base DiscreteLightDarkPOMDP environment for comparison."""
     return DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.05,
-        observation_error_prob=0.05,
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        is_stochastic_reward=True,
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.05,
+            observation_error_prob=0.05,
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            is_stochastic_reward=True,
+        ),
     )
 
 
@@ -71,14 +74,16 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+            ),
         )
         assert base_light_dark_environment == other_env
         assert other_env == base_light_dark_environment  # Test symmetry
@@ -96,14 +101,16 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.8,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+            ),
         )
         assert base_light_dark_environment != other_env
         assert other_env != base_light_dark_environment  # Test symmetry
@@ -121,14 +128,16 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.1,  # Different transition error
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.1,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+            ),
         )
         assert base_light_dark_environment != other_env
 
@@ -145,14 +154,16 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.1,  # Different observation error
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.1,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+            ),
         )
         assert base_light_dark_environment != other_env
 
@@ -169,25 +180,27 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
-            beacons=[
-                (1, 1),
-                (1, 6),
-                (1, 11),
-                (6, 1),
-                (6, 6),
-                (6, 11),
-                (11, 1),
-                (11, 6),
-                (11, 11),
-            ],  # Different beacons
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+                beacons=[
+                    (1, 1),
+                    (1, 6),
+                    (1, 11),
+                    (6, 1),
+                    (6, 6),
+                    (6, 11),
+                    (11, 1),
+                    (11, 6),
+                    (11, 11),
+                ],
+            ),
         )
         assert base_light_dark_environment != other_env
 
@@ -204,15 +217,17 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
-            obstacles=[(4, 8), (6, 6)],  # Different obstacles
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+                obstacles=[(4, 8), (6, 6)],
+            ),
         )
         assert base_light_dark_environment != other_env
 
@@ -229,15 +244,17 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
-            goal_state=np.array([9, 4]),  # Different goal state
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+                goal_state=np.array([9, 4]),
+            ),
         )
         assert base_light_dark_environment != other_env
 
@@ -254,15 +271,17 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
-            start_state=np.array([1, 4]),  # Different start state
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+                start_state=np.array([1, 4]),
+            ),
         )
         assert base_light_dark_environment != other_env
 
@@ -279,14 +298,16 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-20.0,  # Different obstacle reward
-            goal_reward=20.0,  # Different goal reward
-            fuel_cost=3.0,  # Different fuel cost
-            grid_size=11,
-            is_stochastic_reward=True,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-20.0,
+                goal_reward=20.0,
+                fuel_cost=3.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+            ),
         )
         assert base_light_dark_environment != other_env
 
@@ -303,14 +324,16 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=15,  # Different grid size
-            is_stochastic_reward=True,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=15,
+                is_stochastic_reward=True,
+            ),
         )
         assert base_light_dark_environment != other_env
 
@@ -327,15 +350,17 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
-            beacon_radius=2.0,  # Different beacon radius
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+                beacon_radius=2.0,
+            ),
         )
         assert base_light_dark_environment != other_env
 
@@ -352,14 +377,16 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=False,  # Different stochastic reward setting
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=False,
+            ),
         )
         assert base_light_dark_environment != other_env
 
@@ -393,28 +420,32 @@ class TestDiscreteLightDarkPOMDPEquality:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+            ),
         )
         delattr(other_env, "beacons")
         assert base_light_dark_environment != other_env
 
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+            ),
         )
         delattr(other_env, "obstacles")
         assert base_light_dark_environment != other_env
@@ -452,14 +483,16 @@ class TestDiscreteLightDarkPOMDPConfigId:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+            ),
         )
         assert base_light_dark_environment.config_id == other_env.config_id
 
@@ -478,14 +511,16 @@ class TestDiscreteLightDarkPOMDPConfigId:
         """
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.8,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+            ),
         )
         assert base_light_dark_environment.config_id != other_env.config_id
 
@@ -505,53 +540,59 @@ class TestDiscreteLightDarkPOMDPConfigId:
         # Test different transition error
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.1,  # Different
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.1,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+            ),
         )
         assert base_light_dark_environment.config_id != other_env.config_id
 
         # Test different observation error
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.1,  # Different
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.1,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+            ),
         )
         assert base_light_dark_environment.config_id != other_env.config_id
 
         # Test different beacons
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
-            beacons=[
-                (1, 1),
-                (1, 6),
-                (1, 11),
-                (6, 1),
-                (6, 6),
-                (6, 11),
-                (11, 1),
-                (11, 6),
-                (11, 11),
-            ],  # Different
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+                beacons=[
+                    (1, 1),
+                    (1, 6),
+                    (1, 11),
+                    (6, 1),
+                    (6, 6),
+                    (6, 11),
+                    (11, 1),
+                    (11, 6),
+                    (11, 11),
+                ],
+            ),
         )
         assert base_light_dark_environment.config_id != other_env.config_id
 
@@ -614,15 +655,17 @@ class TestDiscreteLightDarkPOMDPConfigId:
 
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
-            beacons=beacons_reordered,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+                beacons=beacons_reordered,
+            ),
         )
         assert base_light_dark_environment.config_id == other_env.config_id
 
@@ -633,31 +676,35 @@ class TestDiscreteLightDarkPOMDPConfigId:
 
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
-            obstacles=obstacles_reordered,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+                obstacles=obstacles_reordered,
+            ),
         )
         assert base_light_dark_environment.config_id == other_env.config_id
 
         # Test both beacons and obstacles reordered together
         other_env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.05,
-            observation_error_prob=0.05,
-            obstacle_hit_probability=0.2,
-            obstacle_reward=-10.0,
-            goal_reward=10.0,
-            fuel_cost=2.0,
-            grid_size=11,
-            is_stochastic_reward=True,
-            beacons=beacons_reordered,
-            obstacles=obstacles_reordered,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.05,
+                observation_error_prob=0.05,
+                obstacle_hit_probability=0.2,
+                obstacle_reward=-10.0,
+                goal_reward=10.0,
+                fuel_cost=2.0,
+                grid_size=11,
+                is_stochastic_reward=True,
+                beacons=beacons_reordered,
+                obstacles=obstacles_reordered,
+            ),
         )
         assert base_light_dark_environment.config_id == other_env.config_id
 
@@ -675,14 +722,16 @@ def test_initialization():
     """
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.05,
-        observation_error_prob=0.05,
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        is_stochastic_reward=True,
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.05,
+            observation_error_prob=0.05,
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            is_stochastic_reward=True,
+        ),
     )
 
     # Check default parameters
@@ -725,14 +774,16 @@ def test_beacons_and_obstacles_array_structure():
     """
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.05,
-        observation_error_prob=0.05,
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        is_stochastic_reward=True,
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.05,
+            observation_error_prob=0.05,
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            is_stochastic_reward=True,
+        ),
     )
 
     # Test beacons structure
@@ -801,16 +852,18 @@ def test_custom_beacons_and_obstacles_array_structure():
 
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.05,
-        observation_error_prob=0.05,
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        is_stochastic_reward=True,
-        beacons=custom_beacons,
-        obstacles=custom_obstacles,
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.05,
+            observation_error_prob=0.05,
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            is_stochastic_reward=True,
+            beacons=custom_beacons,
+            obstacles=custom_obstacles,
+        ),
     )
 
     # Test custom beacons structure
@@ -876,16 +929,18 @@ def test_empty_beacons_and_obstacles():
     """
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.05,
-        observation_error_prob=0.05,
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        is_stochastic_reward=True,
-        beacons=[],  # Empty beacons
-        obstacles=[],  # Empty obstacles
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.05,
+            observation_error_prob=0.05,
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            is_stochastic_reward=True,
+            beacons=[],
+            obstacles=[],
+        ),
     )
 
     # Test empty beacons structure
@@ -920,7 +975,9 @@ def test_state_transition_model():
 
     Test type: unit
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95, transition_error_prob=0.1)
+    env = DiscreteLightDarkPOMDP(
+        discount_factor=0.95, **discrete_light_dark_pinned_kwargs(transition_error_prob=0.1)
+    )
     state = np.array([5, 5])
 
     candidates = [
@@ -949,7 +1006,9 @@ def test_reward_function():
 
     Test type: unit
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95, obstacle_hit_probability=1.0)
+    env = DiscreteLightDarkPOMDP(
+        discount_factor=0.95, **discrete_light_dark_pinned_kwargs(obstacle_hit_probability=1.0)
+    )
 
     # Test goal state reward
     state = np.array([9, 5])
@@ -981,7 +1040,7 @@ def test_is_terminal():
 
     Test type: unit
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
 
     # Test goal state
     assert env.is_terminal(env.goal_state)
@@ -1008,7 +1067,7 @@ def test_initial_distributions():
 
     Test type: unit
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
 
     # Test initial state distribution
     state_dist = env.initial_state_dist()
@@ -1034,7 +1093,7 @@ def test_get_actions():
 
     Test type: unit
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
     actions = env.get_actions()
     assert set(actions) == {"up", "down", "right", "left"}
 
@@ -1050,7 +1109,7 @@ def test_visualize_path(tmp_path):
 
     Test type: unit
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
     path = [np.array([0, 5]), np.array([1, 5]), np.array([2, 5]), np.array([3, 5])]
 
     # Create a simple belief path for testing
@@ -1085,7 +1144,7 @@ def test_compute_metrics():
 
     Test type: unit
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
 
     # Create test histories
     # Create a simple belief for testing
@@ -1282,7 +1341,7 @@ def test_compute_metrics_values_within_confidence_intervals():
 
     Test type: integration
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
 
     def _make_belief(state: np.ndarray) -> WeightedParticleBelief:
         return WeightedParticleBelief(
@@ -1399,7 +1458,7 @@ def test_normal_observation_model():
     """
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.NORMAL,
+        **discrete_light_dark_pinned_kwargs(observation_model_type=ObservationModelType.NORMAL),
     )
     assert env.observation_model_type == ObservationModelType.NORMAL
 
@@ -1425,7 +1484,9 @@ def test_no_obs_in_dark_observation_model():
     """
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.NO_OBS_IN_DARK,
+        **discrete_light_dark_pinned_kwargs(
+            observation_model_type=ObservationModelType.NO_OBS_IN_DARK
+        ),
     )
     assert env.observation_model_type == ObservationModelType.NO_OBS_IN_DARK
     action = "up"
@@ -1453,7 +1514,7 @@ def test_default_observation_model_type():
 
     Test type: unit
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
     assert env.observation_model_type == ObservationModelType.NORMAL
 
     obs = env.sample_observation(np.array([5, 5]), "up")
@@ -1465,24 +1526,30 @@ def test_observation_model_type_equality():
     """Test that environments with different observation model types are not equal."""
     env1 = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.05,
-        observation_error_prob=0.05,
-        observation_model_type=ObservationModelType.NORMAL,
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.05,
+            observation_error_prob=0.05,
+            observation_model_type=ObservationModelType.NORMAL,
+        ),
     )
     env2 = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.05,
-        observation_error_prob=0.05,
-        observation_model_type=ObservationModelType.NO_OBS_IN_DARK,
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.05,
+            observation_error_prob=0.05,
+            observation_model_type=ObservationModelType.NO_OBS_IN_DARK,
+        ),
     )
     assert env1 != env2, "Environments with different observation model types should not be equal"
 
     # Test distance-based vs others
     env3 = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.05,
-        observation_error_prob=0.05,
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.05,
+            observation_error_prob=0.05,
+            observation_model_type=ObservationModelType.DISTANCE_BASED,
+        ),
     )
     assert env1 != env3, "Distance-based should not equal normal"
     assert env2 != env3, "Distance-based should not equal no obs in dark"
@@ -1492,15 +1559,19 @@ def test_observation_model_type_config_id():
     """Test that config_id changes with different observation model types."""
     env1 = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.05,
-        observation_error_prob=0.05,
-        observation_model_type=ObservationModelType.NORMAL,
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.05,
+            observation_error_prob=0.05,
+            observation_model_type=ObservationModelType.NORMAL,
+        ),
     )
     env2 = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.05,
-        observation_error_prob=0.05,
-        observation_model_type=ObservationModelType.NO_OBS_IN_DARK,
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.05,
+            observation_error_prob=0.05,
+            observation_model_type=ObservationModelType.NO_OBS_IN_DARK,
+        ),
     )
     assert (
         env1.config_id != env2.config_id
@@ -1509,9 +1580,11 @@ def test_observation_model_type_config_id():
     # Test distance-based produces different config_id
     env3 = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.05,
-        observation_error_prob=0.05,
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.05,
+            observation_error_prob=0.05,
+            observation_model_type=ObservationModelType.DISTANCE_BASED,
+        ),
     )
     assert (
         env1.config_id != env3.config_id
@@ -1541,8 +1614,9 @@ def test_distance_based_observation_model():
     """
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        observation_error_prob=0.05,
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **discrete_light_dark_pinned_kwargs(
+            observation_error_prob=0.05, observation_model_type=ObservationModelType.DISTANCE_BASED
+        ),
     )
     assert env.observation_model_type == ObservationModelType.DISTANCE_BASED
     action = "up"
@@ -1594,9 +1668,11 @@ def test_distance_based_observation_model_continuous_scaling():
     """
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        observation_error_prob=0.1,
-        beacon_radius=2.0,
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **discrete_light_dark_pinned_kwargs(
+            observation_error_prob=0.1,
+            beacon_radius=2.0,
+            observation_model_type=ObservationModelType.DISTANCE_BASED,
+        ),
     )
     base_error_prob = 0.1
     action = "up"
@@ -1635,8 +1711,9 @@ def test_distance_based_observation_model_probability():
     """
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        beacon_radius=1.0,
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **discrete_light_dark_pinned_kwargs(
+            beacon_radius=1.0, observation_model_type=ObservationModelType.DISTANCE_BASED
+        ),
     )
     action = "up"
 
@@ -1705,7 +1782,7 @@ def test_discrete_sample_next_state_n_samples_shapes(n_samples):
 
     Test type: unit
     """
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
     state = np.array([2, 3])
     action = "up"
 
@@ -1734,9 +1811,11 @@ def test_discrete_sample_observation_n_samples_shapes_normal(n_samples):
     """
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        beacons=[(0, 0), (5, 5)],
-        beacon_radius=1.5,
-        observation_model_type=ObservationModelType.NORMAL,
+        **discrete_light_dark_pinned_kwargs(
+            beacons=[(0, 0), (5, 5)],
+            beacon_radius=1.5,
+            observation_model_type=ObservationModelType.NORMAL,
+        ),
     )
     next_state = np.array([5, 5])
     action = "up"
@@ -1770,9 +1849,9 @@ def test_discrete_sample_observation_n_samples_for_non_normal():
     ):
         env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            beacons=[(0, 0), (5, 5)],
-            beacon_radius=1.5,
-            observation_model_type=obs_type,
+            **discrete_light_dark_pinned_kwargs(
+                beacons=[(0, 0), (5, 5)], beacon_radius=1.5, observation_model_type=obs_type
+            ),
         )
         next_state = np.array([5, 5])
         action = "up"
@@ -1960,7 +2039,7 @@ def test_discrete_sample_observation_frequencies_match_log_probability_normal():
     Test type: unit
     """
     np.random.seed(101)
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
     action = "up"
     n_samples = 5_000
     tol = 3.0 / np.sqrt(n_samples)
@@ -2002,7 +2081,9 @@ def test_discrete_sample_observation_frequencies_match_log_probability_no_obs_in
     np.random.seed(202)
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.NO_OBS_IN_DARK,
+        **discrete_light_dark_pinned_kwargs(
+            observation_model_type=ObservationModelType.NO_OBS_IN_DARK
+        ),
     )
     action = "up"
     n_samples = 5_000
@@ -2051,7 +2132,9 @@ def test_discrete_sample_observation_frequencies_match_log_probability_distance_
     np.random.seed(303)
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **discrete_light_dark_pinned_kwargs(
+            observation_model_type=ObservationModelType.DISTANCE_BASED
+        ),
     )
     action = "up"
     n_samples = 5_000
@@ -2103,7 +2186,7 @@ def test_discrete_sample_outputs_lie_in_grid_or_are_none_sentinel(
     np.random.seed(404)
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        observation_model_type=observation_model_type,
+        **discrete_light_dark_pinned_kwargs(observation_model_type=observation_model_type),
     )
     state = np.array([5.0, 5.0])
     action = "up"
@@ -2155,10 +2238,12 @@ class TestDiscreteLightDarkRewardNextStateConsistency:
         """
         env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.0,
-            obstacle_hit_probability=1.0,
-            obstacles=[(5, 5)],
-            goal_state=np.array([10, 5]),
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.0,
+                obstacle_hit_probability=1.0,
+                obstacles=[(5, 5)],
+                goal_state=np.array([10, 5]),
+            ),
         )
         state = np.array([4, 4])
         action = "up"  # intended next = [4, 5] (clear)
@@ -2192,10 +2277,12 @@ class TestDiscreteLightDarkRewardNextStateConsistency:
         """
         env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.0,
-            obstacle_hit_probability=1.0,
-            obstacles=[(5, 5)],
-            goal_state=np.array([10, 5]),
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.0,
+                obstacle_hit_probability=1.0,
+                obstacles=[(5, 5)],
+                goal_state=np.array([10, 5]),
+            ),
         )
         state = np.array([4, 5])
         action = "right"  # intended next = [5, 5] (obstacle)
@@ -2225,11 +2312,13 @@ class TestDiscreteLightDarkRewardNextStateConsistency:
         """
         env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.5,
-            obstacle_hit_probability=1.0,
-            obstacles=[(5, 5), (3, 7)],
-            goal_state=np.array([10, 5]),
-            observation_model_type=ObservationModelType.DISTANCE_BASED,
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.5,
+                obstacle_hit_probability=1.0,
+                obstacles=[(5, 5), (3, 7)],
+                goal_state=np.array([10, 5]),
+                observation_model_type=ObservationModelType.DISTANCE_BASED,
+            ),
         )
 
         np.random.seed(7)
@@ -2272,10 +2361,12 @@ class TestDiscreteLightDarkRewardNextStateConsistency:
         """
         env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.0,
-            obstacle_hit_probability=1.0,
-            obstacles=[(5, 5)],
-            goal_state=np.array([10, 5]),
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.0,
+                obstacle_hit_probability=1.0,
+                obstacles=[(5, 5)],
+                goal_state=np.array([10, 5]),
+            ),
         )
         states = np.array([[4, 4], [4, 5]], dtype=float)
         next_states = np.array([[5, 5], [4, 6]], dtype=float)
@@ -2316,10 +2407,12 @@ class TestDiscreteLightDarkRewardNextStateConsistency:
         """
         env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            transition_error_prob=0.0,
-            obstacle_hit_probability=0.5,
-            obstacles=[(5, 5)],
-            goal_state=np.array([10, 5]),
+            **discrete_light_dark_pinned_kwargs(
+                transition_error_prob=0.0,
+                obstacle_hit_probability=0.5,
+                obstacles=[(5, 5)],
+                goal_state=np.array([10, 5]),
+            ),
         )
         state = np.array([4, 5])
         action = "right"

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/benchmark_light_dark_vectorized_belief.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/benchmark_light_dark_vectorized_belief.py
@@ -22,10 +22,14 @@ from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
 )
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDP,
+)
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ObservationModelType as ContinuousObsType,
 )
 from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
     DiscreteLightDarkPOMDP,
+)
+from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
     ObservationModelType as DiscreteObsType,
 )
 from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import (
@@ -35,6 +39,10 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import
     DiscreteLightDarkDistanceBasedVectorizedUpdater,
     DiscreteLightDarkNoObsInDarkVectorizedUpdater,
     DiscreteLightDarkVectorizedUpdater,
+)
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_pinned_kwargs,
+    discrete_light_dark_pinned_kwargs,
 )
 
 PARTICLE_COUNTS = [200]
@@ -171,7 +179,9 @@ def _run_continuous_benchmark(
     print(f"Continuous LightDark — {name}")
     print(f"{'=' * 70}")
 
-    env = ContinuousLightDarkPOMDP(discount_factor=0.95, observation_model_type=obs_type)
+    env = ContinuousLightDarkPOMDP(
+        discount_factor=0.95, **continuous_light_dark_pinned_kwargs(observation_model_type=obs_type)
+    )
     updater = updater_cls.from_environment(env)
 
     _benchmark_continuous_transition(env, updater)
@@ -272,7 +282,9 @@ def _run_discrete_benchmark(
     print(f"Discrete LightDark — {name}")
     print(f"{'=' * 70}")
 
-    env = DiscreteLightDarkPOMDP(discount_factor=0.95, observation_model_type=obs_type)
+    env = DiscreteLightDarkPOMDP(
+        discount_factor=0.95, **discrete_light_dark_pinned_kwargs(observation_model_type=obs_type)
+    )
     updater = updater_cls.from_environment(env)
 
     _benchmark_discrete_transition(env, updater)

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_continuous_light_dark_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_continuous_light_dark_belief_factory.py
@@ -21,12 +21,13 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import
     GaussianBeliefUpdaterType,
     create_continuous_light_dark_belief,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import continuous_light_dark_pinned_kwargs
 from POMDPPlanners.utils.belief_factory import BeliefType
 
 
 @pytest.fixture
 def env():
-    return ContinuousLightDarkPOMDP(discount_factor=0.95)
+    return ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
 
 
 class TestCreateContinuousLightDarkBelief:

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_continuous_light_dark_gaussian_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_continuous_light_dark_gaussian_beliefs.py
@@ -22,7 +22,7 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import
     GaussianBeliefUpdaterType,
     create_continuous_light_dark_gaussian_belief,
 )
-
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import continuous_light_dark_pinned_kwargs
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -31,7 +31,7 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import
 
 @pytest.fixture
 def env():
-    return ContinuousLightDarkPOMDP(discount_factor=0.95)
+    return ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
 
 
 @pytest.fixture

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_continuous_light_dark_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_continuous_light_dark_vectorized_updater.py
@@ -22,9 +22,7 @@ from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
 from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
     VectorizedWeightedParticleBelief,
 )
-from POMDPPlanners.environments.light_dark_pomdp import (
-    _native,  # pylint: disable=no-name-in-module
-)
+from POMDPPlanners.environments.light_dark_pomdp import _native  # pylint: disable=no-name-in-module
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDP,
     ContinuousLightDarkPOMDPDiscreteActions,
@@ -44,7 +42,10 @@ from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils imp
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
-
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+    continuous_light_dark_pinned_kwargs,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -53,7 +54,7 @@ from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils imp
 
 @pytest.fixture
 def env():
-    return ContinuousLightDarkPOMDP(discount_factor=0.95)
+    return ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
 
 
 @pytest.fixture
@@ -440,7 +441,9 @@ class TestEquivalenceWithPerParticleLoop:
 
 @pytest.fixture
 def discrete_env():
-    return ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    return ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_light_dark_discrete_actions_pinned_kwargs()
+    )
 
 
 @pytest.fixture
@@ -596,7 +599,9 @@ class TestDiscreteActionConfigId:
 def no_obs_env():
     return ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK,
+        **continuous_light_dark_pinned_kwargs(
+            observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK
+        ),
     )
 
 
@@ -783,7 +788,9 @@ class TestNoObsInDarkConfigId:
 def dist_env():
     return ContinuousLightDarkPOMDP(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **continuous_light_dark_pinned_kwargs(
+            observation_model_type=ObservationModelType.DISTANCE_BASED
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_discrete_light_dark_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_discrete_light_dark_belief_factory.py
@@ -23,12 +23,13 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import
     DiscreteLightDarkVectorizedUpdater,
     create_discrete_light_dark_belief,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import discrete_light_dark_pinned_kwargs
 from POMDPPlanners.utils.belief_factory import BeliefType
 
 
 @pytest.fixture
 def env():
-    return DiscreteLightDarkPOMDP(discount_factor=0.95)
+    return DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
 
 
 class TestCreateDiscreteLightDarkBelief:
@@ -108,7 +109,7 @@ class TestObservationModelTypeDispatch:
         np.random.seed(42)
         env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            observation_model_type=ObservationModelType.NORMAL,
+            **discrete_light_dark_pinned_kwargs(observation_model_type=ObservationModelType.NORMAL),
         )
         belief = create_discrete_light_dark_belief(env)
         assert isinstance(belief, VectorizedWeightedParticleBelief)
@@ -129,7 +130,9 @@ class TestObservationModelTypeDispatch:
         np.random.seed(42)
         env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            observation_model_type=ObservationModelType.NO_OBS_IN_DARK,
+            **discrete_light_dark_pinned_kwargs(
+                observation_model_type=ObservationModelType.NO_OBS_IN_DARK
+            ),
         )
         belief = create_discrete_light_dark_belief(env)
         assert isinstance(belief, VectorizedWeightedParticleBelief)
@@ -149,7 +152,9 @@ class TestObservationModelTypeDispatch:
         np.random.seed(42)
         env = DiscreteLightDarkPOMDP(
             discount_factor=0.95,
-            observation_model_type=ObservationModelType.DISTANCE_BASED,
+            **discrete_light_dark_pinned_kwargs(
+                observation_model_type=ObservationModelType.DISTANCE_BASED
+            ),
         )
         belief = create_discrete_light_dark_belief(env)
         assert isinstance(belief, VectorizedWeightedParticleBelief)

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_discrete_light_dark_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_light_dark_pomdp_beliefs/test_discrete_light_dark_vectorized_updater.py
@@ -23,7 +23,7 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import
     DiscreteLightDarkNoObsInDarkVectorizedUpdater,
     DiscreteLightDarkVectorizedUpdater,
 )
-
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import discrete_light_dark_pinned_kwargs
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -32,7 +32,7 @@ from POMDPPlanners.environments.light_dark_pomdp.light_dark_pomdp_beliefs import
 
 @pytest.fixture
 def env():
-    return DiscreteLightDarkPOMDP(discount_factor=0.95)
+    return DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
 
 
 @pytest.fixture
@@ -249,7 +249,9 @@ class TestConfigId:
 def no_obs_env():
     return DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.NO_OBS_IN_DARK,
+        **discrete_light_dark_pinned_kwargs(
+            observation_model_type=ObservationModelType.NO_OBS_IN_DARK
+        ),
     )
 
 
@@ -403,7 +405,9 @@ class TestNoObsInDarkConfigId:
 def dist_env():
     return DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        observation_model_type=ObservationModelType.DISTANCE_BASED,
+        **discrete_light_dark_pinned_kwargs(
+            observation_model_type=ObservationModelType.DISTANCE_BASED
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
@@ -17,6 +17,7 @@ import pytest
 import scipy.stats
 
 from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import mountain_car_pinned_kwargs
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -34,7 +35,7 @@ def test_mountain_car_initialization():
 
     Test type: unit
     """
-    pomdp = MountainCarPOMDP(discount_factor=0.95)
+    pomdp = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
     assert pomdp.min_position == -1.2
     assert pomdp.max_position == 0.6
     assert pomdp.max_speed == 0.07
@@ -158,7 +159,7 @@ def test_state_transition_default_covariance():
 
     Test type: unit
     """
-    env = MountainCarPOMDP(discount_factor=0.95)
+    env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
     np.testing.assert_array_equal(
         env.state_transition_cov, MountainCarPOMDP.DEFAULT_STATE_TRANSITION_COV
     )
@@ -178,8 +179,7 @@ def test_state_transition_custom_covariance():
     """
     custom_cov = np.diag([1e-4, 1e-5])
     env = MountainCarPOMDP(
-        discount_factor=0.95,
-        state_transition_cov=custom_cov,
+        discount_factor=0.95, **mountain_car_pinned_kwargs(state_transition_cov=custom_cov)
     )
     np.testing.assert_array_equal(env.state_transition_cov, custom_cov)
 
@@ -582,7 +582,7 @@ def test_mountain_car_reward():
 
     Test type: unit
     """
-    pomdp = MountainCarPOMDP(discount_factor=0.95)
+    pomdp = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
 
     # Test reward when not at goal
     state = (0.0, 0.0)
@@ -611,7 +611,7 @@ def test_mountain_car_terminal():
 
     Test type: unit
     """
-    pomdp = MountainCarPOMDP(discount_factor=0.95)
+    pomdp = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
 
     # Test non-terminal state
     state = (0.0, 0.0)
@@ -637,7 +637,7 @@ def test_mountain_car_actions():
 
     Test type: unit
     """
-    pomdp = MountainCarPOMDP(discount_factor=0.95)
+    pomdp = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
     actions = pomdp.get_actions()
 
     assert len(actions) == 3
@@ -657,7 +657,7 @@ def test_reward_range():
 
     Test type: unit
     """
-    pomdp = MountainCarPOMDP(discount_factor=0.95)
+    pomdp = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
     assert pomdp.reward_range == (-1.0, 0.0)
 
     # Verify the actual rewards match the range
@@ -689,7 +689,7 @@ def test_mountain_car_state_bounds():
 
     Test type: unit
     """
-    pomdp = MountainCarPOMDP(discount_factor=0.95)
+    pomdp = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
 
     # Test position bounds
     state = (pomdp.min_position - 0.1, 0.0)
@@ -722,7 +722,7 @@ def base_mountain_car_environment() -> MountainCarPOMDP:
 
     Test type: fixture
     """
-    return MountainCarPOMDP(discount_factor=0.95)
+    return MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
 
 
 class TestMountainCarPOMDPEquality:
@@ -748,7 +748,7 @@ class TestMountainCarPOMDPEquality:
 
         Test type: unit
         """
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         assert base_mountain_car_environment == other_env
         assert other_env == base_mountain_car_environment  # Test symmetry
 
@@ -763,7 +763,7 @@ class TestMountainCarPOMDPEquality:
 
         Test type: unit
         """
-        other_env = MountainCarPOMDP(discount_factor=0.8)
+        other_env = MountainCarPOMDP(discount_factor=0.8, **mountain_car_pinned_kwargs())
         assert base_mountain_car_environment != other_env
         assert other_env != base_mountain_car_environment  # Test symmetry
 
@@ -778,19 +778,19 @@ class TestMountainCarPOMDPEquality:
 
         Test type: unit
         """
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         other_env.min_position = -1.0  # Different from -1.2
         assert base_mountain_car_environment != other_env
 
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         other_env.max_position = 0.7  # Different from 0.6
         assert base_mountain_car_environment != other_env
 
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         other_env.max_speed = 0.08  # Different from 0.07
         assert base_mountain_car_environment != other_env
 
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         other_env.goal_position = 0.6  # Different from 0.5
         assert base_mountain_car_environment != other_env
 
@@ -805,16 +805,16 @@ class TestMountainCarPOMDPEquality:
 
         Test type: unit
         """
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         other_env.position_noise = 0.2  # Different from 0.1
         assert base_mountain_car_environment != other_env
 
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         other_env.velocity_noise = 0.02  # Different from 0.01
         assert base_mountain_car_environment != other_env
 
         # Test covariance matrix changes
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         other_env.cov_matrix = np.array([[0.2**2, 0], [0, 0.02**2]])  # Different from original
         assert base_mountain_car_environment != other_env
 
@@ -829,7 +829,7 @@ class TestMountainCarPOMDPEquality:
 
         Test type: unit
         """
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         other_env.actions = [-1, 0, 1, 2]  # Different from [-1, 0, 1]
         assert base_mountain_car_environment != other_env
 
@@ -859,11 +859,11 @@ class TestMountainCarPOMDPEquality:
 
         Test type: unit
         """
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         delattr(other_env, "min_position")
         assert base_mountain_car_environment != other_env
 
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         delattr(other_env, "cov_matrix")
         assert base_mountain_car_environment != other_env
 
@@ -906,7 +906,7 @@ class TestMountainCarPOMDPConfigId:
 
         Test type: configuration
         """
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         assert base_mountain_car_environment.config_id == other_env.config_id
 
     def test_config_id_different_discount_factor(
@@ -922,7 +922,7 @@ class TestMountainCarPOMDPConfigId:
 
         Test type: configuration
         """
-        other_env = MountainCarPOMDP(discount_factor=0.8)
+        other_env = MountainCarPOMDP(discount_factor=0.8, **mountain_car_pinned_kwargs())
         assert base_mountain_car_environment.config_id != other_env.config_id
 
     def test_config_id_different_parameters(self, base_mountain_car_environment: MountainCarPOMDP):
@@ -937,12 +937,12 @@ class TestMountainCarPOMDPConfigId:
         Test type: configuration
         """
         # Test different position noise
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         other_env.position_noise = 0.2  # Different from 0.1
         assert base_mountain_car_environment.config_id != other_env.config_id
 
         # Test different velocity noise
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         other_env.velocity_noise = 0.02  # Different from 0.01
         assert base_mountain_car_environment.config_id != other_env.config_id
 
@@ -956,11 +956,11 @@ class TestMountainCarPOMDPConfigId:
     
     Test type: configuration
     """
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         other_env.power = 0.002  # Different from 0.001
         assert base_mountain_car_environment.config_id != other_env.config_id
 
-        other_env = MountainCarPOMDP(discount_factor=0.95)
+        other_env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         other_env.gravity = 0.003  # Different from 0.0025
         assert base_mountain_car_environment.config_id != other_env.config_id
 
@@ -1007,7 +1007,7 @@ def test_get_metric_names():
 
     Test type: unit
     """
-    pomdp = MountainCarPOMDP(discount_factor=0.95)
+    pomdp = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
     metric_names = pomdp.get_metric_names()
     assert "goal_reaching_rate" in metric_names
     assert len(metric_names) == 1
@@ -1027,7 +1027,7 @@ def test_compute_metrics_goal_reaching():
     from POMDPPlanners.core.policy import PolicyRunData
     from POMDPPlanners.core.simulation import History, StepData
 
-    pomdp = MountainCarPOMDP(discount_factor=0.95)
+    pomdp = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
 
     # Create a simple belief for testing
     def create_test_belief(state):
@@ -1163,9 +1163,7 @@ def test_compute_metrics_values_within_confidence_intervals():
     from POMDPPlanners.core.belief import (  # pylint: disable=import-outside-toplevel
         WeightedParticleBelief,
     )
-    from POMDPPlanners.core.policy import (  # pylint: disable=import-outside-toplevel
-        PolicyRunData,
-    )
+    from POMDPPlanners.core.policy import PolicyRunData  # pylint: disable=import-outside-toplevel
     from POMDPPlanners.core.simulation import (  # pylint: disable=import-outside-toplevel
         History,
         StepData,
@@ -1179,7 +1177,7 @@ def test_compute_metrics_values_within_confidence_intervals():
         verify_return_shift_linearity,
     )
 
-    env = MountainCarPOMDP(discount_factor=0.95)
+    env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
 
     def _make_belief(state: np.ndarray) -> WeightedParticleBelief:
         return WeightedParticleBelief(
@@ -1294,7 +1292,7 @@ def test_reward_batch_matches_scalar_reward():
 
     Test type: unit
     """
-    env = MountainCarPOMDP(discount_factor=0.95)
+    env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
     np.random.seed(42)
     # Create states with positions spanning below and above goal_position
     states = np.column_stack(
@@ -1343,7 +1341,7 @@ def test_simulate_random_rollout_native_matches_base_class_python() -> None:
         python_random_rollout,
     )  # pylint: disable=import-outside-toplevel
 
-    env = MountainCarPOMDP(discount_factor=0.99)
+    env = MountainCarPOMDP(discount_factor=0.99, **mountain_car_pinned_kwargs())
     state = np.array([-0.5, 0.0], dtype=np.float64)
     max_depth = 10
     gamma = 0.95
@@ -1420,7 +1418,7 @@ def test_scalar_obs_log_prob_un_floored_matches_batch_after_fix() -> None:
 
     Test type: unit
     """
-    env = MountainCarPOMDP(discount_factor=0.95)
+    env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
     next_state = np.array([0.0, 0.0])
     action = 0
     observation = np.array([3.78, 0.0])

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_belief_factory.py
@@ -17,12 +17,13 @@ from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP
 from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp_beliefs import (
     create_mountain_car_belief,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import mountain_car_pinned_kwargs
 from POMDPPlanners.utils.belief_factory import BeliefType
 
 
 @pytest.fixture
 def env():
-    return MountainCarPOMDP(discount_factor=0.99)
+    return MountainCarPOMDP(discount_factor=0.99, **mountain_car_pinned_kwargs())
 
 
 class TestCreateMountainCarBelief:

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_beliefs.py
@@ -27,6 +27,7 @@ from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils imp
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import mountain_car_pinned_kwargs
 
 
 def _make_aligned_beliefs(updater, n_particles=60):
@@ -62,7 +63,7 @@ def _make_aligned_beliefs(updater, n_particles=60):
 
 @pytest.fixture
 def env():
-    return MountainCarPOMDP(discount_factor=0.99)
+    return MountainCarPOMDP(discount_factor=0.99, **mountain_car_pinned_kwargs())
 
 
 @pytest.fixture

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_gaussian_beliefs.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_gaussian_beliefs.py
@@ -19,6 +19,7 @@ from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp_gaussian_b
     GaussianBeliefUpdaterType,
     create_mountain_car_gaussian_belief,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import mountain_car_pinned_kwargs
 
 
 def _deterministic_next_state(env: MountainCarPOMDP, state: np.ndarray, action: int) -> np.ndarray:
@@ -49,7 +50,7 @@ def _deterministic_next_state(env: MountainCarPOMDP, state: np.ndarray, action: 
 
 @pytest.fixture
 def env():
-    return MountainCarPOMDP(discount_factor=0.99)
+    return MountainCarPOMDP(discount_factor=0.99, **mountain_car_pinned_kwargs())
 
 
 @pytest.fixture

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_kernel_cache.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_kernel_cache.py
@@ -17,17 +17,15 @@ import numpy as np
 import pytest
 
 from POMDPPlanners.environments.mountain_car_pomdp import _native
-from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp import (
-    MountainCarPOMDP,
-)
-
+from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp import MountainCarPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import mountain_car_pinned_kwargs
 
 _DISCOUNT_FACTOR: float = 0.99
 _ACTIONS: List[int] = [-1, 0, 1]
 
 
 def _make_env() -> MountainCarPOMDP:
-    return MountainCarPOMDP(discount_factor=_DISCOUNT_FACTOR)
+    return MountainCarPOMDP(discount_factor=_DISCOUNT_FACTOR, **mountain_car_pinned_kwargs())
 
 
 def _fresh_trans_kernel(env: MountainCarPOMDP, action: int) -> "_native.MountainCarTransitionCpp":

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_native_equivalence.py
@@ -23,12 +23,13 @@ import pytest
 
 from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP, _native
 from POMDPPlanners.tests.test_environments import _native_parity
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import mountain_car_pinned_kwargs
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 
 
 @pytest.fixture(name="env")
 def _env_fixture():
-    return MountainCarPOMDP(discount_factor=0.99)
+    return MountainCarPOMDP(discount_factor=0.99, **mountain_car_pinned_kwargs())
 
 
 def _build_transition(env: MountainCarPOMDP, state, action: int):

--- a/POMDPPlanners/tests/test_environments/test_pacman_native/test_pacman_kernel_cache.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_native/test_pacman_kernel_cache.py
@@ -27,7 +27,11 @@ from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import PacManPOMDP
 
 
 def _build_env() -> PacManPOMDP:
+    # num_ghosts overridden to 2; the env auto-generates per-ghost
+    # ``ghost_strategies``, so the single-ghost pinned defaults are not
+    # injected here (they would mismatch the two-ghost configuration).
     return PacManPOMDP(
+        discount_factor=0.95,
         maze_size=(7, 7),
         num_ghosts=2,
         initial_pellets=[(1, 1), (1, 5), (5, 1), (5, 5)],
@@ -35,7 +39,6 @@ def _build_env() -> PacManPOMDP:
         initial_ghost_positions=[(0, 0), (6, 6)],
         ghost_aggressiveness=2.0,
         ghost_coordination="independent",
-        discount_factor=0.95,
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_pacman_native/test_pacman_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_native/test_pacman_native_equivalence.py
@@ -28,11 +28,16 @@ import numpy as np
 
 from POMDPPlanners.environments.pacman_pomdp import _native  # pylint: disable=no-name-in-module
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import PacManPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import pacman_pinned_kwargs
 
 
 def _build_env() -> PacManPOMDP:
     """Small reusable env matching the benchmark fixture from PR #87."""
+    # num_ghosts overridden to 2; the env auto-generates per-ghost
+    # ``ghost_strategies``, so the single-ghost pinned defaults are not
+    # injected here (they would mismatch the two-ghost configuration).
     return PacManPOMDP(
+        discount_factor=0.95,
         maze_size=(7, 7),
         num_ghosts=2,
         initial_pellets=[(1, 1), (1, 5), (5, 1), (5, 5)],
@@ -40,7 +45,6 @@ def _build_env() -> PacManPOMDP:
         initial_ghost_positions=[(0, 0), (6, 6)],
         ghost_aggressiveness=2.0,
         ghost_coordination="independent",
-        discount_factor=0.95,
     )
 
 
@@ -223,15 +227,18 @@ class TestAggressiveDistribution:
         Test type: integration
         """
         env = PacManPOMDP(
-            maze_size=(5, 5),
-            walls=set(),
-            initial_pellets=[(2, 2)],
-            initial_pacman_pos=(0, 0),
-            num_ghosts=1,
-            initial_ghost_positions=[(3, 3)],
-            ghost_aggressiveness=2.0,
-            ghost_coordination="independent",
-            ghost_strategies=["aggressive"],
+            discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(5, 5),
+                walls=set(),
+                initial_pellets=[(2, 2)],
+                initial_pacman_pos=(0, 0),
+                num_ghosts=1,
+                initial_ghost_positions=[(3, 3)],
+                ghost_aggressiveness=2.0,
+                ghost_coordination="independent",
+                ghost_strategies=["aggressive"],
+            ),
         )
         state = env.make_state(
             pacman_pos=(0, 0),

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
@@ -27,6 +27,7 @@ from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_metric_sanity,
     verify_return_shift_linearity,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import pacman_pinned_kwargs
 from POMDPPlanners.environments.pacman_pomdp import (
     PacManPOMDP,
     create_simple_maze_pacman,
@@ -42,7 +43,11 @@ class TestMakeState:
 
     def setup_method(self):
         """Construct a shared env with two ghosts and four pellets."""
+        # num_ghosts overridden to 2; the env auto-generates per-ghost
+        # ``ghost_strategies``, so do not inject the single-ghost pinned
+        # defaults here.
         self.pomdp = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(7, 7),
             walls=set(),
             initial_pellets=[(0, 0), (5, 5), (1, 2), (3, 4)],
@@ -169,12 +174,15 @@ class TestPacManStateTransition:
     def setup_method(self):
         """Set up test environment and states for each test."""
         self.pomdp = PacManPOMDP(
-            maze_size=(5, 5),
-            walls={(2, 2)},
-            initial_pellets=[(1, 1), (3, 3)],
-            initial_pacman_pos=(0, 0),
-            num_ghosts=1,
-            initial_ghost_positions=[(4, 4)],
+            discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(5, 5),
+                walls={(2, 2)},
+                initial_pellets=[(1, 1), (3, 3)],
+                initial_pacman_pos=(0, 0),
+                num_ghosts=1,
+                initial_ghost_positions=[(4, 4)],
+            ),
         )
 
         self.state = self.pomdp.make_state(
@@ -412,14 +420,17 @@ class TestPacManObservation:
     def setup_method(self):
         """Set up test environment for each test."""
         self.pomdp = PacManPOMDP(
-            maze_size=(5, 5),
-            walls={(1, 2), (2, 1), (3, 4)},  # Custom walls that don't conflict
-            initial_pellets=[(1, 1), (1, 3), (3, 1), (3, 3)],  # Valid for 5x5 maze
-            observation_noise_factor=0.5,
-            max_observation_noise=2.0,
-            initial_pacman_pos=(0, 0),
-            num_ghosts=1,
-            initial_ghost_positions=[(4, 4)],
+            discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(5, 5),
+                walls={(1, 2), (2, 1), (3, 4)},  # Custom walls that don't conflict
+                initial_pellets=[(1, 1), (1, 3), (3, 1), (3, 3)],  # Valid for 5x5 maze
+                observation_noise_factor=0.5,
+                max_observation_noise=2.0,
+                initial_pacman_pos=(0, 0),
+                num_ghosts=1,
+                initial_ghost_positions=[(4, 4)],
+            ),
         )
 
     def _sample_observations(self, next_state: np.ndarray, action: int, n: int):
@@ -566,12 +577,15 @@ class TestPacManPOMDP:
     def setup_method(self):
         """Set up test environment for each test."""
         self.pomdp = PacManPOMDP(
-            maze_size=(5, 5),
-            walls={(2, 2), (3, 1)},
-            initial_pellets=[(1, 1), (3, 3)],
-            initial_pacman_pos=(0, 0),
-            num_ghosts=1,
-            initial_ghost_positions=[(4, 4)],
+            discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(5, 5),
+                walls={(2, 2), (3, 1)},
+                initial_pellets=[(1, 1), (3, 3)],
+                initial_pacman_pos=(0, 0),
+                num_ghosts=1,
+                initial_ghost_positions=[(4, 4)],
+            ),
         )
 
     def test_pomdp_initialization(self):
@@ -585,7 +599,7 @@ class TestPacManPOMDP:
 
         Test type: unit
         """
-        pomdp = PacManPOMDP()
+        pomdp = PacManPOMDP(discount_factor=0.95, **pacman_pinned_kwargs())
 
         assert pomdp.maze_size == (7, 7)
         assert pomdp.initial_pacman_pos == (0, 0)
@@ -649,12 +663,15 @@ class TestPacManPOMDP:
         """
         with pytest.raises(ValueError, match="Pellet position .* is inside a wall"):
             PacManPOMDP(
-                maze_size=(5, 5),
-                walls={(2, 2)},
-                initial_pellets=[(2, 2), (3, 3)],  # Pellet inside wall
-                initial_pacman_pos=(0, 0),
-                num_ghosts=1,
-                initial_ghost_positions=[(4, 4)],
+                discount_factor=0.95,
+                **pacman_pinned_kwargs(
+                    maze_size=(5, 5),
+                    walls={(2, 2)},
+                    initial_pellets=[(2, 2), (3, 3)],  # Pellet inside wall
+                    initial_pacman_pos=(0, 0),
+                    num_ghosts=1,
+                    initial_ghost_positions=[(4, 4)],
+                ),
             )
 
     def test_pomdp_parameter_validation_initial_pos_in_wall(self):
@@ -670,22 +687,28 @@ class TestPacManPOMDP:
         """
         with pytest.raises(ValueError, match="Initial PacMan position .* is inside a wall"):
             PacManPOMDP(
-                maze_size=(5, 5),
-                walls={(0, 0)},
-                initial_pellets=[(1, 1)],
-                initial_pacman_pos=(0, 0),  # In wall
-                num_ghosts=1,
-                initial_ghost_positions=[(4, 4)],
+                discount_factor=0.95,
+                **pacman_pinned_kwargs(
+                    maze_size=(5, 5),
+                    walls={(0, 0)},
+                    initial_pellets=[(1, 1)],
+                    initial_pacman_pos=(0, 0),  # In wall
+                    num_ghosts=1,
+                    initial_ghost_positions=[(4, 4)],
+                ),
             )
 
         with pytest.raises(ValueError, match="Initial ghost 0 position .* is inside a wall"):
             PacManPOMDP(
-                maze_size=(5, 5),
-                walls={(4, 4)},
-                initial_pellets=[(1, 1)],
-                initial_pacman_pos=(0, 0),
-                num_ghosts=1,
-                initial_ghost_positions=[(4, 4)],  # In wall
+                discount_factor=0.95,
+                **pacman_pinned_kwargs(
+                    maze_size=(5, 5),
+                    walls={(4, 4)},
+                    initial_pellets=[(1, 1)],
+                    initial_pacman_pos=(0, 0),
+                    num_ghosts=1,
+                    initial_ghost_positions=[(4, 4)],  # In wall
+                ),
             )
 
     def test_get_actions(self):
@@ -901,7 +924,10 @@ class TestPacManPOMDP:
         assert self.pomdp.reward_range == (expected_min, expected_max)
 
         # Test with custom parameters
+        # Legacy single-ghost ``initial_ghost_pos`` is under test here; do not
+        # let the pinned ``initial_ghost_positions`` default override it.
         custom_pomdp = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(5, 5),
             walls={(1, 2), (2, 1), (3, 4)},  # Custom walls that don't conflict
             initial_pellets=[(1, 1), (1, 3), (3, 1), (3, 3)],  # Valid for 5x5 maze
@@ -969,11 +995,14 @@ class TestPacManPOMDPMetrics:
     def setup_method(self):
         """Set up test environment for metrics tests."""
         self.pomdp = PacManPOMDP(
-            maze_size=(5, 5),
-            walls={(1, 2), (3, 1)},  # Custom walls that don't conflict with pellets
-            initial_pellets=[(1, 1), (3, 3)],  # Valid pellets not in walls
-            initial_pacman_pos=(0, 0),
-            initial_ghost_positions=[(4, 4)],  # Multi-ghost format
+            discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(5, 5),
+                walls={(1, 2), (3, 1)},  # Custom walls that don't conflict with pellets
+                initial_pellets=[(1, 1), (3, 3)],  # Valid pellets not in walls
+                initial_pacman_pos=(0, 0),
+                initial_ghost_positions=[(4, 4)],  # Multi-ghost format
+            ),
         )
 
     def test_compute_metrics_empty_histories(self):
@@ -1547,15 +1576,18 @@ class TestPacManPOMDPDangerMetrics:
     def setup_method(self):
         """Set up a PacMan env with a single danger zone at (3, 3) radius 1."""
         self.pomdp = PacManPOMDP(
-            maze_size=(7, 7),
-            walls=set(),
-            initial_pellets=[(0, 6)],
-            initial_pacman_pos=(0, 0),
-            num_ghosts=1,
-            initial_ghost_positions=[(6, 6)],
-            dangerous_areas={(3, 3)},
-            dangerous_area_radius=1.0,
-            dangerous_area_penalty=5.0,
+            discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(7, 7),
+                walls=set(),
+                initial_pellets=[(0, 6)],
+                initial_pacman_pos=(0, 0),
+                num_ghosts=1,
+                initial_ghost_positions=[(6, 6)],
+                dangerous_areas={(3, 3)},
+                dangerous_area_radius=1.0,
+                dangerous_area_penalty=5.0,
+            ),
         )
 
     def _make_state(
@@ -1793,7 +1825,10 @@ def test_pacman_pomdp_usage_example():
     # Execute the exact usage example from docstring
     walls = {(1, 1), (1, 2), (3, 3)}
     pellets = [(0, 2), (2, 0), (4, 4)]
-    pomdp = PacManPOMDP(maze_size=(7, 7), walls=walls, initial_pellets=pellets)
+    pomdp = PacManPOMDP(
+        discount_factor=0.95,
+        **pacman_pinned_kwargs(maze_size=(7, 7), walls=walls, initial_pellets=pellets),
+    )
 
     # Sample initial state
     initial_state = pomdp.initial_state_dist().sample()[0]
@@ -1812,7 +1847,10 @@ class TestMultiGhostFeatures:
 
     def setup_method(self):
         """Set up a default 3-ghost / 4-pellet env for state-construction tests."""
+        # num_ghosts overridden to 3; keep explicit kwargs so the env
+        # auto-generates per-ghost ``ghost_strategies`` for 3 ghosts.
         self.pomdp = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(7, 7),
             walls=set(),
             initial_pellets=[(0, 0), (5, 5), (0, 1), (1, 1)],
@@ -1833,6 +1871,7 @@ class TestMultiGhostFeatures:
         Test type: unit
         """
         pomdp = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(7, 7),
             walls={(2, 2), (3, 3)},
             initial_pellets=[(0, 1), (1, 0)],
@@ -1886,6 +1925,7 @@ class TestMultiGhostFeatures:
         Test type: unit
         """
         pomdp = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(5, 5),
             walls={(2, 2)},
             initial_pellets=[(0, 1)],
@@ -1922,6 +1962,7 @@ class TestMultiGhostFeatures:
         """
         # Test independent coordination
         pomdp_independent = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(5, 5),
             walls=set(),  # No walls to avoid conflicts
             initial_pellets=[(0, 1), (2, 2)],  # Explicit pellets within bounds
@@ -1933,6 +1974,7 @@ class TestMultiGhostFeatures:
 
         # Test coordinated strategy
         pomdp_coordinated = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(5, 5),
             walls=set(),  # No walls to avoid conflicts
             initial_pellets=[(0, 1), (2, 2)],  # Explicit pellets within bounds
@@ -1944,6 +1986,7 @@ class TestMultiGhostFeatures:
 
         # Test mixed strategy
         pomdp_mixed = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(5, 5),
             walls=set(),  # No walls to avoid conflicts
             initial_pellets=[(0, 1), (2, 2)],  # Explicit pellets within bounds
@@ -1965,6 +2008,7 @@ class TestMultiGhostFeatures:
         Test type: unit
         """
         pomdp = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(6, 6),
             walls=set(),  # No walls to avoid conflicts
             initial_pellets=[(0, 1), (1, 0), (2, 2)],  # Explicit pellets within bounds
@@ -1990,6 +2034,7 @@ class TestMultiGhostFeatures:
         Test type: unit
         """
         pomdp = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(5, 5),
             walls=set(),
             initial_pellets=[(0, 0), (3, 3)],
@@ -2034,6 +2079,7 @@ class TestMultiGhostFeatures:
         Test type: integration
         """
         pomdp = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(5, 5),
             walls=set(),  # No walls for simpler testing
             initial_pellets=[(1, 1)],
@@ -2067,6 +2113,7 @@ class TestMultiGhostFeatures:
         Test type: unit
         """
         pomdp = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(5, 5),
             walls=set(),  # No walls to avoid conflicts
             initial_pellets=[(0, 1), (1, 0)],  # Explicit pellets within bounds
@@ -2116,11 +2163,14 @@ class TestMultiGhostFeatures:
         """
         # Build a single-ghost env for this assertion block
         single_ghost_pomdp = PacManPOMDP(
-            maze_size=(5, 5),
-            walls=set(),
-            initial_pellets=[(0, 0), (0, 1), (2, 2)],
-            initial_ghost_positions=[(3, 4)],
-            num_ghosts=1,
+            discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(5, 5),
+                walls=set(),
+                initial_pellets=[(0, 0), (0, 1), (2, 2)],
+                initial_ghost_positions=[(3, 4)],
+                num_ghosts=1,
+            ),
         )
         state = single_ghost_pomdp.make_state(
             pacman_pos=(1, 2),
@@ -2135,18 +2185,24 @@ class TestMultiGhostFeatures:
 
         # Test PacManPOMDP backward compatibility
         pomdp = PacManPOMDP(
-            maze_size=(5, 5),
-            walls=set(),  # No walls to avoid conflicts
-            initial_pellets=[(0, 1), (2, 2)],  # Explicit pellets within bounds
-            initial_ghost_positions=[(4, 4)],  # Single ghost
+            discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(5, 5),
+                walls=set(),  # No walls to avoid conflicts
+                initial_pellets=[(0, 1), (2, 2)],  # Explicit pellets within bounds
+                initial_ghost_positions=[(4, 4)],  # Single ghost
+            ),
         )
 
         # Should work with single ghost
         assert pomdp.num_ghosts == 1
         assert pomdp.initial_ghost_positions == [(4, 4)]
 
-        # Legacy initialization should still work
+        # Legacy initialization should still work. The legacy single-ghost
+        # ``initial_ghost_pos`` param is under test, so the pinned
+        # ``initial_ghost_positions`` default must not be injected here.
         pomdp_legacy = PacManPOMDP(
+            discount_factor=0.95,
             maze_size=(5, 5),
             walls=set(),  # No walls to avoid conflicts
             initial_pellets=[(0, 1), (2, 2)],  # Explicit pellets within bounds
@@ -2168,13 +2224,15 @@ class TestArrayStateLayout:
     @pytest.fixture()
     def env(self):
         return PacManPOMDP(
-            maze_size=(5, 5),
-            walls={(2, 2)},
-            initial_pellets=[(1, 1), (3, 3)],
-            initial_pacman_pos=(0, 0),
-            num_ghosts=1,
-            initial_ghost_positions=[(4, 4)],
             discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(5, 5),
+                walls={(2, 2)},
+                initial_pellets=[(1, 1), (3, 3)],
+                initial_pacman_pos=(0, 0),
+                num_ghosts=1,
+                initial_ghost_positions=[(4, 4)],
+            ),
         )
 
     def test_make_state_shape(self, env):
@@ -2293,13 +2351,15 @@ class TestRewardBatch:
     @pytest.fixture()
     def env(self):
         return PacManPOMDP(
-            maze_size=(5, 5),
-            walls={(2, 2)},
-            initial_pellets=[(1, 1), (3, 3)],
-            initial_pacman_pos=(0, 0),
-            num_ghosts=1,
-            initial_ghost_positions=[(4, 4)],
             discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(5, 5),
+                walls={(2, 2)},
+                initial_pellets=[(1, 1), (3, 3)],
+                initial_pacman_pos=(0, 0),
+                num_ghosts=1,
+                initial_ghost_positions=[(4, 4)],
+            ),
         )
 
     def test_shape(self, env):
@@ -2389,17 +2449,19 @@ class TestNativeSimulateRollout:
 
     def _make_env(self) -> PacManPOMDP:
         return PacManPOMDP(
-            maze_size=(7, 7),
-            walls={(2, 2), (2, 3), (3, 2), (4, 4), (3, 5)},
-            initial_pellets=[(1, 1), (1, 5), (5, 1), (5, 5)],
-            initial_pacman_pos=(0, 0),
-            num_ghosts=1,
-            initial_ghost_positions=[(6, 6)],
-            pellet_reward=10.0,
-            ghost_collision_penalty=-100.0,
-            step_penalty=-1.0,
-            win_reward=100.0,
             discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(7, 7),
+                walls={(2, 2), (2, 3), (3, 2), (4, 4), (3, 5)},
+                initial_pellets=[(1, 1), (1, 5), (5, 1), (5, 5)],
+                initial_pacman_pos=(0, 0),
+                num_ghosts=1,
+                initial_ghost_positions=[(6, 6)],
+                pellet_reward=10.0,
+                ghost_collision_penalty=-100.0,
+                step_penalty=-1.0,
+                win_reward=100.0,
+            ),
         )
 
     def test_pacman_native_simulate_rollout_matches_python(self):
@@ -2601,15 +2663,18 @@ class TestPacManDangerousAreas:
         # by moving east, and (3, 4) sits exactly at distance 1.0 from the
         # center to exercise the squared-distance boundary check.
         self.pomdp = PacManPOMDP(
-            maze_size=(7, 7),
-            walls=set(),
-            initial_pellets=[(0, 6)],
-            initial_pacman_pos=(0, 0),
-            num_ghosts=1,
-            initial_ghost_positions=[(6, 6)],
-            dangerous_areas={(3, 3)},
-            dangerous_area_radius=1.0,
-            dangerous_area_penalty=5.0,
+            discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(7, 7),
+                walls=set(),
+                initial_pellets=[(0, 6)],
+                initial_pacman_pos=(0, 0),
+                num_ghosts=1,
+                initial_ghost_positions=[(6, 6)],
+                dangerous_areas={(3, 3)},
+                dangerous_area_radius=1.0,
+                dangerous_area_penalty=5.0,
+            ),
         )
 
     def _state_with_pac(self, pos: Tuple[int, int], score: float = 0.0) -> np.ndarray:
@@ -2637,12 +2702,15 @@ class TestPacManDangerousAreas:
         Test type: unit
         """
         plain = PacManPOMDP(
-            maze_size=(7, 7),
-            walls=set(),
-            initial_pellets=[(0, 6)],
-            initial_pacman_pos=(0, 0),
-            num_ghosts=1,
-            initial_ghost_positions=[(6, 6)],
+            discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(7, 7),
+                walls=set(),
+                initial_pellets=[(0, 6)],
+                initial_pacman_pos=(0, 0),
+                num_ghosts=1,
+                initial_ghost_positions=[(6, 6)],
+            ),
         )
         state = plain.make_state(pacman_pos=(3, 2), ghost_positions=((6, 6),), pellets=((0, 6),))
         next_state = plain.make_state(
@@ -2771,13 +2839,16 @@ class TestPacManDangerousAreas:
         """
         with pytest.raises(ValueError, match=r"Dangerous area .* is outside maze bounds"):
             PacManPOMDP(
-                maze_size=(5, 5),
-                walls=set(),
-                initial_pellets=[(1, 1)],
-                initial_pacman_pos=(0, 0),
-                num_ghosts=1,
-                initial_ghost_positions=[(4, 4)],
-                dangerous_areas={(5, 0)},
+                discount_factor=0.95,
+                **pacman_pinned_kwargs(
+                    maze_size=(5, 5),
+                    walls=set(),
+                    initial_pellets=[(1, 1)],
+                    initial_pacman_pos=(0, 0),
+                    num_ghosts=1,
+                    initial_ghost_positions=[(4, 4)],
+                    dangerous_areas={(5, 0)},
+                ),
             )
 
     def test_dangerous_area_negative_radius_or_penalty_raises(self):
@@ -2804,9 +2875,15 @@ class TestPacManDangerousAreas:
             "dangerous_areas": {(2, 2)},
         }
         with pytest.raises(ValueError, match=r"dangerous_area_radius must be non-negative"):
-            PacManPOMDP(dangerous_area_radius=-0.1, **common)  # type: ignore[arg-type]
+            PacManPOMDP(
+                discount_factor=0.95,
+                **pacman_pinned_kwargs(dangerous_area_radius=-0.1, **common),  # type: ignore[arg-type]
+            )
         with pytest.raises(ValueError, match=r"dangerous_area_penalty must be non-negative"):
-            PacManPOMDP(dangerous_area_penalty=-1.0, **common)  # type: ignore[arg-type]
+            PacManPOMDP(
+                discount_factor=0.95,
+                **pacman_pinned_kwargs(dangerous_area_penalty=-1.0, **common),  # type: ignore[arg-type]
+            )
 
     def test_dangerous_areas_do_not_block_movement_or_terminate(self):
         """Walking through a zone is allowed and non-terminal.

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_belief_factory.py
@@ -14,18 +14,21 @@ from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_belief_
     create_pacman_belief,
 )
 from POMDPPlanners.utils.belief_factory import BeliefType, create_environment_belief
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import pacman_pinned_kwargs
 
 
 @pytest.fixture()
 def env():
     return PacManPOMDP(
-        maze_size=(5, 5),
-        walls={(2, 2)},
-        initial_pellets=[(1, 1), (3, 3)],
-        initial_pacman_pos=(0, 0),
-        num_ghosts=1,
-        initial_ghost_positions=[(4, 4)],
         discount_factor=0.95,
+        **pacman_pinned_kwargs(
+            maze_size=(5, 5),
+            walls={(2, 2)},
+            initial_pellets=[(1, 1), (3, 3)],
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(4, 4)],
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_belief_integration.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_belief_integration.py
@@ -16,18 +16,21 @@ from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_belief_
     create_pacman_belief,
 )
 from POMDPPlanners.utils.belief_factory import BeliefType
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import pacman_pinned_kwargs
 
 
 @pytest.fixture()
 def env():
     return PacManPOMDP(
-        maze_size=(5, 5),
-        walls={(2, 2)},
-        initial_pellets=[(1, 1), (3, 3)],
-        initial_pacman_pos=(0, 0),
-        num_ghosts=1,
-        initial_ghost_positions=[(4, 4)],
         discount_factor=0.95,
+        **pacman_pinned_kwargs(
+            maze_size=(5, 5),
+            walls={(2, 2)},
+            initial_pellets=[(1, 1), (3, 3)],
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(4, 4)],
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_vectorized_updater.py
@@ -27,6 +27,7 @@ from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils imp
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import pacman_pinned_kwargs
 
 
 def _make_aligned_beliefs(env, updater, n_particles=50):
@@ -63,15 +64,17 @@ def _make_particle_to_array(env):  # pylint: disable=unused-argument
 @pytest.fixture()
 def simple_env():
     return PacManPOMDP(
-        maze_size=(5, 5),
-        walls={(2, 2)},
-        initial_pellets=[(1, 1), (3, 3)],
-        initial_pacman_pos=(0, 0),
-        num_ghosts=1,
-        initial_ghost_positions=[(4, 4)],
-        ghost_aggressiveness=2.0,
-        ghost_coordination="independent",
         discount_factor=0.95,
+        **pacman_pinned_kwargs(
+            maze_size=(5, 5),
+            walls={(2, 2)},
+            initial_pellets=[(1, 1), (3, 3)],
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(4, 4)],
+            ghost_aggressiveness=2.0,
+            ghost_coordination="independent",
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_pacman_visualizer.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_visualizer.py
@@ -24,16 +24,20 @@ from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_beliefs.pacman_vectori
     PacManVectorizedUpdater,
 )
 from POMDPPlanners.environments.pacman_pomdp.pacman_visualizer import PacManVisualizer
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import pacman_pinned_kwargs
 
 
 def _make_env() -> PacManPOMDP:
     return PacManPOMDP(
-        maze_size=(5, 5),
-        walls=set(),
-        initial_pacman_pos=(0, 0),
-        num_ghosts=1,
-        initial_ghost_positions=[(4, 4)],
-        initial_pellets=[(2, 2)],
+        discount_factor=0.95,
+        **pacman_pinned_kwargs(
+            maze_size=(5, 5),
+            walls=set(),
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(4, 4)],
+            initial_pellets=[(2, 2)],
+        ),
     )
 
 
@@ -255,15 +259,18 @@ def test_draw_dangerous_areas_renders_red_overlay_on_configured_cell() -> None:
     Test type: unit
     """
     env = PacManPOMDP(
-        maze_size=(5, 5),
-        walls=set(),
-        initial_pacman_pos=(0, 0),
-        num_ghosts=1,
-        initial_ghost_positions=[(4, 4)],
-        initial_pellets=[(2, 2)],
-        dangerous_areas={(2, 2)},
-        dangerous_area_radius=1.0,
-        dangerous_area_penalty=5.0,
+        discount_factor=0.95,
+        **pacman_pinned_kwargs(
+            maze_size=(5, 5),
+            walls=set(),
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(4, 4)],
+            initial_pellets=[(2, 2)],
+            dangerous_areas={(2, 2)},
+            dangerous_area_radius=1.0,
+            dangerous_area_penalty=5.0,
+        ),
     )
     visualizer = PacManVisualizer(env, tile_size=16)
     canvas = _blank_canvas(env, visualizer.tile_size)

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/push_pomdp_utils/test_push_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/push_pomdp_utils/test_push_reward_cpp_parity.py
@@ -36,6 +36,10 @@ from POMDPPlanners.environments.push_pomdp.push_pomdp import PushPOMDP
 from POMDPPlanners.environments.push_pomdp.push_pomdp_utils.push_reward_models import (
     RewardModelType,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_push_pinned_kwargs,
+    push_pinned_kwargs,
+)
 
 
 _BATCH_SIZE = 2000
@@ -70,16 +74,18 @@ def _build_discrete_env(variant: RewardModelType) -> PushPOMDP:
     """Build a discrete :class:`PushPOMDP` with the requested reward variant."""
     return PushPOMDP(
         discount_factor=0.95,
-        grid_size=10,
-        dangerous_areas=_DANGEROUS_AREAS_DISCRETE,
-        dangerous_area_radius=_DANGEROUS_AREA_RADIUS,
-        dangerous_area_penalty=_DANGEROUS_AREA_PENALTY,
-        dangerous_area_hit_probability=1.0,
-        reward_model_type=variant,
-        penalty_decay=(
-            _PENALTY_DECAY_BY_VARIANT[variant]
-            if variant == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY
-            else 1.0
+        **push_pinned_kwargs(
+            grid_size=10,
+            dangerous_areas=_DANGEROUS_AREAS_DISCRETE,
+            dangerous_area_radius=_DANGEROUS_AREA_RADIUS,
+            dangerous_area_penalty=_DANGEROUS_AREA_PENALTY,
+            dangerous_area_hit_probability=1.0,
+            reward_model_type=variant,
+            penalty_decay=(
+                _PENALTY_DECAY_BY_VARIANT[variant]
+                if variant == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY
+                else 1.0
+            ),
         ),
     )
 
@@ -88,16 +94,18 @@ def _build_continuous_env(variant: RewardModelType) -> ContinuousPushPOMDP:
     """Build a continuous :class:`ContinuousPushPOMDP` with the requested variant."""
     return ContinuousPushPOMDP(
         discount_factor=0.95,
-        grid_size=10,
-        dangerous_areas=_DANGEROUS_AREAS_CONTINUOUS,
-        dangerous_area_radius=_DANGEROUS_AREA_RADIUS,
-        dangerous_area_penalty=_DANGEROUS_AREA_PENALTY,
-        dangerous_area_hit_probability=1.0,
-        reward_model_type=variant,
-        penalty_decay=(
-            _PENALTY_DECAY_BY_VARIANT[variant]
-            if variant == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY
-            else 1.0
+        **continuous_push_pinned_kwargs(
+            grid_size=10,
+            dangerous_areas=_DANGEROUS_AREAS_CONTINUOUS,
+            dangerous_area_radius=_DANGEROUS_AREA_RADIUS,
+            dangerous_area_penalty=_DANGEROUS_AREA_PENALTY,
+            dangerous_area_hit_probability=1.0,
+            reward_model_type=variant,
+            penalty_decay=(
+                _PENALTY_DECAY_BY_VARIANT[variant]
+                if variant == RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY
+                else 1.0
+            ),
         ),
     )
 

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_native_equivalence.py
@@ -25,6 +25,7 @@ import pytest
 from POMDPPlanners.environments.push_pomdp import _native
 from POMDPPlanners.environments.push_pomdp.continuous_push_pomdp import ContinuousPushPOMDP
 from POMDPPlanners.tests.test_environments import _native_parity
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import continuous_push_pinned_kwargs
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 
 
@@ -61,8 +62,10 @@ def _make_observation_kernel(env: ContinuousPushPOMDP, next_state, action):
 def _env_fixture():
     return ContinuousPushPOMDP(
         discount_factor=0.99,
-        state_transition_cov_matrix=np.eye(2) * 0.01,
-        robot_radius=0.3,
+        **continuous_push_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2) * 0.01,
+            robot_radius=0.3,
+        ),
     )
 
 
@@ -473,7 +476,9 @@ def test_transition_push_mechanics_match_python_reference():
     # Use essentially zero noise so we can compare the push output directly.
     tiny_env = ContinuousPushPOMDP(
         discount_factor=0.99,
-        state_transition_cov_matrix=np.eye(2) * 1e-14,
+        **continuous_push_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2) * 1e-14,
+        ),
     )
     state = np.array([2.5, 3.1, 3.0, 3.0, 8.0, 8.0])  # dist ~0.51 < 1.0 threshold
     action = np.array([1.0, 0.0])

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
@@ -29,6 +29,10 @@ from POMDPPlanners.environments.push_pomdp.continuous_push_pomdp import (
 from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
     verify_metrics_within_confidence_intervals,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_push_discrete_actions_pinned_kwargs,
+    continuous_push_pinned_kwargs,
+)
 from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_history_returns_bounded,
     verify_metric_sanity,
@@ -46,7 +50,6 @@ def _make_env(**overrides) -> ContinuousPushPOMDP:
     ``env.sample_next_state``.
     """
     defaults: dict = dict(  # pylint: disable=use-dict-literal
-        discount_factor=0.99,
         grid_size=10,
         push_threshold=1.0,
         friction_coefficient=0.3,
@@ -56,7 +59,11 @@ def _make_env(**overrides) -> ContinuousPushPOMDP:
         state_transition_cov_matrix=np.eye(2) * 0.01,
     )
     defaults.update(overrides)
-    return ContinuousPushPOMDP(**defaults)
+    discount_factor = defaults.pop("discount_factor", 0.99)
+    return ContinuousPushPOMDP(
+        discount_factor=discount_factor,
+        **continuous_push_pinned_kwargs(**defaults),
+    )
 
 
 # ------------------------------------------------------------------
@@ -315,10 +322,12 @@ class TestContinuousPushPOMDP:
         np.random.seed(42)
         self.env = ContinuousPushPOMDP(  # pylint: disable=attribute-defined-outside-init
             discount_factor=0.99,
-            grid_size=10,
-            obstacles=[(5.0, 5.0, 0.5)],
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                obstacles=[(5.0, 5.0, 0.5)],
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+            ),
         )
 
     def test_space_info_continuous(self):
@@ -460,10 +469,12 @@ class TestContinuousPushPOMDP:
         """
         env2 = ContinuousPushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            obstacles=[(5.0, 5.0, 0.5)],
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                obstacles=[(5.0, 5.0, 0.5)],
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+            ),
         )
         assert self.env.config_id == env2.config_id
 
@@ -479,7 +490,9 @@ class TestContinuousPushPOMDP:
         Test type: unit
         """
         fixed = np.array([1.0, 1.0, 5.0, 5.0, 9.0, 9.0])
-        env = ContinuousPushPOMDP(discount_factor=0.99, initial_state=fixed)
+        env = ContinuousPushPOMDP(
+            discount_factor=0.99, **continuous_push_pinned_kwargs(initial_state=fixed)
+        )
         state = env.initial_state_dist().sample()[0]
         np.testing.assert_array_equal(state, fixed)
 
@@ -494,7 +507,7 @@ class TestContinuousPushPOMDP:
 
         Test type: unit
         """
-        env = ContinuousPushPOMDP(discount_factor=0.99)
+        env = ContinuousPushPOMDP(discount_factor=0.99, **continuous_push_pinned_kwargs())
         state = env.initial_state_dist().sample()[0]
         result = env.sample_next_step(state, np.array([1.0, 0.0]))
         assert result[0].shape == (6,)
@@ -695,12 +708,14 @@ class TestContinuousPushStochasticObstacleHitProbability:
     def _stochastic_env(hit_probability: float) -> ContinuousPushPOMDP:
         return ContinuousPushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            obstacles=[(5.0, 5.0, 0.5)],
-            obstacle_penalty=TestContinuousPushStochasticObstacleHitProbability.OBSTACLE_PENALTY,
-            obstacle_hit_probability=hit_probability,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                obstacles=[(5.0, 5.0, 0.5)],
+                obstacle_penalty=TestContinuousPushStochasticObstacleHitProbability.OBSTACLE_PENALTY,
+                obstacle_hit_probability=hit_probability,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+            ),
         )
 
     @staticmethod
@@ -721,7 +736,7 @@ class TestContinuousPushStochasticObstacleHitProbability:
 
         Test type: unit
         """
-        env = ContinuousPushPOMDP(discount_factor=0.99)
+        env = ContinuousPushPOMDP(discount_factor=0.99, **continuous_push_pinned_kwargs())
         assert env.obstacle_hit_probability == 1.0
 
     def test_hit_probability_zero_never_applies_penalty(self):
@@ -861,7 +876,10 @@ class TestContinuousPushStochasticObstacleHitProbability:
         Test type: unit
         """
         with pytest.raises(ValueError, match="obstacle_hit_probability"):
-            ContinuousPushPOMDP(discount_factor=0.99, obstacle_hit_probability=bad_value)
+            ContinuousPushPOMDP(
+                discount_factor=0.99,
+                **continuous_push_pinned_kwargs(obstacle_hit_probability=bad_value),
+            )
 
 
 # ------------------------------------------------------------------
@@ -887,13 +905,15 @@ class TestContinuousPushDangerousAreas:
     def _danger_env(hit_probability: float = 1.0) -> ContinuousPushPOMDP:
         return ContinuousPushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            dangerous_areas=[(5.0, 5.0)],
-            dangerous_area_radius=0.5,
-            dangerous_area_penalty=TestContinuousPushDangerousAreas.DANGER_PENALTY,
-            dangerous_area_hit_probability=hit_probability,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                dangerous_areas=[(5.0, 5.0)],
+                dangerous_area_radius=0.5,
+                dangerous_area_penalty=TestContinuousPushDangerousAreas.DANGER_PENALTY,
+                dangerous_area_hit_probability=hit_probability,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+            ),
         )
 
     @staticmethod
@@ -925,9 +945,11 @@ class TestContinuousPushDangerousAreas:
         env = self._danger_env()
         env_safe = ContinuousPushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+            ),
         )
         state = self._enter_state()
         np.random.seed(0)
@@ -948,7 +970,7 @@ class TestContinuousPushDangerousAreas:
 
         Test type: unit
         """
-        env = ContinuousPushPOMDP(discount_factor=0.99)
+        env = ContinuousPushPOMDP(discount_factor=0.99, **continuous_push_pinned_kwargs())
         assert not env.dangerous_areas
         assert env._dangerous_areas_arr.shape == (0, 2)
         assert env.dangerous_area_hit_probability == 1.0
@@ -970,9 +992,11 @@ class TestContinuousPushDangerousAreas:
         env = self._danger_env()
         env_safe = ContinuousPushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+            ),
         )
         states = np.stack([self._enter_state(), self._safe_state()])
         np.random.seed(0)
@@ -1000,18 +1024,22 @@ class TestContinuousPushDangerousAreas:
         """
         env = ContinuousPushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            dangerous_areas=[(5.0, 5.0), (5.1, 5.0)],
-            dangerous_area_radius=0.5,
-            dangerous_area_penalty=self.DANGER_PENALTY,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                dangerous_areas=[(5.0, 5.0), (5.1, 5.0)],
+                dangerous_area_radius=0.5,
+                dangerous_area_penalty=self.DANGER_PENALTY,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+            ),
         )
         env_safe = ContinuousPushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+            ),
         )
         state = self._enter_state()
         np.random.seed(0)
@@ -1102,13 +1130,15 @@ class TestContinuousPushDangerousAreas:
         """
         env = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            grid_size=10,
-            dangerous_areas=[(5.0, 5.0)],
-            dangerous_area_radius=0.5,
-            dangerous_area_penalty=self.DANGER_PENALTY,
-            dangerous_area_hit_probability=0.5,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                grid_size=10,
+                dangerous_areas=[(5.0, 5.0)],
+                dangerous_area_radius=0.5,
+                dangerous_area_penalty=self.DANGER_PENALTY,
+                dangerous_area_hit_probability=0.5,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+            ),
         )
 
         call_kwargs: List[Dict[str, Any]] = []
@@ -1145,13 +1175,15 @@ class TestContinuousPushDangerousHitProbability:
     def _danger_env(hit_probability: float) -> ContinuousPushPOMDP:
         return ContinuousPushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            dangerous_areas=[(5.0, 5.0)],
-            dangerous_area_radius=0.5,
-            dangerous_area_penalty=TestContinuousPushDangerousHitProbability.DANGER_PENALTY,
-            dangerous_area_hit_probability=hit_probability,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                dangerous_areas=[(5.0, 5.0)],
+                dangerous_area_radius=0.5,
+                dangerous_area_penalty=TestContinuousPushDangerousHitProbability.DANGER_PENALTY,
+                dangerous_area_hit_probability=hit_probability,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+            ),
         )
 
     @staticmethod
@@ -1170,7 +1202,7 @@ class TestContinuousPushDangerousHitProbability:
 
         Test type: unit
         """
-        env = ContinuousPushPOMDP(discount_factor=0.99)
+        env = ContinuousPushPOMDP(discount_factor=0.99, **continuous_push_pinned_kwargs())
         assert env.dangerous_area_hit_probability == 1.0
 
     def test_hit_probability_zero_never_applies_penalty(self):
@@ -1252,7 +1284,10 @@ class TestContinuousPushDangerousHitProbability:
         Test type: unit
         """
         with pytest.raises(ValueError, match="dangerous_area_hit_probability"):
-            ContinuousPushPOMDP(discount_factor=0.99, dangerous_area_hit_probability=bad_value)
+            ContinuousPushPOMDP(
+                discount_factor=0.99,
+                **continuous_push_pinned_kwargs(dangerous_area_hit_probability=bad_value),
+            )
 
     def test_reward_batch_honours_hit_probability_zero(self):
         """Batch reward with hit_probability=0 applies no dangerous-area penalty.
@@ -1297,10 +1332,12 @@ class TestContinuousPushPOMDPDiscreteActionsDangerousAreas:
         """
         env = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            dangerous_areas=[(3.0, 3.0)],
-            dangerous_area_radius=0.4,
-            dangerous_area_penalty=self.DANGER_PENALTY,
-            dangerous_area_hit_probability=0.7,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                dangerous_areas=[(3.0, 3.0)],
+                dangerous_area_radius=0.4,
+                dangerous_area_penalty=self.DANGER_PENALTY,
+                dangerous_area_hit_probability=0.7,
+            ),
         )
         assert env.dangerous_areas == [(3.0, 3.0)]
         assert env.dangerous_area_radius == 0.4
@@ -1325,18 +1362,22 @@ class TestContinuousPushPOMDPDiscreteActionsDangerousAreas:
         """
         env = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            grid_size=10,
-            dangerous_areas=[(5.0, 5.0)],
-            dangerous_area_radius=0.5,
-            dangerous_area_penalty=self.DANGER_PENALTY,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                grid_size=10,
+                dangerous_areas=[(5.0, 5.0)],
+                dangerous_area_radius=0.5,
+                dangerous_area_penalty=self.DANGER_PENALTY,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+            ),
         )
         env_safe = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            grid_size=10,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                grid_size=10,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+            ),
         )
         state = np.array([4.0, 5.0, 1.0, 1.0, 9.0, 9.0])
         np.random.seed(0)
@@ -1360,9 +1401,11 @@ class TestContinuousPushPOMDPDiscreteActions:
         # pylint: disable=attribute-defined-outside-init
         self.env = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            grid_size=10,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                grid_size=10,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+            ),
         )
 
     def test_actions_list(self):
@@ -1424,8 +1467,10 @@ class TestContinuousPushPOMDPDiscreteActions:
         low_cov = np.eye(2) * 1e-8
         env = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            state_transition_cov_matrix=low_cov,
-            robot_radius=0.3,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=low_cov,
+                robot_radius=0.3,
+            ),
         )
         state = np.array([5.0, 5.0, 1.0, 1.0, 9.0, 9.0])
 
@@ -1459,12 +1504,14 @@ class TestContinuousPushDiscreteActionsHitProbability:
     def _stochastic_env(hit_probability: float) -> ContinuousPushPOMDPDiscreteActions:
         return ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            grid_size=10,
-            obstacles=[(5.0, 5.0, 0.5)],
-            obstacle_penalty=TestContinuousPushDiscreteActionsHitProbability.OBSTACLE_PENALTY,
-            obstacle_hit_probability=hit_probability,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                grid_size=10,
+                obstacles=[(5.0, 5.0, 0.5)],
+                obstacle_penalty=TestContinuousPushDiscreteActionsHitProbability.OBSTACLE_PENALTY,
+                obstacle_hit_probability=hit_probability,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+            ),
         )
 
     def test_default_hit_probability_is_one(self):
@@ -1478,7 +1525,9 @@ class TestContinuousPushDiscreteActionsHitProbability:
 
         Test type: unit
         """
-        env = ContinuousPushPOMDPDiscreteActions(discount_factor=0.99)
+        env = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99, **continuous_push_discrete_actions_pinned_kwargs()
+        )
         assert env.obstacle_hit_probability == 1.0
 
     @pytest.mark.parametrize("p", [0.0, 0.3, 0.7, 1.0])
@@ -1534,7 +1583,10 @@ class TestContinuousPushDiscreteActionsHitProbability:
         """
         with pytest.raises(ValueError, match="obstacle_hit_probability"):
             ContinuousPushPOMDPDiscreteActions(
-                discount_factor=0.99, obstacle_hit_probability=bad_value
+                discount_factor=0.99,
+                **continuous_push_discrete_actions_pinned_kwargs(
+                    obstacle_hit_probability=bad_value
+                ),
             )
 
 
@@ -1566,7 +1618,9 @@ class TestDiscreteActionsResolvesAction:
         """
         env = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+            ),
         )
         state = np.array([5.0, 5.0, 5.5, 5.0, 9.0, 9.0])
         for str_action in env.get_actions():
@@ -1591,7 +1645,9 @@ class TestDiscreteActionsResolvesAction:
 
         Test type: unit
         """
-        env = ContinuousPushPOMDPDiscreteActions(discount_factor=0.99)
+        env = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99, **continuous_push_discrete_actions_pinned_kwargs()
+        )
         next_state = np.array([5.0, 5.0, 5.5, 5.0, 9.0, 9.0])
         for str_action in env.get_actions():
             vec = env.action_to_vector[str_action]
@@ -1615,7 +1671,9 @@ class TestDiscreteActionsResolvesAction:
 
         Test type: unit
         """
-        env = ContinuousPushPOMDPDiscreteActions(discount_factor=0.99)
+        env = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.99, **continuous_push_discrete_actions_pinned_kwargs()
+        )
         for action_name, vec in env.action_to_vector.items():
             assert isinstance(vec, np.ndarray), action_name
             assert vec.dtype == np.float64, action_name
@@ -1642,8 +1700,10 @@ class TestDiscreteActionsResolvesAction:
         """
         env = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
-            observation_noise=0.3,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+                observation_noise=0.3,
+            ),
         )
         state = np.array([5.0, 5.0, 5.5, 5.0, 9.0, 9.0])
         next_states = [
@@ -1692,8 +1752,10 @@ class TestSampleNSamplesContract:
         """
         env = ContinuousPushPOMDP(
             discount_factor=0.99,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
-            robot_radius=0.3,
+            **continuous_push_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+                robot_radius=0.3,
+            ),
         )
         state = np.array([2.5, 3.1, 3.0, 3.0, 8.0, 8.0])
         action = np.array([1.0, 0.0])
@@ -1725,8 +1787,10 @@ class TestSampleNSamplesContract:
         """
         env = ContinuousPushPOMDP(
             discount_factor=0.99,
-            observation_noise=0.3,
-            robot_radius=0.3,
+            **continuous_push_pinned_kwargs(
+                observation_noise=0.3,
+                robot_radius=0.3,
+            ),
         )
         next_state = np.array([5.0, 5.0, 4.5, 5.5, 8.0, 8.0])
         action = np.array([0.5, 0.5])
@@ -1764,15 +1828,17 @@ class TestNativeRolloutEquivalence:
     def _make_env(self) -> ContinuousPushPOMDPDiscreteActions:
         return ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            max_push=2.0,
-            observation_noise=0.1,
-            obstacles=[(5.0, 5.0, 0.5)],
-            obstacle_penalty=-10.0,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 0.05,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                max_push=2.0,
+                observation_noise=0.1,
+                obstacles=[(5.0, 5.0, 0.5)],
+                obstacle_penalty=-10.0,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 0.05,
+            ),
         )
 
     def test_native_rollout_is_float(self):
@@ -1998,8 +2064,10 @@ class TestNativeRolloutEquivalence:
 
         env = ContinuousPushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            state_transition_cov_matrix=np.eye(2) * 0.05,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                state_transition_cov_matrix=np.eye(2) * 0.05,
+            ),
         )
         state = np.array([2.0, 2.0, 5.0, 5.0, 9.0, 9.0])
         sampler = UnitCircleActionSampler(max_action_magnitude=1.0)
@@ -2033,22 +2101,26 @@ class TestNativeRolloutEquivalence:
         """
         env_safe = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+            ),
         )
         env_danger = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 1e-8,
-            dangerous_areas=[(5.0, 5.0)],
-            dangerous_area_radius=0.5,
-            dangerous_area_penalty=-7.0,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 1e-8,
+                dangerous_areas=[(5.0, 5.0)],
+                dangerous_area_radius=0.5,
+                dangerous_area_penalty=-7.0,
+            ),
         )
         state = np.array([4.0, 5.0, 1.0, 1.0, 9.0, 9.0])
         sampler = _FixedActionSampler(["right"])
@@ -2082,15 +2154,19 @@ class TestNativeRolloutEquivalence:
         """
         env_a = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            grid_size=10,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                grid_size=10,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+            ),
         )
         env_b = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            grid_size=10,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                grid_size=10,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+            ),
         )
         state = np.array([2.0, 2.0, 6.0, 6.0, 9.0, 9.0])
         sampler = _FixedActionSampler(["right"] * 8)
@@ -2131,23 +2207,29 @@ class TestContinuousPushRewardNextStateConsistency:
     def _obstacle_env() -> ContinuousPushPOMDP:
         return ContinuousPushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            obstacles=[(5.0, 5.0, 0.5)],
-            obstacle_penalty=(TestContinuousPushRewardNextStateConsistency.OBSTACLE_PENALTY),
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                obstacles=[(5.0, 5.0, 0.5)],
+                obstacle_penalty=(TestContinuousPushRewardNextStateConsistency.OBSTACLE_PENALTY),
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+            ),
         )
 
     @staticmethod
     def _danger_env() -> ContinuousPushPOMDP:
         return ContinuousPushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            dangerous_areas=[(5.0, 5.0)],
-            dangerous_area_radius=0.5,
-            dangerous_area_penalty=(TestContinuousPushRewardNextStateConsistency.DANGER_PENALTY),
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                dangerous_areas=[(5.0, 5.0)],
+                dangerous_area_radius=0.5,
+                dangerous_area_penalty=(
+                    TestContinuousPushRewardNextStateConsistency.DANGER_PENALTY
+                ),
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+            ),
         )
 
     def test_reward_obstacle_penalty_uses_realised_next_state(self):
@@ -2283,11 +2365,13 @@ class TestContinuousPushRewardNextStateConsistency:
         """
         env = ContinuousPushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            obstacles=[(5.0, 5.0, 0.5)],
-            obstacle_penalty=self.OBSTACLE_PENALTY,
-            robot_radius=0.3,
-            state_transition_cov_matrix=np.eye(2) * 0.5,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                obstacles=[(5.0, 5.0, 0.5)],
+                obstacle_penalty=self.OBSTACLE_PENALTY,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 0.5,
+            ),
         )
         state = np.array([4.6, 5.0, 1.0, 1.0, 9.0, 9.0])
         action = np.array([0.4, 0.0])

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_discrete_native_transition.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_discrete_native_transition.py
@@ -17,18 +17,21 @@ import numpy as np
 import pytest
 
 from POMDPPlanners.environments.push_pomdp.push_pomdp import PushPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import push_pinned_kwargs
 
 
 @pytest.fixture(name="env")
 def _env_fixture() -> PushPOMDP:
     return PushPOMDP(
         discount_factor=0.95,
-        grid_size=10,
-        push_threshold=1.0,
-        friction_coefficient=0.3,
-        observation_noise=0.1,
-        obstacles=[(5.0, 5.0), (3.0, 7.0)],
-        obstacle_radius=0.5,
+        **push_pinned_kwargs(
+            grid_size=10,
+            push_threshold=1.0,
+            friction_coefficient=0.3,
+            observation_noise=0.1,
+            obstacles=[(5.0, 5.0), (3.0, 7.0)],
+            obstacle_radius=0.5,
+        ),
     )
 
 
@@ -125,12 +128,14 @@ def test_native_transition_log_probability_matches_python_reference() -> None:
     """
     env = PushPOMDP(
         discount_factor=0.95,
-        grid_size=10,
-        push_threshold=1.0,
-        friction_coefficient=0.3,
-        observation_noise=0.1,
-        obstacles=[],
-        transition_error_prob=0.2,
+        **push_pinned_kwargs(
+            grid_size=10,
+            push_threshold=1.0,
+            friction_coefficient=0.3,
+            observation_noise=0.1,
+            obstacles=[],
+            transition_error_prob=0.2,
+        ),
     )
     state = np.array([4.0, 4.0, 6.0, 6.0, 9.0, 9.0])
     intended_action = "right"

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
@@ -22,6 +22,7 @@ from POMDPPlanners.environments.push_pomdp import PushPOMDP, _native as push_nat
 from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
     verify_metrics_within_confidence_intervals,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import push_pinned_kwargs
 from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_history_returns_bounded,
     verify_metric_sanity,
@@ -41,13 +42,15 @@ class TestPushPOMDP:
         # Create Push POMDP environment with obstacles
         self.env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            observation_noise=0.1,
-            obstacles=[(3.0, 3.0), (7.0, 7.0)],  # Two obstacles
-            obstacle_radius=0.5,
-            obstacle_penalty=-10.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                observation_noise=0.1,
+                obstacles=[(3.0, 3.0), (7.0, 7.0)],  # Two obstacles
+                obstacle_radius=0.5,
+                obstacle_penalty=-10.0,
+            ),
         )
 
         # Test positions
@@ -416,9 +419,11 @@ class TestPushPOMDP:
         action = "right"
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=2.0,
-            friction_coefficient=0.3,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=2.0,
+                friction_coefficient=0.3,
+            ),
         )
 
         next_state = env.sample_next_state(state, action)
@@ -446,9 +451,11 @@ class TestPushPOMDP:
         action = "right"
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+            ),
         )
 
         next_state = env.sample_next_state(state, action)
@@ -462,7 +469,10 @@ class TestPushPOMDP:
     def test_observation_model_functionality(self):
         """Test observation model functionality with noise."""
         # Build an env whose observation parameters drive the env-API call.
-        env = PushPOMDP(discount_factor=0.95, grid_size=10, observation_noise=0.1)
+        env = PushPOMDP(
+            discount_factor=0.95,
+            **push_pinned_kwargs(grid_size=10, observation_noise=0.1),
+        )
         state = np.array([5.0, 5.0, 4.0, 5.0, 9.0, 9.0])
 
         observation = env.sample_observation(state, "right")
@@ -499,7 +509,7 @@ class TestPushPOMDP:
     def test_reward_range(self):
         """Test that reward range is correctly calculated."""
         # Test with default grid size (10)
-        env = PushPOMDP(discount_factor=0.95, grid_size=10)
+        env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(grid_size=10))
 
         # Expected calculation from PushPOMDP constructor:
         # Maximum distance is diagonal from corner to corner: sqrt(2) * (grid_size - 1)
@@ -511,7 +521,7 @@ class TestPushPOMDP:
         assert env.reward_range == (expected_min, expected_max)
 
         # Test with different grid size
-        env2 = PushPOMDP(discount_factor=0.95, grid_size=25)
+        env2 = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(grid_size=25))
 
         max_distance2 = np.sqrt(2) * (25 - 1)  # sqrt(2) * 24 ≈ 33.94
         expected_min2 = -max_distance2
@@ -558,10 +568,12 @@ class TestPushPOMDP:
         """
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            obstacles=[(3.0, 3.0)],
-            obstacle_radius=0.5,
-            obstacle_penalty=-10.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                obstacles=[(3.0, 3.0)],
+                obstacle_radius=0.5,
+                obstacle_penalty=-10.0,
+            ),
         )
         state = np.array([3.0, 3.5, 0.0, 0.0, 9.0, 9.0])
         action = "down"
@@ -612,17 +624,21 @@ class TestPushPOMDP:
         # Create two identical environments
         env1 = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            observation_noise=0.1,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                observation_noise=0.1,
+            ),
         )
         env2 = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            observation_noise=0.1,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                observation_noise=0.1,
+            ),
         )
 
         # Test equality
@@ -631,10 +647,12 @@ class TestPushPOMDP:
         # Test inequality with different parameters
         env3 = PushPOMDP(
             discount_factor=0.9,  # Different discount factor
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            observation_noise=0.1,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                observation_noise=0.1,
+            ),
         )
         assert env1 != env3
 
@@ -643,17 +661,21 @@ class TestPushPOMDP:
         # Create two environments with same parameters
         env1 = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            observation_noise=0.1,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                observation_noise=0.1,
+            ),
         )
         env2 = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            observation_noise=0.1,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                observation_noise=0.1,
+            ),
         )
 
         # Test same config_id for identical environments
@@ -662,10 +684,12 @@ class TestPushPOMDP:
         # Test different config_id for different environments
         env3 = PushPOMDP(
             discount_factor=0.9,  # Different discount factor
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            observation_noise=0.1,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                observation_noise=0.1,
+            ),
         )
         assert env1.config_id != env3.config_id
 
@@ -684,7 +708,10 @@ class TestPushPOMDP:
 
         Test type: unit
         """
-        env = PushPOMDP(discount_factor=0.95, grid_size=10, observation_noise=0.1)
+        env = PushPOMDP(
+            discount_factor=0.95,
+            **push_pinned_kwargs(grid_size=10, observation_noise=0.1),
+        )
         next_state = np.array([5.0, 5.0, 4.0, 5.0, 9.0, 9.0])
 
         # Sample many observations to check consistency.
@@ -781,11 +808,13 @@ class TestPushPOMDP:
         action = "right"
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            obstacles=[],
-            obstacle_radius=0.5,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                obstacles=[],
+                obstacle_radius=0.5,
+            ),
         )
 
         # Get the actual next state via the env API.
@@ -827,11 +856,13 @@ class TestPushPOMDP:
         action = "right"  # Will collide with obstacle
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            obstacles=obstacles,
-            obstacle_radius=0.5,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                obstacles=obstacles,
+                obstacle_radius=0.5,
+            ),
         )
 
         # Get the actual next state (robot should stay in place due to collision).
@@ -870,11 +901,13 @@ class TestPushPOMDP:
         friction = 0.5
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,  # Robot is within push threshold
-            friction_coefficient=friction,
-            obstacles=[],
-            obstacle_radius=0.5,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,  # Robot is within push threshold
+                friction_coefficient=friction,
+                obstacles=[],
+                obstacle_radius=0.5,
+            ),
         )
 
         # Get the actual next state with push dynamics.
@@ -916,11 +949,13 @@ class TestPushPOMDP:
         action = "left"  # Try to move beyond boundary
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            obstacles=[],
-            obstacle_radius=0.5,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                obstacles=[],
+                obstacle_radius=0.5,
+            ),
         )
 
         # Get actual next state (should be clipped at boundary).
@@ -957,11 +992,13 @@ class TestPushPOMDP:
         action = "up"
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            obstacles=[],
-            obstacle_radius=0.5,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                obstacles=[],
+                obstacle_radius=0.5,
+            ),
         )
 
         # Get actual next state.
@@ -1003,7 +1040,7 @@ class TestPushPOMDP:
         Test type: unit
         """
         fixed_state = np.array([2.0, 3.0, 5.0, 5.0, 9.0, 9.0])
-        env = PushPOMDP(discount_factor=0.95, initial_state=fixed_state)
+        env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(initial_state=fixed_state))
 
         # Sample multiple times
         samples = [env.initial_state_dist().sample()[0] for _ in range(5)]
@@ -1025,7 +1062,7 @@ class TestPushPOMDP:
         Test type: unit
         """
         fixed_state = np.array([1.0, 2.0, 4.0, 4.0, 9.0, 9.0])
-        env = PushPOMDP(discount_factor=0.95, initial_state=fixed_state)
+        env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(initial_state=fixed_state))
 
         samples = env.initial_state_dist().sample(n_samples=10)
 
@@ -1045,7 +1082,7 @@ class TestPushPOMDP:
         Test type: unit
         """
         fixed_state = np.array([2.0, 3.0, 5.0, 5.0, 9.0, 9.0])
-        env = PushPOMDP(discount_factor=0.95, initial_state=fixed_state)
+        env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(initial_state=fixed_state))
 
         sample1 = env.initial_state_dist().sample()[0]
         sample1[0] = 999.0  # Modify the sample
@@ -1067,7 +1104,7 @@ class TestPushPOMDP:
         Test type: unit
         """
         fixed_state = np.array([3.0, 4.0, 6.0, 6.0, 9.0, 9.0])
-        env = PushPOMDP(discount_factor=0.95, initial_state=fixed_state)
+        env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(initial_state=fixed_state))
 
         observation = env.initial_observation_dist().sample()[0]
 
@@ -1086,7 +1123,7 @@ class TestPushPOMDP:
 
         Test type: unit
         """
-        env = PushPOMDP(discount_factor=0.95)
+        env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs())
 
         samples = [env.initial_state_dist().sample()[0] for _ in range(10)]
 
@@ -1109,8 +1146,10 @@ class TestPushPOMDP:
         obstacles = [(3.0, 3.0), (7.0, 7.0)]
         env = PushPOMDP(
             discount_factor=0.95,
-            obstacles=obstacles,
-            obstacle_radius=0.5,
+            **push_pinned_kwargs(
+                obstacles=obstacles,
+                obstacle_radius=0.5,
+            ),
         )
 
         for _ in range(20):
@@ -1137,7 +1176,7 @@ class TestPushPOMDP:
 
         Test type: unit
         """
-        env = PushPOMDP(discount_factor=0.95, grid_size=10)
+        env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(grid_size=10))
 
         for _ in range(20):
             state = env.initial_state_dist().sample()[0]
@@ -1165,12 +1204,14 @@ class TestPushPOMDP:
         initial_state = np.array([5.0, 5.0, 5.0, 5.0, 9.0, 9.0])
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=2.0,  # Large enough so robot stays within threshold after moving
-            friction_coefficient=0.3,
-            obstacles=[],
-            obstacle_radius=0.5,
-            transition_error_prob=0.0,  # Explicitly set to 0 for deterministic behavior
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=2.0,  # Large enough so robot stays within threshold after moving
+                friction_coefficient=0.3,
+                obstacles=[],
+                obstacle_radius=0.5,
+                transition_error_prob=0.0,  # Explicitly set to 0 for deterministic behavior
+            ),
         )
 
         # Hardcoded expected states for each action.
@@ -1228,12 +1269,14 @@ class TestPushPOMDPStateTransition:
         initial_state = np.array([1.0, 1.0, 8.0, 8.0, 9.0, 9.0])
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            obstacles=[],
-            obstacle_radius=0.5,
-            transition_error_prob=0.0,  # Explicitly set to 0 for deterministic behavior
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                obstacles=[],
+                obstacle_radius=0.5,
+                transition_error_prob=0.0,  # Explicitly set to 0 for deterministic behavior
+            ),
         )
 
         # Hardcoded expected states for each action.
@@ -1293,12 +1336,14 @@ class TestStochasticObstacleHitProbability:
     def _stochastic_env(hit_probability: float) -> PushPOMDP:
         return PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            obstacles=[(3.0, 3.0)],
-            obstacle_radius=0.5,
-            obstacle_penalty=TestStochasticObstacleHitProbability.OBSTACLE_PENALTY,
-            obstacle_hit_probability=hit_probability,
-            transition_error_prob=0.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                obstacles=[(3.0, 3.0)],
+                obstacle_radius=0.5,
+                obstacle_penalty=TestStochasticObstacleHitProbability.OBSTACLE_PENALTY,
+                obstacle_hit_probability=hit_probability,
+                transition_error_prob=0.0,
+            ),
         )
 
     @staticmethod
@@ -1320,7 +1365,7 @@ class TestStochasticObstacleHitProbability:
 
         Test type: unit
         """
-        env = PushPOMDP(discount_factor=0.95)
+        env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs())
         assert env.obstacle_hit_probability == 1.0
 
     def test_hit_probability_zero_never_applies_penalty(self):
@@ -1448,7 +1493,10 @@ class TestStochasticObstacleHitProbability:
         Test type: unit
         """
         with pytest.raises(ValueError, match="obstacle_hit_probability"):
-            PushPOMDP(discount_factor=0.95, obstacle_hit_probability=bad_value)
+            PushPOMDP(
+                discount_factor=0.95,
+                **push_pinned_kwargs(obstacle_hit_probability=bad_value),
+            )
 
 
 class TestPushDangerousAreas:
@@ -1468,12 +1516,14 @@ class TestPushDangerousAreas:
     def _danger_env(hit_probability: float = 1.0) -> PushPOMDP:
         return PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            dangerous_areas=[(3.0, 3.0)],
-            dangerous_area_radius=0.5,
-            dangerous_area_penalty=TestPushDangerousAreas.DANGER_PENALTY,
-            dangerous_area_hit_probability=hit_probability,
-            transition_error_prob=0.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                dangerous_areas=[(3.0, 3.0)],
+                dangerous_area_radius=0.5,
+                dangerous_area_penalty=TestPushDangerousAreas.DANGER_PENALTY,
+                dangerous_area_hit_probability=hit_probability,
+                transition_error_prob=0.0,
+            ),
         )
 
     @staticmethod
@@ -1503,7 +1553,7 @@ class TestPushDangerousAreas:
         env = self._danger_env()
         state = self._enter_state()
         # Reference reward without dangerous area for comparison.
-        env_safe = PushPOMDP(discount_factor=0.95, grid_size=10)
+        env_safe = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(grid_size=10))
         np.random.seed(0)
         baseline = env_safe.reward(state, self.DANGER_ACTION)
         np.random.seed(0)
@@ -1525,7 +1575,7 @@ class TestPushDangerousAreas:
         Test type: unit
         """
         env_danger = self._danger_env()
-        env_safe = PushPOMDP(discount_factor=0.95, grid_size=10)
+        env_safe = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(grid_size=10))
         state = self._safe_state()
         np.random.seed(0)
         baseline = env_safe.reward(state, self.DANGER_ACTION)
@@ -1546,7 +1596,7 @@ class TestPushDangerousAreas:
 
         Test type: unit
         """
-        env = PushPOMDP(discount_factor=0.95)
+        env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs())
         assert not env.dangerous_areas
         assert env._dangerous_areas_arr.shape == (0, 2)
         assert env.dangerous_area_hit_probability == 1.0
@@ -1566,7 +1616,7 @@ class TestPushDangerousAreas:
         Test type: unit
         """
         env = self._danger_env()
-        env_safe = PushPOMDP(discount_factor=0.95, grid_size=10)
+        env_safe = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(grid_size=10))
         states = np.stack([self._enter_state(), self._safe_state()])
         np.random.seed(0)
         baselines = env_safe.reward_batch(states, self.DANGER_ACTION)
@@ -1588,7 +1638,7 @@ class TestPushDangerousAreas:
         Test type: unit
         """
         env = self._danger_env(hit_probability=0.0)
-        env_safe = PushPOMDP(discount_factor=0.95, grid_size=10)
+        env_safe = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(grid_size=10))
         state = self._enter_state()
         baseline = env_safe.reward(state, self.DANGER_ACTION)
         for _ in range(200):
@@ -1606,7 +1656,7 @@ class TestPushDangerousAreas:
         Test type: unit
         """
         env = self._danger_env(hit_probability=1.0)
-        env_safe = PushPOMDP(discount_factor=0.95, grid_size=10)
+        env_safe = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(grid_size=10))
         state = self._enter_state()
         baseline = env_safe.reward(state, self.DANGER_ACTION)
         expected = baseline + self.DANGER_PENALTY
@@ -1625,7 +1675,7 @@ class TestPushDangerousAreas:
         Test type: unit
         """
         env = self._danger_env(hit_probability=0.3)
-        env_safe = PushPOMDP(discount_factor=0.95, grid_size=10)
+        env_safe = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(grid_size=10))
         state = self._enter_state()
         baseline = env_safe.reward(state, self.DANGER_ACTION)
         np.random.seed(123)
@@ -1713,7 +1763,10 @@ class TestPushDangerousAreas:
         Test type: unit
         """
         with pytest.raises(ValueError, match="dangerous_area_hit_probability"):
-            PushPOMDP(discount_factor=0.95, dangerous_area_hit_probability=bad_value)
+            PushPOMDP(
+                discount_factor=0.95,
+                **push_pinned_kwargs(dangerous_area_hit_probability=bad_value),
+            )
 
     def test_native_rollout_used_when_hit_probability_lt_one(self, monkeypatch):
         """Stochastic dangerous-area hit probability is handled by the native rollout.
@@ -1772,12 +1825,14 @@ class TestPushDangerousAreas:
 
         Test type: unit
         """
-        env_no = PushPOMDP(discount_factor=0.95, grid_size=10)
+        env_no = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs(grid_size=10))
         env_yes = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            dangerous_areas=[(2.0, 2.0)],
-            dangerous_area_penalty=-3.5,
+            **push_pinned_kwargs(
+                grid_size=10,
+                dangerous_areas=[(2.0, 2.0)],
+                dangerous_area_penalty=-3.5,
+            ),
         )
         assert env_yes.reward_range[0] == pytest.approx(env_no.reward_range[0] - 3.5)
 
@@ -1800,7 +1855,7 @@ class TestSampleNextStepEquivalence:
         """
         from POMDPPlanners.core.environment import Environment
 
-        env = PushPOMDP(discount_factor=0.95)
+        env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs())
         state = env.initial_state_dist().sample()[0]
 
         for action in env.get_actions():
@@ -1867,10 +1922,12 @@ class TestRewardBatchMatchesScalarLoop:
 
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            obstacles=[(3.0, 3.0), (7.0, 7.0)],
-            obstacle_radius=0.5,
-            obstacle_penalty=-10.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                obstacles=[(3.0, 3.0), (7.0, 7.0)],
+                obstacle_radius=0.5,
+                obstacle_penalty=-10.0,
+            ),
         )
 
         np.random.seed(0)
@@ -1921,7 +1978,7 @@ class TestRewardBatchMatchesScalarLoop:
 
         Test type: unit
         """
-        env = PushPOMDP(discount_factor=0.95)
+        env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs())
         np.random.seed(7)
         particles = env.initial_state_dist().sample(n_samples=16)
         particles_arr = np.array(particles)
@@ -1957,11 +2014,13 @@ class TestRewardBatchMatchesScalarLoop:
         """
         env = PushPOMDP(
             discount_factor=0.95,
-            obstacles=[(3.0, 3.0)],
-            obstacle_radius=0.5,
-            obstacle_penalty=-10.0,
-            transition_error_prob=0.0,
-            friction_coefficient=0.0,
+            **push_pinned_kwargs(
+                obstacles=[(3.0, 3.0)],
+                obstacle_radius=0.5,
+                obstacle_penalty=-10.0,
+                transition_error_prob=0.0,
+                friction_coefficient=0.0,
+            ),
         )
 
         # Realised next-state robot lies inside the obstacle (boundary geometry).
@@ -2014,14 +2073,16 @@ class TestPushNativeSimulateRollout:
 
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            observation_noise=0.1,
-            obstacles=[(3.0, 3.0), (7.0, 7.0)],
-            obstacle_radius=0.5,
-            obstacle_penalty=-10.0,
-            transition_error_prob=0.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                observation_noise=0.1,
+                obstacles=[(3.0, 3.0), (7.0, 7.0)],
+                obstacle_radius=0.5,
+                obstacle_penalty=-10.0,
+                transition_error_prob=0.0,
+            ),
         )
 
         initial_state = np.array([2.0, 3.0, 2.5, 3.1, 9.0, 9.0], dtype=np.float64)
@@ -2092,14 +2153,16 @@ class TestPushNativeSimulateRollout:
 
         env = PushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            push_threshold=1.5,
-            friction_coefficient=0.2,
-            observation_noise=0.1,
-            obstacles=None,
-            obstacle_radius=0.5,
-            obstacle_penalty=-5.0,
-            transition_error_prob=0.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.5,
+                friction_coefficient=0.2,
+                observation_noise=0.1,
+                obstacles=None,
+                obstacle_radius=0.5,
+                obstacle_penalty=-5.0,
+                transition_error_prob=0.0,
+            ),
         )
 
         initial_state = np.array([0.0, 0.0, 5.0, 5.0, 9.0, 9.0], dtype=np.float64)
@@ -2161,11 +2224,13 @@ class TestPushNativeSimulateRollout:
         """
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            observation_noise=0.1,
-            transition_error_prob=0.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                observation_noise=0.1,
+                transition_error_prob=0.0,
+            ),
         )
 
         # Object is at the target: (9-9)^2 + (9-9)^2 = 0 < 0.25, terminal.
@@ -2209,22 +2274,26 @@ class TestPushNativeSimulateRollout:
         _ACTIONS = ["up", "down", "right", "left"]
         env_safe = PushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            observation_noise=0.1,
-            transition_error_prob=0.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                observation_noise=0.1,
+                transition_error_prob=0.0,
+            ),
         )
         env_danger = PushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            observation_noise=0.1,
-            transition_error_prob=0.0,
-            dangerous_areas=[(3.0, 3.0)],
-            dangerous_area_radius=0.5,
-            dangerous_area_penalty=-5.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                observation_noise=0.1,
+                transition_error_prob=0.0,
+                dangerous_areas=[(3.0, 3.0)],
+                dangerous_area_radius=0.5,
+                dangerous_area_penalty=-5.0,
+            ),
         )
         # Robot at (2, 3) → action "right" → intended (3, 3) is in the zone.
         initial_state = np.array([2.0, 3.0, 8.0, 8.0, 9.0, 9.0], dtype=np.float64)
@@ -2293,17 +2362,19 @@ class TestPushNativeSimulateRollout:
         _ACTIONS = ["up", "down", "right", "left"]
         env = PushPOMDP(
             discount_factor=0.99,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.3,
-            observation_noise=0.1,
-            obstacles=[(7.0, 7.0)],
-            obstacle_radius=0.5,
-            obstacle_penalty=-10.0,
-            dangerous_areas=[(3.0, 3.0)],
-            dangerous_area_radius=0.5,
-            dangerous_area_penalty=-5.0,
-            transition_error_prob=0.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.3,
+                observation_noise=0.1,
+                obstacles=[(7.0, 7.0)],
+                obstacle_radius=0.5,
+                obstacle_penalty=-10.0,
+                dangerous_areas=[(3.0, 3.0)],
+                dangerous_area_radius=0.5,
+                dangerous_area_penalty=-5.0,
+                transition_error_prob=0.0,
+            ),
         )
         initial_state = np.array([2.0, 3.0, 2.5, 3.1, 9.0, 9.0], dtype=np.float64)
         max_depth = 20
@@ -2357,13 +2428,15 @@ def test_compute_metrics_values_within_confidence_intervals():
     """
     env = PushPOMDP(
         discount_factor=0.95,
-        grid_size=10,
-        push_threshold=1.0,
-        friction_coefficient=0.3,
-        observation_noise=0.1,
-        obstacles=[(3.0, 3.0), (7.0, 7.0)],
-        obstacle_radius=0.5,
-        obstacle_penalty=-10.0,
+        **push_pinned_kwargs(
+            grid_size=10,
+            push_threshold=1.0,
+            friction_coefficient=0.3,
+            observation_noise=0.1,
+            obstacles=[(3.0, 3.0), (7.0, 7.0)],
+            obstacle_radius=0.5,
+            obstacle_penalty=-10.0,
+        ),
     )
 
     target = np.array([9.0, 9.0])
@@ -2483,13 +2556,15 @@ class TestPushPOMDPRewardNextStateConsistency:
     def _env_with_obstacle() -> PushPOMDP:
         return PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            obstacles=[(3.0, 3.0)],
-            obstacle_radius=0.5,
-            obstacle_penalty=TestPushPOMDPRewardNextStateConsistency.OBSTACLE_PENALTY,
-            obstacle_hit_probability=1.0,
-            transition_error_prob=0.0,
-            friction_coefficient=0.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                obstacles=[(3.0, 3.0)],
+                obstacle_radius=0.5,
+                obstacle_penalty=TestPushPOMDPRewardNextStateConsistency.OBSTACLE_PENALTY,
+                obstacle_hit_probability=1.0,
+                transition_error_prob=0.0,
+                friction_coefficient=0.0,
+            ),
         )
 
     def test_reward_obstacle_penalty_uses_realised_next_state(self):
@@ -2586,13 +2661,15 @@ class TestPushPOMDPRewardNextStateConsistency:
         """
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            obstacles=[(3.0, 3.0)],
-            obstacle_radius=0.5,
-            obstacle_penalty=self.OBSTACLE_PENALTY,
-            obstacle_hit_probability=1.0,
-            transition_error_prob=0.4,
-            friction_coefficient=0.0,
+            **push_pinned_kwargs(
+                grid_size=10,
+                obstacles=[(3.0, 3.0)],
+                obstacle_radius=0.5,
+                obstacle_penalty=self.OBSTACLE_PENALTY,
+                obstacle_hit_probability=1.0,
+                transition_error_prob=0.4,
+                friction_coefficient=0.0,
+            ),
         )
         state = np.array([2.0, 3.0, 8.0, 8.0, 9.0, 9.0])
 

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_continuous_push_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_continuous_push_belief_factory.py
@@ -16,6 +16,10 @@ from POMDPPlanners.environments.push_pomdp.continuous_push_pomdp import (
 from POMDPPlanners.environments.push_pomdp.push_pomdp_beliefs.continuous_push_belief_factory import (
     create_continuous_push_belief,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_push_discrete_actions_pinned_kwargs,
+    continuous_push_pinned_kwargs,
+)
 from POMDPPlanners.utils.belief_factory import BeliefType, create_environment_belief
 
 
@@ -27,8 +31,10 @@ class TestContinuousPushBeliefFactory:
         np.random.seed(42)
         self.env = ContinuousPushPOMDP(
             discount_factor=0.99,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
-            robot_radius=0.3,
+            **continuous_push_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+                robot_radius=0.3,
+            ),
         )
 
     def test_create_vectorized_belief(self):
@@ -106,8 +112,10 @@ class TestContinuousPushBeliefFactory:
         """
         env_d = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
-            robot_radius=0.3,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+                robot_radius=0.3,
+            ),
         )
         belief = create_environment_belief(env_d, n_particles=50)
         assert belief is not None

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_continuous_push_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_continuous_push_vectorized_updater.py
@@ -33,6 +33,10 @@ from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils imp
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_push_discrete_actions_pinned_kwargs,
+    continuous_push_pinned_kwargs,
+)
 
 
 def _make_aligned_beliefs(updater, n_particles=60):
@@ -65,8 +69,10 @@ class TestContinuousPushVectorizedUpdater:
         np.random.seed(42)
         self.env = ContinuousPushPOMDP(
             discount_factor=0.99,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
-            robot_radius=0.3,
+            **continuous_push_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+                robot_radius=0.3,
+            ),
         )
         self.updater = ContinuousPushVectorizedUpdater.from_environment(self.env)
 
@@ -113,8 +119,10 @@ class TestContinuousPushVectorizedUpdater:
         """
         env_d = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
-            robot_radius=0.3,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+                robot_radius=0.3,
+            ),
         )
         updater = ContinuousPushVectorizedUpdater.from_environment(env_d)
         particles = np.tile(env_d.initial_state_dist().sample()[0], (50, 1))
@@ -170,8 +178,10 @@ class TestContinuousPushVectorizedUpdater:
         """
         env2 = ContinuousPushPOMDP(
             discount_factor=0.99,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
-            robot_radius=0.3,
+            **continuous_push_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+                robot_radius=0.3,
+            ),
         )
         updater2 = ContinuousPushVectorizedUpdater.from_environment(env2)
         assert self.updater.config_id == updater2.config_id
@@ -257,8 +267,10 @@ class TestContinuousPushVectorizedUpdater:
         """
         env_d = ContinuousPushPOMDPDiscreteActions(
             discount_factor=0.99,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
-            robot_radius=0.3,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+                robot_radius=0.3,
+            ),
         )
         updater = ContinuousPushVectorizedUpdater.from_environment(env_d)
         assert updater._action_to_vector is not None
@@ -272,8 +284,10 @@ class TestBeliefEquivalenceWithBaseline:
         """Set up shared test fixtures."""
         self.env = ContinuousPushPOMDP(
             discount_factor=0.99,
-            state_transition_cov_matrix=np.eye(2) * 0.01,
-            robot_radius=0.3,
+            **continuous_push_pinned_kwargs(
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+                robot_radius=0.3,
+            ),
         )
         self.updater = ContinuousPushVectorizedUpdater.from_environment(self.env)
 

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_push_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_push_belief_factory.py
@@ -17,12 +17,13 @@ from POMDPPlanners.environments.push_pomdp.push_pomdp import PushPOMDP
 from POMDPPlanners.environments.push_pomdp.push_pomdp_beliefs import (
     create_push_belief,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import push_pinned_kwargs
 from POMDPPlanners.utils.belief_factory import BeliefType
 
 
 @pytest.fixture
 def env():
-    return PushPOMDP(discount_factor=0.95)
+    return PushPOMDP(discount_factor=0.95, **push_pinned_kwargs())
 
 
 class TestCreatePushBelief:

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_push_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_beliefs/test_push_vectorized_updater.py
@@ -27,6 +27,7 @@ from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils imp
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import push_pinned_kwargs
 
 
 def _make_aligned_beliefs(updater, n_particles=100):
@@ -62,12 +63,14 @@ ACTION_STRINGS = ["up", "down", "right", "left"]
 def env():
     return PushPOMDP(
         discount_factor=0.99,
-        grid_size=10,
-        push_threshold=1.0,
-        friction_coefficient=0.3,
-        observation_noise=0.1,
-        obstacles=[(3.0, 3.0), (7.0, 7.0)],
-        obstacle_radius=0.5,
+        **push_pinned_kwargs(
+            grid_size=10,
+            push_threshold=1.0,
+            friction_coefficient=0.3,
+            observation_noise=0.1,
+            obstacles=[(3.0, 3.0), (7.0, 7.0)],
+            obstacle_radius=0.5,
+        ),
     )
 
 
@@ -75,10 +78,12 @@ def env():
 def env_no_obstacles():
     return PushPOMDP(
         discount_factor=0.99,
-        grid_size=10,
-        push_threshold=1.0,
-        friction_coefficient=0.3,
-        observation_noise=0.1,
+        **push_pinned_kwargs(
+            grid_size=10,
+            push_threshold=1.0,
+            friction_coefficient=0.3,
+            observation_noise=0.1,
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/rock_sample_pomdp_utils/test_rock_sample_reward_cpp_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/rock_sample_pomdp_utils/test_rock_sample_reward_cpp_parity.py
@@ -40,6 +40,7 @@ from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import (
     RewardModelType,
     RockSamplePOMDP,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import rock_sample_pinned_kwargs
 
 
 _MAP_SIZE: Tuple[int, int] = (7, 7)
@@ -61,20 +62,23 @@ _NUM_ROCKS: int = len(_ROCK_POSITIONS)
 
 def _make_env(reward_model_type: RewardModelType, penalty_decay: float) -> RockSamplePOMDP:
     return RockSamplePOMDP(
-        map_size=_MAP_SIZE,
-        rock_positions=list(_ROCK_POSITIONS),
-        init_pos=_INIT_POS,
-        bad_rock_penalty=_BAD_ROCK_PENALTY,
-        good_rock_reward=_GOOD_ROCK_REWARD,
-        step_penalty=_STEP_PENALTY,
-        sensor_use_penalty=_SENSOR_USE_PENALTY,
-        exit_reward=_EXIT_REWARD,
-        dangerous_areas=list(_DANGEROUS_AREAS),
-        dangerous_area_radius=_DANGEROUS_AREA_RADIUS,
-        dangerous_area_penalty=_DANGEROUS_AREA_PENALTY,
-        dangerous_area_hit_probability=_DANGEROUS_AREA_HIT_PROBABILITY,
-        reward_model_type=reward_model_type,
-        penalty_decay=penalty_decay,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=_MAP_SIZE,
+            rock_positions=list(_ROCK_POSITIONS),
+            init_pos=_INIT_POS,
+            bad_rock_penalty=_BAD_ROCK_PENALTY,
+            good_rock_reward=_GOOD_ROCK_REWARD,
+            step_penalty=_STEP_PENALTY,
+            sensor_use_penalty=_SENSOR_USE_PENALTY,
+            exit_reward=_EXIT_REWARD,
+            dangerous_areas=list(_DANGEROUS_AREAS),
+            dangerous_area_radius=_DANGEROUS_AREA_RADIUS,
+            dangerous_area_penalty=_DANGEROUS_AREA_PENALTY,
+            dangerous_area_hit_probability=_DANGEROUS_AREA_HIT_PROBABILITY,
+            reward_model_type=reward_model_type,
+            penalty_decay=penalty_decay,
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/rock_sample_pomdp_utils/test_rock_sample_reward_models.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/rock_sample_pomdp_utils/test_rock_sample_reward_models.py
@@ -25,6 +25,7 @@ from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_utils.rock_s
     RockSampleZeroMeanHazardShockRewardModel,
     RockSampleRewardModel,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import rock_sample_pinned_kwargs
 
 
 # ---------------------------------------------------------------------------
@@ -44,7 +45,9 @@ def test_env_builds_standard_reward_model_by_default():
 
     Test type: unit
     """
-    env = RockSamplePOMDP(dangerous_areas=[(2, 2)])
+    env = RockSamplePOMDP(
+        discount_factor=0.95, **rock_sample_pinned_kwargs(dangerous_areas=[(2, 2)])
+    )
     assert type(env.reward_model) is RockSampleRewardModel  # pylint: disable=unidiomatic-typecheck
 
 
@@ -62,9 +65,12 @@ def test_env_builds_high_variance_reward_model_on_request():
     Test type: unit
     """
     env = RockSamplePOMDP(
-        dangerous_areas=[(2, 2)],
-        dangerous_area_penalty=-5.0,
-        reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            dangerous_areas=[(2, 2)],
+            dangerous_area_penalty=-5.0,
+            reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+        ),
     )
     assert isinstance(env.reward_model, RockSampleZeroMeanHazardShockRewardModel)
     # HIGH_VARIANCE flips the penalty sign with probability 0.5, so the
@@ -90,9 +96,12 @@ def test_env_builds_decaying_reward_model_on_request():
     Test type: unit
     """
     env = RockSamplePOMDP(
-        dangerous_areas=[(2, 2)],
-        reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
-        penalty_decay=2.5,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            dangerous_areas=[(2, 2)],
+            reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
+            penalty_decay=2.5,
+        ),
     )
     assert isinstance(env.reward_model, RockSampleDistanceDecayedHazardPenaltyRewardModel)
     assert env.reward_model.penalty_decay == 2.5
@@ -149,11 +158,14 @@ def test_decaying_model_rejects_non_positive_penalty_decay():
 
 def _make_high_variance_env() -> RockSamplePOMDP:
     return RockSamplePOMDP(
-        map_size=(7, 7),
-        rock_positions=[(0, 0), (2, 2), (3, 3), (5, 5)],
-        dangerous_areas=[(2, 2), (4, 4)],
-        dangerous_area_penalty=-5.0,
-        reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=(7, 7),
+            rock_positions=[(0, 0), (2, 2), (3, 3), (5, 5)],
+            dangerous_areas=[(2, 2), (4, 4)],
+            dangerous_area_penalty=-5.0,
+            reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+        ),
     )
 
 
@@ -260,12 +272,15 @@ def test_high_variance_batch_seeded_parity_with_scalar_loop():
 
 def _make_decaying_env(penalty_decay: float = 1.0) -> RockSamplePOMDP:
     return RockSamplePOMDP(
-        map_size=(7, 7),
-        rock_positions=[(0, 0), (2, 2), (3, 3), (5, 5)],
-        dangerous_areas=[(3, 3)],
-        dangerous_area_penalty=-5.0,
-        reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
-        penalty_decay=penalty_decay,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=(7, 7),
+            rock_positions=[(0, 0), (2, 2), (3, 3), (5, 5)],
+            dangerous_areas=[(3, 3)],
+            dangerous_area_penalty=-5.0,
+            reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
+            penalty_decay=penalty_decay,
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_env_api_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_env_api_parity.py
@@ -36,6 +36,7 @@ from POMDPPlanners.environments.rock_sample_pomdp import (
     RockSamplePOMDP,
     create_rock_sample_state,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import rock_sample_pinned_kwargs
 
 
 # ---------------------------------------------------------------------------
@@ -52,10 +53,13 @@ def _make_env(
 ) -> RockSamplePOMDP:
     rocks = rock_positions if rock_positions is not None else [(1, 1), (3, 3)]
     return RockSamplePOMDP(
-        map_size=map_size,
-        rock_positions=rocks,
-        init_pos=init_pos,
-        sensor_efficiency=sensor_efficiency,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=map_size,
+            rock_positions=rocks,
+            init_pos=init_pos,
+            sensor_efficiency=sensor_efficiency,
+        ),
     )
 
 
@@ -317,13 +321,16 @@ def test_reward_dangerous_area_penalty_added_when_next_state_in_zone() -> None:
     Test type: unit
     """
     env = RockSamplePOMDP(
-        map_size=(5, 5),
-        rock_positions=[(0, 0)],
-        init_pos=(0, 0),
-        dangerous_areas=[(2, 1)],
-        dangerous_area_radius=1.0,
-        dangerous_area_penalty=-5.0,
-        step_penalty=0.0,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=(5, 5),
+            rock_positions=[(0, 0)],
+            init_pos=(0, 0),
+            dangerous_areas=[(2, 1)],
+            dangerous_area_radius=1.0,
+            dangerous_area_penalty=-5.0,
+            step_penalty=0.0,
+        ),
     )
     state = create_rock_sample_state((2, 0), (True,))
     reward = env.reward(state, 2)  # east -> next at (2,1)
@@ -344,10 +351,13 @@ def test_reward_check_action_includes_sensor_penalty_no_movement_penalty() -> No
     Test type: unit
     """
     env = RockSamplePOMDP(
-        rock_positions=[(0, 0)],
-        init_pos=(0, 0),
-        step_penalty=-0.25,
-        sensor_use_penalty=-0.5,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            rock_positions=[(0, 0)],
+            init_pos=(0, 0),
+            step_penalty=-0.25,
+            sensor_use_penalty=-0.5,
+        ),
     )
     state = create_rock_sample_state((2, 2), (True,))
     reward = env.reward(state, 5)  # check_rock_0
@@ -369,7 +379,9 @@ def test_default_dangerous_area_penalty_is_non_positive() -> None:
 
     Test type: unit
     """
-    env = RockSamplePOMDP(rock_positions=[(0, 0)])
+    env = RockSamplePOMDP(
+        discount_factor=0.95, **rock_sample_pinned_kwargs(rock_positions=[(0, 0)])
+    )
     assert env.dangerous_area_penalty <= 0.0, (
         "Default dangerous_area_penalty must be non-positive given the "
         "additive reward convention; a positive default rewards danger entry."
@@ -392,13 +404,16 @@ def test_negative_dangerous_area_penalty_decreases_reward() -> None:
     Test type: unit
     """
     env = RockSamplePOMDP(
-        map_size=(5, 5),
-        rock_positions=[(0, 0)],
-        init_pos=(0, 0),
-        dangerous_areas=[(2, 1)],
-        dangerous_area_radius=1.0,
-        dangerous_area_penalty=-7.0,
-        step_penalty=0.0,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=(5, 5),
+            rock_positions=[(0, 0)],
+            init_pos=(0, 0),
+            dangerous_areas=[(2, 1)],
+            dangerous_area_radius=1.0,
+            dangerous_area_penalty=-7.0,
+            step_penalty=0.0,
+        ),
     )
     state = create_rock_sample_state((2, 0), (True,))
     reward = env.reward(state, 2)
@@ -421,10 +436,13 @@ def test_positive_dangerous_area_penalty_emits_warning() -> None:
     """
     with pytest.warns(UserWarning, match="positive"):
         RockSamplePOMDP(
-            map_size=(5, 5),
-            rock_positions=[(0, 0)],
-            dangerous_areas=[(2, 2)],
-            dangerous_area_penalty=5.0,
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                map_size=(5, 5),
+                rock_positions=[(0, 0)],
+                dangerous_areas=[(2, 2)],
+                dangerous_area_penalty=5.0,
+            ),
         )
 
 
@@ -446,14 +464,17 @@ def test_reward_exit_action_does_not_add_dangerous_area_penalty() -> None:
     Test type: unit
     """
     env = RockSamplePOMDP(
-        map_size=(5, 5),
-        rock_positions=[(0, 0)],
-        init_pos=(0, 0),
-        dangerous_areas=[(0, 0)],
-        dangerous_area_radius=0.5,
-        dangerous_area_penalty=-99.0,
-        step_penalty=-1.0,
-        exit_reward=10.0,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=(5, 5),
+            rock_positions=[(0, 0)],
+            init_pos=(0, 0),
+            dangerous_areas=[(0, 0)],
+            dangerous_area_radius=0.5,
+            dangerous_area_penalty=-99.0,
+            step_penalty=-1.0,
+            exit_reward=10.0,
+        ),
     )
     state = create_rock_sample_state((2, 4), (True,))
     reward = env.reward(state, 2)  # east -> exit
@@ -533,11 +554,14 @@ def test_reward_batch_exit_branch_matches_scalar_and_cpp_contract() -> None:
     Test type: integration
     """
     env = RockSamplePOMDP(
-        map_size=(5, 5),
-        rock_positions=[(0, 0)],
-        init_pos=(0, 0),
-        step_penalty=-1.0,
-        exit_reward=10.0,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=(5, 5),
+            rock_positions=[(0, 0)],
+            init_pos=(0, 0),
+            step_penalty=-1.0,
+            exit_reward=10.0,
+        ),
     )
     particles = np.array(
         [
@@ -577,14 +601,17 @@ def test_reward_batch_east_non_exit_includes_dangerous_area_penalty() -> None:
     Test type: integration
     """
     env = RockSamplePOMDP(
-        map_size=(5, 5),
-        rock_positions=[(0, 0)],
-        init_pos=(0, 0),
-        dangerous_areas=[(2, 1)],
-        dangerous_area_radius=1.0,
-        dangerous_area_penalty=-100.0,
-        step_penalty=-1.0,
-        exit_reward=10.0,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=(5, 5),
+            rock_positions=[(0, 0)],
+            init_pos=(0, 0),
+            dangerous_areas=[(2, 1)],
+            dangerous_area_radius=1.0,
+            dangerous_area_penalty=-100.0,
+            step_penalty=-1.0,
+            exit_reward=10.0,
+        ),
     )
     state = create_rock_sample_state((2, 0), (True,))
     scalar_reward = env.reward(state, 2)
@@ -614,14 +641,17 @@ def test_reward_batch_east_on_terminal_sentinel_equals_step_penalty() -> None:
     Test type: integration
     """
     env = RockSamplePOMDP(
-        map_size=(5, 5),
-        rock_positions=[(0, 0)],
-        init_pos=(0, 0),
-        dangerous_areas=[(2, 2)],
-        dangerous_area_radius=1.0,
-        dangerous_area_penalty=-50.0,
-        step_penalty=-1.0,
-        exit_reward=10.0,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=(5, 5),
+            rock_positions=[(0, 0)],
+            init_pos=(0, 0),
+            dangerous_areas=[(2, 2)],
+            dangerous_area_radius=1.0,
+            dangerous_area_penalty=-50.0,
+            step_penalty=-1.0,
+            exit_reward=10.0,
+        ),
     )
     terminal = create_rock_sample_state((-1, -1), (True,))
     scalar_reward = env.reward(terminal, 2)

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_kernel_cache.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_kernel_cache.py
@@ -21,6 +21,7 @@ from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import (
     RockSamplePOMDP,
     create_rock_sample_state,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import rock_sample_pinned_kwargs
 
 _ROCK_POSITIONS: List[Tuple[int, int]] = [(0, 0), (2, 2), (3, 3)]
 _MAP_SIZE: Tuple[int, int] = (5, 5)
@@ -32,11 +33,14 @@ _STATE_DIM: int = 2 + _NUM_ROCKS
 
 def _make_env(dangerous_areas=None) -> RockSamplePOMDP:
     return RockSamplePOMDP(
-        map_size=_MAP_SIZE,
-        rock_positions=list(_ROCK_POSITIONS),
-        init_pos=_INIT_POS,
-        sensor_efficiency=_SENSOR_EFFICIENCY,
-        dangerous_areas=dangerous_areas,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=_MAP_SIZE,
+            rock_positions=list(_ROCK_POSITIONS),
+            init_pos=_INIT_POS,
+            sensor_efficiency=_SENSOR_EFFICIENCY,
+            dangerous_areas=dangerous_areas,
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_native_equivalence.py
@@ -42,6 +42,7 @@ from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rock
 from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
     assert_batch_transition_matches_loop,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import rock_sample_pinned_kwargs
 
 # Shared small-env fixture values used across tests. Rock 0 lives at the
 # robot's starting position so the "distance-zero sensor" case is trivial.
@@ -55,10 +56,13 @@ _STATE_DIM: int = 2 + _NUM_ROCKS
 
 def _make_env() -> RockSamplePOMDP:
     return RockSamplePOMDP(
-        map_size=_MAP_SIZE,
-        rock_positions=list(_ROCK_POSITIONS),
-        init_pos=_INIT_POS,
-        sensor_efficiency=_SENSOR_EFFICIENCY,
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=_MAP_SIZE,
+            rock_positions=list(_ROCK_POSITIONS),
+            init_pos=_INIT_POS,
+            sensor_efficiency=_SENSOR_EFFICIENCY,
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
@@ -31,6 +31,7 @@ from POMDPPlanners.environments.rock_sample_pomdp import (
 from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
     verify_metrics_within_confidence_intervals,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import rock_sample_pinned_kwargs
 from POMDPPlanners.tests.test_utils.history_builders import build_test_history
 from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_history_returns_bounded,
@@ -144,7 +145,7 @@ class TestRockSamplePOMDP:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
 
         assert pomdp.map_size == (5, 5)
         assert pomdp.rock_positions == [(0, 0), (2, 2), (3, 3)]
@@ -170,13 +171,15 @@ class TestRockSamplePOMDP:
         """
         custom_rocks = [(1, 1), (2, 3), (4, 4)]
         pomdp = RockSamplePOMDP(
-            map_size=(7, 8),
-            rock_positions=custom_rocks,
-            init_pos=(1, 0),
-            sensor_efficiency=15.0,
-            bad_rock_penalty=-20.0,
-            good_rock_reward=15.0,
             discount_factor=0.9,
+            **rock_sample_pinned_kwargs(
+                map_size=(7, 8),
+                rock_positions=custom_rocks,
+                init_pos=(1, 0),
+                sensor_efficiency=15.0,
+                bad_rock_penalty=-20.0,
+                good_rock_reward=15.0,
+            ),
         )
 
         assert pomdp.map_size == (7, 8)
@@ -199,10 +202,10 @@ class TestRockSamplePOMDP:
         Test type: unit
         """
         with pytest.raises(ValueError, match="Map size must be positive"):
-            RockSamplePOMDP(map_size=(0, 5))
+            RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs(map_size=(0, 5)))
 
         with pytest.raises(ValueError, match="Map size must be positive"):
-            RockSamplePOMDP(map_size=(5, -1))
+            RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs(map_size=(5, -1)))
 
     def test_pomdp_validation_empty_rocks(self):
         """Test parameter validation for empty rock positions.
@@ -216,7 +219,9 @@ class TestRockSamplePOMDP:
         Test type: unit
         """
         # Empty rocks should be allowed - creates environment with no rocks
-        pomdp = RockSamplePOMDP(rock_positions=[])
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95, **rock_sample_pinned_kwargs(rock_positions=[])
+        )
         assert pomdp.rock_positions == []  # Should remain empty as requested
         assert len(pomdp.get_actions()) == 5  # Only basic actions, no check actions
 
@@ -235,10 +240,16 @@ class TestRockSamplePOMDP:
         Test type: unit
         """
         with pytest.raises(ValueError, match="Rock position .* is outside map bounds"):
-            RockSamplePOMDP(map_size=(3, 3), rock_positions=[(0, 0), (3, 3)])
+            RockSamplePOMDP(
+                discount_factor=0.95,
+                **rock_sample_pinned_kwargs(map_size=(3, 3), rock_positions=[(0, 0), (3, 3)]),
+            )
 
         with pytest.raises(ValueError, match="Rock position .* is outside map bounds"):
-            RockSamplePOMDP(map_size=(5, 5), rock_positions=[(2, 2), (-1, 3)])
+            RockSamplePOMDP(
+                discount_factor=0.95,
+                **rock_sample_pinned_kwargs(map_size=(5, 5), rock_positions=[(2, 2), (-1, 3)]),
+            )
 
     def test_pomdp_validation_init_pos_out_of_bounds(self):
         """Test parameter validation for initial position outside bounds.
@@ -252,10 +263,16 @@ class TestRockSamplePOMDP:
         Test type: unit
         """
         with pytest.raises(ValueError, match="Initial position .* is outside map bounds"):
-            RockSamplePOMDP(map_size=(3, 3), rock_positions=[], init_pos=(3, 2))
+            RockSamplePOMDP(
+                discount_factor=0.95,
+                **rock_sample_pinned_kwargs(map_size=(3, 3), rock_positions=[], init_pos=(3, 2)),
+            )
 
         with pytest.raises(ValueError, match="Initial position .* is outside map bounds"):
-            RockSamplePOMDP(map_size=(5, 5), rock_positions=[], init_pos=(2, -1))
+            RockSamplePOMDP(
+                discount_factor=0.95,
+                **rock_sample_pinned_kwargs(map_size=(5, 5), rock_positions=[], init_pos=(2, -1)),
+            )
 
     def test_get_actions(self):
         """Test action enumeration.
@@ -268,7 +285,10 @@ class TestRockSamplePOMDP:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(rock_positions=[(0, 0), (2, 2), (3, 3)])
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(rock_positions=[(0, 0), (2, 2), (3, 3)]),
+        )
         actions = pomdp.get_actions()
 
         expected_actions = [0, 1, 2, 3, 4, 5, 6, 7]  # 5 basic + 3 check
@@ -289,7 +309,12 @@ class TestRockSamplePOMDP:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(map_size=(3, 3), rock_positions=[(0, 0), (1, 1)], init_pos=(0, 0))
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                map_size=(3, 3), rock_positions=[(0, 0), (1, 1)], init_pos=(0, 0)
+            ),
+        )
         dist = pomdp.initial_state_dist()
 
         assert len(dist.values) == 4  # 2^2 possible rock configurations
@@ -310,7 +335,7 @@ class TestRockSamplePOMDP:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         dist = pomdp.initial_observation_dist()
 
         assert len(dist.values) == 1
@@ -328,7 +353,7 @@ class TestRockSamplePOMDP:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
 
         assert pomdp.is_equal_observation("good", "good")
         assert pomdp.is_equal_observation("bad", "bad")
@@ -347,7 +372,7 @@ class TestRockSamplePOMDP:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
 
         normal_state = create_rock_sample_state((2, 3), (True, False, True))
         terminal_state = create_rock_sample_state((-1, -1), (True, False, True))
@@ -370,7 +395,7 @@ class TestStateTransitionModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         state = create_rock_sample_state((2, 1), (True, False, True))
 
         next_state = pomdp.sample_next_state(state=state, action=1)  # North
@@ -388,7 +413,7 @@ class TestStateTransitionModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         state = create_rock_sample_state((0, 1), (True, False, True))
 
         next_state = pomdp.sample_next_state(state=state, action=1)  # North
@@ -405,7 +430,7 @@ class TestStateTransitionModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         state = create_rock_sample_state((1, 2), (True, False, True))
 
         next_state = pomdp.sample_next_state(state=state, action=2)  # East
@@ -423,7 +448,9 @@ class TestStateTransitionModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()  # Default 5x5 map
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95, **rock_sample_pinned_kwargs()
+        )  # Default 5x5 map
         state = create_rock_sample_state((1, 4), (True, False, True))  # Right boundary
 
         next_state = pomdp.sample_next_state(state=state, action=2)  # East
@@ -440,7 +467,7 @@ class TestStateTransitionModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         state = create_rock_sample_state((1, 2), (True, False, True))
 
         next_state = pomdp.sample_next_state(state=state, action=3)  # South
@@ -458,7 +485,9 @@ class TestStateTransitionModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()  # Default 5x5 map
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95, **rock_sample_pinned_kwargs()
+        )  # Default 5x5 map
         state = create_rock_sample_state((4, 1), (True, False, True))  # Bottom boundary
 
         next_state = pomdp.sample_next_state(state=state, action=3)  # South
@@ -475,7 +504,7 @@ class TestStateTransitionModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         state = create_rock_sample_state((2, 3), (True, False, True))
 
         next_state = pomdp.sample_next_state(state=state, action=4)  # West
@@ -493,7 +522,7 @@ class TestStateTransitionModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         state = create_rock_sample_state((2, 0), (True, False, True))
 
         next_state = pomdp.sample_next_state(state=state, action=4)  # West
@@ -510,7 +539,10 @@ class TestStateTransitionModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(rock_positions=[(0, 0), (2, 2), (3, 3)])
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(rock_positions=[(0, 0), (2, 2), (3, 3)]),
+        )
         state = create_rock_sample_state((0, 0), (True, False, True))  # At rock 0
 
         next_state = pomdp.sample_next_state(state=state, action=0)  # Sample
@@ -528,7 +560,10 @@ class TestStateTransitionModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(rock_positions=[(0, 0), (2, 2), (3, 3)])
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(rock_positions=[(0, 0), (2, 2), (3, 3)]),
+        )
         state = create_rock_sample_state((1, 1), (True, False, True))  # Not at any rock
 
         next_state = pomdp.sample_next_state(state=state, action=0)  # Sample
@@ -546,7 +581,7 @@ class TestStateTransitionModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         state = create_rock_sample_state((2, 1), (True, False, True))
 
         next_state = pomdp.sample_next_state(state=state, action=5)  # Check rock 0
@@ -568,7 +603,7 @@ class TestObservationModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         state = create_rock_sample_state((1, 1), (True, False))
 
         for action in [1, 2, 3, 4]:  # North, East, South, West
@@ -586,7 +621,7 @@ class TestObservationModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         state = create_rock_sample_state((1, 1), (True, False))
 
         observation = pomdp.sample_observation(next_state=state, action=0)  # Sample
@@ -604,7 +639,10 @@ class TestObservationModel:
         Test type: unit
         """
         pomdp = RockSamplePOMDP(
-            rock_positions=[(1, 1), (3, 3)], sensor_efficiency=50.0  # High efficiency
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                rock_positions=[(1, 1), (3, 3)], sensor_efficiency=50.0  # High efficiency
+            ),
         )
         state = create_rock_sample_state((1, 1), (True, False))  # At rock 0 position
 
@@ -627,8 +665,11 @@ class TestObservationModel:
         Test type: unit
         """
         pomdp = RockSamplePOMDP(
-            rock_positions=[(0, 0), (1, 2)],  # Closer rocks
-            sensor_efficiency=2.0,  # Moderate efficiency for reasonable uncertainty
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                rock_positions=[(0, 0), (1, 2)],  # Closer rocks
+                sensor_efficiency=2.0,  # Moderate efficiency for reasonable uncertainty
+            ),
         )
         state = create_rock_sample_state((0, 0), (True, False))  # At rock 0, check rock 1 at (1,2)
 
@@ -652,7 +693,10 @@ class TestObservationModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(rock_positions=[(0, 0), (2, 2)])  # Only 2 rocks
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(rock_positions=[(0, 0), (2, 2)]),
+        )  # Only 2 rocks
         state = create_rock_sample_state((1, 1), (True, False))
 
         observation = pomdp.sample_observation(next_state=state, action=7)  # Check rock 2 (invalid)
@@ -669,7 +713,10 @@ class TestObservationModel:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(rock_positions=[(2, 2)], sensor_efficiency=10.0)
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(rock_positions=[(2, 2)], sensor_efficiency=10.0),
+        )
         state = create_rock_sample_state((1, 1), (True,))  # Good rock at distance sqrt(2)
 
         log_probs = pomdp.observation_log_probability(state, 5, ["good", "bad", "none"])
@@ -697,7 +744,9 @@ class TestRewardFunction:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(step_penalty=-1.0)
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95, **rock_sample_pinned_kwargs(step_penalty=-1.0)
+        )
         state = create_rock_sample_state((2, 2), (True, False))
 
         for action in [1, 2, 3, 4]:  # Movement actions
@@ -715,7 +764,10 @@ class TestRewardFunction:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(step_penalty=-1.0, exit_reward=10.0)
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(step_penalty=-1.0, exit_reward=10.0),
+        )
         state = create_rock_sample_state((2, 4), (True, False))  # At right edge of 5x5 map
 
         reward = pomdp.reward(state, 2)  # East action
@@ -733,7 +785,10 @@ class TestRewardFunction:
         Test type: unit
         """
         pomdp = RockSamplePOMDP(
-            rock_positions=[(1, 1), (3, 3)], step_penalty=-0.5, good_rock_reward=15.0
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                rock_positions=[(1, 1), (3, 3)], step_penalty=-0.5, good_rock_reward=15.0
+            ),
         )
         state = create_rock_sample_state((1, 1), (True, False))  # At good rock
 
@@ -752,7 +807,10 @@ class TestRewardFunction:
         Test type: unit
         """
         pomdp = RockSamplePOMDP(
-            rock_positions=[(1, 1), (3, 3)], step_penalty=-0.5, bad_rock_penalty=-20.0
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                rock_positions=[(1, 1), (3, 3)], step_penalty=-0.5, bad_rock_penalty=-20.0
+            ),
         )
         state = create_rock_sample_state((1, 1), (False, True))  # At bad rock
 
@@ -770,7 +828,10 @@ class TestRewardFunction:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(rock_positions=[(0, 0), (3, 3)], step_penalty=-1.5)
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(rock_positions=[(0, 0), (3, 3)], step_penalty=-1.5),
+        )
         state = create_rock_sample_state((1, 1), (True, False))  # Not at any rock
 
         reward = pomdp.reward(state, 0)  # Sample action
@@ -787,7 +848,10 @@ class TestRewardFunction:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(step_penalty=-1.0, sensor_use_penalty=-2.0)
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(step_penalty=-1.0, sensor_use_penalty=-2.0),
+        )
         state = create_rock_sample_state((2, 2), (True, False))
 
         reward = pomdp.reward(state, 5)  # Check rock 0
@@ -805,11 +869,14 @@ class TestRewardFunction:
         Test type: unit
         """
         pomdp = RockSamplePOMDP(
-            step_penalty=-1.0,
-            bad_rock_penalty=-5.0,
-            good_rock_reward=8.0,
-            exit_reward=12.0,
-            sensor_use_penalty=-0.5,
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                step_penalty=-1.0,
+                bad_rock_penalty=-5.0,
+                good_rock_reward=8.0,
+                exit_reward=12.0,
+                sensor_use_penalty=-0.5,
+            ),
         )
 
         # Expected calculations from RockSamplePOMDP constructor:
@@ -822,10 +889,13 @@ class TestRewardFunction:
 
         # Verify with different parameters
         pomdp2 = RockSamplePOMDP(
-            step_penalty=-0.5,
-            bad_rock_penalty=-10.0,
-            exit_reward=20.0,
-            sensor_use_penalty=-1.0,
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                step_penalty=-0.5,
+                bad_rock_penalty=-10.0,
+                exit_reward=20.0,
+                sensor_use_penalty=-1.0,
+            ),
         )
 
         expected_min2 = -0.5 + (-10.0) + (-1.0)  # -11.5
@@ -848,7 +918,7 @@ class TestDangerousArea:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         assert pomdp._is_in_dangerous_area((0, 0)) is False
         assert pomdp._is_in_dangerous_area((2, 2)) is False
         assert pomdp._is_in_dangerous_area((4, 4)) is False
@@ -864,7 +934,10 @@ class TestDangerousArea:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(dangerous_areas=[(2, 2)], dangerous_area_radius=1.5)
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(dangerous_areas=[(2, 2)], dangerous_area_radius=1.5),
+        )
         # Position at center
         assert pomdp._is_in_dangerous_area((2, 2)) is True
         # Position adjacent (distance = 1.0)
@@ -887,7 +960,10 @@ class TestDangerousArea:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(dangerous_areas=[(2, 2)], dangerous_area_radius=1.0)
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(dangerous_areas=[(2, 2)], dangerous_area_radius=1.0),
+        )
         # Position at center (distance = 0.0)
         assert pomdp._is_in_dangerous_area((2, 2)) is True
         # Position adjacent (distance = 1.0, exactly at boundary)
@@ -912,7 +988,12 @@ class TestDangerousArea:
         """
         import math
 
-        pomdp = RockSamplePOMDP(dangerous_areas=[(2, 2)], dangerous_area_radius=math.sqrt(2))
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                dangerous_areas=[(2, 2)], dangerous_area_radius=math.sqrt(2)
+            ),
+        )
         # Position diagonal (distance = sqrt(2), exactly at boundary)
         assert pomdp._is_in_dangerous_area((3, 3)) is True
         assert pomdp._is_in_dangerous_area((1, 1)) is True
@@ -930,7 +1011,12 @@ class TestDangerousArea:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(dangerous_areas=[(1, 1), (3, 3)], dangerous_area_radius=1.5)
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                dangerous_areas=[(1, 1), (3, 3)], dangerous_area_radius=1.5
+            ),
+        )
         # Position within first area
         assert pomdp._is_in_dangerous_area((1, 1)) is True
         assert pomdp._is_in_dangerous_area((2, 1)) is True
@@ -957,9 +1043,12 @@ class TestDangerousArea:
         Test type: unit
         """
         pomdp = RockSamplePOMDP(
-            map_size=(5, 5),
-            dangerous_areas=[(2, 2)],
-            dangerous_area_radius=10.0,  # Large enough to cover entire map
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                map_size=(5, 5),
+                dangerous_areas=[(2, 2)],
+                dangerous_area_radius=10.0,  # Large enough to cover entire map
+            ),
         )
         # All positions should be within radius
         assert pomdp._is_in_dangerous_area((0, 0)) is True
@@ -977,7 +1066,10 @@ class TestDangerousArea:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP(dangerous_areas=[(2, 2)], dangerous_area_radius=0.1)
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(dangerous_areas=[(2, 2)], dangerous_area_radius=0.1),
+        )
         # Only exact center should be within radius
         assert pomdp._is_in_dangerous_area((2, 2)) is True
         # Adjacent positions should be outside
@@ -1000,14 +1092,17 @@ class TestStochasticDangerousAreaPenalty:
     @staticmethod
     def _stochastic_env(hit_probability: float, penalty: float = -5.0) -> RockSamplePOMDP:
         return RockSamplePOMDP(
-            map_size=(5, 5),
-            rock_positions=[(4, 4)],
-            init_pos=(1, 0),
-            dangerous_areas=[(2, 0)],
-            dangerous_area_radius=1.0,
-            dangerous_area_penalty=penalty,
-            dangerous_area_hit_probability=hit_probability,
-            step_penalty=0.0,
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                map_size=(5, 5),
+                rock_positions=[(4, 4)],
+                init_pos=(1, 0),
+                dangerous_areas=[(2, 0)],
+                dangerous_area_radius=1.0,
+                dangerous_area_penalty=penalty,
+                dangerous_area_hit_probability=hit_probability,
+                step_penalty=0.0,
+            ),
         )
 
     def test_default_hit_probability_is_one(self):
@@ -1022,7 +1117,7 @@ class TestStochasticDangerousAreaPenalty:
 
         Test type: unit
         """
-        env = RockSamplePOMDP()
+        env = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         assert env.dangerous_area_hit_probability == 1.0
 
     def test_hit_probability_zero_never_applies_penalty(self):
@@ -1141,7 +1236,10 @@ class TestStochasticDangerousAreaPenalty:
         Test type: unit
         """
         with pytest.raises(ValueError, match="dangerous_area_hit_probability"):
-            RockSamplePOMDP(dangerous_area_hit_probability=bad_value)
+            RockSamplePOMDP(
+                discount_factor=0.95,
+                **rock_sample_pinned_kwargs(dangerous_area_hit_probability=bad_value),
+            )
 
 
 class TestMetricsComputation:
@@ -1158,7 +1256,7 @@ class TestMetricsComputation:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         metrics = pomdp.compute_metrics([])
         assert metrics == []
 
@@ -1173,7 +1271,7 @@ class TestMetricsComputation:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
 
         # Create mock histories
         histories = []
@@ -1225,7 +1323,7 @@ class TestMetricsComputation:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
 
         histories = []
 
@@ -1282,7 +1380,7 @@ class TestMetricsComputation:
 
         Test type: integration
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
 
         # History 0: sample once and exit successfully.
         sample_state = create_rock_sample_state((0, 0), (True, True))
@@ -1440,7 +1538,12 @@ class TestIntegration:
 
         Test type: integration
         """
-        pomdp = RockSamplePOMDP(map_size=(3, 3), rock_positions=[(0, 0), (2, 2)], init_pos=(0, 0))
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                map_size=(3, 3), rock_positions=[(0, 0), (2, 2)], init_pos=(0, 0)
+            ),
+        )
 
         # Start with initial state
         initial_dist = pomdp.initial_state_dist()
@@ -1484,7 +1587,10 @@ class TestIntegration:
         """
         # High efficiency sensor for deterministic behavior
         pomdp = RockSamplePOMDP(
-            rock_positions=[(1, 1)], sensor_efficiency=100.0  # Very high efficiency
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                rock_positions=[(1, 1)], sensor_efficiency=100.0  # Very high efficiency
+            ),
         )
 
         # Robot at rock position - should get very accurate readings
@@ -1508,7 +1614,10 @@ class TestIntegration:
 
         Test type: integration
         """
-        pomdp = RockSamplePOMDP(rock_positions=[(0, 0), (1, 1)], init_pos=(0, 0))
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(rock_positions=[(0, 0), (1, 1)], init_pos=(0, 0)),
+        )
 
         initial_dist = pomdp.initial_state_dist()
 
@@ -1544,7 +1653,7 @@ class TestSampleNextStepEquivalence:
         """
         from POMDPPlanners.core.environment import Environment
 
-        env = RockSamplePOMDP(discount_factor=0.95)
+        env = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         state = env.initial_state_dist().sample()[0]
 
         for action in [0, 1, 2, 3, 4, 5]:
@@ -1583,11 +1692,15 @@ _RS_STATE_DIM = 2 + _RS_NUM_ROCKS
 
 
 def _make_rs_env(**kwargs) -> RockSamplePOMDP:
+    discount_factor = kwargs.pop("discount_factor", 0.95)
     return RockSamplePOMDP(
-        map_size=_RS_MAP_SIZE,
-        rock_positions=list(_RS_ROCK_POSITIONS),
-        init_pos=(0, 0),
-        **kwargs,
+        discount_factor=discount_factor,
+        **rock_sample_pinned_kwargs(
+            map_size=_RS_MAP_SIZE,
+            rock_positions=list(_RS_ROCK_POSITIONS),
+            init_pos=(0, 0),
+            **kwargs,
+        ),
     )
 
 
@@ -1853,8 +1966,10 @@ def test_scalar_obs_log_prob_un_floored_matches_batch_after_fix() -> None:
     """
     env = RockSamplePOMDP(
         discount_factor=0.95,
-        rock_positions=[(1, 1)],
-        sensor_efficiency=10.0,
+        **rock_sample_pinned_kwargs(
+            rock_positions=[(1, 1)],
+            sensor_efficiency=10.0,
+        ),
     )
     state = create_rock_sample_state((1, 1), (True,))
 
@@ -1884,14 +1999,17 @@ class TestRockSampleRewardBatchNextStateConsistency:
     @staticmethod
     def _danger_env(hit_probability: float = 1.0) -> RockSamplePOMDP:
         return RockSamplePOMDP(
-            map_size=(5, 5),
-            rock_positions=[(4, 4)],
-            init_pos=(0, 0),
-            dangerous_areas=[(2, 0)],
-            dangerous_area_radius=1.0,
-            dangerous_area_penalty=-5.0,
-            dangerous_area_hit_probability=hit_probability,
-            step_penalty=0.0,
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                map_size=(5, 5),
+                rock_positions=[(4, 4)],
+                init_pos=(0, 0),
+                dangerous_areas=[(2, 0)],
+                dangerous_area_radius=1.0,
+                dangerous_area_penalty=-5.0,
+                dangerous_area_hit_probability=hit_probability,
+                step_penalty=0.0,
+            ),
         )
 
     def test_reward_batch_uses_passed_next_states_per_row(self):

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_visualizer.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_visualizer.py
@@ -20,6 +20,7 @@ from POMDPPlanners.environments.rock_sample_pomdp import (
     RockSampleState,
     create_rock_sample_state,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import rock_sample_pinned_kwargs
 
 
 class TestVisualization:
@@ -36,7 +37,7 @@ class TestVisualization:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         state = create_rock_sample_state((0, 0), (True, False))
 
         with pytest.raises(TypeError, match="cache_path must be a Path object"):
@@ -56,7 +57,7 @@ class TestVisualization:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         empty_history = History(
             history=[],
             discount_factor=0.95,
@@ -88,7 +89,7 @@ class TestVisualization:
 
         Test type: unit
         """
-        pomdp = RockSamplePOMDP()
+        pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
 
         # Create history with steps
         state1 = create_rock_sample_state((0, 0), (True, False))

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_belief_factory.py
@@ -11,17 +11,20 @@ from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rock
     RockSampleVectorizedWeightedParticleBelief,
     create_rocksample_belief,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import rock_sample_pinned_kwargs
 from POMDPPlanners.utils.belief_factory import BeliefType, create_environment_belief
 
 
 @pytest.fixture()
 def simple_env():
     return RockSamplePOMDP(
-        map_size=(5, 5),
-        rock_positions=[(1, 1), (3, 3)],
-        init_pos=(2, 2),
-        sensor_efficiency=10.0,
         discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=(5, 5),
+            rock_positions=[(1, 1), (3, 3)],
+            init_pos=(2, 2),
+            sensor_efficiency=10.0,
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_belief_integration.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_belief_integration.py
@@ -20,17 +20,20 @@ from POMDPPlanners.tests.test_core.test_belief.belief_equivalence_utils import (
     assert_update_particles_match,
     assert_update_weights_match,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import rock_sample_pinned_kwargs
 from POMDPPlanners.utils.belief_factory import BeliefType
 
 
 @pytest.fixture()
 def simple_env():
     return RockSamplePOMDP(
-        map_size=(5, 5),
-        rock_positions=[(1, 1), (3, 3)],
-        init_pos=(2, 2),
-        sensor_efficiency=10.0,
         discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=(5, 5),
+            rock_positions=[(1, 1), (3, 3)],
+            init_pos=(2, 2),
+            sensor_efficiency=10.0,
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_vectorized_updater.py
@@ -16,16 +16,19 @@ from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils imp
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import rock_sample_pinned_kwargs
 
 
 @pytest.fixture()
 def simple_env():
     return RockSamplePOMDP(
-        map_size=(5, 5),
-        rock_positions=[(1, 1), (3, 3)],
-        init_pos=(2, 2),
-        sensor_efficiency=10.0,
         discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=(5, 5),
+            rock_positions=[(1, 1), (3, 3)],
+            init_pos=(2, 2),
+            sensor_efficiency=10.0,
+        ),
     )
 
 

--- a/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_native_equivalence.py
@@ -23,12 +23,15 @@ from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_po
     DEFAULT_FORCE_SCALES,
 )
 from POMDPPlanners.tests.test_environments import _native_parity
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    safety_ant_velocity_pinned_kwargs,
+)
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
 
 
 @pytest.fixture(name="env")
 def _env_fixture():
-    return SafeAntVelocityPOMDP(discount_factor=0.99)
+    return SafeAntVelocityPOMDP(discount_factor=0.99, **safety_ant_velocity_pinned_kwargs())
 
 
 def _build_native_transition(env: SafeAntVelocityPOMDP, state: np.ndarray, action: int):

--- a/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp.py
@@ -23,6 +23,9 @@ from POMDPPlanners.environments.safety_ant_velocity_pomdp import SafeAntVelocity
 from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
     verify_metrics_within_confidence_intervals,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    safety_ant_velocity_pinned_kwargs,
+)
 from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_history_returns_bounded,
     verify_metric_sanity,
@@ -34,7 +37,7 @@ from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
 
 @pytest.fixture
 def pomdp():
-    return SafeAntVelocityPOMDP(discount_factor=0.95)
+    return SafeAntVelocityPOMDP(discount_factor=0.95, **safety_ant_velocity_pinned_kwargs())
 
 
 def test_safe_velocity_pomdp_initialization():
@@ -51,15 +54,17 @@ def test_safe_velocity_pomdp_initialization():
     # Test basic initialization
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=2.0,
-        max_force=1.0,
-        dt=0.1,
-        mass=1.0,
-        damping=0.1,
-        position_noise=0.1,
-        velocity_noise=0.2,
-        safety_violation_penalty=-100.0,
-        movement_reward_scale=1.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+            max_force=1.0,
+            dt=0.1,
+            mass=1.0,
+            damping=0.1,
+            position_noise=0.1,
+            velocity_noise=0.2,
+            safety_violation_penalty=-100.0,
+            movement_reward_scale=1.0,
+        ),
     )
 
     assert env.discount_factor == 0.95
@@ -168,9 +173,11 @@ def test_reward_function():
     """
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=2.0,
-        safety_violation_penalty=-100.0,
-        movement_reward_scale=1.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+            safety_violation_penalty=-100.0,
+            movement_reward_scale=1.0,
+        ),
     )
 
     # Test reward for safe velocity
@@ -197,7 +204,9 @@ def test_terminal_state():
     """
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=2.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+        ),
     )
 
     # Test non-terminal state (safe velocity)
@@ -222,9 +231,11 @@ def test_reward_range():
     """
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=2.0,
-        safety_violation_penalty=-50.0,
-        movement_reward_scale=1.5,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+            safety_violation_penalty=-50.0,
+            movement_reward_scale=1.5,
+        ),
     )
 
     # Expected calculations from SafeAntVelocityPOMDP constructor:
@@ -238,9 +249,11 @@ def test_reward_range():
     # Test with different parameters
     env2 = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=3.0,
-        safety_violation_penalty=-100.0,
-        movement_reward_scale=2.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=3.0,
+            safety_violation_penalty=-100.0,
+            movement_reward_scale=2.0,
+        ),
     )
 
     expected_min2 = 0.0 + (-100.0)  # -100.0
@@ -260,7 +273,7 @@ def test_initial_state_distribution():
 
     Test type: unit
     """
-    env = SafeAntVelocityPOMDP(discount_factor=0.95)
+    env = SafeAntVelocityPOMDP(discount_factor=0.95, **safety_ant_velocity_pinned_kwargs())
     initial_dist = env.initial_state_dist()
 
     # Test multiple samples
@@ -289,7 +302,7 @@ def test_get_actions():
 
     Test type: unit
     """
-    env = SafeAntVelocityPOMDP(discount_factor=0.95)
+    env = SafeAntVelocityPOMDP(discount_factor=0.95, **safety_ant_velocity_pinned_kwargs())
     actions = env.get_actions()
 
     assert len(actions) == 4
@@ -308,7 +321,7 @@ def test_is_equal_observation():
 
     Test type: unit
     """
-    env = SafeAntVelocityPOMDP(discount_factor=0.95)
+    env = SafeAntVelocityPOMDP(discount_factor=0.95, **safety_ant_velocity_pinned_kwargs())
 
     # Test equal observations
     obs1 = np.array([0.0, 0.0, 1.0, 1.0])
@@ -331,7 +344,7 @@ def test_sample_next_step():
 
     Test type: unit
     """
-    env = SafeAntVelocityPOMDP(discount_factor=0.95)
+    env = SafeAntVelocityPOMDP(discount_factor=0.95, **safety_ant_velocity_pinned_kwargs())
     state = np.array([0.0, 0.0, 1.0, 1.0])
     action = 2  # Medium force
 
@@ -369,7 +382,9 @@ def test_compute_metrics():
     """
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=2.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+        ),
     )
 
     # Create test histories with different velocity scenarios
@@ -523,7 +538,9 @@ def test_compute_metrics_values_within_confidence_intervals():
     """
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=2.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+        ),
     )
 
     # History 0: all-safe.
@@ -620,27 +637,31 @@ def test_environment_equality():
     # Create two identical environments
     env1 = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=2.0,
-        max_force=1.0,
-        dt=0.1,
-        mass=1.0,
-        damping=0.1,
-        position_noise=0.1,
-        velocity_noise=0.2,
-        safety_violation_penalty=-100.0,
-        movement_reward_scale=1.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+            max_force=1.0,
+            dt=0.1,
+            mass=1.0,
+            damping=0.1,
+            position_noise=0.1,
+            velocity_noise=0.2,
+            safety_violation_penalty=-100.0,
+            movement_reward_scale=1.0,
+        ),
     )
     env2 = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=2.0,
-        max_force=1.0,
-        dt=0.1,
-        mass=1.0,
-        damping=0.1,
-        position_noise=0.1,
-        velocity_noise=0.2,
-        safety_violation_penalty=-100.0,
-        movement_reward_scale=1.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+            max_force=1.0,
+            dt=0.1,
+            mass=1.0,
+            damping=0.1,
+            position_noise=0.1,
+            velocity_noise=0.2,
+            safety_violation_penalty=-100.0,
+            movement_reward_scale=1.0,
+        ),
     )
 
     # Test equality
@@ -649,15 +670,17 @@ def test_environment_equality():
     # Test inequality with different parameters
     env3 = SafeAntVelocityPOMDP(
         discount_factor=0.9,  # Different discount factor
-        safe_velocity_threshold=2.0,
-        max_force=1.0,
-        dt=0.1,
-        mass=1.0,
-        damping=0.1,
-        position_noise=0.1,
-        velocity_noise=0.2,
-        safety_violation_penalty=-100.0,
-        movement_reward_scale=1.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+            max_force=1.0,
+            dt=0.1,
+            mass=1.0,
+            damping=0.1,
+            position_noise=0.1,
+            velocity_noise=0.2,
+            safety_violation_penalty=-100.0,
+            movement_reward_scale=1.0,
+        ),
     )
     assert env1 != env3
 
@@ -676,27 +699,31 @@ def test_config_id():
     # Create two environments with same parameters
     env1 = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=2.0,
-        max_force=1.0,
-        dt=0.1,
-        mass=1.0,
-        damping=0.1,
-        position_noise=0.1,
-        velocity_noise=0.2,
-        safety_violation_penalty=-100.0,
-        movement_reward_scale=1.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+            max_force=1.0,
+            dt=0.1,
+            mass=1.0,
+            damping=0.1,
+            position_noise=0.1,
+            velocity_noise=0.2,
+            safety_violation_penalty=-100.0,
+            movement_reward_scale=1.0,
+        ),
     )
     env2 = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=2.0,
-        max_force=1.0,
-        dt=0.1,
-        mass=1.0,
-        damping=0.1,
-        position_noise=0.1,
-        velocity_noise=0.2,
-        safety_violation_penalty=-100.0,
-        movement_reward_scale=1.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+            max_force=1.0,
+            dt=0.1,
+            mass=1.0,
+            damping=0.1,
+            position_noise=0.1,
+            velocity_noise=0.2,
+            safety_violation_penalty=-100.0,
+            movement_reward_scale=1.0,
+        ),
     )
 
     # Test same config_id for identical environments
@@ -705,15 +732,17 @@ def test_config_id():
     # Test different config_id for different environments
     env3 = SafeAntVelocityPOMDP(
         discount_factor=0.9,  # Different discount factor
-        safe_velocity_threshold=2.0,
-        max_force=1.0,
-        dt=0.1,
-        mass=1.0,
-        damping=0.1,
-        position_noise=0.1,
-        velocity_noise=0.2,
-        safety_violation_penalty=-100.0,
-        movement_reward_scale=1.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+            max_force=1.0,
+            dt=0.1,
+            mass=1.0,
+            damping=0.1,
+            position_noise=0.1,
+            velocity_noise=0.2,
+            safety_violation_penalty=-100.0,
+            movement_reward_scale=1.0,
+        ),
     )
     assert env1.config_id != env3.config_id
 
@@ -792,8 +821,10 @@ def test_observation_log_probability_invalid_observation_raises():
     """
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        position_noise=0.1,
-        velocity_noise=0.2,
+        **safety_ant_velocity_pinned_kwargs(
+            position_noise=0.1,
+            velocity_noise=0.2,
+        ),
     )
     next_state = np.array([0.5, -0.2, 1.0, 0.5])
     empty_observation = np.array([])
@@ -820,8 +851,10 @@ def test_observation_log_probability_various_invalid_shapes():
     """
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        position_noise=0.1,
-        velocity_noise=0.2,
+        **safety_ant_velocity_pinned_kwargs(
+            position_noise=0.1,
+            velocity_noise=0.2,
+        ),
     )
     next_state = np.array([0.5, -0.2, 1.0, 0.5])
 
@@ -854,8 +887,10 @@ def test_env_sample_observation_never_empty():
     """
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        position_noise=0.1,
-        velocity_noise=0.2,
+        **safety_ant_velocity_pinned_kwargs(
+            position_noise=0.1,
+            velocity_noise=0.2,
+        ),
     )
     next_state = np.array([0.5, -0.2, 1.0, 0.5])
     action = 1
@@ -884,9 +919,11 @@ def test_sample_next_step_observation_never_empty():
     """
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=2.0,
-        position_noise=0.1,
-        velocity_noise=0.2,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+            position_noise=0.1,
+            velocity_noise=0.2,
+        ),
     )
 
     # Test with various initial states
@@ -938,8 +975,10 @@ def test_env_observation_log_probability_list_interface():
     """
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        position_noise=0.1,
-        velocity_noise=0.2,
+        **safety_ant_velocity_pinned_kwargs(
+            position_noise=0.1,
+            velocity_noise=0.2,
+        ),
     )
     next_state = np.array([0.5, -0.2, 1.0, 0.5])
     action = 1
@@ -977,9 +1016,11 @@ def test_reward_batch_matches_scalar_reward():
     """
     env = SafeAntVelocityPOMDP(
         discount_factor=0.95,
-        safe_velocity_threshold=2.0,
-        safety_violation_penalty=-100.0,
-        movement_reward_scale=1.0,
+        **safety_ant_velocity_pinned_kwargs(
+            safe_velocity_threshold=2.0,
+            safety_violation_penalty=-100.0,
+            movement_reward_scale=1.0,
+        ),
     )
     np.random.seed(42)
     # 4-dim states: [pos_x, pos_y, vel_x, vel_y]
@@ -1071,7 +1112,7 @@ def test_native_simulate_rollout_safe_ant_matches_python_reference():
     )  # pylint: disable=import-outside-toplevel
 
     np.random.seed(0)
-    env_local = SafeAntVelocityPOMDP(discount_factor=0.99)
+    env_local = SafeAntVelocityPOMDP(discount_factor=0.99, **safety_ant_velocity_pinned_kwargs())
     initial_state = np.array([0.2, -0.1, 0.5, 0.3], dtype=np.float64)
     max_depth = 8
     start_depth = 0
@@ -1128,7 +1169,7 @@ def test_simulate_random_rollout_safe_ant_returns_finite_float():
 
     np.random.seed(0)
     sa_native.set_seed(0)
-    env_local = SafeAntVelocityPOMDP(discount_factor=0.99)
+    env_local = SafeAntVelocityPOMDP(discount_factor=0.99, **safety_ant_velocity_pinned_kwargs())
     state = env_local.initial_state_dist().sample()[0]
     sampler = _FixedActionSamplerSafeAnt(action=1)
 
@@ -1154,7 +1195,7 @@ def test_simulate_random_rollout_safe_ant_returns_zero_at_max_depth():
 
     Test type: unit
     """
-    env_local = SafeAntVelocityPOMDP(discount_factor=0.99)
+    env_local = SafeAntVelocityPOMDP(discount_factor=0.99, **safety_ant_velocity_pinned_kwargs())
     state = env_local.initial_state_dist().sample()[0]
     sampler = _FixedActionSamplerSafeAnt(action=0)
 
@@ -1181,7 +1222,7 @@ def test_simulate_random_rollout_safe_ant_terminal_returns_zero():
 
     Test type: unit
     """
-    env_local = SafeAntVelocityPOMDP(discount_factor=0.99)
+    env_local = SafeAntVelocityPOMDP(discount_factor=0.99, **safety_ant_velocity_pinned_kwargs())
     critical_speed = env_local.safe_velocity_threshold * 2.0
     terminal_state = np.array([0.0, 0.0, critical_speed, 0.0], dtype=np.float64)
     sampler = _FixedActionSamplerSafeAnt(action=0)

--- a/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp_beliefs/test_safety_ant_velocity_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp_beliefs/test_safety_ant_velocity_belief_factory.py
@@ -19,12 +19,15 @@ from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_po
 from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_pomdp_beliefs import (
     create_safety_ant_velocity_belief,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    safety_ant_velocity_pinned_kwargs,
+)
 from POMDPPlanners.utils.belief_factory import BeliefType
 
 
 @pytest.fixture
 def env():
-    return SafeAntVelocityPOMDP(discount_factor=0.95)
+    return SafeAntVelocityPOMDP(discount_factor=0.95, **safety_ant_velocity_pinned_kwargs())
 
 
 class TestCreateSafetyAntVelocityBelief:

--- a/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp_beliefs/test_safety_ant_velocity_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp_beliefs/test_safety_ant_velocity_vectorized_updater.py
@@ -30,6 +30,9 @@ from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils imp
     assert_batch_obs_log_likelihood_matches_loop,
     assert_batch_transition_matches_loop,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    safety_ant_velocity_pinned_kwargs,
+)
 from POMDPPlanners.utils.multivariate_normal import (
     CovarianceParameterizedMultivariateNormal,
 )
@@ -68,7 +71,7 @@ def _make_aligned_beliefs(updater, n_particles=60):
 
 @pytest.fixture
 def env():
-    return SafeAntVelocityPOMDP(discount_factor=0.99)
+    return SafeAntVelocityPOMDP(discount_factor=0.99, **safety_ant_velocity_pinned_kwargs())
 
 
 @pytest.fixture

--- a/POMDPPlanners/tests/test_metric_consistency.py
+++ b/POMDPPlanners/tests/test_metric_consistency.py
@@ -29,6 +29,7 @@ from POMDPPlanners.tests.test_metric_consistency_utils import (
     verify_environment_metric_consistency,
     verify_policy_metric_consistency,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import push_pinned_kwargs
 from POMDPPlanners.tests.test_utils.history_builders import build_test_history
 
 np.random.seed(42)
@@ -87,10 +88,12 @@ class TestEnvironmentMetricConsistency:
         """
         env = PushPOMDP(
             discount_factor=0.95,
-            grid_size=10,
-            push_threshold=1.0,
-            friction_coefficient=0.1,
-            observation_noise=0.1,
+            **push_pinned_kwargs(
+                grid_size=10,
+                push_threshold=1.0,
+                friction_coefficient=0.1,
+                observation_noise=0.1,
+            ),
         )
 
         # Create sample histories with collision data

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_constrained_pft_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_constrained_pft_dpw.py
@@ -14,6 +14,9 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
     ContinuousLightDarkPOMDP,
 )
 from POMDPPlanners.planners.mcts_planners.constrained_pft_dpw import CPFT_DPW
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_pinned_kwargs,
+)
 from POMDPPlanners.utils.action_samplers import UnitCircleActionSampler
 
 
@@ -116,7 +119,9 @@ def test_rejects_unconstrained_environment(action_sampler):
 
     Test type: unit
     """
-    plain_env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    plain_env = ContinuousLightDarkPOMDP(
+        discount_factor=0.95, **continuous_light_dark_pinned_kwargs()
+    )
     with pytest.raises(TypeError, match="ConstrainedEnvironment"):
         CPFT_DPW(
             environment=plain_env,

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pft_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pft_dpw.py
@@ -12,6 +12,9 @@ from POMDPPlanners.core.tree.arena import ACTION, BELIEF, Tree
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDP,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_pinned_kwargs,
+)
 from POMDPPlanners.utils.action_samplers import UnitCircleActionSampler
 from POMDPPlanners.simulations.episodes import run_episode
 from POMDPPlanners.planners.mcts_planners.icvar_pft_dpw import ICVaR_PFT_DPW
@@ -19,7 +22,7 @@ from POMDPPlanners.planners.mcts_planners.icvar_pft_dpw import ICVaR_PFT_DPW
 
 @pytest.fixture
 def env():
-    return ContinuousLightDarkPOMDP(discount_factor=0.95)
+    return ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
 
 
 @pytest.fixture

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pomcpow.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_icvar_pomcpow.py
@@ -16,6 +16,9 @@ from POMDPPlanners.core.belief import (
 from POMDPPlanners.core.cost import belief_expectation_cost
 from POMDPPlanners.core.tree.arena import ACTION, BELIEF, Tree
 from POMDPPlanners.environments import TigerPOMDP, DiscreteLightDarkPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    discrete_light_dark_pinned_kwargs,
+)
 from POMDPPlanners.utils.action_samplers import DiscreteActionSampler
 from POMDPPlanners.simulations.episodes import run_episode
 from POMDPPlanners.planners.mcts_planners.icvar_pomcpow import ICVaR_POMCPOW
@@ -89,7 +92,9 @@ def environment(discount_factor):
 
 @pytest.fixture
 def light_dark_env(discount_factor):
-    return DiscreteLightDarkPOMDP(discount_factor=discount_factor)
+    return DiscreteLightDarkPOMDP(
+        discount_factor=discount_factor, **discrete_light_dark_pinned_kwargs()
+    )
 
 
 @pytest.fixture

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pft_dpw.py
@@ -25,6 +25,10 @@ from POMDPPlanners.planners.planners_utils.dpw import (
     ActionSampler,
     action_progressive_widening,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_pinned_kwargs,
+    discrete_light_dark_pinned_kwargs,
+)
 from POMDPPlanners.utils.action_samplers import (
     DiscreteActionSampler,
     UnitCircleActionSampler,
@@ -36,7 +40,7 @@ random.seed(42)
 
 @pytest.fixture
 def environment():
-    return ContinuousLightDarkPOMDP(discount_factor=0.95)
+    return ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
 
 
 @pytest.fixture
@@ -1017,8 +1021,10 @@ def test_sample_existing_belief_node_recovers_per_action_immediate_reward():
     random.seed(42)
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        obstacle_reward=-100.0,
-        obstacle_hit_probability=1.0,
+        **discrete_light_dark_pinned_kwargs(
+            obstacle_reward=-100.0,
+            obstacle_hit_probability=1.0,
+        ),
     )
 
     n_particles = 20

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp.py
@@ -23,6 +23,7 @@ from POMDPPlanners.core.tree.arena import ACTION, BELIEF, Tree
 from POMDPPlanners.environments.sanity_pomdp import SanityPOMDP
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
 from POMDPPlanners.planners.mcts_planners.pomcp import POMCP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import sanity_pinned_kwargs
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -384,7 +385,7 @@ def test_sanity_pomdp_action_selection():
     Test type: unit
     """
     # Create environment and planner
-    environment = SanityPOMDP()
+    environment = SanityPOMDP(discount_factor=0.95, **sanity_pinned_kwargs())
     planner = POMCP(
         environment=environment,
         discount_factor=0.95,

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp_dpw.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcp_dpw.py
@@ -28,6 +28,11 @@ from POMDPPlanners.planners.planners_utils.dpw import (
     ucb1_exploration,
 )
 from POMDPPlanners.planners.planners_utils.rollout import random_rollout_action_sampler
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+    continuous_light_dark_pinned_kwargs,
+    sanity_pinned_kwargs,
+)
 from POMDPPlanners.utils.action_samplers import UnitCircleActionSampler
 
 np.random.seed(42)
@@ -699,7 +704,7 @@ def test_belief_node_data_structure(planner, belief):
 @pytest.mark.slow
 def test_sanity_pomdp_action_selection():
     """Test POMCP_DPW with SanityPOMDP to verify correct action selection."""
-    environment = SanityPOMDP()
+    environment = SanityPOMDP(discount_factor=0.95, **sanity_pinned_kwargs())
     action_sampler = MockActionSampler([0, 1])
 
     planner = POMCP_DPW(
@@ -974,18 +979,20 @@ def test_numpy_array_observation_comparison():
     environment = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
         name="TestObservationComparison",
-        state_transition_cov_matrix=np.eye(2) * 0.1,
-        observation_cov_matrix=np.eye(2) * 0.5,
-        beacons=[(0, 0)],  # List of tuples as expected
-        goal_state=np.array([1, 1]),
-        start_state=np.array([0, 0]),
-        obstacles=[(0.5, 0.5)],  # Add one obstacle to avoid broadcasting issues
-        goal_reward=1.0,
-        fuel_cost=0.1,
-        grid_size=2,
-        goal_state_radius=0.5,
-        beacon_radius=1.0,
-        reward_model_type=RewardModelType.CONSTANT_HAZARD_PENALTY,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2) * 0.1,
+            observation_cov_matrix=np.eye(2) * 0.5,
+            beacons=[(0, 0)],  # List of tuples as expected
+            goal_state=np.array([1, 1]),
+            start_state=np.array([0, 0]),
+            obstacles=[(0.5, 0.5)],  # Add one obstacle to avoid broadcasting issues
+            goal_reward=1.0,
+            fuel_cost=0.1,
+            grid_size=2,
+            goal_state_radius=0.5,
+            beacon_radius=1.0,
+            reward_model_type=RewardModelType.CONSTANT_HAZARD_PENALTY,
+        ),
     )
 
     # Test that the environment's is_equal_observation method works correctly
@@ -1098,9 +1105,11 @@ def test_pomcp_dpw_config_id_different_action_sampler_values():
     # Create continuous environment for testing
     continuous_environment = ContinuousLightDarkPOMDP(
         discount_factor=0.99,
-        goal_state=np.array([5, 0]),
-        start_state=np.array([0, 0]),
         name="TestContinuous",
+        **continuous_light_dark_pinned_kwargs(
+            goal_state=np.array([5, 0]),
+            start_state=np.array([0, 0]),
+        ),
     )
 
     # Create action samplers with different max_action_magnitude

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcpow.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_pomcpow.py
@@ -36,6 +36,10 @@ from POMDPPlanners.planners.planners_utils.dpw import (
     ucb1_exploration,
 )
 from POMDPPlanners.planners.planners_utils.rollout import random_rollout_action_sampler
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_pinned_kwargs,
+    sanity_pinned_kwargs,
+)
 from POMDPPlanners.utils.action_samplers import UnitCircleActionSampler
 
 # Set seeds for reproducible tests
@@ -660,7 +664,7 @@ def test_sanity_pomdp_action_selection():
 
     Test type: integration
     """
-    environment = SanityPOMDP()
+    environment = SanityPOMDP(discount_factor=0.95, **sanity_pinned_kwargs())
     action_sampler = MockActionSampler([0, 1])
 
     planner = POMCPOW(
@@ -930,9 +934,11 @@ def test_pomcpow_config_id_different_action_sampler_values():
     # Create continuous environment for testing
     continuous_environment = ContinuousLightDarkPOMDP(
         discount_factor=0.99,
-        goal_state=np.array([5, 0]),
-        start_state=np.array([0, 0]),
         name="TestContinuous",
+        **continuous_light_dark_pinned_kwargs(
+            goal_state=np.array([5, 0]),
+            start_state=np.array([0, 0]),
+        ),
     )
 
     # Create action samplers with different max_action_magnitude
@@ -1098,9 +1104,11 @@ def test_pomcpow_config_id_action_sampler_attribute_changes():
     # Create continuous environment for testing
     continuous_environment = ContinuousLightDarkPOMDP(
         discount_factor=0.99,
-        goal_state=np.array([5, 0]),
-        start_state=np.array([0, 0]),
         name="TestContinuous",
+        **continuous_light_dark_pinned_kwargs(
+            goal_state=np.array([5, 0]),
+            start_state=np.array([0, 0]),
+        ),
     )
 
     # Create initial action sampler and POMCPOW

--- a/POMDPPlanners/tests/test_planners/test_mcts_planners/test_sparse_pft.py
+++ b/POMDPPlanners/tests/test_planners/test_mcts_planners/test_sparse_pft.py
@@ -12,6 +12,7 @@ from POMDPPlanners.core.tree.arena import ACTION, BELIEF, Tree
 from POMDPPlanners.environments.sanity_pomdp import SanityPOMDP
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
 from POMDPPlanners.planners.mcts_planners.sparse_pft import SparsePFT
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import sanity_pinned_kwargs
 
 np.random.seed(42)
 random.seed(42)
@@ -384,7 +385,7 @@ def test_sanity_pomdp_action_selection():
     Test type: unit
     """
     # Create environment and planner with appropriate parameters
-    environment = SanityPOMDP()
+    environment = SanityPOMDP(discount_factor=0.95, **sanity_pinned_kwargs())
     planner = SparsePFT(
         environment=environment,
         discount_factor=0.95,
@@ -428,7 +429,7 @@ def test_sanity_pomdp_belief_children():
 
     Test type: unit
     """
-    environment = SanityPOMDP()
+    environment = SanityPOMDP(discount_factor=0.95, **sanity_pinned_kwargs())
     planner = SparsePFT(
         environment=environment,
         discount_factor=0.95,

--- a/POMDPPlanners/tests/test_planners/test_planner_save_load_interface.py
+++ b/POMDPPlanners/tests/test_planners/test_planner_save_load_interface.py
@@ -28,6 +28,9 @@ from POMDPPlanners.planners import (
     SparsePFT,
     SparseSamplingDiscreteActionsPlanner,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    discrete_light_dark_pinned_kwargs,
+)
 from POMDPPlanners.utils.action_samplers import DiscreteActionSampler
 
 # Set seeds for reproducible tests
@@ -40,7 +43,9 @@ class TestPlannerSaveLoadInterface:
     def setup_method(self):
         """Set up test environments for each test."""
         self.tiger_env = TigerPOMDP(discount_factor=0.95)
-        self.light_dark_env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+        self.light_dark_env = DiscreteLightDarkPOMDP(
+            discount_factor=0.95, **discrete_light_dark_pinned_kwargs()
+        )
 
     def _test_planner_save_load(self, planner_class: type, init_params: Dict[str, Any]):
         """Helper to test planner save/load.

--- a/POMDPPlanners/tests/test_planners/test_planner_serialization.py
+++ b/POMDPPlanners/tests/test_planners/test_planner_serialization.py
@@ -33,6 +33,9 @@ from POMDPPlanners.planners.mcts_planners.beta_zero import BetaZero
 from POMDPPlanners.planners.mcts_planners.beta_zero.beta_zero_action_sampler import (
     BetaZeroActionSampler,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    discrete_light_dark_pinned_kwargs,
+)
 from POMDPPlanners.utils.action_samplers import DiscreteActionSampler
 
 # Set seeds for reproducible tests
@@ -45,7 +48,9 @@ class TestPlannerSerialization:
     def setup_method(self):
         """Set up test environments for each test."""
         self.tiger_env = TigerPOMDP(discount_factor=0.95)
-        self.light_dark_env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+        self.light_dark_env = DiscreteLightDarkPOMDP(
+            discount_factor=0.95, **discrete_light_dark_pinned_kwargs()
+        )
 
     def _test_planner_serialization(self, planner_class: type, init_params: Dict[str, Any]) -> None:
         """Helper method to test planner serialization.

--- a/POMDPPlanners/tests/test_planners/test_planners_utils/test_rollout.py
+++ b/POMDPPlanners/tests/test_planners/test_planners_utils/test_rollout.py
@@ -23,6 +23,10 @@ from POMDPPlanners.planners.planners_utils.rollout import (
     python_random_rollout,
     random_rollout_action_sampler,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    cartpole_pinned_kwargs,
+    sanity_pinned_kwargs,
+)
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -60,14 +64,14 @@ def tiger_environment():
 @pytest.fixture
 def sanity_environment():
     """Sanity POMDP environment fixture."""
-    return SanityPOMDP(discount_factor=0.9)
+    return SanityPOMDP(discount_factor=0.9, **sanity_pinned_kwargs())
 
 
 @pytest.fixture
 def cartpole_environment():
     """CartPole POMDP environment fixture."""
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    return CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
+    return CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
 
 @pytest.fixture
@@ -365,7 +369,7 @@ def test_rollout_variance_reduction():
 
     Test type: unit
     """
-    sanity = SanityPOMDP(discount_factor=0.95)
+    sanity = SanityPOMDP(discount_factor=0.95, **sanity_pinned_kwargs())
     sampler = MockActionSampler([0, 1])
     state = 0
 
@@ -415,7 +419,7 @@ def test_rollout_recursion_depth():
 
     Test type: unit
     """
-    sanity = SanityPOMDP(discount_factor=0.99)
+    sanity = SanityPOMDP(discount_factor=0.99, **sanity_pinned_kwargs())
     sampler = MockActionSampler([0, 1])
 
     # Test with very deep max_depth
@@ -503,7 +507,7 @@ def test_cartpole_rollout_usage_example():
 
     # Create CartPole environment (from docstring)
     noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-    cartpole = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
+    cartpole = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov, **cartpole_pinned_kwargs())
     action_sampler = CartPoleActionSampler()
 
     # Sample initial state and perform rollout (from docstring)
@@ -541,7 +545,7 @@ def test_multiple_rollouts_usage_example():
         def sample(self, belief_node=None):
             return np.random.choice([0, 1])
 
-    sanity = SanityPOMDP(discount_factor=0.95)
+    sanity = SanityPOMDP(discount_factor=0.95, **sanity_pinned_kwargs())
     action_sampler = SanityActionSampler()
 
     # Perform multiple rollouts to reduce variance (from docstring)
@@ -589,7 +593,7 @@ def test_rollout_depth_comparison_usage_example():
         def sample(self, belief_node=None):
             return np.random.choice([0, 1])
 
-    sanity = SanityPOMDP(discount_factor=0.95)
+    sanity = SanityPOMDP(discount_factor=0.95, **sanity_pinned_kwargs())
     action_sampler = SanityActionSampler()
     state = 0
 
@@ -703,7 +707,7 @@ def test_rollout_parameter_validation():
 
     Test type: unit
     """
-    sanity = SanityPOMDP(discount_factor=0.5)
+    sanity = SanityPOMDP(discount_factor=0.5, **sanity_pinned_kwargs())
     sampler = MockActionSampler([0, 1])
 
     # Test with discount_factor of 0 (no future value)

--- a/POMDPPlanners/tests/test_planners/test_sparse_sampling_planners/test_sparse_sampling.py
+++ b/POMDPPlanners/tests/test_planners/test_sparse_sampling_planners/test_sparse_sampling.py
@@ -15,6 +15,7 @@ from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
 from POMDPPlanners.planners.sparse_sampling_planners.sparse_sampling import (
     SparseSamplingDiscreteActionsPlanner,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import sanity_pinned_kwargs
 
 np.random.seed(42)
 random.seed(42)
@@ -374,7 +375,7 @@ def test_sanity_pomdp_action_selection():
     Test type: unit
     """
     # Create environment and planner with higher branching factor and depth for better accuracy
-    environment = SanityPOMDP()
+    environment = SanityPOMDP(discount_factor=0.95, **sanity_pinned_kwargs())
     planner = SparseSamplingDiscreteActionsPlanner(
         environment=environment,
         branching_factor=4,  # Higher branching factor for better exploration

--- a/POMDPPlanners/tests/test_simulations/test_hyper_parameter_tuning_simulations.py
+++ b/POMDPPlanners/tests/test_simulations/test_hyper_parameter_tuning_simulations.py
@@ -84,6 +84,22 @@ from POMDPPlanners.environments.laser_tag_pomdp.continuous_laser_tag_pomdp impor
     ContinuousLaserTagPOMDP,
     ContinuousLaserTagPOMDPDiscreteActions,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    cartpole_pinned_kwargs,
+    continuous_laser_tag_discrete_actions_pinned_kwargs,
+    continuous_laser_tag_pinned_kwargs,
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+    continuous_light_dark_pinned_kwargs,
+    continuous_push_discrete_actions_pinned_kwargs,
+    continuous_push_pinned_kwargs,
+    discrete_light_dark_pinned_kwargs,
+    laser_tag_pinned_kwargs,
+    mountain_car_pinned_kwargs,
+    pacman_pinned_kwargs,
+    push_pinned_kwargs,
+    rock_sample_pinned_kwargs,
+    safety_ant_velocity_pinned_kwargs,
+)
 import warnings
 
 np.random.seed(42)
@@ -2072,7 +2088,9 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = ContinuousLightDarkPOMDP(discount_factor=0.95)
+        env = ContinuousLightDarkPOMDP(
+            discount_factor=0.95, **continuous_light_dark_pinned_kwargs()
+        )
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = UnitCircleActionSampler()
 
@@ -2122,7 +2140,7 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = ContinuousPushPOMDP(discount_factor=0.95)
+        env = ContinuousPushPOMDP(discount_factor=0.95, **continuous_push_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = UnitCircleActionSampler()
 
@@ -2172,7 +2190,7 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = ContinuousLaserTagPOMDP(discount_factor=0.95)
+        env = ContinuousLaserTagPOMDP(discount_factor=0.95, **continuous_laser_tag_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = LaserTagContinuousActionSampler()
 
@@ -2222,7 +2240,11 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = CartPolePOMDP(discount_factor=0.95, noise_cov=np.eye(4) * 0.1)
+        env = CartPolePOMDP(
+            discount_factor=0.95,
+            noise_cov=np.eye(4) * 0.1,
+            **cartpole_pinned_kwargs(),
+        )
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = DiscreteActionSampler(env.get_actions())
 
@@ -2272,7 +2294,7 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = MountainCarPOMDP(discount_factor=0.95)
+        env = MountainCarPOMDP(discount_factor=0.95, **mountain_car_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = DiscreteActionSampler(env.get_actions())
 
@@ -2372,7 +2394,7 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = PushPOMDP(discount_factor=0.95)
+        env = PushPOMDP(discount_factor=0.95, **push_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = DiscreteActionSampler(env.get_actions())
 
@@ -2422,7 +2444,7 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = LaserTagPOMDP(discount_factor=0.95)
+        env = LaserTagPOMDP(discount_factor=0.95, **laser_tag_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = DiscreteActionSampler(env.get_actions())
 
@@ -2472,7 +2494,7 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = RockSamplePOMDP(discount_factor=0.95)
+        env = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = DiscreteActionSampler(env.get_actions())
 
@@ -2522,7 +2544,7 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = PacManPOMDP(discount_factor=0.95)
+        env = PacManPOMDP(discount_factor=0.95, **pacman_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = DiscreteActionSampler(env.get_actions())
 
@@ -2572,7 +2594,7 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = SafeAntVelocityPOMDP(discount_factor=0.95)
+        env = SafeAntVelocityPOMDP(discount_factor=0.95, **safety_ant_velocity_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = DiscreteActionSampler(env.get_actions())
 
@@ -2622,7 +2644,7 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = DiscreteLightDarkPOMDP(discount_factor=0.95)
+        env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = DiscreteActionSampler(env.get_actions())
 
@@ -2674,7 +2696,10 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+        env = ContinuousLightDarkPOMDPDiscreteActions(
+            discount_factor=0.95,
+            **continuous_light_dark_discrete_actions_pinned_kwargs(),
+        )
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = DiscreteActionSampler(env.get_actions())
 
@@ -2726,7 +2751,10 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = ContinuousPushPOMDPDiscreteActions(discount_factor=0.95)
+        env = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.95,
+            **continuous_push_discrete_actions_pinned_kwargs(),
+        )
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = DiscreteActionSampler(env.get_actions())
 
@@ -2778,7 +2806,10 @@ class TestSingleEnvironmentOptimizationSmoke:
 
         Test type: integration
         """
-        env = ContinuousLaserTagPOMDPDiscreteActions(discount_factor=0.95)
+        env = ContinuousLaserTagPOMDPDiscreteActions(
+            discount_factor=0.95,
+            **continuous_laser_tag_discrete_actions_pinned_kwargs(),
+        )
         belief = get_initial_belief(env, n_particles=10)
         action_sampler = DiscreteActionSampler(env.get_actions())
 

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_episode_simulation_task.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_episode_simulation_task.py
@@ -23,6 +23,9 @@ from POMDPPlanners.core.belief import get_initial_belief
 from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
     DiscreteLightDarkPOMDP,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    discrete_light_dark_pinned_kwargs,
+)
 
 
 def _build_environment_and_belief_instances():
@@ -44,7 +47,9 @@ def _build_environment_and_belief_instances():
         env, belief = config_method(n_particles=n_particles)
         envs[key] = env
         beliefs[key] = belief
-    discrete_ld = DiscreteLightDarkPOMDP(discount_factor=0.95)
+    discrete_ld = DiscreteLightDarkPOMDP(
+        discount_factor=0.95, **discrete_light_dark_pinned_kwargs()
+    )
     beliefs["discrete_light_dark"] = get_initial_belief(
         pomdp=discrete_ld, n_particles=n_particles, resampling=True
     )

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_task_serialization.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_task_serialization.py
@@ -27,6 +27,9 @@ from POMDPPlanners.core.simulation.hyperparameter_tuning import (
     HyperParameterOptimizationDirection,
 )
 from POMDPPlanners.environments import TigerPOMDP, ContinuousLightDarkPOMDPDiscreteActions
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+)
 from POMDPPlanners.planners import POMCP, SparsePFT, POMCPOW
 from POMDPPlanners.simulations.simulations_deployment.tasks import (
     EpisodeSimulationTask,
@@ -636,7 +639,10 @@ class TestComplexHyperparameterTuningTaskSerialization:
     def setup_method(self):
         """Set up complex test environment for each test."""
         # Use the complex environment from the failure report
-        self.env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+        self.env = ContinuousLightDarkPOMDPDiscreteActions(
+            discount_factor=0.95,
+            **continuous_light_dark_discrete_actions_pinned_kwargs(),
+        )
 
         # Create action sampler for POMCPOW
         self.action_sampler = DiscreteActionSampler(self.env.get_actions())

--- a/POMDPPlanners/tests/test_simulations/test_simulator.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulator.py
@@ -37,6 +37,9 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
     ContinuousLightDarkPOMDPDiscreteActions,
 )
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+)
 from POMDPPlanners.planners.mcts_planners.pomcp import POMCP
 from POMDPPlanners.planners.mcts_planners.pft_dpw import PFT_DPW
 from POMDPPlanners.utils.action_samplers import DiscreteActionSampler
@@ -1546,12 +1549,14 @@ def test_simulator_caches_visualizations_with_continuous_light_dark_pomdp(
     # Setup continuous light-dark environment with discrete actions
     environment = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        goal_state=np.array([3, 3]),
-        start_state=np.array([1, 1]),
-        beacons=[(1, 2), (1, 2)],  # Beacons as list of tuples
-        obstacles=[(2, 1)],  # Single obstacle as list of tuples
-        grid_size=4,
         name="IntegrationTestEnv",
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state=np.array([3, 3]),
+            start_state=np.array([1, 1]),
+            beacons=[(1, 2), (1, 2)],  # Beacons as list of tuples
+            obstacles=[(2, 1)],  # Single obstacle as list of tuples
+            grid_size=4,
+        ),
     )
 
     # Create test policy directory to simulate the structure the simulator creates
@@ -1715,12 +1720,14 @@ def test_simulator_skips_visualization_caching_when_disabled(temp_cache_dir):
     # Setup continuous light-dark environment
     environment = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        goal_state=np.array([5, 5]),
-        start_state=np.array([1, 1]),
-        beacons=[(2, 4), (2, 4)],  # Beacons as list of tuples
-        obstacles=[(3, 3)],  # Single obstacle as list of tuples
-        grid_size=6,
         name="TestLightDarkNoViz",
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state=np.array([5, 5]),
+            start_state=np.array([1, 1]),
+            beacons=[(2, 4), (2, 4)],  # Beacons as list of tuples
+            obstacles=[(3, 3)],  # Single obstacle as list of tuples
+            grid_size=6,
+        ),
     )
 
     action_sampler = DiscreteActionSampler(environment.get_actions())
@@ -1813,12 +1820,14 @@ def test_simulator_cache_episode_visualizations_method_integration(temp_cache_di
 
     environment = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        goal_state=np.array([3, 3]),
-        start_state=np.array([0, 0]),
-        beacons=[(1, 2), (1, 2)],  # Beacons as list of tuples
-        obstacles=[(2, 1)],  # Single obstacle as list of tuples
-        grid_size=4,
         name="DirectMethodTest",
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state=np.array([3, 3]),
+            start_state=np.array([0, 0]),
+            beacons=[(1, 2), (1, 2)],  # Beacons as list of tuples
+            obstacles=[(2, 1)],  # Single obstacle as list of tuples
+            grid_size=4,
+        ),
     )
 
     # Create test policy directory
@@ -1959,12 +1968,14 @@ def test_simulator_visualization_error_handling_with_continuous_light_dark(
 
     environment = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        goal_state=np.array([3, 3]),
-        start_state=np.array([0, 0]),
-        beacons=[(1, 2), (1, 2)],  # Beacons as list of tuples
-        obstacles=[(2, 1)],  # Single obstacle as list of tuples
-        grid_size=4,
         name="ErrorTestEnv",
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state=np.array([3, 3]),
+            start_state=np.array([0, 0]),
+            beacons=[(1, 2), (1, 2)],  # Beacons as list of tuples
+            obstacles=[(2, 1)],  # Single obstacle as list of tuples
+            grid_size=4,
+        ),
     )
 
     # Create test policy directory
@@ -2054,12 +2065,14 @@ def test_create_and_log_environment_visualizations_creates_cache_directory(
 
     environment = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        goal_state=np.array([3, 3]),
-        start_state=np.array([0, 0]),
-        beacons=[(1, 2), (1, 2)],
-        obstacles=[(2, 1)],
-        grid_size=4,
         name="CacheTestEnv",
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state=np.array([3, 3]),
+            start_state=np.array([0, 0]),
+            beacons=[(1, 2), (1, 2)],
+            obstacles=[(2, 1)],
+            grid_size=4,
+        ),
     )
 
     action_sampler = DiscreteActionSampler(environment.get_actions())
@@ -2172,22 +2185,26 @@ def test_create_and_log_environment_visualizations_parallel_execution(temp_cache
     # Create two environments
     env1 = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        goal_state=np.array([3, 3]),
-        start_state=np.array([0, 0]),
-        beacons=[(1, 2), (1, 2)],
-        obstacles=[(2, 1)],
-        grid_size=4,
         name="ParallelEnv1",
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state=np.array([3, 3]),
+            start_state=np.array([0, 0]),
+            beacons=[(1, 2), (1, 2)],
+            obstacles=[(2, 1)],
+            grid_size=4,
+        ),
     )
 
     env2 = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        goal_state=np.array([5, 5]),
-        start_state=np.array([1, 1]),
-        beacons=[(2, 4), (2, 4)],
-        obstacles=[(3, 3)],
-        grid_size=6,
         name="ParallelEnv2",
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state=np.array([5, 5]),
+            start_state=np.array([1, 1]),
+            beacons=[(2, 4), (2, 4)],
+            obstacles=[(3, 3)],
+            grid_size=6,
+        ),
     )
 
     # Create policies for each environment
@@ -2323,12 +2340,14 @@ def test_create_and_log_environment_visualizations_mlflow_integration(temp_cache
 
     environment = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        goal_state=np.array([3, 3]),
-        start_state=np.array([0, 0]),
-        beacons=[(1, 2), (1, 2)],
-        obstacles=[(2, 1)],
-        grid_size=4,
         name="MLflowTestEnv",
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state=np.array([3, 3]),
+            start_state=np.array([0, 0]),
+            beacons=[(1, 2), (1, 2)],
+            obstacles=[(2, 1)],
+            grid_size=4,
+        ),
     )
 
     action_sampler = DiscreteActionSampler(environment.get_actions())
@@ -2439,12 +2458,14 @@ def test_create_and_log_environment_visualizations_cache_cleanup(temp_cache_dir)
 
     environment = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        goal_state=np.array([3, 3]),
-        start_state=np.array([0, 0]),
-        beacons=[(1, 2), (1, 2)],
-        obstacles=[(2, 1)],
-        grid_size=4,
         name="CleanupTestEnv",
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state=np.array([3, 3]),
+            start_state=np.array([0, 0]),
+            beacons=[(1, 2), (1, 2)],
+            obstacles=[(2, 1)],
+            grid_size=4,
+        ),
     )
 
     action_sampler = DiscreteActionSampler(environment.get_actions())
@@ -2540,12 +2561,14 @@ def test_create_and_log_environment_visualizations_disabled_caching(temp_cache_d
 
     environment = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        goal_state=np.array([3, 3]),
-        start_state=np.array([0, 0]),
-        beacons=[(1, 2), (1, 2)],
-        obstacles=[(2, 1)],
-        grid_size=4,
         name="DisabledCachingEnv",
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state=np.array([3, 3]),
+            start_state=np.array([0, 0]),
+            beacons=[(1, 2), (1, 2)],
+            obstacles=[(2, 1)],
+            grid_size=4,
+        ),
     )
 
     action_sampler = DiscreteActionSampler(environment.get_actions())
@@ -3493,7 +3516,9 @@ def test_get_output_metric_names_multiple_environments(tmp_path):
     """
     tiger_env = TigerPOMDP(discount_factor=0.95)
     light_dark_env = ContinuousLightDarkPOMDPDiscreteActions(
-        discount_factor=0.95, name="LightDarkPOMDP"
+        discount_factor=0.95,
+        name="LightDarkPOMDP",
+        **continuous_light_dark_discrete_actions_pinned_kwargs(),
     )
 
     simulator = POMDPSimulator(

--- a/POMDPPlanners/tests/test_utils/env_pinned_kwargs.py
+++ b/POMDPPlanners/tests/test_utils/env_pinned_kwargs.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: MIT
+
+"""Pinned (snapshotted) constructor defaults for every instantiable env.
+
+Each ``<env_slug>_pinned_kwargs`` function returns a fresh dict of all the
+environment's *optional* (defaulted) config kwargs, with each value pinned to a
+literal snapshot of the env's *current* default. ``overrides`` are merged on top
+(overrides win).
+
+Excluded from every dict:
+
+* ``discount_factor`` — callers always pass it explicitly.
+* any required (no-default) constructor argument (e.g. ``CartPolePOMDP``'s
+  ``noise_cov``) — callers pass those too.
+* the framework kwargs ``name``, ``output_dir``, ``debug``, ``use_queue_logger``
+  — they never affect transitions / observations / rewards / shape.
+
+For ``None``-sentinel kwargs that ``__init__`` substitutes with a concrete value
+(e.g. continuous laser-tag ``walls`` / ``dangerous_areas``, push / pacman /
+rock-sample obstacle / pellet / ghost defaults, cartpole / mountain-car
+``state_transition_cov``), the concrete substituted value is pinned rather than
+``None``. ``None`` is pinned only when it stays the meaningful default (e.g.
+``initial_state``).
+
+All mutable values are materialized as fresh objects on every call so two
+constructions never share the same backing object, and the snapshot stays fixed
+even if the env source default later changes.
+"""
+
+from typing import Any, Dict
+
+import numpy as np
+
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import (
+    RewardModelType as LaserTagRewardModelType,
+)
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils import (
+    OpponentPolicy,
+)
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ObservationModelType as ContinuousLightDarkObservationModelType,
+    RewardModelType as ContinuousLightDarkRewardModelType,
+)
+from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
+    ObservationModelType as DiscreteLightDarkObservationModelType,
+)
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import (
+    RewardModelType as PacManRewardModelType,
+)
+from POMDPPlanners.environments.push_pomdp.push_pomdp_utils.push_reward_models import (
+    RewardModelType as PushRewardModelType,
+)
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import (
+    RewardModelType as RockSampleRewardModelType,
+)
+
+
+def tiger_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``TigerPOMDP`` (no non-framework optionals)."""
+    pinned: Dict[str, Any] = {}
+    pinned.update(overrides)
+    return pinned
+
+
+def sanity_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``SanityPOMDP`` (no non-framework optionals)."""
+    pinned: Dict[str, Any] = {}
+    pinned.update(overrides)
+    return pinned
+
+
+def laser_tag_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``LaserTagPOMDP``."""
+    pinned: Dict[str, Any] = {
+        "floor_shape": (11, 7),
+        "walls": {
+            (1, 2),
+            (3, 0),
+            (3, 4),
+            (5, 0),
+            (6, 4),
+            (9, 1),
+            (9, 4),
+            (10, 6),
+        },
+        "tag_reward": 10.0,
+        "tag_penalty": 10.0,
+        "step_cost": 1.0,
+        "measurement_noise": 1.0,
+        "dangerous_areas": {(5, 3), (7, 1), (2, 5)},
+        "dangerous_area_radius": 1.0,
+        "dangerous_area_penalty": 5.0,
+        "initial_state": None,
+        "transition_error_prob": 0.0,
+        "reward_model_type": LaserTagRewardModelType.CONSTANT_HAZARD_PENALTY,
+        "penalty_decay": 1.0,
+        "opponent_policy": OpponentPolicy.EVADE,
+    }
+    pinned.update(overrides)
+    return pinned
+
+
+def _continuous_laser_tag_default_walls() -> list:
+    half = 0.5
+    cells = [
+        (1, 2),
+        (3, 0),
+        (3, 4),
+        (5, 0),
+        (6, 4),
+        (9, 1),
+        (9, 4),
+        (10, 6),
+    ]
+    return [(float(r), float(c), half, half) for r, c in cells]
+
+
+def continuous_laser_tag_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``ContinuousLaserTagPOMDP``."""
+    pinned: Dict[str, Any] = {
+        "grid_size": (11.0, 7.0),
+        "walls": _continuous_laser_tag_default_walls(),
+        "robot_radius": 0.3,
+        "opponent_radius": 0.3,
+        "tag_radius": 0.5,
+        "tag_reward": 10.0,
+        "tag_penalty": 10.0,
+        "step_cost": 1.0,
+        "measurement_noise": 1.0,
+        "robot_transition_cov_matrix": np.eye(2) * 0.1,
+        "opponent_transition_cov_matrix": np.eye(2) * 0.05,
+        "evasion_speed": 0.6,
+        "dangerous_areas": [(5.0, 3.0), (7.0, 1.0), (2.0, 5.0)],
+        "dangerous_area_radius": 1.0,
+        "dangerous_area_penalty": 5.0,
+        "dangerous_area_hit_probability": 1.0,
+        "initial_state": None,
+        "opponent_policy": OpponentPolicy.EVADE,
+    }
+    pinned.update(overrides)
+    return pinned
+
+
+def continuous_laser_tag_discrete_actions_pinned_kwargs(
+    **overrides: Any,
+) -> Dict[str, Any]:
+    """Pinned optional defaults for ``ContinuousLaserTagPOMDPDiscreteActions``."""
+    pinned = continuous_laser_tag_pinned_kwargs()
+    pinned.update(overrides)
+    return pinned
+
+
+def cartpole_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``CartPolePOMDP`` (``noise_cov`` is required)."""
+    pinned: Dict[str, Any] = {
+        "state_transition_cov": np.diag([1e-4, 1e-4, 2.5e-5, 1e-4]),
+    }
+    pinned.update(overrides)
+    return pinned
+
+
+def mountain_car_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``MountainCarPOMDP``."""
+    pinned: Dict[str, Any] = {
+        "state_transition_cov": np.diag([2.5e-5, 1e-6]),
+    }
+    pinned.update(overrides)
+    return pinned
+
+
+def _light_dark_default_beacons() -> list:
+    return [
+        (0, 0),
+        (0, 5),
+        (0, 10),
+        (5, 0),
+        (5, 5),
+        (5, 10),
+        (10, 0),
+        (10, 5),
+        (10, 10),
+    ]
+
+
+def discrete_light_dark_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``DiscreteLightDarkPOMDP``."""
+    pinned: Dict[str, Any] = {
+        "transition_error_prob": 0.05,
+        "observation_error_prob": 0.05,
+        "beacons": _light_dark_default_beacons(),
+        "goal_state": np.array([10, 5]),
+        "start_state": np.array([0, 5]),
+        "obstacles": [(3, 7), (5, 5)],
+        "obstacle_hit_probability": 0.2,
+        "obstacle_reward": -10.0,
+        "goal_reward": 10.0,
+        "beacon_radius": 1.0,
+        "fuel_cost": 2.0,
+        "grid_size": 11,
+        "is_stochastic_reward": True,
+        "observation_model_type": DiscreteLightDarkObservationModelType.NORMAL,
+    }
+    pinned.update(overrides)
+    return pinned
+
+
+def continuous_light_dark_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``ContinuousLightDarkPOMDP``."""
+    pinned: Dict[str, Any] = {
+        "state_transition_cov_matrix": np.eye(2) * 0.05,
+        "observation_cov_matrix": np.eye(2) * 0.05,
+        "beacons": _light_dark_default_beacons(),
+        "goal_state": np.array([10, 5]),
+        "start_state": np.array([0, 5]),
+        "obstacles": [(3, 7), (5, 5)],
+        "obstacle_hit_probability": 0.2,
+        "obstacle_reward": -10.0,
+        "goal_reward": 10.0,
+        "fuel_cost": 2.0,
+        "grid_size": 11,
+        "goal_state_radius": 1.5,
+        "beacon_radius": 1.0,
+        "obstacle_radius": 1.5,
+        "reward_model_type": ContinuousLightDarkRewardModelType.CONSTANT_HAZARD_PENALTY,
+        "observation_model_type": ContinuousLightDarkObservationModelType.NORMAL_NOISE,
+        "penalty_decay": 1.0,
+        "is_obstacle_hit_terminal": True,
+    }
+    pinned.update(overrides)
+    return pinned
+
+
+def continuous_light_dark_discrete_actions_pinned_kwargs(
+    **overrides: Any,
+) -> Dict[str, Any]:
+    """Pinned optional defaults for ``ContinuousLightDarkPOMDPDiscreteActions``.
+
+    Note: this variant's covariance defaults are ``np.eye(2)`` (unscaled),
+    which differ from the continuous parent's ``np.eye(2) * 0.05``.
+    """
+    pinned: Dict[str, Any] = {
+        "state_transition_cov_matrix": np.eye(2),
+        "observation_cov_matrix": np.eye(2),
+        "obstacle_hit_probability": 0.2,
+        "obstacle_reward": -10.0,
+        "goal_reward": 10.0,
+        "fuel_cost": 2.0,
+        "grid_size": 11,
+        "goal_state_radius": 1.5,
+        "beacon_radius": 1.0,
+        "obstacle_radius": 1.5,
+        "beacons": _light_dark_default_beacons(),
+        "goal_state": np.array([10, 5]),
+        "start_state": np.array([0, 5]),
+        "obstacles": [(3, 7), (5, 5)],
+        "reward_model_type": ContinuousLightDarkRewardModelType.CONSTANT_HAZARD_PENALTY,
+        "observation_model_type": ContinuousLightDarkObservationModelType.NORMAL_NOISE,
+        "penalty_decay": 1.0,
+        "is_obstacle_hit_terminal": True,
+    }
+    pinned.update(overrides)
+    return pinned
+
+
+def push_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``PushPOMDP``."""
+    pinned: Dict[str, Any] = {
+        "grid_size": 10,
+        "push_threshold": 1.0,
+        "friction_coefficient": 0.3,
+        "observation_noise": 0.1,
+        "obstacles": [],
+        "obstacle_radius": 0.5,
+        "obstacle_penalty": -10.0,
+        "obstacle_hit_probability": 1.0,
+        "dangerous_areas": [],
+        "dangerous_area_radius": 0.5,
+        "dangerous_area_penalty": -10.0,
+        "dangerous_area_hit_probability": 1.0,
+        "reward_model_type": PushRewardModelType.CONSTANT_HAZARD_PENALTY,
+        "penalty_decay": 1.0,
+        "initial_state": None,
+        "transition_error_prob": 0.0,
+    }
+    pinned.update(overrides)
+    return pinned
+
+
+def continuous_push_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``ContinuousPushPOMDP``."""
+    pinned: Dict[str, Any] = {
+        "grid_size": 10,
+        "push_threshold": 1.0,
+        "friction_coefficient": 0.3,
+        "max_push": 2.0,
+        "observation_noise": 0.1,
+        "obstacles": [],
+        "obstacle_penalty": -10.0,
+        "obstacle_hit_probability": 1.0,
+        "dangerous_areas": [],
+        "dangerous_area_radius": 0.5,
+        "dangerous_area_penalty": -10.0,
+        "dangerous_area_hit_probability": 1.0,
+        "reward_model_type": PushRewardModelType.CONSTANT_HAZARD_PENALTY,
+        "penalty_decay": 1.0,
+        "robot_radius": 0.3,
+        "state_transition_cov_matrix": np.eye(2) * 0.1,
+        "initial_state": None,
+    }
+    pinned.update(overrides)
+    return pinned
+
+
+def continuous_push_discrete_actions_pinned_kwargs(
+    **overrides: Any,
+) -> Dict[str, Any]:
+    """Pinned optional defaults for ``ContinuousPushPOMDPDiscreteActions``."""
+    pinned = continuous_push_pinned_kwargs()
+    pinned.update(overrides)
+    return pinned
+
+
+def pacman_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``PacManPOMDP``.
+
+    The ghost / pellet / wall ``None`` sentinels are pinned to the concrete
+    values ``__init__`` substitutes for the default ``maze_size=(7, 7)`` and
+    ``num_ghosts=1`` (auto-generated ghost corner ``(6, 6)``, corner-adjacent
+    pellets, and the predefined wall set).
+    """
+    pinned: Dict[str, Any] = {
+        "maze_size": (7, 7),
+        "walls": {(2, 2), (2, 3), (3, 2), (4, 4), (3, 5)},
+        "initial_pellets": [(1, 1), (1, 5), (5, 1), (5, 5)],
+        "initial_pacman_pos": (0, 0),
+        "num_ghosts": 1,
+        "initial_ghost_positions": [(6, 6)],
+        "pellet_reward": 10.0,
+        "ghost_collision_penalty": -100.0,
+        "step_penalty": -1.0,
+        "win_reward": 100.0,
+        "ghost_aggressiveness": 2.0,
+        "ghost_coordination": "independent",
+        "ghost_strategies": ["aggressive"],
+        "observation_noise_factor": 0.3,
+        "max_observation_noise": 1.5,
+        "dangerous_areas": None,
+        "dangerous_area_radius": 1.0,
+        "dangerous_area_penalty": 5.0,
+        "reward_model_type": PacManRewardModelType.CONSTANT_HAZARD_PENALTY,
+        "penalty_decay": 1.0,
+    }
+    pinned.update(overrides)
+    return pinned
+
+
+def rock_sample_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``RockSamplePOMDP``."""
+    pinned: Dict[str, Any] = {
+        "map_size": (5, 5),
+        "rock_positions": [(0, 0), (2, 2), (3, 3)],
+        "init_pos": (0, 0),
+        "sensor_efficiency": 10.0,
+        "bad_rock_penalty": -10.0,
+        "good_rock_reward": 10.0,
+        "step_penalty": 0.0,
+        "sensor_use_penalty": 0.0,
+        "exit_reward": 10.0,
+        "dangerous_areas": [],
+        "dangerous_area_radius": 1.0,
+        "dangerous_area_penalty": -5.0,
+        "dangerous_area_hit_probability": 1.0,
+        "reward_model_type": RockSampleRewardModelType.CONSTANT_HAZARD_PENALTY,
+        "penalty_decay": 1.0,
+    }
+    pinned.update(overrides)
+    return pinned
+
+
+def safety_ant_velocity_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
+    """Pinned optional defaults for ``SafeAntVelocityPOMDP``."""
+    pinned: Dict[str, Any] = {
+        "safe_velocity_threshold": 2.0,
+        "max_force": 1.0,
+        "dt": 0.1,
+        "mass": 1.0,
+        "damping": 0.1,
+        "position_noise": 0.1,
+        "velocity_noise": 0.2,
+        "safety_violation_penalty": -100.0,
+        "movement_reward_scale": 1.0,
+    }
+    pinned.update(overrides)
+    return pinned

--- a/POMDPPlanners/tests/test_utils/test_action_samplers.py
+++ b/POMDPPlanners/tests/test_utils/test_action_samplers.py
@@ -23,6 +23,9 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
     ContinuousLightDarkPOMDP,
 )
 from POMDPPlanners.planners.mcts_planners.pft_dpw import PFT_DPW
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_pinned_kwargs,
+)
 from POMDPPlanners.utils.action_samplers import (
     DiscreteActionSampler,
     UnitCircleActionSampler,
@@ -353,9 +356,11 @@ class TestUnitCircleActionSampler:
         # Create environment
         env = ContinuousLightDarkPOMDP(
             discount_factor=0.99,
-            goal_state=np.array([5, 0]),
-            start_state=np.array([0, 0]),
             name="TestContinuousLightDark",
+            **continuous_light_dark_pinned_kwargs(
+                goal_state=np.array([5, 0]),
+                start_state=np.array([0, 0]),
+            ),
         )
 
         # Create action sampler
@@ -588,8 +593,10 @@ class TestUsageExamples:
         # Create 2D navigation environment (reduced size for testing)
         nav_env = ContinuousLightDarkPOMDP(
             discount_factor=0.99,
-            goal_state=np.array([10, 0]),
-            start_state=np.array([0, 0]),
+            **continuous_light_dark_pinned_kwargs(
+                goal_state=np.array([10, 0]),
+                start_state=np.array([0, 0]),
+            ),
         )
 
         # Create unit circle action sampler

--- a/POMDPPlanners/tests/test_utils/test_belief_factory.py
+++ b/POMDPPlanners/tests/test_utils/test_belief_factory.py
@@ -13,6 +13,11 @@ from POMDPPlanners.core.belief.particle_beliefs import WeightedParticleBelief
 from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
     VectorizedWeightedParticleBelief,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    cartpole_pinned_kwargs,
+    continuous_light_dark_pinned_kwargs,
+    mountain_car_pinned_kwargs,
+)
 from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_belief_invariants,
 )
@@ -35,14 +40,18 @@ def tiger_env():
 def cartpole_env():
     from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
 
-    return CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    return CartPolePOMDP(
+        discount_factor=0.99,
+        noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]),
+        **cartpole_pinned_kwargs(),
+    )
 
 
 @pytest.fixture
 def mountain_car_env():
     from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP
 
-    return MountainCarPOMDP(discount_factor=0.99)
+    return MountainCarPOMDP(discount_factor=0.99, **mountain_car_pinned_kwargs())
 
 
 @pytest.fixture
@@ -51,7 +60,7 @@ def light_dark_env():
         ContinuousLightDarkPOMDP,
     )
 
-    return ContinuousLightDarkPOMDP(discount_factor=0.95)
+    return ContinuousLightDarkPOMDP(discount_factor=0.95, **continuous_light_dark_pinned_kwargs())
 
 
 # ---------------------------------------------------------------------------

--- a/POMDPPlanners/tests/test_utils/test_config_to_id.py
+++ b/POMDPPlanners/tests/test_utils/test_config_to_id.py
@@ -6,6 +6,7 @@ from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
 from POMDPPlanners.planners.mcts_planners.pomcp import POMCP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import cartpole_pinned_kwargs
 from POMDPPlanners.utils.config_to_id import config_to_id, NumpyEncoder
 
 
@@ -501,8 +502,10 @@ class TestConfigToIdIntegration:
         noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
 
         # Create multiple identical environments
-        env1 = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
-        env2 = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov.copy())
+        env1 = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov, **cartpole_pinned_kwargs())
+        env2 = CartPolePOMDP(
+            discount_factor=0.99, noise_cov=noise_cov.copy(), **cartpole_pinned_kwargs()
+        )
 
         # Extract configuration dictionaries
         config1 = {
@@ -547,7 +550,7 @@ class TestConfigToIdIntegration:
 
         # Configuration 1: Base configuration
         noise_cov1 = np.diag([0.1, 0.1, 0.1, 0.1])
-        env1 = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov1)
+        env1 = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov1, **cartpole_pinned_kwargs())
         configs.append(
             {
                 "discount_factor": env1.discount_factor,
@@ -558,7 +561,7 @@ class TestConfigToIdIntegration:
 
         # Configuration 2: Different discount factor
         noise_cov2 = np.diag([0.1, 0.1, 0.1, 0.1])
-        env2 = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov2)
+        env2 = CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov2, **cartpole_pinned_kwargs())
         configs.append(
             {
                 "discount_factor": env2.discount_factor,
@@ -569,7 +572,7 @@ class TestConfigToIdIntegration:
 
         # Configuration 3: Different noise covariance
         noise_cov3 = np.diag([0.2, 0.2, 0.2, 0.2])
-        env3 = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov3)
+        env3 = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov3, **cartpole_pinned_kwargs())
         configs.append(
             {
                 "discount_factor": env3.discount_factor,
@@ -804,7 +807,7 @@ class TestConfigToIdIntegration:
         """
         # Create POMDP components with config_id attributes
         noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-        env = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
+        env = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
         particles = [np.array([0.0, 0.0, 0.1, 0.0]), np.array([0.1, 0.0, 0.0, 0.0])]
         log_weights = np.log(np.array([0.5, 0.5]))
@@ -840,7 +843,7 @@ class TestConfigToIdIntegration:
         Test type: integration
         """
         noise_cov = np.diag([0.1, 0.1, 0.1, 0.1])
-        env = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov)
+        env = CartPolePOMDP(discount_factor=0.99, noise_cov=noise_cov, **cartpole_pinned_kwargs())
 
         # Configuration 1: Keys in one order
         config1 = {

--- a/POMDPPlanners/tests/test_utils/test_planner_episode_visualization.py
+++ b/POMDPPlanners/tests/test_utils/test_planner_episode_visualization.py
@@ -18,6 +18,10 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
 )
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
 from POMDPPlanners.planners.mcts_planners.pomcp import POMCP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    cartpole_pinned_kwargs,
+    continuous_light_dark_pinned_kwargs,
+)
 from POMDPPlanners.utils.planner_episode_visualization import visualize_planner_episode
 
 np.random.seed(42)
@@ -532,8 +536,17 @@ class TestVisualizePlannerEpisode:
         noise_cov = np.eye(4) * 0.01  # 4x4 identity matrix with small noise
         environments = [
             TigerPOMDP(discount_factor=0.95, name="TigerPOMDP"),
-            ContinuousLightDarkPOMDP(discount_factor=0.95, name="LightDarkPOMDP"),
-            CartPolePOMDP(discount_factor=0.95, noise_cov=noise_cov, name="CartPolePOMDP"),
+            ContinuousLightDarkPOMDP(
+                discount_factor=0.95,
+                name="LightDarkPOMDP",
+                **continuous_light_dark_pinned_kwargs(),
+            ),
+            CartPolePOMDP(
+                discount_factor=0.95,
+                noise_cov=noise_cov,
+                name="CartPolePOMDP",
+                **cartpole_pinned_kwargs(),
+            ),
         ]
 
         # Mock cache_visualization for all environments to avoid file I/O

--- a/POMDPPlanners/tests/test_utils/test_visualization/test_policy_simulation_plots.py
+++ b/POMDPPlanners/tests/test_utils/test_visualization/test_policy_simulation_plots.py
@@ -15,6 +15,10 @@ from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp impor
     DiscreteLightDarkPOMDP,
 )
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+    discrete_light_dark_pinned_kwargs,
+)
 from POMDPPlanners.utils.visualization import AgentPath, plot_policy_returns
 
 # Set up logger for tests
@@ -121,19 +125,21 @@ def test_plot_policy_returns_discrete_light_dark_pomdp(temp_cache_dir):
     # Setup - optimized for test performance
     env = DiscreteLightDarkPOMDP(
         discount_factor=0.95,
-        transition_error_prob=0.05,
-        observation_error_prob=0.20,
-        beacons=[(0, 0), (0, 5), (5, 0), (5, 5)],  # Convert to list of tuples
-        goal_state=np.array([5, 2]),  # Smaller grid
-        start_state=np.array([0, 2]),
-        obstacles=[(2, 2)],  # Convert to list of tuples
-        obstacle_reward=-16.0,
-        goal_reward=10.0,
-        obstacle_hit_probability=0.5,
-        beacon_radius=1.0,
-        fuel_cost=2.0,
-        grid_size=6,  # Reduced from 11 to 6
-        is_stochastic_reward=True,
+        **discrete_light_dark_pinned_kwargs(
+            transition_error_prob=0.05,
+            observation_error_prob=0.20,
+            beacons=[(0, 0), (0, 5), (5, 0), (5, 5)],  # Convert to list of tuples
+            goal_state=np.array([5, 2]),  # Smaller grid
+            start_state=np.array([0, 2]),
+            obstacles=[(2, 2)],  # Convert to list of tuples
+            obstacle_reward=-16.0,
+            goal_reward=10.0,
+            obstacle_hit_probability=0.5,
+            beacon_radius=1.0,
+            fuel_cost=2.0,
+            grid_size=6,  # Reduced from 11 to 6
+            is_stochastic_reward=True,
+        ),
     )
 
     # Create simplified agent paths for testing
@@ -182,30 +188,32 @@ def test_plot_policy_returns_continuous_light_dark_pomdp(temp_cache_dir):
     # Setup
     env = ContinuousLightDarkPOMDPDiscreteActions(
         discount_factor=0.95,
-        state_transition_cov_matrix=np.eye(2) * 0.1,
-        observation_cov_matrix=np.eye(2) * 0.1,
-        obstacle_hit_probability=0.2,
-        obstacle_reward=-10.0,
-        goal_reward=10.0,
-        fuel_cost=2.0,
-        grid_size=11,
-        goal_state_radius=1.5,
-        beacon_radius=1.0,
-        obstacle_radius=1.5,
-        beacons=[
-            (0, 0),
-            (0, 5),
-            (0, 10),
-            (5, 0),
-            (5, 5),
-            (5, 10),
-            (10, 0),
-            (10, 5),
-            (10, 10),
-        ],  # Convert to list of tuples
-        goal_state=np.array([10, 5]),
-        start_state=np.array([0, 5]),
-        obstacles=[(3, 7), (5, 5)],  # Convert to list of tuples
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            state_transition_cov_matrix=np.eye(2) * 0.1,
+            observation_cov_matrix=np.eye(2) * 0.1,
+            obstacle_hit_probability=0.2,
+            obstacle_reward=-10.0,
+            goal_reward=10.0,
+            fuel_cost=2.0,
+            grid_size=11,
+            goal_state_radius=1.5,
+            beacon_radius=1.0,
+            obstacle_radius=1.5,
+            beacons=[
+                (0, 0),
+                (0, 5),
+                (0, 10),
+                (5, 0),
+                (5, 5),
+                (5, 10),
+                (10, 0),
+                (10, 5),
+                (10, 10),
+            ],  # Convert to list of tuples
+            goal_state=np.array([10, 5]),
+            start_state=np.array([0, 5]),
+            obstacles=[(3, 7), (5, 5)],  # Convert to list of tuples
+        ),
     )
 
     # Create agent paths for Continuous Light Dark POMDP

--- a/POMDPPlanners/tests/test_utils/test_weighted_particle_belief.py
+++ b/POMDPPlanners/tests/test_utils/test_weighted_particle_belief.py
@@ -17,6 +17,9 @@ import pytest
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDPDiscreteActions,
 )
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    continuous_light_dark_discrete_actions_pinned_kwargs,
+)
 from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_belief_invariants,
 )
@@ -91,7 +94,9 @@ def test_reinvigoration():
     )
 
     # Create ContinuousLightDarkPOMDP environment
-    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_light_dark_discrete_actions_pinned_kwargs()
+    )
 
     # Test reinvigoration
     action = "up"
@@ -228,7 +233,9 @@ def test_full_coverage_reinvigoration():
     )
 
     # Create ContinuousLightDarkPOMDP environment
-    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_light_dark_discrete_actions_pinned_kwargs()
+    )
 
     # Test reinvigoration
     action = "up"
@@ -306,7 +313,9 @@ def test_full_coverage_resampling():
     assert initial_ess < belief.ess_threshold
 
     # Create ContinuousLightDarkPOMDP environment
-    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_light_dark_discrete_actions_pinned_kwargs()
+    )
 
     # Test reinvigoration
     action = "up"
@@ -390,7 +399,9 @@ def test_continuous_full_coverage_reinvigoration():
     )
 
     # Create ContinuousLightDarkPOMDP environment
-    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_light_dark_discrete_actions_pinned_kwargs()
+    )
 
     # Test reinvigoration
     action = "up"
@@ -478,7 +489,9 @@ def test_continuous_full_coverage_resampling():
     assert initial_ess < belief.ess_threshold
 
     # Create ContinuousLightDarkPOMDP environment
-    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_light_dark_discrete_actions_pinned_kwargs()
+    )
 
     # Test reinvigoration
     action = "up"
@@ -526,7 +539,9 @@ def test_continuous_full_coverage_gmm_sampling():
     )
 
     # Create ContinuousLightDarkPOMDP environment
-    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_light_dark_discrete_actions_pinned_kwargs()
+    )
 
     # Test reinvigoration
     action = "up"
@@ -575,7 +590,9 @@ def test_continuous_full_coverage_particle_type_preservation_after_update():
     )
 
     # Create environment
-    env = ContinuousLightDarkPOMDPDiscreteActions(discount_factor=0.95)
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95, **continuous_light_dark_discrete_actions_pinned_kwargs()
+    )
 
     # Verify original particle types and shapes
     for particle in belief.particles:


### PR DESCRIPTION
## Summary

Promotes the latest `develop` changes to `master`.

Includes (most recent first):
- #200 — Standardize planner `References:` sections: one reference per planner, conference/published links preferred over arXiv, corrected Jamgochian et al. 2023 citation to the ICAPS proceedings version.
- #199 — Make environment tests independent of constructor defaults; laser_tag observation/belief-filtering coverage.

## Notes

Docstring/test changes. black / pylint / pyright pass via pre-commit hooks.