### PR TITLE
refactor(environments): make environments own visualization file naming

### DIFF
--- a/POMDPPlanners/core/environment/environment.py
+++ b/POMDPPlanners/core/environment/environment.py
@@ -643,15 +643,20 @@ class Environment(ABC):  # pylint: disable=too-many-public-methods
 
         return next_state, next_observation, reward
 
-    def cache_visualization(self, history: "List[StepData]", cache_path: Path) -> None:
+    def cache_visualization(
+        self, history: "List[StepData]", output_dir: Path, episode_index: int
+    ) -> None:
         """Cache visualization data for an episode history.
 
         This method can be overridden by subclasses to provide environment-specific
-        visualization caching capabilities.
+        visualization caching capabilities. The environment owns the output file
+        name and extension: callers provide only the destination directory and the
+        episode index, and each environment writes whatever artifact(s) it chooses.
 
         Args:
             history: List of step data from an episode
-            cache_path: Path where visualization data should be cached
+            output_dir: Directory into which the visualization file(s) are written
+            episode_index: Zero-based index of the episode, used to name the file
         """
 
     def get_metric_names(self) -> List[str]:

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -820,7 +820,10 @@ class ContinuousLaserTagPOMDP(Environment):
     # Visualization
     # ------------------------------------------------------------------
 
-    def cache_visualization(self, history: List[StepData], cache_path: Path) -> None:
+    def cache_visualization(
+        self, history: List[StepData], output_dir: Path, episode_index: int
+    ) -> None:
+        cache_path = output_dir / f"agent_path_{episode_index}.gif"
         visualizer = ContinuousLaserTagVisualizer(
             grid_size=self._grid_size,
             walls=self._walls,

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -1433,7 +1433,9 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             all_dangerous_encounters_ci,
         )
 
-    def cache_visualization(self, history: List[StepData], cache_path: Path) -> None:
+    def cache_visualization(
+        self, history: List[StepData], output_dir: Path, episode_index: int
+    ) -> None:
         """Cache visualization of the LaserTag episode as an animated GIF.
 
         Creates an animated visualization showing:
@@ -1448,12 +1450,13 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
 
         Args:
             history: The history of states, actions, and observations from an episode
-            cache_path: Path where to save the visualization GIF
+            output_dir: Directory into which the ``.gif`` visualization is written
+            episode_index: Zero-based episode index, used to name the file
 
         Raises:
             ValueError: If history is empty or contains invalid data
-            TypeError: If cache_path is not a Path object or doesn't end with .gif
         """
