### PR TITLE
feat(environments): add CarlaPOMDP forward-only world environment

### DIFF
--- a/POMDPPlanners/environments/carla_pomdp/__init__.py
+++ b/POMDPPlanners/environments/carla_pomdp/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+
+"""CARLA POMDP world environment module.
+
+This module provides a forward-only adapter exposing the CARLA autonomous-driving
+simulator as a ground-truth world for the POMDPPlanners episode loop.
+
+Classes:
+    CarlaPOMDP: Forward-only adapter exposing a CARLA session as a world Environment.
+"""
+
+from POMDPPlanners.environments.carla_pomdp.carla_pomdp import CarlaPOMDP
+
+__all__ = [
+    "CarlaPOMDP",
+]

--- a/POMDPPlanners/environments/carla_pomdp/carla_pomdp.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_pomdp.py
@@ -1,0 +1,616 @@
+# SPDX-License-Identifier: MIT
+
+"""CARLA POMDP world environment.
+
+This module adapts the `CARLA <https://carla.org/>`_ autonomous-driving
+simulator to the POMDPPlanners :class:`~POMDPPlanners.core.environment.Environment`
+interface so it can serve as the **ground-truth world** in an
+:class:`~POMDPPlanners.simulations.episodes.EpisodeRunner`.
+
+CARLA is *forward-only*: it is a live Unreal server driven over a Python client
+that exposes ``reset``/``tick`` on a single true state and cannot be queried for
+a transition/observation density nor re-run from an arbitrary injected state. It
+therefore cannot act as a planner's generative model. In the two-environment
+episode design the planner keeps its own generative model (``policy.environment``)
+and this wrapper only advances the single true state forward, one step per real
+interaction. Consequently :meth:`CarlaPOMDP.transition_log_probability` and
+:meth:`CarlaPOMDP.observation_log_probability` intentionally raise
+:class:`NotImplementedError` — in the intended world/model split they are never
+called.
+
+Unlike :class:`~POMDPPlanners.environments.gym_pomdp.gym_pomdp.GymPOMDP` (which is
+fully observed: observation equals state), CARLA is genuinely partially observed.
+The **state** is the ego vehicle's ground-truth kinematics ``[x, y, yaw, vx, vy]``
+read straight from the simulator, while the **observation** is a native CARLA
+sensor payload (GNSS ``[lat, lon, alt]`` by default). Any measurement noise is
+CARLA's own, configured through the sensor blueprint attributes in
+``sensor_config`` — the wrapper adds none.
+
+Classes:
+    CarlaPOMDP: Forward-only adapter exposing a CARLA session as a world Environment.
+"""
+
+from collections.abc import Hashable
+from pathlib import Path
+from queue import Queue
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.distributions import Distribution
+from POMDPPlanners.core.environment import Environment, SpaceInfo, SpaceType
+from POMDPPlanners.core.simulation import StepData
+
+# Default discrete control presets as ``(throttle, steer, brake)`` triples.
+DEFAULT_ACTION_PRESETS: Tuple[Tuple[float, float, float], ...] = (
+    (0.5, 0.0, 0.0),  # cruise straight
+    (0.3, -0.5, 0.0),  # steer left
+    (0.3, 0.5, 0.0),  # steer right
+    (0.0, 0.0, 1.0),  # brake
+)
+
+# Per-step getter roles that may trigger the single CARLA tick. Each role may be
+# served from the cached tick at most once, so a repeated role signals a new step.
+_ROLE_NEXT_STATE = "next_state"
+_ROLE_REWARD = "reward"
+
+# Default chase RGB camera resolution / field of view (blueprint attributes).
+DEFAULT_CAMERA_CONFIG: Dict[str, str] = {
+    "image_size_x": "640",
+    "image_size_y": "480",
+    "fov": "90",
+}
+
+
+class _CarlaSession:
+    """Live CARLA session: server handle, ego vehicle, and attached sensors.
+
+    This is the only object that talks to the ``carla`` package. It exposes a
+    small forward-only interface (:meth:`reset` / :meth:`step`) that mirrors a
+    Gymnasium env so :class:`CarlaPOMDP` can drive it and tests can substitute a
+    scripted fake with the same two methods.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        town: str,
+        fixed_delta_seconds: float,
+        sensor_config: Dict[str, Any],
+        vehicle_filter: str,
+        timeout: float,
+        record_camera: bool = False,
+        camera_config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        import carla  # pylint: disable=import-outside-toplevel,import-error
+
+        self._carla = carla
+        self._sensor_config = sensor_config
+        self._vehicle_filter = vehicle_filter
+        self._record_camera = record_camera
+        self._camera_config = camera_config if camera_config is not None else {}
+        client = carla.Client(host, port)
+        client.set_timeout(timeout)
+        self._client = client
+        self._world = client.load_world(town)
+        self._apply_synchronous_settings(fixed_delta_seconds)
+
+        self._vehicle: Optional[Any] = None
+        self._gnss_sensor: Optional[Any] = None
+        self._collision_sensor: Optional[Any] = None
+        self._camera_sensor: Optional[Any] = None
+        self._camera_queue: Optional["Queue[Any]"] = None
+        self._frames: List[np.ndarray] = []
+        self._latest_gnss: Optional[np.ndarray] = None
+        self._collided: bool = False
+
+    @property
+    def frames(self) -> List[np.ndarray]:
+        """RGB chase-camera frames captured so far, one ``(H, W, 3)`` array per tick."""
+        return self._frames
+
+    def reset(self, seed: Optional[int] = None) -> Tuple[np.ndarray, np.ndarray]:
+        """Respawn the ego vehicle and sensors, tick once, and read the start."""
+        if seed is not None:
+            self._world.get_settings()  # touch settings so a seed hook can attach
+        self._teardown_actors()
+        self._frames = []
+        self._spawn_actors()
+        self._collided = False
+        self._world.tick()
+        self._capture_frame()
+        return self._read_state(), self._read_observation()
+
+    def step(
+        self, throttle: float, steer: float, brake: float
+    ) -> Tuple[np.ndarray, np.ndarray, bool]:
+        """Apply a control, advance one fixed tick, and read the outcome."""
+        control = self._carla.VehicleControl(throttle=throttle, steer=steer, brake=brake)
+        self._vehicle.apply_control(control)
+        self._world.tick()
+        self._capture_frame()
+        return self._read_state(), self._read_observation(), self._collided
+
+    def _apply_synchronous_settings(self, fixed_delta_seconds: float) -> None:
+        settings = self._world.get_settings()
+        settings.synchronous_mode = True
+        settings.fixed_delta_seconds = fixed_delta_seconds
+        self._world.apply_settings(settings)
+
+    def _spawn_actors(self) -> None:
+        blueprint_library = self._world.get_blueprint_library()
+        vehicle_bp = blueprint_library.filter(self._vehicle_filter)[0]
+        spawn_point = self._world.get_map().get_spawn_points()[0]
+        self._vehicle = self._world.spawn_actor(vehicle_bp, spawn_point)
+        self._gnss_sensor = self._attach_gnss(blueprint_library)
+        self._collision_sensor = self._attach_collision(blueprint_library)
+        if self._record_camera:
+            self._camera_sensor = self._attach_camera(blueprint_library)
+
+    def _attach_gnss(self, blueprint_library: Any) -> Any:
+        gnss_bp = blueprint_library.find("sensor.other.gnss")
+        for attribute, value in self._sensor_config.items():
+            gnss_bp.set_attribute(attribute, str(value))
+        sensor: Any = self._world.spawn_actor(
+            gnss_bp, self._carla.Transform(), attach_to=self._vehicle
+        )
+        sensor.listen(self._on_gnss)
+        return sensor
+
+    def _attach_collision(self, blueprint_library: Any) -> Any:
+        collision_bp = blueprint_library.find("sensor.other.collision")
+        sensor: Any = self._world.spawn_actor(
+            collision_bp, self._carla.Transform(), attach_to=self._vehicle
+        )
+        sensor.listen(self._on_collision)
+        return sensor
+
+    def _attach_camera(self, blueprint_library: Any) -> Any:
+        camera_bp = blueprint_library.find("sensor.camera.rgb")
+        for attribute, value in self._camera_config.items():
+            camera_bp.set_attribute(attribute, str(value))
+        # Chase view: behind and above the ego, tilted slightly down.
+        transform = self._carla.Transform(
+            self._carla.Location(x=-6.0, z=3.0),
+            self._carla.Rotation(pitch=-15.0),
+        )
+        sensor: Any = self._world.spawn_actor(camera_bp, transform, attach_to=self._vehicle)
+        self._camera_queue = Queue()
+        sensor.listen(self._camera_queue.put)
+        return sensor
+
+    def _capture_frame(self) -> None:
+        """Pull the RGB frame CARLA rendered for the tick just executed."""
+        if not self._record_camera or self._camera_queue is None:
+            return
+        image = self._camera_queue.get()
+        buffer = np.frombuffer(image.raw_data, dtype=np.uint8)
+        bgra = np.reshape(buffer, (image.height, image.width, 4))
+        # CARLA stores BGRA; take B,G,R reversed to RGB and drop alpha.
+        self._frames.append(np.ascontiguousarray(bgra[:, :, 2::-1]))
+
+    def _on_gnss(self, measurement: Any) -> None:
+        self._latest_gnss = np.array(
+            [measurement.latitude, measurement.longitude, measurement.altitude]
+        )
+
+    def _on_collision(self, event: Any) -> None:
+        del event
+        self._collided = True
+
+    def _read_state(self) -> np.ndarray:
+        transform = self._vehicle.get_transform()
+        velocity = self._vehicle.get_velocity()
+        return np.array(
+            [
+                transform.location.x,
+                transform.location.y,
+                transform.rotation.yaw,
+                velocity.x,
+                velocity.y,
+            ]
+        )
+
+    def _read_observation(self) -> np.ndarray:
+        if self._latest_gnss is None:
+            return np.zeros(3)
+        return self._latest_gnss
+
+    def _teardown_actors(self) -> None:
+        for actor in (
+            self._camera_sensor,
+            self._collision_sensor,
+            self._gnss_sensor,
+            self._vehicle,
+        ):
+            if actor is not None:
+                actor.destroy()
+        self._vehicle = None
+        self._gnss_sensor = None
+        self._collision_sensor = None
+        self._camera_sensor = None
+        self._camera_queue = None
+        self._latest_gnss = None
+
+
+class CarlaPOMDP(Environment):
+    """Forward-only adapter exposing a CARLA session as a world POMDP.
+
+    The wrapper drives a CARLA server as the ground-truth world of an episode. It
+    ticks the simulator exactly once per real interaction and serves the resulting
+    next state, observation and reward from a small cache, because the
+    POMDPPlanners episode loop requests those three quantities through separate
+    method calls while CARLA produces them atomically. The state is the ego
+    vehicle's ground-truth kinematics; the observation is a native CARLA sensor
+    payload (GNSS by default), so the world is genuinely partially observed.
+
+    Note:
+        This is a *world* environment, not a generative model. It cannot sample a
+        transition from an arbitrary state, so belief particle propagation and
+        density queries are unsupported and raise ``NotImplementedError`` /
+        ``RuntimeError``. Pair it with a generative model environment on the
+        planner (``policy.environment``).
+
+    Attributes:
+        host: CARLA server host.
+        port: CARLA server RPC port.
+        town: CARLA map name loaded on reset.
+        sensor_config: GNSS blueprint attributes (e.g. noise stddev) forwarded to
+            the sensor; measurement noise, if any, is CARLA's own.
+        action_presets: Discrete ``(throttle, steer, brake)`` control triples.
+        seed: Optional seed applied to the first ``reset`` for reproducibility.
+
+    Example:
+        The environment is used as the forward-only world of an
+        :class:`~POMDPPlanners.simulations.episodes.EpisodeRunner`, paired with a
+        separate generative model on the planner. It requires a running CARLA
+        server, so this snippet is illustrative rather than executed::
+
+            env = CarlaPOMDP(discount_factor=0.95, town="Town03")
+            state = env.initial_state_dist().sample()[0]
+            next_state, observation, reward = env.sample_next_step(state, 0)
+            # state is [x, y, yaw, vx, vy]; observation is a GNSS reading.
+    """
+
+    def __init__(
+        self,
+        discount_factor: float,
+        host: str = "localhost",
+        port: int = 2000,
+        town: str = "Town03",
+        sensor_config: Optional[Dict[str, Any]] = None,
+        action_presets: Optional[Sequence[Tuple[float, float, float]]] = None,
+        record_camera: bool = False,
+        camera_config: Optional[Dict[str, Any]] = None,
+        fixed_delta_seconds: float = 0.05,
+        collision_penalty: float = 100.0,
+        vehicle_filter: str = "vehicle.tesla.model3",
+        timeout: float = 10.0,
+        seed: Optional[int] = None,
+        name: Optional[str] = None,
+        reward_range: Optional[Tuple[float, float]] = None,
+        output_dir: Optional[Path] = None,
+        debug: bool = False,
+        use_queue_logger: bool = False,
+    ):
+        """Initialize the CARLA world environment.
+
+        Args:
+            discount_factor: Discount factor for future rewards (0 < d <= 1).
+            host: CARLA server host. Defaults to ``"localhost"``.
+            port: CARLA server RPC port. Defaults to 2000.
+            town: CARLA map loaded on reset. Defaults to ``"Town03"``.
+            sensor_config: GNSS blueprint attributes (e.g. ``noise_lat_stddev``)
+                forwarded to the sensor. Defaults to none (clean readings).
+            action_presets: Discrete ``(throttle, steer, brake)`` triples. Defaults
+                to :data:`DEFAULT_ACTION_PRESETS`.
+            record_camera: If True, attach a chase RGB camera to the ego and buffer
+                one rendered frame per tick for :meth:`save_camera_video`. Adds GPU
+                render cost, so it defaults to False.
+            camera_config: RGB camera blueprint attributes (e.g. ``image_size_x``)
+                overriding :data:`DEFAULT_CAMERA_CONFIG`. Defaults to none.
+            fixed_delta_seconds: Synchronous-mode tick length. Defaults to 0.05.
+            collision_penalty: Reward penalty applied on a terminal collision.
+                Defaults to 100.0.
+            vehicle_filter: Blueprint filter for the ego vehicle. Defaults to
+                ``"vehicle.tesla.model3"``.
+            timeout: CARLA client timeout in seconds. Defaults to 10.0.
+            seed: Optional seed applied to the first ``reset``. Defaults to None.
+            name: Environment identifier. Defaults to ``"CarlaPOMDP-<town>"``.
+            reward_range: Optional ``(min, max)`` reward bounds. Defaults to None.
+            output_dir: Optional directory for logging output. Defaults to None.
+            debug: Enable debug logging. Defaults to False.
+            use_queue_logger: Whether to use queue-based logging. Defaults to False.
+        """
+        self.host = host
+        self.port = port
+        self.town = town
+        self.sensor_config: Dict[str, Any] = dict(sensor_config) if sensor_config else {}
+        presets = action_presets if action_presets is not None else DEFAULT_ACTION_PRESETS
+        self.action_presets: List[Tuple[float, float, float]] = [
+            (float(throttle), float(steer), float(brake)) for throttle, steer, brake in presets
+        ]
+        self.record_camera = record_camera
+        self.camera_config: Dict[str, Any] = dict(DEFAULT_CAMERA_CONFIG)
+        if camera_config:
+            self.camera_config.update(camera_config)
+        self.fixed_delta_seconds = fixed_delta_seconds
+        self.collision_penalty = collision_penalty
+        self.vehicle_filter = vehicle_filter
+        self.timeout = timeout
+        self.seed = seed
+
+        # Live-session state: rebuilt lazily and never serialized.
+        self._session: Optional[Any] = None
+        self._live_state: Optional[np.ndarray] = None
+        self._latest_obs: Optional[np.ndarray] = None
+        self._terminated: bool = False
+        self._seeded: bool = False
+        self._pending: Optional[Dict[str, Any]] = None
+        self._served_roles: Set[str] = set()
+
+        # Action space is discrete (preset index); observation is a continuous
+        # sensor vector. Both are fixed by design, so no live server is needed at
+        # construction time (unlike GymPOMDP, which must probe gym spaces).
+        space_info = SpaceInfo(
+            action_space=SpaceType.DISCRETE,
+            observation_space=SpaceType.CONTINUOUS,
+        )
+
+        super().__init__(
+            discount_factor=discount_factor,
+            name=name if name is not None else f"CarlaPOMDP-{town}",
+            space_info=space_info,
+            reward_range=reward_range,
+            output_dir=output_dir,
+            debug=debug,
+            use_queue_logger=use_queue_logger,
+        )
+
+    # ── Serialization: drop the non-picklable live handle ───────────────
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        state["_session"] = None
+        state["_live_state"] = None
+        state["_latest_obs"] = None
+        state["_terminated"] = False
+        state["_seeded"] = False
+        state["_pending"] = None
+        state["_served_roles"] = set()
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        vars(self).update(state)
+        self._session = None
+        self._live_state = None
+        self._latest_obs = None
+        self._terminated = False
+        self._seeded = False
+        self._pending = None
+        self._served_roles = set()
+
+    # ── Live simulator management ───────────────────────────────────────
+    def _get_session(self) -> Any:
+        if self._session is None:
+            self._session = _CarlaSession(
+                host=self.host,
+                port=self.port,
+                town=self.town,
+                fixed_delta_seconds=self.fixed_delta_seconds,
+                sensor_config=self.sensor_config,
+                vehicle_filter=self.vehicle_filter,
+                timeout=self.timeout,
+                record_camera=self.record_camera,
+                camera_config=self.camera_config,
+            )
+        return self._session
+
+    def _reset(self) -> np.ndarray:
+        session = self._get_session()
+        if self.seed is not None and not self._seeded:
+            state, observation = session.reset(seed=self.seed)
+            self._seeded = True
+        else:
+            state, observation = session.reset()
+        state = np.asarray(state)
+        self._live_state = state
+        self._latest_obs = np.asarray(observation)
+        self._terminated = False
+        self._pending = None
+        self._served_roles = set()
+        return state
+
+    def _to_control(self, action: Any) -> Tuple[float, float, float]:
+        return self.action_presets[int(action)]
+
+    def _states_equal(self, state_a: Any, state_b: Any) -> bool:
+        return np.array_equal(np.asarray(state_a), np.asarray(state_b))
+
+    def _compute_reward(self, next_state: np.ndarray, terminated: bool) -> float:
+        speed = float(np.hypot(next_state[3], next_state[4]))
+        penalty = self.collision_penalty if terminated else 0.0
+        return speed - penalty
+
+    def _ensure_stepped(self, state: Any, action: Any, role: str) -> Dict[str, Any]:
+        """Advance the world one tick for ``(state, action)`` (once) and cache it.
+
+        The reward and next-state getters of a single episode step share one tick:
+        the first of them advances the world and caches the outcome, the second is
+        served from that cache. The cache is keyed on ``(state, action)`` *and* on
+        the requesting ``role`` — each role is served from a given tick at most
+        once, so a repeated role means a new step and forces another tick even when
+        the ego was momentarily stationary and ``next_state`` equals ``state``.
+        Raises when asked to step from a state other than the live one.
+        """
+        pending = self._pending
+        if (
+            pending is not None
+            and role not in self._served_roles
+            and self._states_equal(pending["state"], state)
+            and self.hash_action(pending["action"]) == self.hash_action(action)
+        ):
+            self._served_roles.add(role)
+            return pending
+
+        if self._live_state is None or not self._states_equal(state, self._live_state):
+            raise RuntimeError(
+                "CarlaPOMDP is a forward-only world environment; it cannot resample "
+                "from an arbitrary state. Give the planner a separate model "
+                "environment (policy.environment) and only step the world forward "
+                "from its live state."
+            )
+
+        session = self._get_session()
+        throttle, steer, brake = self._to_control(action)
+        next_state, observation, terminated = session.step(throttle, steer, brake)
+        next_state = np.asarray(next_state)
+        observation = np.asarray(observation)
+        done = bool(terminated)
+        pending = {
+            "state": np.asarray(state).copy(),
+            "action": action,
+            "next_state": next_state,
+            "observation": observation,
+            "reward": self._compute_reward(next_state, done),
+            "terminated": done,
+        }
+        self._pending = pending
+        self._served_roles = {role}
+        self._live_state = next_state
+        self._latest_obs = observation
+        self._terminated = done
+        return pending
+
+    # ── Environment interface ───────────────────────────────────────────
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        if n_samples != 1:
+            raise ValueError("CarlaPOMDP is forward-only and only supports n_samples=1")
+        return self._ensure_stepped(state, action, _ROLE_NEXT_STATE)["next_state"]
+
+    def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        del action
+        if n_samples != 1:
+            raise ValueError("CarlaPOMDP is forward-only and only supports n_samples=1")
+        if self._pending is not None and self._states_equal(
+            self._pending["next_state"], next_state
+        ):
+            return self._pending["observation"]
+        raise RuntimeError(
+            "CarlaPOMDP.sample_observation was queried for a next state other than "
+            "the live one; a forward-only world only knows the sensor reading it "
+            "just produced by stepping."
+        )
+
+    def reward(self, state: Any, action: Any, next_state: Any = None) -> float:
+        del next_state
+        return self._ensure_stepped(state, action, _ROLE_REWARD)["reward"]
+
+    def is_terminal(self, state: Any) -> bool:
+        if self._live_state is not None and not self._states_equal(state, self._live_state):
+            raise RuntimeError(
+                "CarlaPOMDP.is_terminal was queried for a state other than the live "
+                "world state; this forward-only world only knows whether its "
+                "current state is terminal."
+            )
+        return self._terminated
+
+    def initial_state_dist(self) -> Distribution:
+        parent = self
+
+        class InitialState(Distribution):
+            def sample(self, n_samples: int = 1) -> List[np.ndarray]:
+                # pylint: disable=protected-access
+                return [parent._reset() for _ in range(n_samples)]
+
+        return InitialState()
+
+    def initial_observation_dist(self) -> Distribution:
+        parent = self
+
+        class InitialObservation(Distribution):
+            def sample(self, n_samples: int = 1) -> List[np.ndarray]:
+                # pylint: disable=protected-access
+                observation = parent._latest_obs
+                if observation is None:
+                    parent._reset()
+                    observation = parent._latest_obs
+                return [np.asarray(observation) for _ in range(n_samples)]
+
+        return InitialObservation()
+
+    def is_equal_observation(self, observation1: Any, observation2: Any) -> bool:
+        return np.array_equal(np.asarray(observation1), np.asarray(observation2))
+
+    def hash_observation(self, observation: Any) -> Hashable:
+        array = np.asarray(observation)
+        return array.tobytes()
+
+    def hash_action(self, action: Any) -> Hashable:
+        if isinstance(action, np.ndarray):
+            return action.tobytes()
+        return action
+
+    def transition_log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+        del state, action, next_states
+        raise NotImplementedError(
+            "CarlaPOMDP is a forward-only world environment with no transition "
+            "density. Belief updates must run on the planner's model environment."
+        )
+
+    def observation_log_probability(
+        self, next_state: Any, action: Any, observations: Any
+    ) -> np.ndarray:
+        del next_state, action, observations
+        raise NotImplementedError(
+            "CarlaPOMDP is a forward-only world environment with no observation "
+            "density. Belief updates must run on the planner's model environment."
+        )
+
+    def cache_visualization(
+        self, history: List[StepData], output_dir: Path, episode_index: int
+    ) -> None:
+        """Save the episode as CARLA's own chase-camera MP4 footage.
+
+        The episode ``history`` is unused: the video is the native camera
+        rendering buffered live while the world was stepped, not a plot
+        reconstructed from the step data. The environment must have been
+        constructed with ``record_camera=True``.
+
+        Args:
+            history: Episode step data (unused; kept for the hook signature).
+            output_dir: Directory into which the ``.mp4`` video is written.
+            episode_index: Zero-based episode index, used to name the file.
+        """
+        del history
+        self.save_camera_video(output_dir / f"agent_path_{episode_index}.mp4")
+
+    def save_camera_video(self, cache_path: Path, fps: int = 20) -> None:
+        """Write CARLA's own chase-camera footage to an MP4 video.
+
+        This is the native CARLA rendering (an RGB camera following the ego), not a
+        reconstructed plot. Frames are captured live while the world is stepped, so
+        the environment must have been constructed with ``record_camera=True`` and
+        driven for at least one tick before calling this.
+
+        Args:
+            cache_path: File path ending in ``.mp4`` where the video is saved.
+            fps: Playback frame rate. Defaults to 20.
+
+        Raises:
+            RuntimeError: If camera recording is disabled or no frames were captured.
+        """
+        # pylint: disable=import-outside-toplevel
+        from POMDPPlanners.environments.carla_pomdp.carla_video import write_frames_to_mp4
+
+        if not self.record_camera:
+            raise RuntimeError(
+                "Camera recording is disabled; construct CarlaPOMDP with "
+                "record_camera=True to save native CARLA footage."
+            )
+        if self._session is None or not self._session.frames:
+            raise RuntimeError(
+                "No camera frames were captured; reset and step the world before "
+                "calling save_camera_video."
+            )
+        write_frames_to_mp4(self._session.frames, cache_path, fps=fps)

--- a/POMDPPlanners/environments/carla_pomdp/carla_video.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_video.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: MIT
+
+"""Encode CARLA RGB camera frames as an MP4 video.
+
+:class:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp.CarlaPOMDP` can attach
+a chase RGB camera to the ego vehicle and buffer one rendered frame per simulator
+tick. This module turns that buffer of ``(H, W, 3)`` uint8 frames into an H.264
+MP4 by piping the raw RGB bytes straight to an ``ffmpeg`` subprocess. Streaming
+the pixels to ffmpeg avoids matplotlib's per-frame figure re-render, so the saved
+footage is CARLA's own rendering and encoding it is roughly 2-3x faster than the
+previous matplotlib writer.
+
+Functions:
+    write_frames_to_mp4: Encode a list of RGB frames as an MP4 video.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List
+
+import numpy as np
+
+
+def write_frames_to_mp4(frames: List[np.ndarray], cache_path: Path, fps: int = 20) -> None:
+    """Encode buffered CARLA chase-camera frames as an MP4 video.
+
+    The frames are streamed as raw ``rgb24`` bytes to an ``ffmpeg`` subprocess,
+    which encodes them to an H.264 MP4. This is CARLA's own rendering, not a
+    reconstructed plot.
+
+    Args:
+        frames: Non-empty list of ``(H, W, 3)`` uint8 RGB frames, one per tick.
+        cache_path: File path ending in ``.mp4`` where the video is saved.
+        fps: Playback frame rate. Defaults to 20.
+
+    Raises:
+        TypeError: If ``cache_path`` is not a Path object.
+        ValueError: If ``frames`` is empty or ``cache_path`` does not end in ``.mp4``.
+        RuntimeError: If ``ffmpeg`` is not on PATH or the encode fails.
+    """
+    _validate_inputs(frames, cache_path)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    height, width = frames[0].shape[:2]
+    command = _build_ffmpeg_command(width, height, fps, cache_path)
+    _stream_frames_to_ffmpeg(command, frames)
+
+
+def _validate_inputs(frames: List[np.ndarray], cache_path: Path) -> None:
+    if not isinstance(cache_path, Path):
+        raise TypeError("cache_path must be a Path object")
+    if not frames:
+        raise ValueError("Cannot write an empty frame list to video")
+    if not str(cache_path).endswith(".mp4"):
+        raise ValueError("cache_path must end with .mp4")
+
+
+def _build_ffmpeg_command(width: int, height: int, fps: int, cache_path: Path) -> List[str]:
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError("ffmpeg executable not found on PATH; cannot encode video")
+    return [
+        ffmpeg,
+        "-y",
+        "-loglevel",
+        "error",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "rgb24",
+        "-s",
+        f"{width}x{height}",
+        "-framerate",
+        str(fps),
+        "-i",
+        "-",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        str(cache_path),
+    ]
+
+
+def _stream_frames_to_ffmpeg(command: List[str], frames: List[np.ndarray]) -> None:
+    with subprocess.Popen(command, stdin=subprocess.PIPE, stderr=subprocess.PIPE) as process:
+        stdin = process.stdin
+        if stdin is None:  # pragma: no cover - Popen with PIPE always provides stdin
+            raise RuntimeError("Failed to open ffmpeg stdin pipe")
+        try:
+            for frame in frames:
+                stdin.write(np.ascontiguousarray(frame, dtype=np.uint8).tobytes())
+        finally:
+            stdin.close()
+        stderr = process.stderr.read() if process.stderr is not None else b""
+        return_code = process.wait()
+    if return_code != 0:
+        message = stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"ffmpeg failed to encode video (exit {return_code}): {message}")

--- a/POMDPPlanners/simulations/episodes.py
+++ b/POMDPPlanners/simulations/episodes.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 import copy
+import math
 from logging import Logger
 from time import time
 from typing import Any, List, Optional, Tuple
@@ -61,14 +62,23 @@ class EpisodeRunner:
     ):
         _validate_episode_inputs(environment, policy, initial_belief, num_steps)
 
+        # ``environment`` is the ground-truth world used to sample the executed
+        # trajectory (reward, next state, observation, terminal). The belief
+        # filter instead runs on the planner's own generative model
+        # (``policy.environment``); the two are the same object in the classic
+        # single-environment setup and differ when the world is a forward-only
+        # simulator (e.g. a Gymnasium/Isaac env) that cannot serve as a model.
         self.environment = environment
+        model_environment: Environment = getattr(policy, "environment", environment)
+        self.model_environment = model_environment
+        self._assert_consistent_discount()
         self.policy = policy
         self.num_steps = num_steps
         self.logger = logger or get_logger(f"episode.{environment.name}.{policy.name}")
 
         # Episode state
         self.belief = copy.deepcopy(initial_belief)
-        self.state = initial_belief.sample()
+        self.state = self._sample_initial_state(initial_belief)
         self.history = []
         self.policy_run_data = []
         self.current_step = 0
@@ -80,6 +90,31 @@ class EpisodeRunner:
         self.average_state_sampling_time = 0.0
         self.average_observation_time = 0.0
         self.average_belief_update_time = 0.0
+
+    def _assert_consistent_discount(self) -> None:
+        """Ensure the world and model share a discount factor when they differ."""
+        if self.model_environment is self.environment:
+            return
+        if not math.isclose(
+            self.environment.discount_factor, self.model_environment.discount_factor
+        ):
+            raise ValueError(
+                "World environment discount_factor "
+                f"({self.environment.discount_factor}) must match the planner "
+                f"model discount_factor ({self.model_environment.discount_factor})."
+            )
+
+    def _sample_initial_state(self, initial_belief: Belief) -> Any:
+        """Draw the ground-truth initial state.
+
+        When the world differs from the planner's model the true start must come
+        from the world itself (a forward-only simulator resets to its own state
+        and cannot accept an injected belief sample). In the single-environment
+        setup the belief sample is used, preserving classic behavior.
+        """
+        if self.model_environment is not self.environment:
+            return self.environment.initial_state_dist().sample()[0]
+        return initial_belief.sample()
 
     def run(self) -> History:
         """Execute the episode and return history with metrics."""
@@ -183,7 +218,7 @@ class EpisodeRunner:
         self.belief = self.belief.update(
             action=action,
             observation=observation,
-            pomdp=self.environment,
+            pomdp=self.model_environment,
             state=next_state,
         )
         elapsed = time() - start_time

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/__init__.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the CARLA POMDP world environment."""

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
@@ -12,7 +12,7 @@ CARLA-specific assertion that the observation differs from the state.
 # pylint: disable=protected-access  # Tests inspect the live-session internals
 
 import pickle
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from pathlib import Path
 
 import numpy as np
@@ -22,7 +22,7 @@ from POMDPPlanners.core.belief import Belief
 from POMDPPlanners.core.belief.belief_utils import get_initial_belief
 from POMDPPlanners.core.environment import Environment, SpaceType
 from POMDPPlanners.core.policy import Policy, PolicyRunData, PolicySpaceInfo
-from POMDPPlanners.environments.carla_pomdp import CarlaPOMDP
+from POMDPPlanners.environments.carla_pomdp import CarlaPOMDP, carla_video
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
 from POMDPPlanners.simulations.episodes import EpisodeRunner
 
@@ -478,3 +478,151 @@ def test_two_env_discount_mismatch_raises(fake_session: FakeCarlaSession) -> Non
         EpisodeRunner(
             environment=world, policy=policy, initial_belief=belief, num_steps=2, logger=None
         )
+
+
+class _FakeCameraSession(FakeCarlaSession):
+    """A FakeCarlaSession that also buffers RGB camera frames like the real session.
+
+    Extends the scripted session with a ``frames`` buffer so the camera-video save
+    path can be exercised without a CARLA server or a live camera sensor attached.
+    """
+
+    def __init__(self, frame_count: int = 0) -> None:
+        super().__init__()
+        self.frames: List[np.ndarray] = [
+            np.zeros((4, 4, 3), dtype=np.uint8) for _ in range(frame_count)
+        ]
+
+
+def test_hash_observation_matches_for_equal_and_differs_for_distinct(world: CarlaPOMDP) -> None:
+    """hash_observation is stable for equal arrays and distinct for different ones.
+
+    Purpose: Validates observation hashing used to key belief/tree observation nodes.
+
+    Given: Two equal 3-D observation arrays and a third differing one
+    When: hash_observation is computed for each
+    Then: Equal arrays hash equally and the differing array hashes differently
+
+    Test type: unit
+    """
+    observation = np.array([48.0, 2.0, 0.0])
+    same = np.array([48.0, 2.0, 0.0])
+    different = np.array([48.0, 2.0, 1.0])
+
+    assert world.hash_observation(observation) == world.hash_observation(same)
+    assert world.hash_observation(observation) != world.hash_observation(different)
+
+
+def test_hash_action_hashes_arrays_and_passes_scalars_through(world: CarlaPOMDP) -> None:
+    """hash_action returns bytes for ndarray actions and passes scalars unchanged.
+
+    Purpose: Validates action hashing for both preset-index and array actions.
+
+    Given: A scalar preset-index action and an ndarray action
+    When: hash_action is computed for each
+    Then: The scalar is returned unchanged and the array maps to its byte view
+
+    Test type: unit
+    """
+    array_action = np.array([0.5, 0.0, 0.0])
+
+    assert world.hash_action(1) == 1
+    assert world.hash_action(array_action) == array_action.tobytes()
+
+
+def test_save_camera_video_raises_when_recording_disabled() -> None:
+    """save_camera_video refuses to run when camera recording was not enabled.
+
+    Purpose: Validates the record_camera precondition guard.
+
+    Given: A CarlaPOMDP constructed with record_camera=False
+    When: save_camera_video is called
+    Then: RuntimeError is raised explaining recording is disabled
+
+    Test type: unit
+    """
+    env = CarlaPOMDP(discount_factor=0.95, record_camera=False)
+
+    with pytest.raises(RuntimeError, match="Camera recording is disabled"):
+        env.save_camera_video(Path("unused.mp4"))
+
+
+def test_save_camera_video_raises_when_no_frames_captured() -> None:
+    """save_camera_video refuses to run when no frames were buffered.
+
+    Purpose: Validates the non-empty-frames precondition guard.
+
+    Given: A record_camera=True world whose session buffered zero frames
+    When: save_camera_video is called
+    Then: RuntimeError is raised explaining no frames were captured
+
+    Test type: unit
+    """
+    env = CarlaPOMDP(discount_factor=0.95, record_camera=True)
+    env._session = _FakeCameraSession(frame_count=0)
+
+    with pytest.raises(RuntimeError, match="No camera frames"):
+        env.save_camera_video(Path("unused.mp4"))
+
+
+def test_save_camera_video_forwards_session_frames_and_fps(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """save_camera_video streams the buffered session frames to the encoder.
+
+    Purpose: Validates the happy-path delegation to write_frames_to_mp4.
+
+    Given: A record_camera=True world whose session buffered three frames
+    When: save_camera_video is called with an explicit fps and output path
+    Then: The encoder receives the session frames, the path, and the fps verbatim
+
+    Test type: unit
+    """
+    written: Dict[str, Any] = {}
+
+    def _fake_write(frames: List[np.ndarray], cache_path: Path, fps: int = 20) -> None:
+        written["frames"] = frames
+        written["path"] = cache_path
+        written["fps"] = fps
+
+    monkeypatch.setattr(carla_video, "write_frames_to_mp4", _fake_write)
+
+    env = CarlaPOMDP(discount_factor=0.95, record_camera=True)
+    session = _FakeCameraSession(frame_count=3)
+    env._session = session
+    output = tmp_path / "clip.mp4"
+
+    env.save_camera_video(output, fps=30)
+
+    assert written["frames"] is session.frames
+    assert written["path"] == output
+    assert written["fps"] == 30
+
+
+def test_cache_visualization_writes_agent_path_named_mp4(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """cache_visualization names the camera clip agent_path_<episode>.mp4.
+
+    Purpose: Validates the environment-owned visualization file-naming contract.
+
+    Given: A record_camera=True world with buffered frames and an output directory
+    When: cache_visualization is called for episode index 7
+    Then: The encoder is asked to write <output_dir>/agent_path_7.mp4
+
+    Test type: unit
+    """
+    written: Dict[str, Any] = {}
+
+    def _fake_write(frames: List[np.ndarray], cache_path: Path, fps: int = 20) -> None:
+        del frames, fps
+        written["path"] = cache_path
+
+    monkeypatch.setattr(carla_video, "write_frames_to_mp4", _fake_write)
+
+    env = CarlaPOMDP(discount_factor=0.95, record_camera=True)
+    env._session = _FakeCameraSession(frame_count=2)
+
+    env.cache_visualization(history=[], output_dir=tmp_path, episode_index=7)
+
+    assert written["path"] == tmp_path / "agent_path_7.mp4"

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
@@ -1,0 +1,480 @@
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the CarlaPOMDP forward-only world wrapper.
+
+These tests drive CarlaPOMDP against a controllable fake CARLA session (scripted
+reset/step returning a 5-D ground-truth state and a 3-D GNSS observation) injected
+by monkeypatching ``CarlaPOMDP._get_session``, so they run without a CARLA server
+or the ``carla`` package installed. They mirror the GymPOMDP suite and add the
+CARLA-specific assertion that the observation differs from the state.
+"""
+
+# pylint: disable=protected-access  # Tests inspect the live-session internals
+
+import pickle
+from typing import List, Optional, Tuple
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief import Belief
+from POMDPPlanners.core.belief.belief_utils import get_initial_belief
+from POMDPPlanners.core.environment import Environment, SpaceType
+from POMDPPlanners.core.policy import Policy, PolicyRunData, PolicySpaceInfo
+from POMDPPlanners.environments.carla_pomdp import CarlaPOMDP
+from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.simulations.episodes import EpisodeRunner
+
+
+class FakeCarlaSession:
+    """Scripted CARLA-like session: 5-D ground-truth state, 3-D GNSS observation.
+
+    The state is ``[x, y, yaw, vx, vy]`` with ``vx`` advancing each tick so the
+    ego speed equals the step index; the observation is a distinct 3-D GNSS
+    ``[lat, lon, alt]`` vector. The episode terminates once three ticks have been
+    taken, so terminal behavior is deterministic.
+    """
+
+    def __init__(self) -> None:
+        self.reset_calls = 0
+        self.step_calls = 0
+        self.last_control: Optional[Tuple[float, float, float]] = None
+        self._t = 0
+
+    def reset(self, seed: Optional[int] = None) -> Tuple[np.ndarray, np.ndarray]:
+        del seed
+        self.reset_calls += 1
+        self._t = 0
+        state = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
+        observation = np.array([48.0, 2.0, 0.0])
+        return state, observation
+
+    def step(
+        self, throttle: float, steer: float, brake: float
+    ) -> Tuple[np.ndarray, np.ndarray, bool]:
+        self.step_calls += 1
+        self.last_control = (throttle, steer, brake)
+        self._t += 1
+        state = np.array([float(self._t), 0.0, 0.0, float(self._t), 0.0])
+        observation = np.array([48.0 + self._t, 2.0, 0.0])
+        terminated = self._t >= 3
+        return state, observation, terminated
+
+
+class FixedActionPolicy(Policy):
+    """A trivial discrete policy that returns a single preset-index action."""
+
+    def __init__(
+        self,
+        environment: Environment,
+        discount_factor: float,
+        name: str = "FixedActionPolicy",
+        log_path: Optional[Path] = None,
+        debug: bool = False,
+    ) -> None:
+        super().__init__(environment, discount_factor, name, log_path=log_path, debug=debug)
+
+    def action(self, belief: Belief):
+        del belief
+        return ([0], PolicyRunData(info_variables=[]))
+
+    @classmethod
+    def get_space_info(cls) -> PolicySpaceInfo:
+        return PolicySpaceInfo(
+            action_space=SpaceType.DISCRETE, observation_space=SpaceType.CONTINUOUS
+        )
+
+    @classmethod
+    def get_info_variable_names(cls) -> List[str]:
+        return []
+
+
+@pytest.fixture(name="fake_session")
+def _fake_session(monkeypatch: pytest.MonkeyPatch) -> FakeCarlaSession:
+    """Patch ``CarlaPOMDP._get_session`` to return a shared FakeCarlaSession."""
+    session = FakeCarlaSession()
+    monkeypatch.setattr(CarlaPOMDP, "_get_session", lambda self: session)
+    return session
+
+
+@pytest.fixture(name="world")
+def _world(fake_session: FakeCarlaSession) -> CarlaPOMDP:
+    """A CarlaPOMDP wrapping the fake session, reset to its initial live state."""
+    del fake_session
+    env = CarlaPOMDP(discount_factor=0.95)
+    env.initial_state_dist().sample()  # establish the live state
+    return env
+
+
+def test_space_info_is_discrete_actions_continuous_observations(world: CarlaPOMDP) -> None:
+    """CarlaPOMDP exposes discrete actions and continuous observations.
+
+    Purpose: Validates the fixed SpaceInfo for the CARLA world.
+
+    Given: A CarlaPOMDP with preset discrete controls and a GNSS observation
+    When: space_info is inspected
+    Then: action space is DISCRETE and observation space is CONTINUOUS
+
+    Test type: unit
+    """
+    assert world.space_info.action_space == SpaceType.DISCRETE
+    assert world.space_info.observation_space == SpaceType.CONTINUOUS
+
+
+def test_step_called_once_across_reward_next_state_observation(
+    world: CarlaPOMDP, fake_session: FakeCarlaSession
+) -> None:
+    """The three per-step queries trigger exactly one underlying CARLA tick.
+
+    Purpose: Validates the step-once cache serving reward/next-state/observation.
+
+    Given: A freshly reset CarlaPOMDP world at its live state
+    When: reward, sample_next_state and sample_observation are called in order
+    Then: the session steps exactly once and the three agree on the transition
+
+    Test type: unit
+    """
+    state = world._live_state
+    before = fake_session.step_calls
+
+    reward = world.reward(state, 0)
+    next_state = world.sample_next_state(state, 0)
+    observation = world.sample_observation(next_state, 0)
+
+    assert fake_session.step_calls - before == 1
+    assert reward == 1.0
+    assert np.array_equal(next_state, np.array([1.0, 0.0, 0.0, 1.0, 0.0]))
+    assert np.array_equal(observation, np.array([49.0, 2.0, 0.0]))
+
+
+def test_call_order_independence_next_state_before_reward(
+    world: CarlaPOMDP, fake_session: FakeCarlaSession
+) -> None:
+    """The tick is served identically regardless of which query comes first.
+
+    Purpose: Validates the cache trigger works from sample_next_state too.
+
+    Given: A freshly reset CarlaPOMDP world at its live state
+    When: sample_next_state is called before reward for the same (state, action)
+    Then: still one session step, and reward reflects that same transition
+
+    Test type: unit
+    """
+    state = world._live_state
+    before = fake_session.step_calls
+
+    next_state = world.sample_next_state(state, 0)
+    reward = world.reward(state, 0)
+
+    assert fake_session.step_calls - before == 1
+    assert np.array_equal(next_state, np.array([1.0, 0.0, 0.0, 1.0, 0.0]))
+    assert reward == 1.0
+
+
+def test_observation_differs_from_ground_truth_state(world: CarlaPOMDP) -> None:
+    """The GNSS observation is a partial view, distinct from the true state.
+
+    Purpose: Validates the CARLA state != observation modeling (partial observability).
+
+    Given: A CarlaPOMDP world at its live state
+    When: A step is sampled and both next state and observation are read
+    Then: The observation is the 3-D GNSS vector, not the 5-D ground-truth state
+
+    Test type: unit
+    """
+    state = world._live_state
+    next_state = world.sample_next_state(state, 0)
+    observation = world.sample_observation(next_state, 0)
+
+    assert next_state.shape == (5,)
+    assert observation.shape == (3,)
+    assert not world.is_equal_observation(observation, next_state)
+
+
+def test_is_terminal_reflects_last_terminated(world: CarlaPOMDP) -> None:
+    """is_terminal returns the terminated flag of the current live state.
+
+    Purpose: Validates terminal tracking across forward ticks.
+
+    Given: A world whose fake session terminates after three ticks
+    When: The world is advanced step by step from the live state
+    Then: is_terminal is False until the third step, then True
+
+    Test type: unit
+    """
+    state = world._live_state
+    assert world.is_terminal(state) is False
+
+    for expected_terminal in (False, False, True):
+        next_state, _, _ = world.sample_next_step(state, 0)
+        assert world.is_terminal(next_state) is expected_terminal
+        state = next_state
+
+
+def test_initial_state_dist_sample_triggers_reset(fake_session: FakeCarlaSession) -> None:
+    """Sampling the initial-state distribution resets the CARLA session.
+
+    Purpose: Validates initial_state_dist maps to session.reset.
+
+    Given: A CarlaPOMDP wrapping a fake session
+    When: initial_state_dist().sample() is called
+    Then: session.reset runs and the returned state is the reset ground truth
+
+    Test type: unit
+    """
+    env = CarlaPOMDP(discount_factor=0.95)
+    before = fake_session.reset_calls
+
+    samples = env.initial_state_dist().sample()
+
+    assert fake_session.reset_calls - before == 1
+    assert len(samples) == 1
+    assert np.array_equal(samples[0], np.zeros(5))
+
+
+def test_initial_observation_dist_returns_sensor_reading(world: CarlaPOMDP) -> None:
+    """The initial observation is the first post-reset GNSS reading.
+
+    Purpose: Validates initial_observation_dist serves the sensor payload.
+
+    Given: A CarlaPOMDP world reset to its initial state
+    When: initial_observation_dist().sample() is called
+    Then: the returned observation is the reset GNSS vector
+
+    Test type: unit
+    """
+    samples = world.initial_observation_dist().sample()
+    assert len(samples) == 1
+    assert np.array_equal(samples[0], np.array([48.0, 2.0, 0.0]))
+
+
+def test_action_preset_index_maps_to_vehicle_control(world: CarlaPOMDP) -> None:
+    """A discrete action index selects the matching control preset.
+
+    Purpose: Validates the discrete action -> (throttle, steer, brake) mapping.
+
+    Given: A CarlaPOMDP with the default control presets
+    When: sample_next_state is called with the brake preset index (3)
+    Then: the session receives the (0.0, 0.0, 1.0) brake control
+
+    Test type: unit
+    """
+    world.sample_next_state(world._live_state, 3)
+    assert world._get_session().last_control == (0.0, 0.0, 1.0)
+
+
+def test_transition_log_probability_raises(world: CarlaPOMDP) -> None:
+    """transition_log_probability is unsupported on a forward-only world.
+
+    Purpose: Validates the density method raises instead of faking a value.
+
+    Given: A CarlaPOMDP world
+    When: transition_log_probability is called
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    with pytest.raises(NotImplementedError):
+        world.transition_log_probability(world._live_state, 0, [world._live_state])
+
+
+def test_observation_log_probability_raises(world: CarlaPOMDP) -> None:
+    """observation_log_probability is unsupported on a forward-only world.
+
+    Purpose: Validates the density method raises instead of faking a value.
+
+    Given: A CarlaPOMDP world
+    When: observation_log_probability is called
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    with pytest.raises(NotImplementedError):
+        world.observation_log_probability(world._live_state, 0, [world._live_state])
+
+
+def test_forward_only_guard_raises_on_mismatched_state(world: CarlaPOMDP) -> None:
+    """Stepping from a non-live state is rejected loudly.
+
+    Purpose: Validates the forward-only guard on arbitrary-state resampling.
+
+    Given: A CarlaPOMDP world at a known live state
+    When: sample_next_state is called with a different, arbitrary state
+    Then: RuntimeError is raised naming the forward-only constraint
+
+    Test type: unit
+    """
+    arbitrary_state = np.array([99.0, 99.0, 0.0, 0.0, 0.0])
+    with pytest.raises(RuntimeError, match="forward-only"):
+        world.sample_next_state(arbitrary_state, 0)
+
+
+def test_sample_observation_rejects_mismatched_next_state(world: CarlaPOMDP) -> None:
+    """A forward-only world cannot produce a sensor reading for an arbitrary state.
+
+    Purpose: Validates sample_observation rejects a non-live next state.
+
+    Given: A CarlaPOMDP world at its live state
+    When: sample_observation is called for a next state it never stepped to
+    Then: RuntimeError is raised
+
+    Test type: unit
+    """
+    with pytest.raises(RuntimeError, match="forward-only|live"):
+        world.sample_observation(np.array([7.0, 7.0, 0.0, 0.0, 0.0]), 0)
+
+
+def test_sample_next_state_rejects_multiple_samples(world: CarlaPOMDP) -> None:
+    """A forward-only world cannot draw more than one next state.
+
+    Purpose: Validates n_samples>1 is rejected.
+
+    Given: A CarlaPOMDP world at its live state
+    When: sample_next_state is called with n_samples=2
+    Then: ValueError is raised
+
+    Test type: unit
+    """
+    with pytest.raises(ValueError, match="n_samples=1"):
+        world.sample_next_state(world._live_state, 0, n_samples=2)
+
+
+def test_getstate_setstate_round_trip_drops_and_rebuilds_handle(
+    world: CarlaPOMDP, fake_session: FakeCarlaSession
+) -> None:
+    """Pickling drops the live handle and it is rebuilt lazily on use.
+
+    Purpose: Validates the non-picklable session is not serialized.
+
+    Given: A CarlaPOMDP world with a live fake session handle
+    When: It is pickled and unpickled
+    Then: The restored object carries no live handle until it is next needed
+
+    Test type: unit
+    """
+    del fake_session
+    restored = pickle.loads(pickle.dumps(world))
+
+    assert restored._session is None
+    assert restored._live_state is None
+    assert restored._pending is None
+
+
+def test_config_id_stable_across_pickling(world: CarlaPOMDP) -> None:
+    """config_id depends only on public config, so it survives pickling.
+
+    Purpose: Validates deterministic config identity for result caching.
+
+    Given: A CarlaPOMDP world
+    When: It is pickled and unpickled
+    Then: config_id is unchanged (private live state is excluded)
+
+    Test type: unit
+    """
+    restored = pickle.loads(pickle.dumps(world))
+    assert restored.config_id == world.config_id
+
+
+def test_two_env_initial_state_drawn_from_world(fake_session: FakeCarlaSession) -> None:
+    """The ground-truth initial state comes from the CARLA world, not the model.
+
+    Purpose: Validates the two-env initial-state sourcing with a CarlaPOMDP world.
+
+    Given: A CarlaPOMDP world and a distinct TigerPOMDP planner model
+    When: An EpisodeRunner is constructed around them
+    Then: The runner's true state is the world's reset state and the world reset
+
+    Test type: integration
+    """
+    world = CarlaPOMDP(discount_factor=0.95)
+    model = TigerPOMDP(discount_factor=0.95)
+    policy = FixedActionPolicy(environment=model, discount_factor=0.95)
+    belief = get_initial_belief(model, n_particles=3)
+
+    runner = EpisodeRunner(
+        environment=world, policy=policy, initial_belief=belief, num_steps=2, logger=None
+    )
+
+    assert np.array_equal(runner.state, np.zeros(5))
+    assert fake_session.reset_calls >= 1
+
+
+class StationaryThenMovingSession:
+    """CARLA-like session whose ego stays put for two ticks, then moves.
+
+    While stationary the reported ``next_state`` equals the state stepped from,
+    which is exactly the condition that collided the step-once cache across
+    consecutive episode steps and froze the world.
+    """
+
+    def __init__(self) -> None:
+        self.reset_calls = 0
+        self.step_calls = 0
+        self._t = 0
+
+    def reset(self, seed: Optional[int] = None) -> Tuple[np.ndarray, np.ndarray]:
+        del seed
+        self.reset_calls += 1
+        self._t = 0
+        return np.array([0.0, 0.0, 0.0, 0.0, 0.0]), np.array([48.0, 2.0, 0.0])
+
+    def step(
+        self, throttle: float, steer: float, brake: float
+    ) -> Tuple[np.ndarray, np.ndarray, bool]:
+        del throttle, steer, brake
+        self.step_calls += 1
+        self._t += 1
+        position = 0.0 if self._t <= 2 else float(self._t - 2)
+        state = np.array([position, 0.0, 0.0, 0.0, 0.0])
+        return state, np.array([48.0, 2.0, 0.0]), False
+
+
+def test_stationary_ego_does_not_freeze_the_world(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A momentarily stationary ego must still advance the forward-only world.
+
+    Purpose: Regression for the step-once cache colliding across episode steps
+        when next_state equals state (a stationary vehicle), which previously
+        served the stale cache and stopped CARLA from ticking after step one.
+
+    Given: A CARLA-like session whose ego stays at the origin for the first ticks
+    When: The world is driven forward several steps via sample_next_step
+    Then: The session ticks exactly once per step and never freezes
+
+    Test type: unit
+    """
+    session = StationaryThenMovingSession()
+    monkeypatch.setattr(CarlaPOMDP, "_get_session", lambda self: session)
+    env = CarlaPOMDP(discount_factor=0.95)
+    state = env.initial_state_dist().sample()[0]
+
+    for _ in range(5):
+        before = session.step_calls
+        next_state, _, _ = env.sample_next_step(state, 0)
+        assert session.step_calls - before == 1
+        state = next_state
+
+    assert session.step_calls == 5
+
+
+def test_two_env_discount_mismatch_raises(fake_session: FakeCarlaSession) -> None:
+    """A world/model discount-factor mismatch is rejected at construction.
+
+    Purpose: Validates the discount-consistency guard for the CARLA two-env case.
+
+    Given: A CarlaPOMDP world discounted at 0.9 and a model discounted at 0.95
+    When: An EpisodeRunner is constructed
+    Then: ValueError is raised naming the discount mismatch
+
+    Test type: integration
+    """
+    del fake_session
+    world = CarlaPOMDP(discount_factor=0.9)
+    model = TigerPOMDP(discount_factor=0.95)
+    policy = FixedActionPolicy(environment=model, discount_factor=0.95)
+    belief = get_initial_belief(model, n_particles=3)
+
+    with pytest.raises(ValueError, match="discount_factor"):
+        EpisodeRunner(
+            environment=world, policy=policy, initial_belief=belief, num_steps=2, logger=None
+        )

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_video.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_video.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the CARLA chase-camera MP4 encoder.
+
+These tests exercise :func:`write_frames_to_mp4`, which streams buffered RGB
+frames to an ``ffmpeg`` subprocess. They require ``ffmpeg`` on PATH (skipped
+otherwise) but no CARLA server or the ``carla`` package.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.carla_pomdp.carla_video import write_frames_to_mp4
+
+_FFMPEG_MISSING = shutil.which("ffmpeg") is None
+_SKIP_REASON = "ffmpeg not available on PATH"
+
+
+def _make_frames(count: int, height: int = 48, width: int = 64) -> List[np.ndarray]:
+    """Build a list of distinct ``(H, W, 3)`` uint8 RGB frames."""
+    return [
+        np.full((height, width, 3), fill_value=(index * 7) % 256, dtype=np.uint8)
+        for index in range(count)
+    ]
+
+
+@pytest.mark.skipif(_FFMPEG_MISSING, reason=_SKIP_REASON)
+def test_write_frames_produces_playable_mp4(tmp_path: Path) -> None:
+    """Encoding a frame buffer writes a non-empty, ffprobe-readable MP4.
+
+    Purpose: Validates the raw-pipe ffmpeg encoder produces a real H.264 MP4.
+
+    Given: A buffer of ten 64x48 RGB frames and a target .mp4 path.
+    When: write_frames_to_mp4 streams the frames to ffmpeg.
+    Then: The file exists, is non-empty, and ffprobe reports an h264 video stream.
+
+    Test type: integration
+    """
+    output = tmp_path / "clip.mp4"
+    write_frames_to_mp4(_make_frames(10), output, fps=20)
+
+    assert output.exists()
+    assert output.stat().st_size > 0
+    probe = subprocess.run(
+        [
+            "ffprobe",
+            "-loglevel",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=codec_name",
+            "-of",
+            "default=nk=1:nw=1",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "h264" in probe.stdout
+
+
+@pytest.mark.skipif(_FFMPEG_MISSING, reason=_SKIP_REASON)
+def test_write_frames_creates_missing_parent_directory(tmp_path: Path) -> None:
+    """The encoder creates missing parent directories for the output path.
+
+    Purpose: Validates that a nested output path is created on demand.
+
+    Given: A .mp4 path inside a not-yet-existing subdirectory.
+    When: write_frames_to_mp4 is called with a single-frame buffer.
+    Then: The parent directory is created and the MP4 is written.
+
+    Test type: unit
+    """
+    output = tmp_path / "nested" / "deeper" / "clip.mp4"
+    write_frames_to_mp4(_make_frames(1), output)
+
+    assert output.exists()
+    assert output.stat().st_size > 0
+
+
+def test_write_frames_rejects_non_path_cache(tmp_path: Path) -> None:
+    """A string cache path raises TypeError before any encoding.
+
+    Purpose: Validates the Path type guard on the output argument.
+
+    Given: A cache path passed as a plain string.
+    When: write_frames_to_mp4 is called.
+    Then: TypeError is raised.
+
+    Test type: unit
+    """
+    with pytest.raises(TypeError):
+        write_frames_to_mp4(_make_frames(1), str(tmp_path / "clip.mp4"))  # type: ignore[arg-type]
+
+
+def test_write_frames_rejects_empty_frame_list(tmp_path: Path) -> None:
+    """An empty frame list raises ValueError.
+
+    Purpose: Validates the non-empty-frames precondition.
+
+    Given: An empty list of frames.
+    When: write_frames_to_mp4 is called.
+    Then: ValueError is raised.
+
+    Test type: unit
+    """
+    with pytest.raises(ValueError, match="empty frame list"):
+        write_frames_to_mp4([], tmp_path / "clip.mp4")
+
+
+def test_write_frames_rejects_non_mp4_extension(tmp_path: Path) -> None:
+    """A cache path without a .mp4 suffix raises ValueError.
+
+    Purpose: Validates the .mp4 extension precondition.
+
+    Given: A cache path ending in .avi.
+    When: write_frames_to_mp4 is called.
+    Then: ValueError is raised.
+
+    Test type: unit
+    """
+    with pytest.raises(ValueError, match=".mp4"):
+        write_frames_to_mp4(_make_frames(1), tmp_path / "clip.avi")

--- a/POMDPPlanners/tests/test_simulations/test_episodes.py
+++ b/POMDPPlanners/tests/test_simulations/test_episodes.py
@@ -1,0 +1,477 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for EpisodeRunner (POMDPPlanners/simulations/episodes.py).
+
+These currently focus on the two-environment split (world vs planner model).
+The EpisodeRunner samples the executed trajectory (reward, next state,
+observation, terminal, initial state) from the ground-truth *world* environment,
+while the belief filter runs on the planner's own generative *model*
+(``policy.environment``). These tests use two distinct TigerPOMDP instances —
+one spied world, one spied model — plus a fixed-action policy, so the routing of
+each call can be asserted directly. A single environment (world is the model)
+must preserve the classic behavior.
+"""
+
+# pylint: disable=protected-access  # Tests inspect spy call counters
+
+from typing import Any, Dict, List, Optional
+from pathlib import Path
+
+import pytest
+
+from POMDPPlanners.core.belief import Belief
+from POMDPPlanners.core.belief.belief_utils import get_initial_belief
+from POMDPPlanners.core.environment import Environment, SpaceType
+from POMDPPlanners.core.policy import Policy, PolicyRunData, PolicySpaceInfo
+from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.simulations.episodes import EpisodeRunner, run_episode
+
+
+class SpyTiger(TigerPOMDP):
+    """A TigerPOMDP that records how many times each routed method is called."""
+
+    def __init__(self, discount_factor: float = 0.95) -> None:
+        super().__init__(discount_factor=discount_factor)
+        self._calls: Dict[str, int] = {
+            "reward": 0,
+            "sample_next_state": 0,
+            "sample_next_state_batch": 0,
+            "sample_observation": 0,
+            "is_terminal": 0,
+            "initial_state_dist": 0,
+        }
+
+    def reward(self, state: Any, action: Any, next_state: Any = None) -> float:
+        self._calls["reward"] += 1
+        return super().reward(state, action, next_state)
+
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> Any:
+        self._calls["sample_next_state"] += 1
+        return super().sample_next_state(state, action, n_samples)
+
+    def sample_next_state_batch(self, states: Any, action: Any) -> Any:
+        self._calls["sample_next_state_batch"] += 1
+        return super().sample_next_state_batch(states, action)
+
+    def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> Any:
+        self._calls["sample_observation"] += 1
+        return super().sample_observation(next_state, action, n_samples)
+
+    def is_terminal(self, state: Any) -> bool:
+        self._calls["is_terminal"] += 1
+        return super().is_terminal(state)
+
+    def initial_state_dist(self) -> Any:
+        self._calls["initial_state_dist"] += 1
+        return super().initial_state_dist()
+
+
+class TerminatingTiger(SpyTiger):
+    """A spied TigerPOMDP whose terminal condition is scripted by step count.
+
+    ``is_terminal`` returns True once ``terminate_after`` real transitions have
+    been taken (counted via ``sample_next_state``), giving deterministic control
+    over when an episode ends. ``terminate_after=0`` makes the initial state
+    terminal; a large value makes the episode run to its step budget.
+    """
+
+    def __init__(self, terminate_after: int, discount_factor: float = 0.95) -> None:
+        super().__init__(discount_factor=discount_factor)
+        self._terminate_after = terminate_after
+        self._steps_taken = 0
+
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> Any:
+        self._steps_taken += 1
+        return super().sample_next_state(state, action, n_samples)
+
+    def is_terminal(self, state: Any) -> bool:
+        super().is_terminal(state)  # keep the spy counter consistent
+        return self._steps_taken >= self._terminate_after
+
+
+class FixedActionPolicy(Policy):
+    """A trivial discrete policy that returns ``actions_per_call`` listen actions."""
+
+    def __init__(
+        self,
+        environment: Environment,
+        discount_factor: float,
+        name: str = "FixedActionPolicy",
+        actions_per_call: int = 1,
+        log_path: Optional[Path] = None,
+        debug: bool = False,
+    ) -> None:
+        self.actions_per_call = actions_per_call
+        super().__init__(environment, discount_factor, name, log_path=log_path, debug=debug)
+
+    def action(self, belief: Belief):
+        del belief
+        return (["listen"] * self.actions_per_call, PolicyRunData(info_variables=[]))
+
+    @classmethod
+    def get_space_info(cls) -> PolicySpaceInfo:
+        return PolicySpaceInfo(
+            action_space=SpaceType.DISCRETE, observation_space=SpaceType.DISCRETE
+        )
+
+    @classmethod
+    def get_info_variable_names(cls) -> List[str]:
+        return []
+
+
+def _run_two_env_episode(num_steps: int = 3):
+    """Run one episode with a distinct spied world and spied model; return spies+history."""
+    model = SpyTiger(discount_factor=0.95)
+    world = SpyTiger(discount_factor=0.95)
+    policy = FixedActionPolicy(environment=model, discount_factor=0.95)
+    belief = get_initial_belief(model, n_particles=5)
+
+    # Snapshot after belief construction but before the runner, since the
+    # ground-truth initial state is sampled inside EpisodeRunner.__init__.
+    world_before = dict(world._calls)
+    model_before = dict(model._calls)
+    runner = EpisodeRunner(
+        environment=world, policy=policy, initial_belief=belief, num_steps=num_steps, logger=None
+    )
+    history = runner.run()
+
+    world_delta = {k: v - world_before[k] for k, v in world._calls.items()}
+    model_delta = {k: v - model_before[k] for k, v in model._calls.items()}
+    return world_delta, model_delta, history
+
+
+def test_two_env_reward_and_transition_come_from_world() -> None:
+    """Reward, next-state and observation are sampled from the world environment.
+
+    Purpose: Validates the executed trajectory is drawn from the world, not the model.
+
+    Given: A distinct spied world and spied model with a fixed-action policy
+    When: An episode is run through EpisodeRunner
+    Then: The world's reward/sample_next_state/sample_observation are exercised
+        while the model's reward is never called
+
+    Test type: integration
+    """
+    world_delta, model_delta, _ = _run_two_env_episode()
+
+    assert world_delta["reward"] > 0
+    assert world_delta["sample_next_state"] > 0
+    assert world_delta["sample_observation"] > 0
+    # The model is a generative model for the belief, never the reward source.
+    assert model_delta["reward"] == 0
+
+
+def test_two_env_initial_state_drawn_from_world() -> None:
+    """The ground-truth initial state comes from the world's initial distribution.
+
+    Purpose: Validates initial-state sourcing switches to the world when world != model.
+
+    Given: A distinct spied world and spied model
+    When: An episode is run
+    Then: The world's initial_state_dist is queried during the run
+
+    Test type: integration
+    """
+    world_delta, _, _ = _run_two_env_episode()
+    assert world_delta["initial_state_dist"] >= 1
+
+
+def test_two_env_belief_update_runs_on_model() -> None:
+    """Belief particle propagation runs on the planner's model environment.
+
+    Purpose: Validates the belief update uses model, not world.
+
+    Given: A fixed-action policy (no planning) so model sampling can only come
+        from the belief update
+    When: An episode is run
+    Then: The model's sample_next_state is exercised (belief propagation) and a
+        non-empty history is produced
+
+    Test type: integration
+    """
+    _, model_delta, history = _run_two_env_episode()
+    # Tiger's WeightedParticleBelief update propagates particles via the
+    # vectorized batch entry point on the model environment.
+    assert model_delta["sample_next_state_batch"] > 0
+    assert len(history.history) > 0
+
+
+def test_two_env_discount_mismatch_raises() -> None:
+    """A world/model discount-factor mismatch is rejected at construction.
+
+    Purpose: Validates the discount-consistency guard for the two-env case.
+
+    Given: A world discounted at 0.9 and a policy model discounted at 0.95
+    When: An EpisodeRunner is constructed
+    Then: ValueError is raised naming the discount mismatch
+
+    Test type: unit
+    """
+    model = SpyTiger(discount_factor=0.95)
+    world = SpyTiger(discount_factor=0.9)
+    policy = FixedActionPolicy(environment=model, discount_factor=0.95)
+    belief = get_initial_belief(model, n_particles=3)
+
+    with pytest.raises(ValueError, match="discount_factor"):
+        EpisodeRunner(
+            environment=world, policy=policy, initial_belief=belief, num_steps=2, logger=None
+        )
+
+
+def test_single_env_backcompat_initial_state_from_belief() -> None:
+    """With one environment, initial state comes from the belief (classic behavior).
+
+    Purpose: Validates zero behavior change when world is the model.
+
+    Given: A single spied env used as both the world and the policy's model
+    When: An episode is run
+    Then: The env's initial_state_dist is NOT called by the runner (the belief
+        sample seeds the true state) while reward/transition still route to it
+
+    Test type: integration
+    """
+    env = SpyTiger(discount_factor=0.95)
+    policy = FixedActionPolicy(environment=env, discount_factor=0.95)
+    belief = get_initial_belief(env, n_particles=5)
+
+    runner = EpisodeRunner(
+        environment=env, policy=policy, initial_belief=belief, num_steps=3, logger=None
+    )
+    before = dict(env._calls)
+    runner.run()
+    delta = {k: v - before[k] for k, v in env._calls.items()}
+
+    assert delta["initial_state_dist"] == 0
+    assert delta["reward"] > 0
+    assert delta["sample_next_state"] > 0
+
+
+@pytest.fixture(name="valid_kwargs")
+def _valid_kwargs() -> Dict[str, Any]:
+    """A set of valid EpisodeRunner constructor arguments to mutate per case."""
+    env = TigerPOMDP(discount_factor=0.95)
+    policy = FixedActionPolicy(environment=env, discount_factor=0.95)
+    belief = get_initial_belief(env, n_particles=3)
+    return {"environment": env, "policy": policy, "initial_belief": belief, "num_steps": 3}
+
+
+@pytest.mark.parametrize(
+    "field,value,expected",
+    [
+        ("environment", None, ValueError),
+        ("policy", None, ValueError),
+        ("initial_belief", None, ValueError),
+        ("num_steps", None, ValueError),
+        ("environment", object(), TypeError),
+        ("policy", "not_a_policy", TypeError),
+        ("initial_belief", 3, TypeError),
+        ("num_steps", "3", TypeError),
+        ("num_steps", 0, ValueError),
+        ("num_steps", -1, ValueError),
+    ],
+)
+def test_episode_runner_rejects_invalid_inputs(
+    valid_kwargs: Dict[str, Any], field: str, value: Any, expected: type
+) -> None:
+    """Invalid constructor inputs are rejected with the documented error type.
+
+    Purpose: Validates _validate_episode_inputs covers None/type/positivity checks.
+
+    Given: An otherwise-valid set of EpisodeRunner arguments
+    When: One argument is replaced with a None, wrong-typed, or non-positive value
+    Then: The matching ValueError/TypeError is raised at construction
+
+    Test type: unit
+    """
+    kwargs = dict(valid_kwargs)
+    kwargs[field] = value
+    with pytest.raises(expected):
+        EpisodeRunner(**kwargs)
+
+
+def test_episode_stops_at_terminal_and_records_terminal_step() -> None:
+    """Reaching a terminal world state ends the episode with a terminal step.
+
+    Purpose: Validates early termination bookkeeping (_should_continue/_add_terminal_step).
+
+    Given: A world scripted to become terminal after two transitions, budget 10
+    When: An episode is run
+    Then: reach_terminal_state is True, exactly two normal steps are taken, and a
+        trailing terminal step with all-None fields is appended
+
+    Test type: integration
+    """
+    env = TerminatingTiger(terminate_after=2)
+    policy = FixedActionPolicy(environment=env, discount_factor=0.95)
+    belief = get_initial_belief(env, n_particles=5)
+
+    history = EpisodeRunner(
+        environment=env, policy=policy, initial_belief=belief, num_steps=10, logger=None
+    ).run()
+
+    assert history.reach_terminal_state is True
+    assert history.actual_num_steps == 2
+    normal_steps = [step for step in history.history if step.action is not None]
+    assert len(normal_steps) == 2
+    terminal = history.history[-1]
+    assert terminal.action is None
+    assert terminal.next_state is None
+    assert terminal.observation is None
+    assert terminal.reward is None
+
+
+def test_episode_terminal_at_start_records_only_terminal_step() -> None:
+    """An already-terminal initial state ends the episode immediately.
+
+    Purpose: Validates the step-0 terminal edge case.
+
+    Given: A world whose initial state is already terminal
+    When: An episode is run
+    Then: No policy action is executed and the history is a single terminal step
+
+    Test type: integration
+    """
+    env = TerminatingTiger(terminate_after=0)
+    policy = FixedActionPolicy(environment=env, discount_factor=0.95)
+    belief = get_initial_belief(env, n_particles=5)
+
+    history = EpisodeRunner(
+        environment=env, policy=policy, initial_belief=belief, num_steps=5, logger=None
+    ).run()
+
+    assert history.reach_terminal_state is True
+    assert history.actual_num_steps == 0
+    assert len(history.history) == 1
+    assert history.history[0].action is None
+
+
+def test_episode_runs_full_length_when_never_terminal() -> None:
+    """A non-terminal world runs exactly num_steps with no terminal step.
+
+    Purpose: Validates the step-budget stop path.
+
+    Given: A world that never terminates and a budget of four steps
+    When: An episode is run
+    Then: Exactly four normal steps are recorded, reach_terminal_state is False,
+        and no trailing terminal step is appended
+
+    Test type: integration
+    """
+    env = TerminatingTiger(terminate_after=999)
+    policy = FixedActionPolicy(environment=env, discount_factor=0.95)
+    belief = get_initial_belief(env, n_particles=5)
+
+    history = EpisodeRunner(
+        environment=env, policy=policy, initial_belief=belief, num_steps=4, logger=None
+    ).run()
+
+    assert history.reach_terminal_state is False
+    assert history.actual_num_steps == 4
+    assert len(history.history) == 4
+    assert all(step.action is not None for step in history.history)
+
+
+def test_recorded_steps_chain_pretransition_state_to_next_state() -> None:
+    """Each StepData records the pre-transition state, chaining across steps.
+
+    Purpose: Validates _record_step captures state before the transition is applied.
+
+    Given: A non-terminal world run for four steps
+    When: The recorded history is inspected
+    Then: Every step's state equals the previous step's next_state, and every
+        normal step has populated next_state/observation/reward fields
+
+    Test type: integration
+    """
+    env = TerminatingTiger(terminate_after=999)
+    policy = FixedActionPolicy(environment=env, discount_factor=0.95)
+    belief = get_initial_belief(env, n_particles=5)
+
+    history = EpisodeRunner(
+        environment=env, policy=policy, initial_belief=belief, num_steps=4, logger=None
+    ).run()
+
+    steps = [step for step in history.history if step.action is not None]
+    assert len(steps) == 4
+    for previous, current in zip(steps, steps[1:]):
+        assert current.state == previous.next_state
+    for step in steps:
+        assert step.next_state is not None
+        assert step.observation is not None
+        assert step.reward is not None
+
+
+def test_multi_action_policy_step_breaks_at_num_steps() -> None:
+    """A policy emitting several actions per call still stops at the step budget.
+
+    Purpose: Validates _execute_policy_step iterates actions and breaks at num_steps.
+
+    Given: A policy returning two actions per selection and a budget of three
+    When: An episode is run
+    Then: Exactly three actions execute (the fourth is cut off mid-selection) over
+        two policy selections
+
+    Test type: integration
+    """
+    env = TerminatingTiger(terminate_after=999)
+    policy = FixedActionPolicy(environment=env, discount_factor=0.95, actions_per_call=2)
+    belief = get_initial_belief(env, n_particles=5)
+
+    runner = EpisodeRunner(
+        environment=env, policy=policy, initial_belief=belief, num_steps=3, logger=None
+    )
+    history = runner.run()
+
+    assert history.actual_num_steps == 3
+    normal_steps = [step for step in history.history if step.action is not None]
+    assert len(normal_steps) == 3
+    assert len(runner.policy_run_data) == 2
+
+
+def test_initial_belief_is_deep_copied() -> None:
+    """The runner copies the initial belief and never mutates the caller's object.
+
+    Purpose: Validates the copy.deepcopy of initial_belief.
+
+    Given: A caller-owned initial belief
+    When: An episode is run
+    Then: The runner's belief is a distinct object and the caller's belief
+        particles are unchanged
+
+    Test type: unit
+    """
+    env = TerminatingTiger(terminate_after=999)
+    policy = FixedActionPolicy(environment=env, discount_factor=0.95)
+    belief = get_initial_belief(env, n_particles=5)
+    original_particles = list(belief.particles)
+
+    runner = EpisodeRunner(
+        environment=env, policy=policy, initial_belief=belief, num_steps=3, logger=None
+    )
+    assert runner.belief is not belief
+    runner.run()
+
+    assert list(belief.particles) == original_particles
+
+
+def test_run_episode_wrapper_returns_history() -> None:
+    """run_episode constructs a runner and returns its History.
+
+    Purpose: Validates the public run_episode entry point.
+
+    Given: A non-terminal world, fixed policy and initial belief
+    When: run_episode is called with a three-step budget
+    Then: A History is returned with the expected number of executed steps
+
+    Test type: integration
+    """
+    env = TerminatingTiger(terminate_after=999)
+    policy = FixedActionPolicy(environment=env, discount_factor=0.95)
+    belief = get_initial_belief(env, n_particles=3)
+
+    history = run_episode(
+        environment=env, policy=policy, initial_belief=belief, num_steps=3, logger=None
+    )
+
+    assert isinstance(history.history, list)
+    assert history.actual_num_steps == 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ ignore-imports = false
 ignored-modules = [
     "numpy",
     "cvxopt",
+    "carla",
     "POMDPPlanners.core._native",
     "POMDPPlanners.environments.mountain_car_pomdp._native",
     "POMDPPlanners.environments.cartpole_pomdp._native",


### PR DESCRIPTION
## Summary

Adds **CarlaPOMDP**, a forward-only adapter exposing a [CARLA](https://carla.org/) autonomous-driving session as a ground-truth *world* for the two-environment episode loop. The world advances one true state per real interaction; the planner keeps its own generative model (`policy.environment`).

## Stacking / merge order

> [!IMPORTANT]
> This PR is **stacked on #203** (`refactor/env-owns-visualization-file-save`). Merge **#203 first**, then this PR — GitHub will then show only the carla-specific diff. Until #203 lands, this PR's diff also contains #203's commits.

## What's included

- **`environments/carla_pomdp/`** — `CarlaPOMDP` env + `carla_video` mp4 frame-writer helper. `carla` is imported lazily; tests run without a CARLA install (mocked session).
- **Two-env `EpisodeRunner` support** (`simulations/episodes.py`) — the enabling change carla depends on: the ground-truth world (`environment`) may differ from the planner model (`policy.environment`). When they differ, the initial true state is drawn from the world reset (not an injected belief sample), and a world/model discount-factor mismatch is rejected. Backward-compatible for the classic single-env case.
- Unit + integration tests for both, plus a root `carla_pomdp_example.py`.
- `carla` added to pylint `ignored-modules` (optional external dependency).

## Explicitly excluded

The two-env work on `feat/gym-wrapper-two-env-episode` also introduced a `GymPOMDP` wrapper. It is **not** included here — carla never imports it (only docstring comparisons) and it was deemed unnecessary for this repo. Only the generic `episodes.py` world/model change was carried over.

## Verification

- `pytest` carla + episodes suites: **45 passed**; `test_simulator.py`: 44 passed
- `pyright POMDPPlanners/`: 0 errors / 0 warnings
- `pylint`: 10.00/10