### PR TITLE
test(carla_pomdp): cover observation equality and collision-penalty reward

### DIFF
--- a/POMDPPlanners/simulations/hyper_parameter_tuning_simulations.py
+++ b/POMDPPlanners/simulations/hyper_parameter_tuning_simulations.py
@@ -121,6 +121,7 @@ Note:
     - Results include optimized policies with their chosen hyperparameters
 """
 
+import os
 import uuid
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
@@ -309,6 +310,10 @@ class HyperParameterOptimizer:
 
         # Create the mlruns directory and set up MLflow
         self.mlruns_path.mkdir(parents=True, exist_ok=True)
+        # MLflow >= 3.6 gates the local filesystem tracking backend behind an
+        # explicit opt-in. This project deliberately uses local file storage,
+        # so enable it unless the caller has already chosen otherwise.
+        os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
         self.mlflow_tracking_uri: str = f"file://{self.mlruns_path.absolute()}"
         mlflow.set_tracking_uri(self.mlflow_tracking_uri)
         mlflow.set_experiment(experiment_name)

--- a/POMDPPlanners/simulations/simulator/base_simulator.py
+++ b/POMDPPlanners/simulations/simulator/base_simulator.py
@@ -4,6 +4,7 @@
 
 import cProfile
 import io
+import os
 import pstats
 import shutil
 import tempfile
@@ -231,6 +232,11 @@ class BaseSimulator(ABC):
 
         trash_path = mlruns_path / ".trash"
         trash_path.mkdir(parents=True, exist_ok=True)
+
+        # MLflow >= 3.6 gates the local filesystem tracking backend behind an
+        # explicit opt-in. This project deliberately uses local file storage,
+        # so enable it unless the caller has already chosen otherwise.
+        os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
 
         tracking_uri = f"file://{mlruns_path.absolute()}"
         mlflow.set_tracking_uri(tracking_uri)

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
@@ -626,3 +626,47 @@ def test_cache_visualization_writes_agent_path_named_mp4(
     env.cache_visualization(history=[], output_dir=tmp_path, episode_index=7)
 
     assert written["path"] == tmp_path / "agent_path_7.mp4"
+
+
+def test_is_equal_observation_true_for_identical_false_for_distinct(world: CarlaPOMDP) -> None:
+    """is_equal_observation compares GNSS observation vectors element-wise.
+
+    Purpose: Validates the observation-equality predicate directly.
+
+    Given: Two identical GNSS observations and a third differing one
+    When: is_equal_observation compares the identical pair and the differing pair
+    Then: The identical pair compares equal and the differing pair compares unequal
+
+    Test type: unit
+    """
+    observation = np.array([48.0, 2.0, 0.0])
+    same = np.array([48.0, 2.0, 0.0])
+    different = np.array([48.0, 2.0, 1.0])
+
+    assert world.is_equal_observation(observation, same) is True
+    assert world.is_equal_observation(observation, different) is False
+
+
+def test_reward_subtracts_collision_penalty_on_terminal_step(world: CarlaPOMDP) -> None:
+    """The reward is ego speed on live steps and speed minus the penalty on collision.
+
+    Purpose: Validates the collision-penalty branch of the reward model.
+
+    Given: A world whose fake session terminates on the third tick at speed 3
+    When: The world is driven forward three steps, reading each reward
+    Then: Non-terminal rewards equal the speed and the terminal reward has the
+        default collision penalty subtracted (3.0 - 100.0 == -97.0)
+
+    Test type: unit
+    """
+    assert world.collision_penalty == 100.0
+    state = world._live_state
+    rewards = []
+    for _ in range(3):
+        next_state, _, reward = world.sample_next_step(state, 0)
+        rewards.append(reward)
+        state = next_state
+
+    assert rewards[0] == 1.0
+    assert rewards[1] == 2.0
+    assert rewards[2] == 3.0 - 100.0

--- a/POMDPPlanners/tests/test_environments/test_pacman_native/test_pacman_feature_driven.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_native/test_pacman_feature_driven.py
@@ -1,0 +1,638 @@
+"""Feature-driven tests for the PacMan POMDP environment.
+
+These tests target gaps not covered by ``test_pacman_pomdp.py`` and
+``test_pacman_native_equivalence.py``. They are intentionally written from
+the published env API so that any divergence between code paths that
+*should* describe the same probability model surfaces as a hard test
+failure.
+
+The key invariant under test in this file is:
+
+    For any (next_state, action, observation), the scalar API
+    ``env.observation_log_probability(next_state, action, [observation])``
+    and the batch API
+    ``env.observation_log_probability_per_state(np.stack([next_state]),
+        action, observation)`` must agree element-wise — they describe
+    the *same* observation model.
+
+Light-dark exposed an asymmetric floor on this invariant; the tests below
+check the same property for PacMan and surface several other feature
+regions (terminal sampling, observation clamping, transition probability
+normalization, etc.).
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.pacman_pomdp import _native  # pylint: disable=no-name-in-module
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import PacManPOMDP
+
+
+def _build_small_env(num_ghosts: int = 1) -> PacManPOMDP:
+    """Construct a small PacMan env with no walls for predictable transitions."""
+    if num_ghosts == 1:
+        ghosts: List[Tuple[int, int]] = [(4, 4)]
+    else:
+        ghosts = [(0, 4), (4, 0)]
+    return PacManPOMDP(
+        maze_size=(5, 5),
+        walls=set(),
+        initial_pellets=[(2, 2)],
+        initial_pacman_pos=(0, 0),
+        num_ghosts=num_ghosts,
+        initial_ghost_positions=ghosts,
+    )
+
+
+def _build_low_noise_env() -> PacManPOMDP:
+    """Env with very small observation noise to exercise extreme log-PDFs."""
+    return PacManPOMDP(
+        maze_size=(20, 20),
+        walls=set(),
+        initial_pellets=[(0, 0)],
+        initial_pacman_pos=(0, 0),
+        num_ghosts=1,
+        initial_ghost_positions=[(0, 1)],
+        observation_noise_factor=0.01,
+        max_observation_noise=0.05,
+    )
+
+
+class TestObservationLogProbScalarBatchParity:
+    """Parity invariants between scalar and batch observation log-prob APIs."""
+
+    def test_scalar_and_batch_agree_for_true_observation(self) -> None:
+        """Scalar/batch observation log-probabilities agree for the true ghost obs.
+
+        Purpose: Validates that ``observation_log_probability`` and
+            ``observation_log_probability_per_state`` describe the same
+            per-particle observation model on a finite, well-conditioned input.
+
+        Given: A non-terminal next-state and an observation equal to the true
+            ghost position, where the analytic 2-D Gaussian log-PDF is finite.
+        When: The scalar API and the batch API are evaluated on the same
+            (next_state, action, observation).
+        Then: The two log-probabilities are equal to within tight float
+            tolerance (the same C++ kernel computes both).
+
+        Test type: unit
+        """
+        env = _build_small_env()
+        next_state = env.make_state(pacman_pos=(2, 2), ghost_positions=((2, 3),), pellets=((2, 2),))
+        scalar = env.observation_log_probability(next_state, 0, [((2, 3),)])
+        batch = env.observation_log_probability_per_state(np.stack([next_state]), 0, ((2, 3),))
+        assert scalar.shape == (1,)
+        assert batch.shape == (1,)
+        assert np.isclose(scalar[0], batch[0], rtol=1e-12, atol=0.0)
+
+    def test_scalar_and_batch_agree_for_terminal_state_terminal_obs(self) -> None:
+        """Scalar/batch agree when both state and observation are terminal sentinels.
+
+        Purpose: Confirms the model assigns log-prob 0 (probability 1) to the
+            sentinel terminal observation under a terminal state, on both APIs.
+
+        Given: A terminal next-state (terminal flag set) and the canonical
+            terminal observation ``((-1, -1),)``.
+        When: Both the scalar and the batch log-prob APIs are evaluated.
+        Then: Both return exactly ``log 1 = 0.0``.
+
+        Test type: unit
+        """
+        env = _build_small_env()
+        terminal_state = env.make_state(
+            pacman_pos=(2, 2),
+            ghost_positions=((4, 4),),
+            pellets=((2, 2),),
+            terminal=True,
+        )
+        scalar = env.observation_log_probability(terminal_state, 0, [((-1, -1),)])
+        batch = env.observation_log_probability_per_state(
+            np.stack([terminal_state]), 0, ((-1, -1),)
+        )
+        assert scalar[0] == 0.0
+        assert batch[0] == 0.0
+
+    def test_scalar_and_batch_agree_for_terminal_obs_under_nonterminal_state(self) -> None:
+        """Scalar/batch agree on impossible terminal-obs under non-terminal state.
+
+        Purpose: This is the asymmetry that surfaced in the light-dark POMDP:
+            the scalar API runs the C++ ``probability`` (which collapses
+            non-finite log-PDFs to 0) and then computes ``log(p + 1e-300)``,
+            flooring at ``log(1e-300) ≈ -690.78``. The batch API
+            (``batch_log_likelihood``) returns the raw ``-inf`` log-PDF.
+            The two must agree because they describe the *same* model.
+
+        Given: A non-terminal next-state and the sentinel terminal observation
+            ``((-1, -1),)``, which has zero probability under any non-terminal
+            state.
+        When: Both the scalar and the batch log-prob APIs are evaluated.
+        Then: Both return the same value (either both ``-inf`` or both equal
+            up to tight floating-point tolerance).
+
+        Test type: unit
+        """
+        env = _build_small_env()
+        non_terminal = env.make_state(
+            pacman_pos=(2, 2), ghost_positions=((2, 3),), pellets=((2, 2),)
+        )
+        scalar = env.observation_log_probability(non_terminal, 0, [((-1, -1),)])
+        batch = env.observation_log_probability_per_state(np.stack([non_terminal]), 0, ((-1, -1),))
+        # If both are -inf, treat them as equal.
+        if np.isneginf(scalar[0]) and np.isneginf(batch[0]):
+            return
+        assert np.isclose(scalar[0], batch[0], rtol=1e-9, atol=1e-9), (
+            f"scalar/batch obs log-prob mismatch on terminal-obs vs "
+            f"non-terminal-state: scalar={scalar[0]}, batch={batch[0]}"
+        )
+
+    def test_scalar_and_batch_agree_for_extreme_log_pdf(self) -> None:
+        """Scalar/batch agree even when the analytic log-PDF is extremely negative.
+
+        Purpose: When noise is very small relative to the (ghost, observation)
+            offset, the analytic Gaussian log-PDF can be far below
+            ``log(1e-300) ≈ -690.78``. The scalar API converts log-PDF to
+            probability via ``exp`` (which underflows to 0), then back via
+            ``log(p + 1e-300)`` — losing information. The batch API returns
+            the raw log-PDF. Both must agree.
+
+        Given: An env with ``observation_noise_factor=0.01`` and
+            ``max_observation_noise=0.05``, plus an observation at distance
+            (10, 10) from the true ghost. The analytic log-PDF is on the order
+            of ``-9e5``, well below the scalar floor of ~-690.
+        When: Both APIs are evaluated on the same input.
+        Then: Both return the same value to within tight tolerance.
+
+        Test type: unit
+        """
+        env = _build_low_noise_env()
+        next_state = env.make_state(pacman_pos=(0, 0), ghost_positions=((0, 1),), pellets=((0, 0),))
+        scalar = env.observation_log_probability(next_state, 0, [((10, 10),)])
+        batch = env.observation_log_probability_per_state(np.stack([next_state]), 0, ((10, 10),))
+        if np.isneginf(scalar[0]) and np.isneginf(batch[0]):
+            return
+        assert np.isclose(scalar[0], batch[0], rtol=1e-9, atol=1e-9), (
+            f"scalar/batch obs log-prob mismatch on extreme log-PDF: "
+            f"scalar={scalar[0]}, batch={batch[0]}"
+        )
+
+    def test_scalar_and_batch_agree_for_2d_obs_array_input(self) -> None:
+        """Scalar (2-D ndarray) path and batch path agree on terminal-sentinel obs.
+
+        Purpose: ``observation_log_probability`` accepts a 2-D ndarray of
+            observations as well as a sequence of tuples. Both call
+            ``kernel.probability`` (with the ``log(p + 1e-300)`` floor),
+            whereas ``observation_log_probability_per_state`` calls
+            ``batch_log_likelihood`` (no floor). These must still agree.
+
+        Given: A non-terminal next-state and a 2-D ndarray containing the
+            terminal-sentinel observation ``[-1, -1]``.
+        When: The scalar (2-D path) and the batch APIs are evaluated.
+        Then: The two log-probabilities are equal (both ``-inf`` or both
+            finite and close).
+
+        Test type: unit
+        """
+        env = _build_small_env()
+        non_terminal = env.make_state(
+            pacman_pos=(2, 2), ghost_positions=((2, 3),), pellets=((2, 2),)
+        )
+        obs_array = np.array([[-1.0, -1.0]], dtype=np.float64)
+        scalar = env.observation_log_probability(non_terminal, 0, obs_array)
+        batch = env.observation_log_probability_per_state(
+            np.stack([non_terminal]), 0, obs_array.ravel()
+        )
+        if np.isneginf(scalar[0]) and np.isneginf(batch[0]):
+            return
+        assert np.isclose(scalar[0], batch[0], rtol=1e-9, atol=1e-9)
+
+
+class TestObservationFeatureRegions:
+    """Tests for distinct feature regions of the observation model."""
+
+    def test_terminal_state_always_samples_terminal_sentinel(self) -> None:
+        """Terminal state -> sample_observation always returns the all-(-1) sentinel.
+
+        Purpose: Validates the contract that terminal next-states emit the
+            sentinel observation (per-ghost (-1, -1)), so downstream particle
+            filters can treat it as a deterministic absorbing observation.
+
+        Given: A terminal next-state.
+        When: ``sample_observation`` is called many times.
+        Then: Every sample is ``((-1, -1),)``.
+
+        Test type: unit
+        """
+        env = _build_small_env()
+        terminal_state = env.make_state(
+            pacman_pos=(2, 2),
+            ghost_positions=((4, 4),),
+            pellets=((2, 2),),
+            terminal=True,
+        )
+        _native.set_seed(7)
+        samples = env.sample_observation(terminal_state, 0, n_samples=128)
+        for obs in samples:
+            assert obs == ((-1, -1),), f"unexpected terminal sample: {obs}"
+
+    def test_observations_are_clamped_to_maze_bounds(self) -> None:
+        """Sampled observations fall inside ``[0, maze_rows-1] × [0, maze_cols-1]``.
+
+        Purpose: Validates the C++ kernel's coordinate clamping prevents
+            observations from leaking outside the maze (otherwise downstream
+            particle filters would assign zero likelihood unexpectedly).
+
+        Given: A small maze with a corner ghost and large noise (factor
+            ``2.0``, max ``10.0``) so unclamped Gaussian draws would routinely
+            exit the maze.
+        When: Many observations are sampled.
+        Then: Every sampled coordinate is inside the maze bounds.
+
+        Test type: unit
+        """
+        env = PacManPOMDP(
+            maze_size=(5, 5),
+            walls=set(),
+            initial_pellets=[(2, 2)],
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(0, 4)],
+            observation_noise_factor=2.0,
+            max_observation_noise=10.0,
+        )
+        next_state = env.make_state(pacman_pos=(0, 0), ghost_positions=((0, 4),), pellets=((2, 2),))
+        _native.set_seed(11)
+        samples = env.sample_observation(next_state, 0, n_samples=256)
+        for obs in samples:
+            (row, col) = obs[0]
+            assert 0 <= row <= 4, f"row {row} out of bounds"
+            assert 0 <= col <= 4, f"col {col} out of bounds"
+
+    def test_wrong_ghost_count_observation_has_zero_probability(self) -> None:
+        """Observation tuple with wrong ghost count -> log-prob is ``-inf``.
+
+        Purpose: Validates that an observation whose length disagrees with
+            ``num_ghosts`` is impossible under the model. The scalar API
+            documents this in code (rows with the wrong ghost count are
+            skipped, so probability stays at 0). The model invariant says
+            log-prob should be ``-inf`` (probability 0).
+
+        Given: A 2-ghost env and a non-terminal next-state.
+        When: The scalar API is given a 1-ghost observation tuple.
+        Then: The returned log-probability is ``-inf`` (impossible event).
+
+        Test type: unit
+        """
+        env = _build_small_env(num_ghosts=2)
+        next_state = env.make_state(
+            pacman_pos=(0, 0),
+            ghost_positions=((0, 4), (4, 0)),
+            pellets=((2, 2),),
+        )
+        scalar = env.observation_log_probability(next_state, 0, [((0, 4),)])
+        assert scalar.shape == (1,)
+        assert np.isneginf(scalar[0]), (
+            f"impossible (wrong-ghost-count) observation should have log-prob "
+            f"-inf, got {scalar[0]}"
+        )
+
+
+class TestTransitionFeatureRegions:
+    """Tests for distinct feature regions of the transition model."""
+
+    def test_transition_probabilities_normalize_to_one(self) -> None:
+        """Transition probabilities sum to ~1 over the full reachable next-state set.
+
+        Purpose: Validates that ``transition_log_probability`` returns a
+            properly normalized distribution. Mis-normalization would silently
+            bias particle-filter weights.
+
+        Given: A 4×4 maze, single ghost at (2, 2), PacMan at (0, 0), action
+            South. PacMan moves deterministically to (1, 0); the ghost moves
+            to one of {(1, 2), (2, 1), (2, 3), (3, 2), (2, 2)}.
+        When: The five reachable next-states are evaluated.
+        Then: Their probabilities (un-floored, finite) sum to 1.0 to within
+            tight tolerance.
+
+        Test type: unit
+        """
+        env = PacManPOMDP(
+            maze_size=(4, 4),
+            walls=set(),
+            initial_pellets=[(0, 0)],
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(2, 2)],
+        )
+        state = env.make_state(pacman_pos=(0, 0), ghost_positions=((2, 2),), pellets=((0, 0),))
+        candidates = [
+            env.make_state(pacman_pos=(1, 0), ghost_positions=((gr, gc),), pellets=((0, 0),))
+            for (gr, gc) in [(1, 2), (2, 1), (2, 3), (3, 2), (2, 2)]
+        ]
+        log_probs = env.transition_log_probability(state, 2, candidates)
+        probs = np.exp(log_probs)
+        assert np.isclose(probs.sum(), 1.0, atol=1e-9), (
+            f"transition probabilities should sum to 1 over reachable "
+            f"next-states, got {probs.sum()} (probs={probs})"
+        )
+
+    def test_terminal_state_is_absorbing_under_log_probability(self) -> None:
+        """From a terminal state, only the identity transition has non-zero prob.
+
+        Purpose: Validates the absorbing-terminal contract on the analytic
+            log-prob path (``transition_log_probability``), complementing the
+            sample-side test in ``test_pacman_native_equivalence.py``.
+
+        Given: A terminal state ``s`` and any action.
+        When: ``transition_log_probability`` is queried at ``s`` itself and at
+            a different state ``s'``.
+        Then: ``log P(s | s, a) = 0`` (probability 1) and the impossible
+            transition has log-prob below the scalar floor (i.e. probability
+            collapsed to zero).
+
+        Test type: unit
+        """
+        env = _build_small_env()
+        terminal = env.make_state(
+            pacman_pos=(2, 2),
+            ghost_positions=((4, 4),),
+            pellets=((2, 2),),
+            terminal=True,
+        )
+        other = env.make_state(
+            pacman_pos=(3, 3),
+            ghost_positions=((4, 4),),
+            pellets=((2, 2),),
+            terminal=False,
+        )
+        log_probs = env.transition_log_probability(terminal, 1, [terminal, other])
+        assert np.isclose(log_probs[0], 0.0, atol=1e-12)
+        assert log_probs[1] < -100.0
+
+
+class TestTerminalAndIsTerminal:
+    """Tests for the ``is_terminal`` predicate boundary cases."""
+
+    def test_is_terminal_treats_flag_strictly_above_half(self) -> None:
+        """``is_terminal`` requires ``state[idx_terminal] > 0.5``.
+
+        Purpose: Validates the boundary semantics of the terminal predicate so
+            that callers can rely on the strict ``> 0.5`` convention used by
+            both Python and C++ paths.
+
+        Given: A state whose terminal slot is set to 0.4, 0.5, 0.6, and 1.0.
+        When: ``is_terminal`` is called.
+        Then: Only states with terminal slot strictly greater than 0.5 are
+            classified as terminal.
+
+        Test type: unit
+        """
+        env = _build_small_env()
+        base = env.make_state(
+            pacman_pos=(2, 2),
+            ghost_positions=((4, 4),),
+            pellets=((2, 2),),
+            terminal=False,
+        )
+        cases = [(0.0, False), (0.4, False), (0.5, False), (0.6, True), (1.0, True)]
+        for value, expected in cases:
+            arr = base.copy()
+            arr[-1] = value
+            assert env.is_terminal(arr) is expected, (
+                f"is_terminal({value}) -> got {env.is_terminal(arr)}, " f"expected {expected}"
+            )
+
+
+class TestRewardFeatureRegions:
+    """Tests for distinct feature regions of the reward function."""
+
+    def test_terminal_state_reward_is_zero(self) -> None:
+        """``reward`` returns 0 for a terminal state regardless of action.
+
+        Purpose: Validates the absorbing-terminal contract on the reward
+            function: terminal states should not accrue further reward.
+
+        Given: A terminal state.
+        When: ``reward`` is called for every action.
+        Then: All rewards equal exactly 0.0.
+
+        Test type: unit
+        """
+        env = _build_small_env()
+        terminal = env.make_state(
+            pacman_pos=(2, 2),
+            ghost_positions=((4, 4),),
+            pellets=((2, 2),),
+            terminal=True,
+        )
+        for action in env.get_actions():
+            assert env.reward(terminal, action) == 0.0
+
+    def test_reward_batch_includes_win_bonus_when_last_pellet_eaten(self) -> None:
+        """``reward_batch`` adds win bonus when the last pellet is collected.
+
+        Purpose: Validates the deterministic win-bonus branch of
+            ``_compute_reward_batch``: when an action moves PacMan onto the
+            last active pellet, the batch reward equals
+            ``step_penalty + pellet_reward + win_reward``.
+
+        Given: A 5×5 wall-free env with a single pellet at (1, 1), PacMan at
+            (0, 1) (one step North of the pellet) and the ghost far away.
+        When: ``reward_batch`` is called for action South (which moves PacMan
+            onto the pellet).
+        Then: The reward equals ``-1 + 10 + 100 = 109`` (no ghost-collision
+            term because batch path excludes stochastic components).
+
+        Test type: unit
+        """
+        env = _build_small_env()
+        state = env.make_state(pacman_pos=(0, 1), ghost_positions=((4, 4),), pellets=((2, 2),))
+        # Replace the (2, 2) pellet with (1, 1), the only active pellet.
+        env_with_pellet = PacManPOMDP(
+            maze_size=(5, 5),
+            walls=set(),
+            initial_pellets=[(1, 1)],
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(4, 4)],
+        )
+        state = env_with_pellet.make_state(
+            pacman_pos=(0, 1), ghost_positions=((4, 4),), pellets=((1, 1),)
+        )
+        rewards = env_with_pellet.reward_batch(np.stack([state]), 2)  # South
+        expected = (
+            env_with_pellet.step_penalty
+            + env_with_pellet.pellet_reward
+            + env_with_pellet.win_reward
+        )
+        assert np.isclose(
+            rewards[0], expected
+        ), f"expected win-condition batch reward {expected}, got {rewards[0]}"
+
+    def test_reward_batch_step_penalty_only_when_no_pellet_eaten(self) -> None:
+        """``reward_batch`` returns just the step penalty for empty-cell moves.
+
+        Purpose: Validates the simplest reward branch: an action that moves
+            PacMan to a non-pellet, non-collision cell receives only the step
+            penalty.
+
+        Given: PacMan at (0, 0), pellet at (2, 2), ghost at (4, 4); action
+            East moves PacMan to (0, 1) (no pellet, no collision).
+        When: ``reward_batch`` is called.
+        Then: The reward equals ``step_penalty``.
+
+        Test type: unit
+        """
+        env = _build_small_env()
+        state = env.make_state(pacman_pos=(0, 0), ghost_positions=((4, 4),), pellets=((2, 2),))
+        rewards = env.reward_batch(np.stack([state]), 1)  # East
+        assert np.isclose(rewards[0], env.step_penalty)
+
+
+class TestNativeBatchSampleConsistency:
+    """Cross-checks between scalar ``sample_next_state`` and ``sample_next_state_batch``."""
+
+    def test_batch_sample_marginal_matches_scalar_sample(self) -> None:
+        """Empirical marginal of ``sample_next_state_batch`` matches scalar sampling.
+
+        Purpose: Validates that the batched native sampler does not
+            inadvertently couple particles or shift the per-particle
+            distribution. Since the only stochastic component (with
+            independent ghosts) is the ghost move, the marginal distribution
+            of (g_row, g_col) should match between the two APIs at a 3-sigma
+            Wilson interval at N = 5000.
+
+        Given: A small env, a single fixed input state, action East.
+        When: 5000 samples are drawn through ``sample_next_state`` and 5000
+            through ``sample_next_state_batch`` (with the same fixed input
+            replicated).
+        Then: For every ghost cell, the empirical proportions agree to within
+            ``3 / sqrt(N) ≈ 0.042`` (Wilson-style tolerance, well above the
+            true 1.96 95% bound).
+
+        Test type: unit
+        """
+        env = _build_small_env()
+        state = env.make_state(pacman_pos=(0, 0), ghost_positions=((4, 4),), pellets=((2, 2),))
+        n_samples = 5000
+        action = 1  # East
+
+        _native.set_seed(31)
+        scalar_samples = [env.sample_next_state(state, action) for _ in range(n_samples)]
+        scalar_ghosts = np.array([(int(s[2]), int(s[3])) for s in scalar_samples], dtype=np.int64)
+
+        _native.set_seed(31)
+        batch_input = np.stack([state] * n_samples)
+        batch_samples = env.sample_next_state_batch(batch_input, action)
+        batch_ghosts = np.array(
+            [(int(row[2]), int(row[3])) for row in batch_samples], dtype=np.int64
+        )
+
+        # Compare per-cell empirical proportions.
+        all_cells = set(map(tuple, scalar_ghosts.tolist())) | set(map(tuple, batch_ghosts.tolist()))
+        tol = 3.0 / np.sqrt(n_samples)
+        for cell in all_cells:
+            scalar_p = float(np.mean(np.all(scalar_ghosts == np.array(cell), axis=1)))
+            batch_p = float(np.mean(np.all(batch_ghosts == np.array(cell), axis=1)))
+            assert abs(scalar_p - batch_p) < tol, (
+                f"ghost cell {cell}: scalar={scalar_p:.4f}, batch={batch_p:.4f}, "
+                f"diff exceeds 3/sqrt(N) = {tol:.4f}"
+            )
+
+
+class TestSampleObservationEmpiricalVsAnalytic:
+    """Empirical observation samples should align with the analytic PDF."""
+
+    def test_marginal_empirical_matches_observation_log_probability(self) -> None:
+        """Empirical sample frequencies match ``observation_log_probability``.
+
+        Purpose: Validates the sample/PDF consistency invariant of the
+            observation model: for an integer-clamped 2-D Gaussian, summing
+            empirical proportions over each unique sampled cell should track
+            ``exp(observation_log_probability)`` of the same cell to within a
+            Wilson tolerance for the cells with non-trivial mass.
+
+        Given: A 5×5 env with moderate noise (factor 0.5, max 2.0), single
+            ghost; 5000 observation samples are drawn.
+        When: Empirical proportions are computed for every unique sampled
+            observation and compared against the analytic continuous-Gaussian
+            PDF returned by the env API.
+        Then: For every sampled cell whose empirical proportion exceeds 1%,
+            the analytic PDF agrees to within ``3 / sqrt(N) ≈ 0.042``. The
+            larger sampled set may include high-PDF cells that did not sample
+            this run; we don't enforce match in that direction.
+
+        Test type: unit
+
+        Note: the analytic PDF uses the *continuous* 2-D Gaussian density,
+            which is only an approximation of the true (clamped, rounded)
+            discrete distribution. We therefore restrict the comparison to
+            cells with non-trivial empirical mass and use a generous Wilson
+            tolerance.
+        """
+        env = PacManPOMDP(
+            maze_size=(5, 5),
+            walls=set(),
+            initial_pellets=[(2, 2)],
+            initial_pacman_pos=(0, 0),
+            num_ghosts=1,
+            initial_ghost_positions=[(2, 2)],
+            observation_noise_factor=0.5,
+            max_observation_noise=2.0,
+        )
+        next_state = env.make_state(pacman_pos=(0, 0), ghost_positions=((2, 2),), pellets=((2, 2),))
+        _native.set_seed(77)
+        n_samples = 5000
+        samples = env.sample_observation(next_state, 0, n_samples=n_samples)
+
+        from collections import Counter  # pylint: disable=import-outside-toplevel
+
+        counts = Counter(samples)
+        # Pick cells with at least 1% empirical mass — the PDF approximation
+        # of the discretized obs is closest to truth in the high-density
+        # central region.
+        focused = [obs for obs, c in counts.items() if c / n_samples >= 0.01]
+        assert focused, "expected at least one frequently-sampled observation"
+        log_probs = env.observation_log_probability(next_state, 0, focused)
+        analytic = np.exp(log_probs)
+        empirical = np.array([counts[obs] / n_samples for obs in focused])
+        # Wilson 3/sqrt(N) tolerance, plus a small absolute slack for the
+        # continuous-vs-discrete mismatch.
+        tol = 3.0 / np.sqrt(n_samples) + 0.06
+        for obs, emp, ana in zip(focused, empirical, analytic):
+            assert abs(emp - ana) < tol, (
+                f"obs {obs}: empirical={emp:.4f}, analytic_pdf={ana:.4f}, "
+                f"diff exceeds tolerance {tol:.4f}"
+            )
+
+
+@pytest.mark.parametrize("num_ghosts", [1, 2])
+def test_initial_observation_dist_matches_observation_space(num_ghosts: int) -> None:
+    """``initial_observation_dist`` returns an obs of the right shape per ghost count.
+
+    Purpose: Validates that ``initial_observation_dist`` produces an
+        observation tuple whose length matches ``num_ghosts``, regardless of
+        whether the env has 1 or 2 ghosts. Length mismatches would silently
+        misalign downstream particle-filter weight computations.
+
+    Given: A PacMan env with ``num_ghosts ∈ {1, 2}``.
+    When: ``initial_observation_dist().sample()`` is called.
+    Then: The returned observation is a tuple of length ``num_ghosts``, and
+        each element is itself a length-2 tuple of ints inside the maze
+        bounds.
+
+    Test type: unit
+    """
+    env = _build_small_env(num_ghosts=num_ghosts)
+    obs = env.initial_observation_dist().sample()[0]
+    assert isinstance(obs, tuple)
+    assert len(obs) == num_ghosts
+    for ghost_obs in obs:
+        assert isinstance(ghost_obs, tuple)
+        assert len(ghost_obs) == 2
+        row, col = ghost_obs
+        assert 0 <= row < env.maze_size[0]
+        assert 0 <= col < env.maze_size[1]

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp_features.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp_features.py
@@ -1,0 +1,601 @@
+"""Feature-driven tests for ``ContinuousPushPOMDP``.
+
+Targets gaps in :mod:`test_continuous_push_pomdp` and
+:mod:`test_continuous_push_native_equivalence` by exercising the **env-level**
+API contracts that are most likely to drift between the scalar and batch
+code paths or between the documented spec and the underlying C++ kernels.
+
+Coverage focus:
+
+* Reward components (distance penalty, goal bonus, obstacle penalty) at
+  feature-region boundaries.
+* ``is_terminal`` at the documented ``< 0.5`` boundary.
+* Sample / PDF consistency for the transition (robot slice) and observation
+  (object slice) at the env-level via 2-D histogram density match.
+* Scalar vs batch parity for ``observation_log_probability`` /
+  ``observation_log_probability_per_state`` (mirrors the asymmetry that
+  surfaced in the light-dark POMDP).
+* ``transition_log_probability`` underflow regime — exposes the
+  ``np.log(probs)`` flooring path.
+* ``initial_state_dist`` always produces collision-free, in-bounds samples.
+"""
+
+# pylint: disable=too-few-public-methods
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.push_pomdp.continuous_push_pomdp import (
+    ContinuousPushPOMDP,
+)
+
+
+def _make_env(**overrides) -> ContinuousPushPOMDP:
+    """Return a ``ContinuousPushPOMDP`` with overridable defaults."""
+    defaults: dict = {
+        "discount_factor": 0.99,
+        "grid_size": 10,
+        "push_threshold": 1.0,
+        "friction_coefficient": 0.3,
+        "max_push": 2.0,
+        "observation_noise": 0.1,
+        "robot_radius": 0.3,
+        "obstacle_penalty": -10.0,
+        "state_transition_cov_matrix": np.eye(2) * 0.04,
+    }
+    defaults.update(overrides)
+    return ContinuousPushPOMDP(**defaults)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Reward feature regions
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestRewardFeatureRegions:
+    """Exercise each branch of ``reward_batch_array`` independently."""
+
+    def test_reward_far_from_target_is_negative_distance(self):
+        """Reward equals -dist(object, target) when not at goal and no obstacle.
+
+        Purpose: Validates the baseline ``rewards = -dist_to_target`` branch
+            of ``_reward_batch_array`` when the goal bonus and obstacle
+            penalty are both inactive.
+
+        Given: An obstacle-free env with deterministic transitions (tiny
+            covariance, ``max_push=0`` so the object cannot move) and a
+            state where the object is far (>0.5) from the target.
+        When: ``reward_batch`` is called over many states sharing the same
+            object/target slice.
+        Then: Mean reward agrees with ``-||object - target||`` to within
+            0.05 (loose because tiny noise on the robot does not shift the
+            object slice when ``max_push=0``).
+
+        Test type: unit
+        """
+        env = _make_env(
+            state_transition_cov_matrix=np.eye(2) * 1e-12,
+            max_push=0.0,
+        )
+        state = np.array([2.0, 2.0, 3.0, 3.0, 9.0, 9.0])
+        states = np.tile(state, (32, 1))
+        rewards = env.reward_batch(states, np.array([0.0, 0.0]))
+        expected = -float(np.linalg.norm(state[2:4] - state[4:6]))
+        np.testing.assert_allclose(rewards.mean(), expected, atol=0.05)
+
+    def test_reward_includes_goal_bonus_when_object_at_target(self):
+        """Reward includes the +100 goal bonus when next-object is within 0.5.
+
+        Purpose: Validates the ``rewards[dist < 0.5] += 100`` branch.
+
+        Given: A state with the object pinned at the target and a covariance
+            small enough that the sampled next-object slice stays within
+            0.5 of the target.
+        When: ``reward`` is called.
+        Then: The reward is at least ``100 - 0.5`` (bonus minus the residual
+            distance penalty for any tiny drift).
+
+        Test type: unit
+        """
+        env = _make_env(
+            state_transition_cov_matrix=np.eye(2) * 1e-12,
+            max_push=0.0,
+        )
+        state = np.array([2.0, 2.0, 9.0, 9.0, 9.0, 9.0])
+        rew = env.reward(state, np.array([0.0, 0.0]))
+        assert rew > 100.0 - 0.5
+
+    def test_reward_obstacle_penalty_uses_pre_action_robot_plus_action(self):
+        """Obstacle penalty triggers when ``state[:2] + action`` lands inside obstacle.
+
+        Purpose: Validates that the obstacle penalty branch is keyed on the
+            **post-action** robot position (``state[:2] + action``) rather
+            than the sampled next-state robot, matching the documented
+            implementation.
+
+        Given: Two states differing only in robot position; one such that
+            ``robot + action`` enters an obstacle, the other safe; same
+            target/object so the distance penalty matches.
+        When: ``reward`` is called on each.
+        Then: ``rew_collide - rew_safe`` is approximately
+            ``obstacle_penalty`` (allowing slack for sample noise on the
+            distance term).
+
+        Test type: unit
+        """
+        env = _make_env(
+            obstacles=[(5.0, 5.0, 0.5)],
+            obstacle_penalty=-10.0,
+            state_transition_cov_matrix=np.eye(2) * 1e-12,
+            max_push=0.0,
+        )
+        # Robot at (4, 5) + action (1, 0) → (5, 5) which is inside obstacle
+        # AABB centred at (5,5) with half=0.5.
+        state_collide = np.array([4.0, 5.0, 1.0, 1.0, 9.0, 9.0])
+        # Robot at (1, 1) + action (1, 0) → (2, 1) far from obstacle.
+        state_safe = np.array([1.0, 1.0, 1.0, 1.0, 9.0, 9.0])
+        action = np.array([1.0, 0.0])
+        rew_collide = env.reward(state_collide, action)
+        rew_safe = env.reward(state_safe, action)
+        # Distance term cancels because object/target slices are identical.
+        diff = rew_collide - rew_safe
+        np.testing.assert_allclose(diff, env.obstacle_penalty, atol=0.05)
+
+    def test_reward_no_penalty_when_obstacle_list_empty(self):
+        """No obstacle penalty when ``self.obstacles`` is empty.
+
+        Purpose: Guards the ``if self.obstacles.shape[0] > 0`` short-circuit
+            in ``_reward_batch_array``.
+
+        Given: An env with no obstacles and an action that would otherwise
+            land the robot in an obstacle had one existed.
+        When: ``reward`` is called.
+        Then: The reward equals ``-dist_to_target`` within 0.05 (no penalty).
+
+        Test type: unit
+        """
+        env = _make_env(
+            state_transition_cov_matrix=np.eye(2) * 1e-12,
+            max_push=0.0,
+        )
+        state = np.array([4.0, 5.0, 1.0, 1.0, 9.0, 9.0])
+        rew = env.reward(state, np.array([1.0, 0.0]))
+        expected = -float(np.linalg.norm(state[2:4] - state[4:6]))
+        np.testing.assert_allclose(rew, expected, atol=0.05)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# is_terminal boundary
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestIsTerminalBoundary:
+    """Exercise ``is_terminal`` exactly at and on either side of dist=0.5."""
+
+    def test_is_terminal_just_inside_boundary(self):
+        """Object at distance 0.499 from target is terminal.
+
+        Purpose: Validates the ``< 0.5`` open-boundary semantics implemented
+            as ``dx*dx + dy*dy < 0.25``.
+
+        Given: An object placed at distance 0.499 from the target.
+        When: ``is_terminal`` is called.
+        Then: Returns ``True``.
+
+        Test type: unit
+        """
+        env = _make_env()
+        # 0.499 / sqrt(2) per axis → distance 0.499.
+        d = 0.499 / np.sqrt(2.0)
+        state = np.array([1.0, 1.0, 9.0 - d, 9.0 - d, 9.0, 9.0])
+        assert env.is_terminal(state)
+
+    def test_is_terminal_just_outside_boundary(self):
+        """Object at distance 0.501 from target is NOT terminal.
+
+        Purpose: Validates the upper side of the ``< 0.5`` boundary.
+
+        Given: An object at distance 0.501 from the target.
+        When: ``is_terminal`` is called.
+        Then: Returns ``False``.
+
+        Test type: unit
+        """
+        env = _make_env()
+        d = 0.501 / np.sqrt(2.0)
+        state = np.array([1.0, 1.0, 9.0 - d, 9.0 - d, 9.0, 9.0])
+        assert not env.is_terminal(state)
+
+    def test_is_terminal_exactly_at_boundary_is_not_terminal(self):
+        """Object exactly at distance 0.5 is NOT terminal (strict ``<``).
+
+        Purpose: Validates that ``is_terminal`` uses a strict-less-than
+            comparison rather than ``<=``.
+
+        Given: ``dx*dx + dy*dy == 0.25`` exactly.
+        When: ``is_terminal`` is called.
+        Then: Returns ``False``.
+
+        Test type: unit
+        """
+        env = _make_env()
+        # dx=0.3, dy=0.4 → dx^2+dy^2 = 0.25 exactly.
+        state = np.array([1.0, 1.0, 9.0 - 0.3, 9.0 - 0.4, 9.0, 9.0])
+        assert not env.is_terminal(state)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Sample / PDF consistency at the env-API level
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _histogram2d_density_match(
+    samples_xy: np.ndarray,
+    pdf_fn,
+    bin_centers_x: np.ndarray,
+    bin_centers_y: np.ndarray,
+    bin_width: float,
+) -> float:
+    """Mass-weighted L1 distance between empirical and analytic density.
+
+    ``samples_xy`` shape ``(N, 2)``; ``pdf_fn(grid_xy)`` returns analytic
+    density values at the bin-centre 2-D grid. Returns
+    ``sum_i p_i * |emp_i - p_i| / sum_i p_i^2`` — a relative L1 weighted by
+    the analytic mass (so far-tail bins do not dominate).
+    """
+    n_samples = samples_xy.shape[0]
+    edges_x = np.concatenate(
+        [bin_centers_x - bin_width / 2.0, [bin_centers_x[-1] + bin_width / 2.0]]
+    )
+    edges_y = np.concatenate(
+        [bin_centers_y - bin_width / 2.0, [bin_centers_y[-1] + bin_width / 2.0]]
+    )
+    counts, _, _ = np.histogram2d(samples_xy[:, 0], samples_xy[:, 1], bins=[edges_x, edges_y])
+    empirical = counts / (n_samples * bin_width * bin_width)
+    grid_x, grid_y = np.meshgrid(bin_centers_x, bin_centers_y, indexing="ij")
+    analytic = pdf_fn(np.stack([grid_x.ravel(), grid_y.ravel()], axis=1)).reshape(
+        len(bin_centers_x), len(bin_centers_y)
+    )
+    weights = analytic
+    weight_total = float(weights.sum())
+    if weight_total <= 0.0:
+        return float("inf")
+    return float((weights * np.abs(empirical - analytic)).sum() / weight_total)
+
+
+class TestSamplePDFConsistency:
+    """Empirical samples agree with the documented analytic densities."""
+
+    def test_observation_object_slice_matches_isotropic_gaussian(self):
+        """Observation object slice histogram matches a 2-D isotropic Gaussian.
+
+        Purpose: Validates that ``sample_observation`` and
+            ``observation_log_probability`` are consistent at the env level.
+            The observation model adds isotropic Gaussian noise of std
+            ``observation_noise`` to the **object** slice and clamps to
+            ``[0, grid_size - 1]``. With the centre well inside the box,
+            clamp is inactive.
+
+        Given: ``next_state = (5, 5, 5, 5, 9, 9)``,
+            ``observation_noise = 0.3``, and ``N = 20_000`` env-level
+            observation samples.
+        When: ``env.sample_observation`` is called once with ``n_samples=N``
+            and the empirical 21x21 histogram on the object slice is
+            compared against ``exp(observation_log_probability)`` evaluated
+            at each bin centre.
+        Then: Mass-weighted L1 distance < 0.10.
+
+        Test type: unit
+        """
+        rng = np.random.default_rng(0)
+        env = _make_env(observation_noise=0.3)
+        next_state = np.array([5.0, 5.0, 5.0, 5.0, 9.0, 9.0])
+        action = np.array([0.5, 0.0])
+        n_samples = 20_000
+        # Use legacy seed for the C++ RNG which drives the observation noise.
+        from POMDPPlanners.environments.push_pomdp import (
+            _native,
+        )  # pylint: disable=import-outside-toplevel
+
+        _native.set_seed(int(rng.integers(0, 2**31 - 1)))
+        samples = env.sample_observation(next_state, action, n_samples=n_samples)
+        samples_arr = np.stack(list(samples), axis=0)
+        # Object slice: cols 2..3.
+        object_samples = samples_arr[:, 2:4]
+
+        # 21 bins centred at the mean ±3 sigma.
+        sigma = env.observation_noise
+        centres = np.linspace(5.0 - 3.0 * sigma, 5.0 + 3.0 * sigma, 21)
+        bin_width = float(centres[1] - centres[0])
+
+        def pdf_fn(grid_xy):
+            # Pad to (N, 6) observations: only the object slice is read by
+            # ``observation_log_probability``.
+            n_grid = grid_xy.shape[0]
+            obs_batch = np.tile(next_state, (n_grid, 1))
+            obs_batch[:, 2:4] = grid_xy
+            log_prob = env.observation_log_probability(next_state, action, obs_batch)
+            return np.exp(log_prob)
+
+        l1 = _histogram2d_density_match(object_samples, pdf_fn, centres, centres, bin_width)
+        assert l1 < 0.10, f"observation sample/pdf mismatch: weighted L1 = {l1:.4f}"
+
+    def test_transition_robot_slice_matches_gaussian_in_open_region(self):
+        """Robot transition histogram matches the 2-D Gaussian in the open region.
+
+        Purpose: Validates that ``sample_next_state`` and
+            ``transition_log_probability`` are consistent at the env level
+            for the robot slice when the deterministic post-sample
+            geometry (wall resolve, grid clamp, push) is **inactive**.
+
+        Given: A state with the robot well inside the grid and far from
+            obstacles, and a tiny action so the noise dominates. With no
+            obstacles and a centred robot, ``resolve_circle_wall_collision``
+            is a no-op and the grid clamp is inactive — so the transition
+            density on the robot slice equals an isotropic Gaussian centred
+            at ``robot + action``.
+        When: ``env.sample_next_state`` is called ``N=20_000`` times via
+            the batch path and the 21x21 histogram on the robot slice is
+            compared against ``exp(transition_log_probability)`` at the bin
+            centres (which constructs a full (state, action, candidate)
+            evaluation per bin).
+        Then: Mass-weighted L1 distance < 0.10.
+
+        Test type: unit
+        """
+        env = _make_env(
+            state_transition_cov_matrix=np.eye(2) * 0.04,
+            obstacles=None,
+        )
+        state = np.array([5.0, 5.0, 1.0, 1.0, 9.0, 9.0])
+        action = np.array([0.1, 0.0])
+        n_samples = 80_000
+        from POMDPPlanners.environments.push_pomdp import (
+            _native,
+        )  # pylint: disable=import-outside-toplevel
+
+        _native.set_seed(7)
+        samples = env.sample_next_state(state, action, n_samples=n_samples)
+        samples_arr = np.stack(list(samples), axis=0)
+        robot_samples = samples_arr[:, :2]
+
+        # 21 bins around the post-action mean, ±3 sigma.
+        sigma = float(np.sqrt(env.state_transition_cov_matrix[0, 0]))
+        mean = state[:2] + action
+        centres_x = np.linspace(mean[0] - 3.0 * sigma, mean[0] + 3.0 * sigma, 21)
+        centres_y = np.linspace(mean[1] - 3.0 * sigma, mean[1] + 3.0 * sigma, 21)
+        bin_width = float(centres_x[1] - centres_x[0])
+
+        def pdf_fn(grid_xy):
+            n_grid = grid_xy.shape[0]
+            candidates = np.tile(state, (n_grid, 1))
+            candidates[:, 0] = grid_xy[:, 0]
+            candidates[:, 1] = grid_xy[:, 1]
+            log_prob = env.transition_log_probability(state, action, candidates)
+            return np.exp(log_prob)
+
+        l1 = _histogram2d_density_match(robot_samples, pdf_fn, centres_x, centres_y, bin_width)
+        assert l1 < 0.10, f"transition sample/pdf mismatch: weighted L1 = {l1:.4f}"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Scalar vs batch parity for observation_log_probability
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestScalarBatchObservationLogProbParity:
+    """Mirror the light-dark asymmetry probe at the env API level.
+
+    The scalar ``observation_log_probability`` calls
+    ``_native.observation_log_probability_step``; the batch
+    ``observation_log_probability_per_state`` calls
+    ``ContinuousPushObservationCpp.batch_log_likelihood``. Both compute the
+    same isotropic-Gaussian log-pdf on the object slice — these tests pin
+    them to bit-exact agreement so any future flooring / clamp drift is
+    caught.
+    """
+
+    @pytest.mark.parametrize(
+        "obj_offset",
+        [
+            np.array([0.0, 0.0]),  # zero-distance: maximum density
+            np.array([0.05, 0.0]),  # near-typical
+            np.array([1.0, 1.0]),  # far tail
+            np.array([5.0, 5.0]),  # extreme tail (probability underflow regime)
+        ],
+        ids=["zero", "near", "far", "extreme"],
+    )
+    def test_scalar_matches_batch_for_single_observation(self, obj_offset):
+        """Scalar and batch return the same log-pdf for one (state, obs).
+
+        Purpose: Catches any flooring / clamp asymmetry between the scalar
+            and batch observation log-pdf paths (mirrors a real bug found
+            in the light-dark POMDP where scalar floored at log(1e-300) but
+            batch did not).
+
+        Given: A fixed ``next_state`` and an observation displaced from it
+            on the object slice. The batch path is called with a
+            ``(1, 6)`` particles input and the scalar with a single
+            observation row.
+        When: Both ``observation_log_probability`` and
+            ``observation_log_probability_per_state`` are evaluated.
+        Then: Their length-1 outputs agree to ``rtol=0`` ``atol=1e-12``.
+
+        Test type: unit
+        """
+        env = _make_env(observation_noise=0.3)
+        next_state = np.array([5.0, 5.0, 5.0, 5.0, 9.0, 9.0])
+        action = np.array([0.5, 0.5])
+        observation = next_state.copy()
+        observation[2:4] += obj_offset
+
+        scalar = env.observation_log_probability(next_state, action, observation)
+        batch = env.observation_log_probability_per_state(
+            next_state.reshape(1, -1), action, observation
+        )
+        assert scalar.shape == (1,)
+        assert batch.shape == (1,)
+        np.testing.assert_allclose(scalar[0], batch[0], rtol=0.0, atol=1e-12)
+
+    def test_scalar_agrees_with_batch_across_grid(self):
+        """Scalar over many obs == batch over many particles (transposed).
+
+        Purpose: Sweeps the full obs/particle grid: for a fixed
+            ``next_state`` and a list of observations, the scalar path
+            returns one log-prob per observation; for a fixed observation
+            and a list of next-states, the batch path returns one log-prob
+            per particle. By symmetry of the Gaussian (the particle index
+            and the observation index swap roles), a diagonal sweep — one
+            ``next_state`` per observation — must produce the same value
+            on both paths.
+
+        Given: ``N=64`` independent ``(next_state, observation)`` pairs
+            with random offsets.
+        When: For each pair, ``observation_log_probability(next_state, ...,
+            observation)`` and
+            ``observation_log_probability_per_state(next_state, ...,
+            observation)`` are compared.
+        Then: All pairwise log-probabilities agree within ``atol=1e-12``.
+
+        Test type: unit
+        """
+        rng = np.random.default_rng(123)
+        env = _make_env(observation_noise=0.2)
+        action = np.array([0.0, 0.0])
+        n_pairs = 64
+        next_states = np.tile([3.0, 3.0, 4.0, 4.0, 8.0, 8.0], (n_pairs, 1)).astype(float)
+        observations = next_states.copy()
+        # Perturb the object slice on both sides independently.
+        next_states[:, 2:4] += rng.normal(scale=0.5, size=(n_pairs, 2))
+        observations[:, 2:4] += rng.normal(scale=0.5, size=(n_pairs, 2))
+
+        scalar_logs = np.empty(n_pairs)
+        batch_logs = np.empty(n_pairs)
+        for i in range(n_pairs):
+            scalar_logs[i] = env.observation_log_probability(
+                next_states[i], action, observations[i]
+            )[0]
+            batch_logs[i] = env.observation_log_probability_per_state(
+                next_states[i].reshape(1, -1), action, observations[i]
+            )[0]
+        np.testing.assert_allclose(scalar_logs, batch_logs, rtol=0.0, atol=1e-12)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# transition_log_probability underflow regime
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestTransitionLogProbabilityUnderflow:
+    """Document the behavior of ``transition_log_probability`` deep in the tail.
+
+    Unlike the observation path, the transition log-prob goes through
+    ``np.log(kernel.probability(...))``. ``kernel.probability`` returns the
+    linear PDF, so for next-states many sigmas away the probability
+    underflows to 0 and ``np.log(0) = -inf``. The corresponding scalar /
+    batch observation paths use the raw log-pdf and do **not** underflow
+    in the same regime. These tests document that asymmetry so future
+    refactors are constrained.
+    """
+
+    def test_finite_at_typical_displacement(self):
+        """Log-prob is finite for next-states within a few sigma.
+
+        Purpose: Sanity check that the typical-regime log-prob is finite.
+
+        Given: A small covariance and a candidate next-state displaced by
+            one sigma on the robot slice.
+        When: ``transition_log_probability`` is called.
+        Then: The returned log-prob is finite.
+
+        Test type: unit
+        """
+        env = _make_env(state_transition_cov_matrix=np.eye(2) * 0.04)
+        state = np.array([4.0, 4.0, 5.0, 5.0, 9.0, 9.0])
+        action = np.array([0.5, 0.0])
+        sigma = float(np.sqrt(env.state_transition_cov_matrix[0, 0]))
+        candidate = np.array(
+            [state[0] + action[0] + sigma, state[1] + action[1], 5.0, 5.0, 9.0, 9.0]
+        )
+        log_prob = env.transition_log_probability(state, action, [candidate])
+        assert np.isfinite(log_prob[0])
+
+    def test_underflow_to_neg_inf_far_tail(self):
+        """Far-tail next-state produces ``-inf`` from ``np.log(0)``.
+
+        Purpose: Documents the current behavior of
+            ``transition_log_probability`` deep in the tail. This is *not*
+            an asymmetry bug — there is no batch alternative for the
+            transition log-prob — but pinning the behavior guards against
+            silent introduction of a flooring path that would diverge from
+            the observation handling.
+
+        Given: A 6 sigma displacement on the robot slice; the linear PDF
+            value is below 1e-300 so ``np.log(probs)`` returns ``-inf``.
+        When: ``transition_log_probability`` is called.
+        Then: The result is ``-inf``.
+
+        Test type: unit
+        """
+        env = _make_env(state_transition_cov_matrix=np.eye(2) * 0.0001)
+        state = np.array([4.0, 4.0, 5.0, 5.0, 9.0, 9.0])
+        action = np.array([0.5, 0.0])
+        sigma = float(np.sqrt(env.state_transition_cov_matrix[0, 0]))
+        candidate = np.array(
+            [state[0] + action[0] + 60.0 * sigma, state[1] + action[1], 5.0, 5.0, 9.0, 9.0]
+        )
+        log_prob = env.transition_log_probability(state, action, [candidate])
+        assert np.isneginf(log_prob[0])
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Initial-state distribution sanity
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestInitialStateDistribution:
+    """Random initial states must be in-bounds and collision-free."""
+
+    def test_random_initial_states_robot_collision_free(self):
+        """All random-initial robot positions clear all obstacles.
+
+        Purpose: Validates ``_RandomInitialStateDistribution._generate_robot_position``
+            actually rejects colliding samples (only the random-initial
+            constructor branch is hit when ``initial_state is None``).
+
+        Given: An env with a single obstacle at the centre and 50 random
+            initial states.
+        When: Each sample is checked against the obstacle via
+            ``_is_circle_colliding_with_obstacle``.
+        Then: No sample is in collision.
+
+        Test type: unit
+        """
+        env = _make_env(obstacles=[(5.0, 5.0, 0.5)])
+        np.random.seed(0)
+        for _ in range(50):
+            state = env.initial_state_dist().sample()[0]
+            # pylint: disable=protected-access
+            assert not env._is_circle_colliding_with_obstacle(state[:2], env.robot_radius)
+
+    def test_random_initial_states_in_bounds(self):
+        """All random-initial robot/object positions are inside the grid.
+
+        Purpose: Validates the in-bounds spec for the random-initial
+            distribution.
+
+        Given: An obstacle-free env and 50 random initial states.
+        When: The robot and object slices are inspected.
+        Then: Robot lies in ``[radius, grid_size - 1 - radius]`` and the
+            object lies in ``[0, grid_size - 1]`` on both axes.
+
+        Test type: unit
+        """
+        env = _make_env()
+        np.random.seed(1)
+        for _ in range(50):
+            state = env.initial_state_dist().sample()[0]
+            assert env.robot_radius <= state[0] <= env.grid_size - 1 - env.robot_radius
+            assert env.robot_radius <= state[1] <= env.grid_size - 1 - env.robot_radius
+            assert 0.0 <= state[2] <= env.grid_size - 1
+            assert 0.0 <= state[3] <= env.grid_size - 1

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_feature_driven.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_feature_driven.py
@@ -1,0 +1,661 @@
+"""Feature-driven bug-hunting tests for PushPOMDP (discrete).
+
+This module complements ``test_push_pomdp.py`` with feature-driven tests
+that target asymmetries and edge cases between scalar and batch APIs,
+boundary semantics for terminal/obstacle-collision predicates, and the
+sample/PDF pair on the observation model.
+
+The test file was created after a sibling skill run on the light-dark
+POMDP exposed a real asymmetry between
+``observation_log_probability`` (scalar, floored) and
+``observation_log_probability_per_state`` (batch, un-floored).  The
+tests below specifically check that no analogous asymmetry exists in
+the Push POMDP and exercise other features that lack dedicated coverage.
+"""
+
+# pylint: disable=protected-access  # Tests need to access protected helpers.
+
+from typing import List
+
+import numpy as np
+
+from POMDPPlanners.environments.push_pomdp import PushPOMDP, _native as push_native
+
+
+_ACTION_NAMES: List[str] = ["up", "down", "right", "left"]
+
+
+def _make_default_env(**overrides: object) -> PushPOMDP:
+    """Build a PushPOMDP with deterministic-friendly defaults.
+
+    Helper used across multiple tests so each test reads one focused
+    setup line rather than a wall of constructor arguments.
+    """
+    params: dict = {
+        "discount_factor": 0.95,
+        "grid_size": 10,
+        "push_threshold": 1.0,
+        "friction_coefficient": 0.3,
+        "observation_noise": 0.1,
+        "obstacles": [(3.0, 3.0), (7.0, 7.0)],
+        "obstacle_radius": 0.5,
+        "obstacle_penalty": -10.0,
+        "transition_error_prob": 0.0,
+    }
+    params.update(overrides)
+    return PushPOMDP(**params)  # type: ignore[arg-type]
+
+
+# ----------------------------------------------------------------------
+# Reward feature regions
+# ----------------------------------------------------------------------
+
+
+def test_reward_at_target_includes_terminal_bonus() -> None:
+    """Reward includes +100 bonus when next-state object is within 0.5 of target.
+
+    Purpose: Validates that ``_reward_from_next_state`` adds the +100
+        terminal bonus exactly when the object distance to target is
+        below 0.5, and that the bonus is omitted just outside that band.
+
+    Given: A PushPOMDP without obstacles. Two next-states that share the
+        same robot position but differ only in the object-target
+        distance: one with object exactly at the target (distance 0),
+        another with object 0.5 units away (distance == 0.5).
+    When: ``_reward_from_next_state`` is called for both.
+    Then: The first returns +100.0 (bonus) - 0.0 (distance) = 100.0.
+        The second returns -0.5 (no bonus, because 0.5 is NOT < 0.5).
+
+    Test type: unit
+    """
+    env = _make_default_env(obstacles=None)
+    state = np.array([5.0, 5.0, 5.0, 5.0, 9.0, 9.0])
+
+    next_at_target = np.array([5.0, 5.0, 9.0, 9.0, 9.0, 9.0])
+    reward_at_target = env._compute_reward(state, "up", next_at_target)
+    assert reward_at_target == 100.0
+
+    next_just_outside = np.array([5.0, 5.0, 9.5, 9.0, 9.0, 9.0])
+    reward_just_outside = env._compute_reward(state, "up", next_just_outside)
+    assert np.isclose(reward_just_outside, -0.5)
+
+
+def test_reward_obstacle_penalty_uses_realised_position_not_intended() -> None:
+    """Obstacle penalty triggers off the REALISED robot position, not the intended move.
+
+    Purpose: Pins the corrected design — ``_reward_from_next_state`` applies
+        ``obstacle_penalty`` based on the realised ``next_state[:2]``, not on
+        ``state[:2] + action_dxy``. When a move is blocked by an obstacle the
+        robot stays put, the realised position is clear, and no penalty fires.
+
+    Given: A PushPOMDP with one obstacle at (3, 3), radius 0.5. Robot at
+        (2, 3); action "right" intends (3, 3) which is inside the obstacle,
+        but the transition blocks the move so the robot stays at (2, 3).
+    When: ``env.reward(state, "right")`` is called.
+    Then: The reward equals the bare ``-distance`` term — no obstacle
+        penalty (because the realised position is clear).
+
+    Test type: unit
+    """
+    env = _make_default_env(obstacles=[(3.0, 3.0)])
+    state = np.array([2.0, 3.0, 5.0, 5.0, 9.0, 9.0])
+
+    next_state = env.sample_next_state(state, "right")
+    assert np.allclose(next_state[:2], state[:2]), "Robot should stay put due to collision"
+
+    reward = env.reward(state, "right", next_state=next_state)
+    distance = float(np.linalg.norm(state[2:4] - state[4:6]))
+    expected = -distance
+    assert np.isclose(reward, expected), f"Expected {expected}, got {reward}"
+
+
+# ----------------------------------------------------------------------
+# is_terminal boundary
+# ----------------------------------------------------------------------
+
+
+def test_is_terminal_strictly_less_than_half_unit() -> None:
+    """is_terminal uses strict ``< 0.25`` on squared distance, NOT ``<=``.
+
+    Purpose: Pins down the boundary semantics of ``is_terminal`` so a
+        future change from ``<`` to ``<=`` (or vice versa) is caught.
+
+    Given: A state where the object-target squared distance equals
+        exactly 0.25 (object 0.5 units away from target).
+    When: ``env.is_terminal(state)`` is queried.
+    Then: Returns False (because 0.25 < 0.25 is False).
+        And for distance epsilon under 0.5, returns True.
+
+    Test type: unit
+    """
+    env = _make_default_env()
+
+    state_exactly_half = np.array([1.0, 1.0, 9.0, 8.5, 9.0, 9.0])
+    assert env.is_terminal(state_exactly_half) is False
+
+    eps = 1e-6
+    state_just_under = np.array([1.0, 1.0, 9.0, 9.0 - 0.5 + eps, 9.0, 9.0])
+    assert env.is_terminal(state_just_under) is True
+
+
+# ----------------------------------------------------------------------
+# Observation log-probability: scalar vs batch parity (the light-dark bug)
+# ----------------------------------------------------------------------
+
+
+def test_observation_log_probability_scalar_matches_batch_kernel() -> None:
+    """Scalar ``observation_log_probability`` equals batch ``per_state`` form.
+
+    Purpose: Mirror of the asymmetry found in the light-dark POMDP:
+        scalar floored at log(1e-300) while the batch path returned the
+        un-floored kernel.  This test asserts no such asymmetry exists
+        in the Push POMDP for a fixed observation evaluated against many
+        next-states (or vice versa).
+
+    Given: A PushPOMDP with observation_noise=0.1 and no obstacles.  A
+        fixed observation and a fixed next-state.
+    When: ``env.observation_log_probability(next_state, action,
+        [observation])`` (scalar path) and
+        ``env.observation_log_probability_per_state([next_state],
+        action, observation)`` (batch path) are both evaluated.
+    Then: Both return the same value (single Gaussian log-pdf at the
+        same point).  Tested across a sweep of (next_state, observation)
+        pairs that include points far from the mean (where the
+        light-dark bug manifests via under/un-flooring).
+
+    Test type: unit
+    """
+    env = _make_default_env(obstacles=None, observation_noise=0.1)
+
+    rng = np.random.default_rng(seed=2024)
+    next_states_grid = rng.uniform(0.0, 9.0, size=(20, 6))
+    observations_grid = rng.uniform(0.0, 9.0, size=(20, 6))
+
+    for next_state in next_states_grid:
+        for observation in observations_grid:
+            scalar_log_prob = env.observation_log_probability(next_state, "right", [observation])
+            batch_log_prob = env.observation_log_probability_per_state(
+                [next_state], "right", observation
+            )
+
+            assert scalar_log_prob.shape == (1,)
+            assert batch_log_prob.shape == (1,)
+            np.testing.assert_allclose(
+                scalar_log_prob,
+                batch_log_prob,
+                atol=1e-12,
+                err_msg=(
+                    f"Scalar and batch observation log-prob disagree: "
+                    f"next_state={next_state}, observation={observation}, "
+                    f"scalar={scalar_log_prob[0]}, batch={batch_log_prob[0]}"
+                ),
+            )
+
+
+def test_observation_log_probability_extreme_far_observation_no_floor_asymmetry() -> None:
+    """At extreme distance both scalar and batch return the same un-floored value.
+
+    Purpose: Specifically targets the light-dark-style asymmetry where
+        the scalar path could clip ``log(p)`` at ``log(1e-300)`` while
+        the batch path would return the raw kernel output.  An extreme
+        observation (object position 1e6 away from next_state's object
+        position) drives the kernel into log-prob territory far below
+        ``log(1e-300) ≈ -690``.
+
+    Given: A PushPOMDP and a next_state with object at (5, 5); an
+        observation with object at (1e6, 1e6).  At that distance the
+        true Gaussian log-pdf is on the order of -1e13.
+    When: Both scalar and batch log-prob APIs evaluate this pair.
+    Then: Both return identical, finite (non-NaN) values that are far
+        below -700 (i.e. neither path floors).  If the scalar path is
+        floored, this test fails.
+
+    Test type: unit
+    """
+    env = _make_default_env(obstacles=None, observation_noise=0.1)
+
+    next_state = np.array([5.0, 5.0, 5.0, 5.0, 9.0, 9.0])
+    extreme_obs = np.array([5.0, 5.0, 1.0e6, 1.0e6, 9.0, 9.0])
+
+    scalar_lp = float(env.observation_log_probability(next_state, "right", [extreme_obs])[0])
+    batch_lp = float(
+        env.observation_log_probability_per_state([next_state], "right", extreme_obs)[0]
+    )
+
+    assert np.isfinite(scalar_lp), f"Scalar log-prob should be finite, got {scalar_lp}"
+    assert np.isfinite(batch_lp), f"Batch log-prob should be finite, got {batch_lp}"
+    assert scalar_lp < -1.0e10, "Far-tail log-prob should be very negative, not floored"
+    np.testing.assert_allclose(scalar_lp, batch_lp, atol=1e-3)
+
+
+# ----------------------------------------------------------------------
+# Observation: sample-vs-PDF consistency (Gaussian on object slice)
+# ----------------------------------------------------------------------
+
+
+def test_sample_observation_matches_log_probability_density_2d_gaussian() -> None:
+    """Empirical density from samples matches closed-form log-prob (2-D Gaussian).
+
+    Purpose: Validates the sample/PDF pair for ``sample_observation`` and
+        ``observation_log_probability`` under the 2-D Gaussian noise on
+        the object slice (cols 2:4).  An asymmetry between sampler and
+        PDF (e.g. wrong variance, missing factor of 2*pi) would surface
+        as a Wilson-CI violation.
+
+    Given: A PushPOMDP with grid_size large enough that clipping is
+        negligible (grid_size=100) and observation_noise=0.5 (small
+        relative to grid).  next_state object centred at (50, 50).
+        N=5000 observations sampled.
+    When: We bin the sampled object positions (col 2 only — the
+        marginal in x) into a histogram and compare the empirical bin
+        probability to the integral of the predicted PDF over each bin
+        (computed from ``observation_log_probability`` evaluated at bin
+        centres, multiplied by bin width).
+    Then: Each bin's empirical probability is within 3/sqrt(N)
+        (Wilson-style) of the predicted probability.
+
+    Test type: unit
+    """
+    env = PushPOMDP(
+        discount_factor=0.95,
+        grid_size=100,
+        observation_noise=0.5,
+        transition_error_prob=0.0,
+    )
+    next_state = np.array([50.0, 50.0, 50.0, 50.0, 99.0, 99.0])
+
+    np.random.seed(20240426)
+    n_samples = 5000
+    samples = env.sample_observation(next_state, "right", n_samples=n_samples)
+    sample_arr = np.array(samples)
+    object_x_samples = sample_arr[:, 2]
+
+    bin_edges = np.linspace(48.0, 52.0, 9)  # 8 bins centred on 50
+    bin_centres = 0.5 * (bin_edges[:-1] + bin_edges[1:])
+    bin_width = bin_edges[1] - bin_edges[0]
+
+    empirical_counts, _ = np.histogram(object_x_samples, bins=bin_edges)
+    empirical_probs = empirical_counts / n_samples
+
+    # Build full observation rows at each bin centre to feed to the
+    # closed-form log-prob (object_y fixed at the mean to isolate the
+    # x-marginal; the kernel is separable so this gives exactly the
+    # 1-D Gaussian times a constant we factor out below).
+    predicted_marginal_pdf = (
+        1.0
+        / (env.observation_noise * np.sqrt(2.0 * np.pi))
+        * np.exp(-0.5 * ((bin_centres - 50.0) / env.observation_noise) ** 2)
+    )
+    predicted_probs = predicted_marginal_pdf * bin_width
+
+    tol = 3.0 / np.sqrt(n_samples)
+    diffs = np.abs(empirical_probs - predicted_probs)
+    assert np.all(diffs < tol), (
+        f"Sample/PDF Wilson check failed: max diff {np.max(diffs)} "
+        f">= tol {tol}; empirical={empirical_probs}, predicted={predicted_probs}"
+    )
+
+
+# ----------------------------------------------------------------------
+# Batch vs scalar transition parity (deterministic path)
+# ----------------------------------------------------------------------
+
+
+def test_sample_next_state_batch_matches_scalar_deterministic() -> None:
+    """Batch ``sample_next_state_batch`` agrees byte-exactly with scalar path.
+
+    Purpose: Validates that ``PushVectorizedUpdater.batch_transition``
+        (the engine behind ``sample_next_state_batch``) produces results
+        identical to ``_sample_one_next_state`` when
+        ``transition_error_prob=0`` (so no RNG is involved).  Any
+        divergence in collision-radius semantics (``<`` vs ``<=``),
+        clipping, or push-threshold comparison would surface here.
+
+    Given: A PushPOMDP with obstacles and ``transition_error_prob=0``.
+        A diverse batch of 200 random states and one fixed action.
+    When: ``sample_next_state_batch(states, action)`` and a scalar loop
+        ``[sample_next_state(s, action) for s in states]`` are both
+        evaluated.
+    Then: Every row of the batch result equals the corresponding scalar
+        result exactly (atol=1e-12).
+
+    Test type: unit
+    """
+    env = _make_default_env(obstacles=[(3.0, 3.0), (7.0, 7.0)])
+
+    rng = np.random.default_rng(seed=42)
+    states = rng.uniform(0.0, 9.0, size=(200, 6))
+    states[:, 4:6] = 9.0  # Fix target.
+
+    for action in _ACTION_NAMES:
+        batch_next = env.sample_next_state_batch(states, action)
+        scalar_next = np.array([env.sample_next_state(s, action) for s in states])
+
+        np.testing.assert_allclose(
+            batch_next,
+            scalar_next,
+            atol=1e-12,
+            err_msg=f"Batch vs scalar transition mismatch for action={action}",
+        )
+
+
+def test_sample_next_state_batch_push_threshold_boundary() -> None:
+    """Batch path uses ``<`` (strict) on push-threshold, matching scalar path.
+
+    Purpose: Pins down the push-threshold comparison.  Scalar path uses
+        ``dist_sq < push_threshold_sq`` (strict).  Batch path uses
+        ``dist_to_obj < self.push_threshold`` (strict).  This test
+        verifies both yield the same answer at the exact boundary.
+
+    Given: A PushPOMDP with push_threshold=1.0 and friction=0.3.  Robot
+        positioned exactly 1.0 unit away from the object.  Action
+        "right" attempts to move the robot directly toward the object.
+    When: Batch and scalar transitions are computed.
+    Then: Both produce identical next-states.  The object's position
+        determines whether a strict-less-than at exactly 1.0 means "no
+        push" (the documented behaviour).  This test asserts the two
+        APIs agree on whatever the boundary semantics are.
+
+    Test type: unit
+    """
+    env = _make_default_env(obstacles=None, push_threshold=1.0, friction_coefficient=0.3)
+
+    boundary_state = np.array([2.0, 5.0, 3.0, 5.0, 9.0, 9.0])
+    states = np.tile(boundary_state, (10, 1))
+
+    batch_next = env.sample_next_state_batch(states, "right")
+    scalar_next = env.sample_next_state(boundary_state, "right")
+
+    for row in batch_next:
+        np.testing.assert_allclose(
+            row,
+            scalar_next,
+            atol=1e-12,
+            err_msg=f"Batch row diverges at push-threshold boundary: {row} vs {scalar_next}",
+        )
+
+
+# ----------------------------------------------------------------------
+# Reward batch obstacle-penalty parity
+# ----------------------------------------------------------------------
+
+
+def test_reward_batch_obstacle_radius_boundary_matches_scalar() -> None:
+    """Batch and scalar obstacle-penalty agree at the exact radius boundary.
+
+    Purpose: Both ``_obstacle_penalty_batch`` and the scalar
+        ``_is_colliding_with_obstacle_scalar`` use ``<=`` against the
+        squared radius, which is the *only* consistent choice. This
+        test confirms they agree when the intended position lies
+        exactly on the obstacle radius (squared distance == r^2).
+
+    Given: A PushPOMDP with obstacle at (3, 3), radius 0.5,
+        friction_coefficient=0.0 and transition_error_prob=0 (so the
+        transition is fully deterministic).  Robot at (2.5, 3.0):
+        action "right" intends (3.5, 3.0) which is at squared distance
+        0.25 from the obstacle centre — exactly on the boundary.
+    When: ``reward_batch`` is called on a batch of 5 copies and
+        ``reward`` on one scalar.
+    Then: Both yield the same reward (same obstacle-penalty decision).
+
+    Test type: unit
+    """
+    env = _make_default_env(
+        obstacles=[(3.0, 3.0)],
+        obstacle_radius=0.5,
+        friction_coefficient=0.0,
+    )
+    state = np.array([2.5, 3.0, 6.0, 6.0, 9.0, 9.0])
+
+    batch_states = np.tile(state, (5, 1))
+    np.random.seed(0)
+    batch_rewards = env.reward_batch(batch_states, "right")
+    np.random.seed(0)
+    scalar_reward = env.reward(state, "right")
+
+    np.testing.assert_allclose(
+        batch_rewards,
+        scalar_reward,
+        atol=1e-12,
+        err_msg=(
+            f"Batch and scalar reward disagree at obstacle radius boundary: "
+            f"batch={batch_rewards}, scalar={scalar_reward}"
+        ),
+    )
+
+
+# ----------------------------------------------------------------------
+# transition_log_probability: error path distribution sums to 1
+# ----------------------------------------------------------------------
+
+
+def test_transition_log_probability_distribution_sums_to_one_with_error() -> None:
+    """transition_log_probability gives probabilities that sum to 1 across distinct outcomes.
+
+    Purpose: Validates the closed-form mixture formula in
+        ``transition_log_probability`` when ``transition_error_prob>0``:
+        the total mass over the at-most-4 distinct intended outcomes
+        (for the 4 actions) sums exactly to 1.0.  A mistake in the
+        ``num_error_actions`` denominator or in the ``error_match_count``
+        accumulator would break this invariant.
+
+    Given: A PushPOMDP with no obstacles, ``transition_error_prob=0.5``,
+        and a state where the 4 actions yield 4 distinct next-states
+        (robot in the interior of the grid; no friction; no pushing).
+    When: We enumerate the 4 distinct intended next-states and sum the
+        probabilities ``np.exp(transition_log_probability(...))``.
+    Then: The sum equals 1.0 exactly (within 1e-12).
+
+    Test type: unit
+    """
+    env = _make_default_env(
+        obstacles=None,
+        push_threshold=0.0,  # Disable pushing — keep object fixed.
+        friction_coefficient=0.0,
+        transition_error_prob=0.5,
+    )
+    state = np.array([5.0, 5.0, 7.5, 7.5, 9.0, 9.0])
+
+    distinct_next_states = [
+        env._compute_next_state_for_action(state, action) for action in env.get_actions()
+    ]
+
+    # Action "right" is the intended action for this experiment.
+    log_probs = env.transition_log_probability(state, "right", distinct_next_states)
+    probs = np.exp(log_probs)
+
+    assert np.isclose(np.sum(probs), 1.0, atol=1e-12), (
+        f"Transition probabilities should sum to 1.0, got {np.sum(probs)}; " f"per-outcome={probs}"
+    )
+
+
+# ----------------------------------------------------------------------
+# hash_observation contract
+# ----------------------------------------------------------------------
+
+
+def test_hash_observation_consistent_with_equality() -> None:
+    """``hash_observation`` returns equal hashes for equal observations.
+
+    Purpose: Sanity-check the hash-equality contract used by belief
+        clustering. Equal observations (per ``is_equal_observation``)
+        must hash to equal values; unequal observations should hash
+        to different values for at least one numerically-different pair.
+
+    Given: A PushPOMDP and three observations: two that are
+        ``np.array_equal`` and one that differs in the object slice.
+    When: Their hash values (as bytes) are compared.
+    Then: The two equal observations have the same hash; the third
+        differs from them.
+
+    Test type: unit
+    """
+    env = _make_default_env()
+    obs_a = np.array([1.0, 2.0, 3.0, 4.0, 9.0, 9.0])
+    obs_a_copy = np.array([1.0, 2.0, 3.0, 4.0, 9.0, 9.0])
+    obs_b = np.array([1.0, 2.0, 3.0, 4.5, 9.0, 9.0])
+
+    assert env.is_equal_observation(obs_a, obs_a_copy)
+    assert env.hash_observation(obs_a) == env.hash_observation(obs_a_copy)
+    assert env.hash_observation(obs_a) != env.hash_observation(obs_b)
+
+
+# ----------------------------------------------------------------------
+# Reward range bounds actual rewards
+# ----------------------------------------------------------------------
+
+
+def test_reward_range_bounds_actual_rewards_across_random_states() -> None:
+    """All sampled rewards lie inside ``env.reward_range`` for many random states.
+
+    Purpose: Cross-checks that the ``reward_range`` advertised by the
+        environment actually bounds the rewards returned by
+        ``env.reward(...)`` for a representative random sample of
+        states.  A mismatch (e.g. obstacle penalty pushing the reward
+        below the lower bound) would expose a stale or wrong range.
+
+    Given: A PushPOMDP with obstacles and obstacle_penalty=-10.0.
+    When: For each of 50 random states and each action, we compute
+        ``env.reward(state, action)``.
+    Then: Every reward lies within the closed interval
+        ``[reward_range[0], reward_range[1]]``.
+
+    Test type: unit
+    """
+    env = _make_default_env()
+    rng = np.random.default_rng(seed=11)
+    assert env.reward_range is not None
+    lo, hi = env.reward_range
+
+    for _ in range(50):
+        state = rng.uniform(0.0, 9.0, size=6)
+        state[4:6] = 9.0  # Target.
+        for action in env.get_actions():
+            r = env.reward(state, action)
+            assert lo <= r <= hi, (
+                f"Reward {r} out of advertised range [{lo}, {hi}] "
+                f"for state={state}, action={action}"
+            )
+
+
+# ----------------------------------------------------------------------
+# Native rollout: error-prob path consistency
+# ----------------------------------------------------------------------
+
+
+def test_native_simulate_rollout_with_error_prob_runs_and_is_finite() -> None:
+    """Native rollout with non-zero transition_error_prob returns a finite scalar.
+
+    Purpose: Smoke-test the C++ error-action path in
+        ``simulate_rollout_discrete`` (which uses the kErrorActions
+        table and an extra RNG draw per step).  Without this test, the
+        error branch in C++ would be untested by the existing
+        deterministic-only parity tests.
+
+    Given: A PushPOMDP with transition_error_prob=0.4 and a fixed
+        initial state.  Native RNG seeded and called via
+        ``env.simulate_random_rollout`` (which delegates to the C++
+        kernel).
+    When: A 30-step rollout is executed.
+    Then: The discounted return is finite, lies in
+        ``[reward_range[0]*30, reward_range[1]*30]``, and a second call
+        with a different native seed yields a (likely) different return,
+        confirming the error-action RNG is actually used.
+
+    Test type: integration
+    """
+    env = _make_default_env(transition_error_prob=0.4)
+    initial_state = np.array([2.0, 3.0, 2.5, 3.0, 9.0, 9.0])
+
+    class _DummySampler:
+        def sample(self) -> str:
+            return "up"
+
+    push_native.set_seed(7)
+    np.random.seed(7)
+    return_a = env.simulate_random_rollout(
+        state=initial_state,
+        action_sampler=_DummySampler(),
+        max_depth=30,
+        discount_factor=env.discount_factor,
+    )
+
+    push_native.set_seed(8)
+    np.random.seed(8)
+    return_b = env.simulate_random_rollout(
+        state=initial_state,
+        action_sampler=_DummySampler(),
+        max_depth=30,
+        discount_factor=env.discount_factor,
+    )
+
+    assert np.isfinite(return_a)
+    assert np.isfinite(return_b)
+    assert env.reward_range is not None
+    horizon_lo = env.reward_range[0] * 30
+    horizon_hi = env.reward_range[1] * 30
+    assert horizon_lo <= return_a <= horizon_hi
+    assert horizon_lo <= return_b <= horizon_hi
+
+
+# ----------------------------------------------------------------------
+# Metric names match compute_metrics output
+# ----------------------------------------------------------------------
+
+
+def test_metric_names_match_compute_metrics_output() -> None:
+    """``get_metric_names`` matches the names emitted by ``compute_metrics``.
+
+    Purpose: Validates the data-integrity contract: the
+        ``get_metric_names`` declaration must exactly match the names
+        produced by ``compute_metrics`` so downstream simulation
+        consumers can index by name reliably.
+
+    Given: A PushPOMDP and a one-step history.
+    When: ``get_metric_names()`` and ``compute_metrics(...)`` are both
+        invoked.
+    Then: The set of names from each is identical.
+
+    Test type: unit
+    """
+    # pylint: disable=import-outside-toplevel
+    from POMDPPlanners.core.belief import WeightedParticleBelief
+    from POMDPPlanners.core.simulation import History, StepData
+
+    env = _make_default_env()
+    declared_names = set(env.get_metric_names())
+
+    np.random.seed(0)
+    state = env.initial_state_dist().sample()[0]
+    next_state, observation, reward = env.sample_next_step(state, "up")
+
+    # WeightedParticleBelief requires at least one nonzero log-weight, so
+    # use two particles with arbitrary unequal log-weights.
+    belief = WeightedParticleBelief([state, state], np.array([0.0, -1.0]))
+    step = StepData(
+        state=state,
+        action="up",
+        next_state=next_state,
+        observation=observation,
+        reward=reward,
+        belief=belief,
+    )
+    history = History(
+        history=[step],
+        discount_factor=env.discount_factor,
+        average_state_sampling_time=0.0,
+        average_action_time=0.0,
+        average_observation_time=0.0,
+        average_belief_update_time=0.0,
+        average_reward_time=0.0,
+        actual_num_steps=1,
+        reach_terminal_state=False,
+        policy_run_data=[],
+    )
+
+    emitted = env.compute_metrics([history])
+    emitted_names = {m.name for m in emitted}
+
+    assert (
+        declared_names == emitted_names
+    ), f"Declared names {declared_names} != emitted names {emitted_names}"


### PR DESCRIPTION
## Summary

Follow-up test coverage for `CarlaPOMDP`, landing after #204 merged. Adds the two remaining untested behaviors on the environment's public/reward surface:

- **`is_equal_observation`** — direct test that identical GNSS observation vectors compare equal and distinct ones compare unequal (previously only exercised incidentally via a single negative assertion).
- **Collision-penalty reward branch** — drives the world to its terminal collision tick and asserts the reward model returns ego speed on live steps and `speed - collision_penalty` on the terminal step (`3.0 - 100.0 == -97.0`). This branch of `_compute_reward` was previously untested.

## Verification

- `pytest POMDPPlanners/tests/test_environments/test_carla_pomdp/`: **31 passed**
- `pyright`: 0 errors / 0 warnings
- `pylint`: 10.00/10