+        cache_path = output_dir / f"agent_path_{episode_index}.gif"
         # Lazy import to avoid circular dependency
         visualizer = LaserTagVisualizer(
             floor_shape=self.floor_shape,

--- a/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/base_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/light_dark_pomdp_utils/base_light_dark_pomdp.py
@@ -322,18 +322,21 @@ class BaseLightDarkPOMDP(Environment, ABC):
         visualizer = LightDarkPOMDPVisualizer(self)
         visualizer.visualize_path(path, agent_belief_path, actions, cache_path)
 
-    def cache_visualization(self, history: List[StepData], cache_path: Path) -> None:
+    def cache_visualization(
+        self, history: List[StepData], output_dir: Path, episode_index: int
+    ) -> None:
         """Cache visualization of agent's path and belief.
 
         Args:
             history: List of step data from an episode.
-            cache_path: Path where to save the visualization.
+            output_dir: Directory into which the ``.gif`` visualization is written.
+            episode_index: Zero-based episode index, used to name the file.
 
         Raises:
-            TypeError: If history is not a List or contains non-StepData objects,
-                or if cache_path is not a Path object.
+            TypeError: If history is not a List or contains non-StepData objects.
             ValueError: If history is empty or contains invalid data.
         """
+        cache_path = output_dir / f"agent_path_{episode_index}.gif"
         visualizer = LightDarkPOMDPVisualizer(self)
         visualizer.cache_visualization(history, cache_path)
 

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
@@ -367,8 +367,10 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
     def get_actions(self) -> List[Any]:
         return self.actions
 
-    def cache_visualization(self, history: List[StepData], cache_path: Path) -> None:
-        # Create a figure and axis
+    def cache_visualization(
+        self, history: List[StepData], output_dir: Path, episode_index: int
+    ) -> None:
+        # No per-episode visualization for this environment.
         pass
 
     def is_equal_observation(

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -1384,17 +1384,21 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         visualizer = PacManVisualizer(self)
         visualizer.visualize_path(path, actions, cache_path)
 
-    def cache_visualization(self, history: List[StepData], cache_path: Path) -> None:
+    def cache_visualization(
+        self, history: List[StepData], output_dir: Path, episode_index: int
+    ) -> None:
         """Cache visualization of episode history.
 
         Args:
             history: List of StepData objects representing the episode
-            cache_path: Path where the GIF should be saved
+            output_dir: Directory into which the ``.gif`` visualization is written
+            episode_index: Zero-based episode index, used to name the file
         """
         from POMDPPlanners.environments.pacman_pomdp.pacman_visualizer import (
             PacManVisualizer,
         )  # pylint: disable=import-outside-toplevel
 
+        cache_path = output_dir / f"agent_path_{episode_index}.gif"
         visualizer = PacManVisualizer(self)
         visualizer.cache_visualization(history, cache_path)
 

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -676,7 +676,9 @@ class ContinuousPushPOMDP(Environment):
         # np.array_equal semantics for arrays of identical shape and dtype.
         return np.ascontiguousarray(action, dtype=np.float64).tobytes()
 
-    def cache_visualization(self, history: List[StepData], cache_path: Path) -> None:
+    def cache_visualization(
+        self, history: List[StepData], output_dir: Path, episode_index: int
+    ) -> None:
         """Cache animated visualization of the continuous push episode.
 
         Creates an animated GIF showing the robot pushing the object toward
@@ -685,13 +687,13 @@ class ContinuousPushPOMDP(Environment):
 
         Args:
             history: Episode history containing states, actions, and rewards.
-            cache_path: Path where to save the visualization (must end with .gif).
+            output_dir: Directory into which the ``.gif`` visualization is written.
+            episode_index: Zero-based episode index, used to name the file.
 
         Raises:
-            ValueError: If history is empty or cache_path doesn't end with .gif.
-            TypeError: If cache_path is not a Path object.
+            ValueError: If history is empty.
         """
-
+        cache_path = output_dir / f"agent_path_{episode_index}.gif"
         visualizer = ContinuousPushPOMDPVisualizer(self)
         visualizer.create_visualization(history, cache_path)
 

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -913,7 +913,9 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         sq = np.sum(diffs * diffs, axis=1)
         return log_norm - 0.5 * sq / variance
 
-    def cache_visualization(self, history: List[StepData], cache_path: Path) -> None:
+    def cache_visualization(
+        self, history: List[StepData], output_dir: Path, episode_index: int
+    ) -> None:
         """Cache animated visualization of the push episode.
 
         Creates an animated GIF showing the robot pushing the object toward the target,
@@ -921,12 +923,13 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
 
         Args:
             history: Episode history containing states, actions, and rewards
-            cache_path: Path where to save the visualization (must end with .gif)
+            output_dir: Directory into which the ``.gif`` visualization is written
+            episode_index: Zero-based episode index, used to name the file
 
         Raises:
-            ValueError: If history is empty or cache_path doesn't end with .gif
-            TypeError: If cache_path is not a Path object
+            ValueError: If history is empty
         """
+        cache_path = output_dir / f"agent_path_{episode_index}.gif"
         visualizer = PushPOMDPVisualizer(self)
         visualizer.create_visualization(history, cache_path)
 

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -813,17 +813,21 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
 
         return metrics
 
-    def cache_visualization(self, history: List[StepData], cache_path: Path) -> None:
+    def cache_visualization(
+        self, history: List[StepData], output_dir: Path, episode_index: int
+    ) -> None:
         """Cache visualization of episode history.
 
         Args:
             history: Episode history containing states, actions, and rewards
-            cache_path: Path where to save the visualization (must end with .gif)
+            output_dir: Directory into which the ``.gif`` visualization is written
+            episode_index: Zero-based episode index, used to name the file
         """
         from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_visualizer import (  # pylint: disable=import-outside-toplevel
             RockSampleVisualizer,
         )
 
+        cache_path = output_dir / f"agent_path_{episode_index}.gif"
         visualizer = RockSampleVisualizer(self)
         visualizer.create_visualization(history, cache_path)
 

--- a/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
+++ b/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
@@ -282,7 +282,9 @@ class SafeAntVelocityPOMDP(DiscreteActionsEnvironment):
         # Discrete int actions (force levels); already hashable.
         return action
 
-    def cache_visualization(self, history: List[StepData], cache_path: Path) -> None:
+    def cache_visualization(
+        self, history: List[StepData], output_dir: Path, episode_index: int
+    ) -> None:
         """Cache animated visualization of the safety ant velocity episode.
 
         Creates an animated GIF showing the ant's movement trajectory with velocity vectors,
@@ -290,12 +292,13 @@ class SafeAntVelocityPOMDP(DiscreteActionsEnvironment):
 
         Args:
             history: Episode history containing states, actions, and rewards
-            cache_path: Path where to save the visualization (must end with .gif)
+            output_dir: Directory into which the ``.gif`` visualization is written
+            episode_index: Zero-based episode index, used to name the file
 
         Raises:
-            ValueError: If history is empty or cache_path doesn't end with .gif
-            TypeError: If cache_path is not a Path object
+            ValueError: If history is empty
         """
+        cache_path = output_dir / f"agent_path_{episode_index}.gif"
         visualizer = SafeAntVelocityVisualizer(self)
         visualizer.create_animation(history, cache_path)
 

--- a/POMDPPlanners/simulations/simulator/episode_returns_visualizer.py
+++ b/POMDPPlanners/simulations/simulator/episode_returns_visualizer.py
@@ -153,12 +153,11 @@ class EpisodeReturnsVisualizer(ExperimentVisualizer):
         viz_dir.mkdir(exist_ok=True)
 
         for episode_idx, history in enumerate(policy_histories):
-            file_name = f"agent_path_{episode_idx}.gif"
-            cache_path = viz_dir / file_name
             try:
                 environment.cache_visualization(
                     history=history.history,
-                    cache_path=cache_path,
+                    output_dir=viz_dir,
+                    episode_index=episode_idx,
                 )
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 logger.warning("Visualization failed for episode %s: %s", episode_idx, str(exc))

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_visualizer.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_visualizer.py
@@ -8,8 +8,8 @@ This module tests the LaserTag POMDP visualization features, focusing on:
 """
 
 import random
+import tempfile
 from pathlib import Path
-from typing import cast
 
 import numpy as np
 import pytest
@@ -18,6 +18,9 @@ from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.core.policy import PolicyRunData
 from POMDPPlanners.core.simulation import History, StepData
 from POMDPPlanners.environments.laser_tag_pomdp import LaserTagPOMDP
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_visualizer import (
+    LaserTagVisualizer,
+)
 from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
     laser_tag_pinned_kwargs as _lt_pinned_kwargs,
 )
@@ -96,16 +99,10 @@ class TestLaserTagVisualization:
             policy_run_data=[PolicyRunData(info_variables=[])],
         )
 
-        cache_path = Path("test_laser_tag_visualization.gif")
-
         try:
-            # This should not raise an exception
-            env.cache_visualization(history.history, cache_path)
-
-            # Clean up if file was created
-            if cache_path.exists():
-                cache_path.unlink()
-
+            with tempfile.TemporaryDirectory() as temp_dir:
+                # This should not raise an exception
+                env.cache_visualization(history.history, Path(temp_dir), 0)
         except Exception as e:
             pytest.fail(f"cache_visualization raised an exception: {e}")
 
@@ -166,17 +163,28 @@ class TestLaserTagVisualization:
             policy_run_data=[PolicyRunData(info_variables=[])],
         )
 
+        # The environment owns the output file name; path-shape validation now
+        # lives in the visualizer it delegates to, so those cases target it directly.
+        visualizer = LaserTagVisualizer(
+            floor_shape=env.floor_shape,
+            walls=env.walls,
+            dangerous_areas=env.dangerous_areas,
+            dangerous_area_radius=env.dangerous_area_radius,
+        )
+
         # Test with non-Path cache_path
         with pytest.raises(TypeError, match="cache_path must be a Path object"):
-            env.cache_visualization(non_empty_history.history, cast(Path, "invalid_path"))
+            visualizer.create_visualization(
+                non_empty_history.history, "invalid_path"  # type: ignore[arg-type]
+            )
 
         # Test with non-gif extension
         with pytest.raises(ValueError, match="cache_path must end with .gif"):
-            env.cache_visualization(non_empty_history.history, Path("test.png"))
+            visualizer.create_visualization(non_empty_history.history, Path("test.png"))
 
-        # Test with empty history
+        # Test with empty history (validated through the environment hook)
         with pytest.raises(ValueError, match="Cannot visualize empty history"):
-            env.cache_visualization(dummy_history.history, Path("test.gif"))
+            env.cache_visualization(dummy_history.history, Path("test_dir"), 0)
 
 
 if __name__ == "__main__":

--- a/POMDPPlanners/tests/test_environments/test_pacman_visualizer.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_visualizer.py
@@ -221,8 +221,8 @@ def test_cache_visualization_vectorized_belief_renders_red_overlay() -> None:
     ]
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        gif_path = Path(tmpdir) / "viz.gif"
-        env.cache_visualization(history, gif_path)
+        env.cache_visualization(history, Path(tmpdir), 0)
+        gif_path = Path(tmpdir) / "agent_path_0.gif"
         assert gif_path.exists()
 
         frame = Image.open(gif_path).convert("RGBA")

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_visualizer.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_visualizer.py
@@ -73,8 +73,7 @@ class TestVisualization:
 
         with pytest.raises(ValueError, match="Cannot visualize empty history"):
             with tempfile.TemporaryDirectory() as temp_dir:
-                cache_path = Path(temp_dir) / "test.gif"
-                pomdp.cache_visualization(empty_history.history, cache_path)
+                pomdp.cache_visualization(empty_history.history, Path(temp_dir), 0)
 
     @patch("matplotlib.pyplot.close")
     @patch("matplotlib.animation.FuncAnimation.save")
@@ -126,10 +125,8 @@ class TestVisualization:
         )
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            cache_path = Path(temp_dir) / "test.gif"
-
             # Should not raise any exceptions
-            pomdp.cache_visualization(history.history, cache_path)
+            pomdp.cache_visualization(history.history, Path(temp_dir), 0)
 
             # Verify mocks were called
             mock_save.assert_called_once()

--- a/POMDPPlanners/tests/test_simulations/test_simulator.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulator.py
@@ -1643,13 +1643,17 @@ def test_simulator_caches_visualizations_with_continuous_light_dark_pomdp(
     cache_viz_sig = signature(environment.cache_visualization)
     param_names = list(cache_viz_sig.parameters.keys())
 
-    # The method should have 'history' and 'cache_path' parameters (plus 'self')
+    # The environment owns the output file name: the hook takes a destination
+    # directory and an episode index (plus 'history' and 'self').
     assert (
         "history" in param_names
     ), f"cache_visualization missing 'history' parameter. Found: {param_names}"
     assert (
-        "cache_path" in param_names
-    ), f"cache_visualization missing 'cache_path' parameter. Found: {param_names}"
+        "output_dir" in param_names
+    ), f"cache_visualization missing 'output_dir' parameter. Found: {param_names}"
+    assert (
+        "episode_index" in param_names
+    ), f"cache_visualization missing 'episode_index' parameter. Found: {param_names}"
 
     # 4. If integration was successful, verify GIF files
     if integration_successful:
@@ -1674,14 +1678,14 @@ def test_simulator_caches_visualizations_with_continuous_light_dark_pomdp(
 
     # 5. Verify that environment works with the simulator's expected interface
     # Test that environment can handle the exact data structure the simulator provides
-    test_cache_path = viz_dir / "integration_test.gif"
-
     # This is the key integration test - can the environment handle simulator's data?
     environment_compatible = False
     environment_error = ""  # Initialize to avoid unbound variable error
     try:
         # Test the exact interface the simulator uses (List[StepData])
-        environment.cache_visualization(history=test_history.history, cache_path=test_cache_path)
+        environment.cache_visualization(
+            history=test_history.history, output_dir=viz_dir, episode_index=0
+        )
         environment_compatible = True
     except Exception as e:
         environment_error = str(e)

--- a/POMDPPlanners/tests/test_utils/test_planner_episode_visualization.py
+++ b/POMDPPlanners/tests/test_utils/test_planner_episode_visualization.py
@@ -158,20 +158,17 @@ class TestVisualizePlannerEpisode:
             # Verify environment visualization was called twice
             assert tiger_environment.cache_visualization.call_count == 2
 
-            # Verify cache paths are correct
-            expected_cache_paths = [
-                temp_cache_dir / "TestPlanner_0.gif",
-                temp_cache_dir / "TestPlanner_1.gif",
-            ]
+            # The environment owns the output file name; the planner name scopes
+            # the output directory and the episode id becomes the episode index.
+            expected_output_dir = temp_cache_dir / "TestPlanner"
 
             for i, call_args in enumerate(tiger_environment.cache_visualization.call_args_list):
-                history_arg = call_args[1]["history"]
-                cache_path_arg = call_args[1]["cache_path"]
-
+                kwargs = call_args[1]
                 assert (
-                    history_arg == sample_episode_history.history
+                    kwargs["history"] == sample_episode_history.history
                 )  # Pass the history list, not the History object
-                assert cache_path_arg == expected_cache_paths[i]
+                assert kwargs["output_dir"] == expected_output_dir
+                assert kwargs["episode_index"] == i
 
     def test_visualize_planner_episode_single_episode(
         self,
@@ -219,7 +216,8 @@ class TestVisualizePlannerEpisode:
 
             tiger_environment.cache_visualization.assert_called_once_with(
                 history=sample_episode_history.history,  # Pass the history list, not the History object
-                cache_path=temp_cache_dir / "TestPlanner_0.gif",
+                output_dir=temp_cache_dir / "TestPlanner",
+                episode_index=0,
             )
 
     def test_visualize_planner_episode_zero_episodes(
@@ -267,7 +265,8 @@ class TestVisualizePlannerEpisode:
 
         Given: Planner with specific name, belief, and multiple episodes
         When: visualize_planner_episode generates cache paths
-        Then: Cache paths follow expected format: {planner_name}_{episode_id}.
+        Then: The planner name scopes the output directory and the episode id
+            is passed as the episode index.
 
         Test type: unit
         """
@@ -291,19 +290,18 @@ class TestVisualizePlannerEpisode:
                 num_steps=5,
             )
 
-            # Extract cache paths from calls
-            cache_paths = []
+            # Extract output directories and episode indices from calls
+            output_dirs = []
+            episode_indices = []
             for call_args in tiger_environment.cache_visualization.call_args_list:
-                cache_paths.append(call_args[1]["cache_path"])
+                output_dirs.append(call_args[1]["output_dir"])
+                episode_indices.append(call_args[1]["episode_index"])
 
-            # Verify cache path formatting
-            expected_paths = [
-                temp_cache_dir / "POMCP_TestPlanner_123_0.gif",
-                temp_cache_dir / "POMCP_TestPlanner_123_1.gif",
-                temp_cache_dir / "POMCP_TestPlanner_123_2.gif",
-            ]
-
-            assert cache_paths == expected_paths
+            # Each planner writes into its own subdirectory; the environment owns
+            # the per-episode file name.
+            expected_dir = temp_cache_dir / "POMCP_TestPlanner_123"
+            assert output_dirs == [expected_dir, expected_dir, expected_dir]
+            assert episode_indices == [0, 1, 2]
 
     def test_visualize_planner_episode_real_policy_integration(self, temp_cache_dir):
         """Test integration with real POMCP policy and TigerPOMDP.
@@ -348,19 +346,16 @@ class TestVisualizePlannerEpisode:
         # Verify visualization was called
         assert env.cache_visualization.call_count == 2
 
-        # Verify cache paths
-        expected_paths = [
-            temp_cache_dir / "RealPOMCP_0.gif",
-            temp_cache_dir / "RealPOMCP_1.gif",
-        ]
+        # Verify per-planner output directory and episode indices
+        expected_dir = temp_cache_dir / "RealPOMCP"
 
         for i, call_args in enumerate(env.cache_visualization.call_args_list):
-            cache_path_arg = call_args[1]["cache_path"]
-            assert cache_path_arg == expected_paths[i]
+            kwargs = call_args[1]
+            assert kwargs["output_dir"] == expected_dir
+            assert kwargs["episode_index"] == i
 
             # Verify history is a valid list of StepData
-            history_arg = call_args[1]["history"]
-            assert isinstance(history_arg, list)  # Should be a list of StepData
+            assert isinstance(kwargs["history"], list)  # Should be a list of StepData
 
     def test_visualize_planner_episode_exception_handling(
         self, test_planner, tiger_environment, test_belief, temp_cache_dir
@@ -604,11 +599,11 @@ class TestVisualizePlannerEpisode:
                     num_steps=5,
                 )
 
-                # Verify cache path is constructed correctly
-                expected_cache_path = temp_path / "TestPlanner_0.gif"
+                # Verify the output directory and episode index are passed correctly
                 tiger_environment.cache_visualization.assert_called_with(
                     history=sample_episode_history.history,  # Pass the history list, not the History object
-                    cache_path=expected_cache_path,
+                    output_dir=temp_path / "TestPlanner",
+                    episode_index=0,
                 )
 
     def test_visualize_planner_episode_docstring_example(self, temp_cache_dir):
@@ -652,12 +647,11 @@ class TestVisualizePlannerEpisode:
         # Verify expected behavior
         assert env.cache_visualization.call_count == 3
 
-        # Verify cache paths follow expected pattern
+        # Verify per-planner output directory and episode indices
         for i in range(3):
-            call_args = env.cache_visualization.call_args_list[i]
-            cache_path = call_args[1]["cache_path"]
-            expected_path = temp_cache_dir / f"POMCP_{i}.gif"
-            assert cache_path == expected_path
+            kwargs = env.cache_visualization.call_args_list[i][1]
+            assert kwargs["output_dir"] == temp_cache_dir / "POMCP"
+            assert kwargs["episode_index"] == i
 
     def test_visualize_planner_episode_parallel_basic(
         self,

--- a/POMDPPlanners/tests/test_utils/test_planner_episode_visualization.py
+++ b/POMDPPlanners/tests/test_utils/test_planner_episode_visualization.py
@@ -16,11 +16,16 @@ from POMDPPlanners.environments.cartpole_pomdp import CartPolePOMDP
 from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
     ContinuousLightDarkPOMDP,
 )
+from POMDPPlanners.environments.rock_sample_pomdp import (
+    RockSamplePOMDP,
+    create_rock_sample_state,
+)
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
 from POMDPPlanners.planners.mcts_planners.pomcp import POMCP
 from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
     cartpole_pinned_kwargs,
     continuous_light_dark_pinned_kwargs,
+    rock_sample_pinned_kwargs,
 )
 from POMDPPlanners.utils.planner_episode_visualization import visualize_planner_episode
 
@@ -1002,3 +1007,86 @@ class TestVisualizePlannerEpisode:
             # Verify parallel execution was triggered
             mock_parallel.assert_called_once_with(n_jobs=2)
             mock_parallel.return_value.assert_called_once()
+
+    def test_visualize_planner_episode_writes_per_planner_subdir_hierarchy(self, temp_cache_dir):
+        """Test the on-disk output hierarchy with a real rendering environment.
+
+        Purpose: Validates that the environment now owns the file name and each
+            planner's visualizations land in their own subdirectory, i.e.
+            ``cache_dir/<planner_name>/agent_path_{episode}.gif``.
+
+        Given: A real RockSamplePOMDP (which renders a GIF), a POMCP planner, and
+            a mocked run_episode returning a fixed two-step history.
+        When: visualize_planner_episode is called with n_episodes=2.
+        Then: ``cache_dir/HierarchyPOMCP/agent_path_{0,1}.gif`` exist as non-empty
+            files, and nothing is written flat under ``cache_dir``.
+
+        Test type: integration
+        """
+        environment = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
+        planner = POMCP(
+            environment=environment,
+            discount_factor=0.95,
+            name="HierarchyPOMCP",
+            exploration_constant=1.0,
+            n_simulations=5,  # Minimal for testing
+            depth=3,
+        )
+
+        state1 = create_rock_sample_state((0, 0), (True, False))
+        state2 = create_rock_sample_state((0, 1), (True, False))
+        history = History(
+            history=[
+                StepData(
+                    state=state1,
+                    action=2,
+                    next_state=state2,
+                    observation="none",
+                    reward=-1.0,
+                    belief=Mock(spec=Belief),
+                ),
+                StepData(
+                    state=state2,
+                    action=None,
+                    next_state=state2,
+                    observation="none",
+                    reward=0.0,
+                    belief=Mock(spec=Belief),
+                ),
+            ],
+            discount_factor=0.95,
+            average_state_sampling_time=0.0,
+            average_action_time=0.0,
+            average_observation_time=0.0,
+            average_belief_update_time=0.0,
+            average_reward_time=0.0,
+            actual_num_steps=2,
+            reach_terminal_state=False,
+            policy_run_data=[],
+        )
+
+        with patch(
+            "POMDPPlanners.utils.planner_episode_visualization.run_episode",
+            return_value=history,
+        ):
+            visualize_planner_episode(
+                planner=planner,
+                environment=environment,
+                belief=Mock(spec=Belief),
+                n_episodes=2,
+                cache_dir=temp_cache_dir,
+                num_steps=5,
+            )
+
+        # The planner name scopes its own subdirectory.
+        planner_dir = temp_cache_dir / "HierarchyPOMCP"
+        assert planner_dir.is_dir(), f"Per-planner directory not created: {planner_dir}"
+
+        # The environment owns the file name: agent_path_{episode}.gif inside it.
+        for episode_index in range(2):
+            gif_path = planner_dir / f"agent_path_{episode_index}.gif"
+            assert gif_path.is_file(), f"Missing visualization file: {gif_path}"
+            assert gif_path.stat().st_size > 0, f"Empty visualization file: {gif_path}"
+
+        # Nothing is written flat under cache_dir; the per-planner subdir is used.
+        assert not list(temp_cache_dir.glob("agent_path_*.gif"))

--- a/POMDPPlanners/utils/planner_episode_visualization.py
+++ b/POMDPPlanners/utils/planner_episode_visualization.py
@@ -29,10 +29,15 @@ def _run_single_episode(
         num_steps=num_steps,
         logger=logger,
     )
-    cache_path = cache_dir / f"{planner.name}_{episode_id}.gif"
-
-    # Visualize the episode
-    environment.cache_visualization(history=episode_result.history, cache_path=cache_path)
+    # The environment owns the output file name/extension; keep each planner's
+    # visualizations separated by writing them into a per-planner subdirectory.
+    planner_output_dir = cache_dir / planner.name
+    planner_output_dir.mkdir(parents=True, exist_ok=True)
+    environment.cache_visualization(
+        history=episode_result.history,
+        output_dir=planner_output_dir,
+        episode_index=episode_id,
+    )
 
 
 def visualize_planner_episode(


### PR DESCRIPTION
## What

Moves per-episode visualization **file naming** out of the episode visualizer and into each environment. `cache_visualization` now takes an **output directory** and an **episode index** instead of a fully-formed `cache_path`, so each environment decides its own filename and extension.

Before:
```python
env.cache_visualization(history, viz_dir / "agent_path_0.gif")  # caller picks the name
```
After:
```python
env.cache_visualization(history, viz_dir, 0)  # env picks agent_path_0.gif itself
```

## Why

The caller (`EpisodeReturnsVisualizer`) hardcoded `agent_path_{i}.gif`, forcing a `.gif` extension on every environment. Ownership of the artifact name belongs with the environment that produces it, so environments that render a different format aren't boxed into `.gif`.

## Changes

- **core**: `cache_visualization(history, output_dir, episode_index)`.
- **`episode_returns_visualizer`**: passes the visualizations directory + episode index; no longer builds the filename. Output name (`agent_path_{i}.gif`) is unchanged.
- **All existing environments** (mountain_car, light_dark, laser_tag + continuous, pacman, safety_ant_velocity, push + continuous, rock_sample): build `agent_path_{i}.gif` themselves. Path-shape validation stays in each environment's delegated visualizer.
- **`utils/planner_episode_visualization`**: since the environment now owns the file name, each planner writes into its **own subdirectory** (`cache_dir/<planner_name>/agent_path_{i}.gif`). This preserves the previous per-planner separation and avoids collisions between planners sharing one `cache_dir`.
- **Tests**: updated to the new signature (including `test_planner_episode_visualization` and the laser-tag path-validation cases, which now target the visualizer directly — the layer that still validates paths).

## Scope

Existing environments only — CARLA and Isaac Lab environments are intentionally excluded from this PR.

## Testing

Relevant suites pass locally (82 passed, 8 skipped — golden-file tests):
- environment visualizer tests (laser_tag, rock_sample, pacman)
- golden-file consistency tests
- `planner_episode_visualization`, `episode_returns_visualizer`, `simulator` tests

Static analysis: whole-tree `pyright POMDPPlanners/` → 0 errors; pre-commit (black / pylint / pyright) passed.