### PR TITLE
feat(carla): pluggable generative-model interface + multi-agent perception world

### DIFF
--- a/POMDPPlanners/environments/carla_pomdp/__init__.py
+++ b/POMDPPlanners/environments/carla_pomdp/__init__.py
@@ -1,16 +1,25 @@
 # SPDX-License-Identifier: MIT
 
-"""CARLA POMDP world environment module.
+"""CARLA POMDP environment module.
 
 This module provides a forward-only adapter exposing the CARLA autonomous-driving
-simulator as a ground-truth world for the POMDPPlanners episode loop.
+simulator as a ground-truth world for the POMDPPlanners episode loop, plus the
+planner-side generative-model interface paired with it and a concrete reference model.
 
 Classes:
     CarlaPOMDP: Forward-only adapter exposing a CARLA session as a world Environment.
+    CarlaModelPOMDP: Abstract generative-model interface over the CARLA schema.
+    FactoredCarlaModelPOMDP: Concrete CARLA model with a factored observation model.
 """
 
 from POMDPPlanners.environments.carla_pomdp.carla_pomdp import CarlaPOMDP
+from POMDPPlanners.environments.carla_pomdp.carla_model_pomdp import CarlaModelPOMDP
+from POMDPPlanners.environments.carla_pomdp.carla_factored_model_pomdp import (
+    FactoredCarlaModelPOMDP,
+)
 
 __all__ = [
     "CarlaPOMDP",
+    "CarlaModelPOMDP",
+    "FactoredCarlaModelPOMDP",
 ]

--- a/POMDPPlanners/environments/carla_pomdp/carla_factored_model_pomdp.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_factored_model_pomdp.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: MIT
+
+"""Reference concrete CARLA generative model with a fixed factored observation model.
+
+:class:`FactoredCarlaModelPOMDP` implements the
+:class:`~POMDPPlanners.environments.carla_pomdp.carla_model_pomdp.CarlaModelPOMDP`
+interface with a fixed, factored observation model (per-slot agent detection with range +
+occlusion gating and additive Gaussian pose noise, plus a Gaussian GNSS reading) and the
+same gym-carla driving-quality reward the world uses. The transition dynamics are a
+documented identity placeholder for a specific study to replace with real (e.g. learned)
+motion.
+
+State/observation layout, geometry helpers, detection constants, and the shared reward are
+imported from :mod:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp` so world and model
+agree by construction.
+
+Classes:
+    FactoredCarlaModelPOMDP: Concrete CARLA model with a factored observation model.
+"""
+
+from typing import Any, Optional, Sequence, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.distributions import Distribution
+from POMDPPlanners.environments.carla_pomdp.carla_model_pomdp import CarlaModelPOMDP
+from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
+    AGENT_SLOT_WIDTH,
+    DEFAULT_MAX_TRACKED_AGENTS,
+    DEFAULT_OCCLUSION_RADIUS,
+    DEFAULT_PERCEPTION_RANGE,
+    _segment_occludes,
+    driving_quality_reward,
+)
+
+_LOG_EPS = -50.0  # log-prob floor for impossible / near-zero events
+
+
+class FactoredCarlaModelPOMDP(CarlaModelPOMDP):
+    """Concrete CARLA generative model with a fixed factored observation model.
+
+    The observation model is factored per agent slot (detection gated by perception range
+    and geometric occlusion, additive Gaussian pose noise) plus a Gaussian GNSS reading;
+    the reward is the shared gym-carla driving-quality reward. The transition is a
+    documented identity placeholder to be replaced with real dynamics per study.
+
+    Attributes:
+        perception_range: Metres beyond which an agent is undetectable.
+        occlusion_radius: Sight-line blocking radius among agents.
+        pose_std: Std of Gaussian noise on a detected agent's ``[rel_x, rel_y, rel_yaw,
+            rel_speed]`` measurement.
+        gnss_std: Std of Gaussian noise on the ``gnss`` reading.
+        detect_prob: Probability of detecting a visible (in-range, un-occluded) agent;
+            ``1 - detect_prob`` is the miss rate.
+        desired_speed: Target longitudinal speed (m/s) used by the reward.
+        out_lane_thresh: Lateral offset (m) beyond which the reward penalises out-of-lane.
+        collision_penalty: Penalty scale applied on a terminal collision in the reward.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(42)  # For reproducible results
+        >>>
+        >>> from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
+        ...     AGENT_SLOT_WIDTH, EGO_STATE_WIDTH)
+        >>> env = FactoredCarlaModelPOMDP(discount_factor=0.95)
+        >>>
+        >>> width = EGO_STATE_WIDTH + env.max_tracked_agents * AGENT_SLOT_WIDTH
+        >>> state = np.zeros(width)
+        >>> action = env.get_actions()[0]
+        >>>
+        >>> next_state, observation, reward = env.sample_next_step(state, action)
+        >>> sorted(observation)
+        ['agents', 'gnss']
+        >>> env.is_terminal(state)
+        False
+    """
+
+    def __init__(
+        self,
+        discount_factor: float,
+        action_presets: Optional[Sequence[Tuple[float, float, float]]] = None,
+        max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
+        perception_range: float = DEFAULT_PERCEPTION_RANGE,
+        occlusion_radius: float = DEFAULT_OCCLUSION_RADIUS,
+        pose_std: float = 0.5,
+        gnss_std: float = 1e-5,
+        detect_prob: float = 0.95,
+        desired_speed: float = 8.0,
+        out_lane_thresh: float = 2.0,
+        collision_penalty: float = 100.0,
+        name: Optional[str] = None,
+    ) -> None:
+        """Initialize the factored CARLA generative model.
+
+        Args:
+            discount_factor: Discount factor for future rewards (0 < d <= 1).
+            action_presets: Discrete ``(throttle, steer, brake)`` triples. Defaults to
+                the world's default presets.
+            max_tracked_agents: Number of fixed agent slots in state/observation.
+            perception_range: Metres beyond which an agent is undetectable.
+            occlusion_radius: Sight-line blocking radius among agents.
+            pose_std: Std of Gaussian noise on a detected agent's pose measurement.
+            gnss_std: Std of Gaussian noise on the ``gnss`` reading.
+            detect_prob: Probability of detecting a visible agent.
+            desired_speed: Target longitudinal speed (m/s) for the reward.
+            out_lane_thresh: Lateral offset (m) beyond which the reward penalises.
+            collision_penalty: Penalty scale for a terminal collision in the reward.
+            name: Environment identifier. Defaults to the class name.
+        """
+        self.perception_range = perception_range
+        self.occlusion_radius = occlusion_radius
+        self.pose_std = pose_std
+        self.gnss_std = gnss_std
+        self.detect_prob = detect_prob
+        self.desired_speed = desired_speed
+        self.out_lane_thresh = out_lane_thresh
+        self.collision_penalty = collision_penalty
+        super().__init__(
+            discount_factor=discount_factor,
+            action_presets=action_presets,
+            max_tracked_agents=max_tracked_agents,
+            name=name,
+        )
+
+    # ── Transition (identity placeholder — replace per study) ────────────
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        # Placeholder identity dynamics: a study replaces this with ego-kinematics
+        # propagation under the control preset plus an agent-slot motion model.
+        del action
+        state = np.asarray(state, dtype=float)
+        if n_samples == 1:
+            return state
+        return np.stack([state for _ in range(n_samples)])
+
+    def transition_log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+        # Placeholder: implement the density matching sample_next_state's motion model.
+        del state, action, next_states
+        raise NotImplementedError("FactoredCarlaModelPOMDP transition density not yet implemented.")
+
+    # ── Observation model (fixed, factored) ─────────────────────────────
+    def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> Any:
+        del action
+        obs = self._render_observation(np.asarray(next_state, dtype=float), noisy=True)
+        return [obs for _ in range(n_samples)] if n_samples != 1 else obs
+
+    def observation_log_probability(
+        self, next_state: Any, action: Any, observations: Any
+    ) -> np.ndarray:
+        del action
+        state = np.asarray(next_state, dtype=float)
+        obs_list = observations if isinstance(observations, list) else [observations]
+        return np.array([self._log_prob_single(state, obs) for obs in obs_list])
+
+    # ── Reward (shared with the world by construction) ───────────────────
+    def reward(self, state: Any, action: Any, next_state: Any = None) -> float:
+        resulting = np.asarray(next_state if next_state is not None else state, dtype=float)
+        _, steer, _ = self.action_presets[int(action)]
+        # The model cannot observe collisions, so the terminal collision term is
+        # necessarily approximated (is_terminal is always False for the model).
+        return driving_quality_reward(
+            resulting,
+            steer,
+            self.is_terminal(resulting),
+            self.desired_speed,
+            self.out_lane_thresh,
+            self.collision_penalty,
+        )
+
+    # ── Terminal / initial hooks ─────────────────────────────────────────
+    def is_terminal(self, state: Any) -> bool:
+        del state
+        return False
+
+    def initial_state_dist(self) -> Distribution:
+        raise NotImplementedError("Seed the belief from the world's initial observation.")
+
+    def initial_observation_dist(self) -> Distribution:
+        raise NotImplementedError("Seed the belief from the world's initial observation.")
+
+    # ── Factored observation helpers ─────────────────────────────────────
+    def _visible(self, rows: np.ndarray, slot: int) -> bool:
+        """Whether true agent ``slot`` is in range and not occluded (ego-frame)."""
+        rel_x, rel_y = rows[slot, 1], rows[slot, 2]
+        if float(np.hypot(rel_x, rel_y)) > self.perception_range:
+            return False
+        for other in range(self.max_tracked_agents):
+            if other == slot or rows[other, 0] != 1.0:
+                continue
+            if _segment_occludes(
+                0.0, 0.0, rel_x, rel_y, rows[other, 1], rows[other, 2], self.occlusion_radius
+            ):
+                return False
+        return True
+
+    def _render_observation(self, state: np.ndarray, noisy: bool) -> dict:
+        rows = self._state_agent_rows(state).copy()
+        for slot in range(self.max_tracked_agents):
+            if rows[slot, 0] != 1.0 or not self._visible(rows, slot):
+                rows[slot] = 0.0
+            elif noisy:
+                rows[slot, 1:] += np.random.normal(0.0, self.pose_std, size=AGENT_SLOT_WIDTH - 1)
+        gnss = state[:2].copy()
+        if noisy:
+            gnss = gnss + np.random.normal(0.0, self.gnss_std, size=2)
+        return {"gnss": gnss, "agents": rows.reshape(-1)}
+
+    def _log_prob_single(self, state: np.ndarray, obs: dict) -> float:
+        rows = self._state_agent_rows(state)
+        obs_rows = np.asarray(obs["agents"], dtype=float).reshape(
+            self.max_tracked_agents, AGENT_SLOT_WIDTH
+        )
+        total = self._gnss_log_prob(state, obs)
+        for slot in range(self.max_tracked_agents):
+            total += self._slot_log_prob(rows, obs_rows, slot)
+        return float(total)
+
+    def _gnss_log_prob(self, state: np.ndarray, obs: dict) -> float:
+        gnss = np.asarray(obs["gnss"], dtype=float)[:2]
+        diff = gnss - state[:2]
+        return float(-0.5 * np.sum((diff / self.gnss_std) ** 2) - 2 * np.log(self.gnss_std))
+
+    def _slot_log_prob(self, rows: np.ndarray, obs_rows: np.ndarray, slot: int) -> float:
+        true_present = rows[slot, 0] == 1.0
+        obs_present = obs_rows[slot, 0] == 1.0
+        if not true_present:
+            return 0.0 if not obs_present else _LOG_EPS  # empty state slot -> empty obs slot
+        if not self._visible(rows, slot):
+            return 0.0 if not obs_present else _LOG_EPS  # invisible -> must be missed
+        if not obs_present:
+            return float(np.log(max(1.0 - self.detect_prob, np.exp(_LOG_EPS))))  # a miss
+        diff = obs_rows[slot, 1:] - rows[slot, 1:]
+        gauss = -0.5 * np.sum((diff / self.pose_std) ** 2) - (AGENT_SLOT_WIDTH - 1) * np.log(
+            self.pose_std
+        )
+        return float(np.log(self.detect_prob) + gauss)

--- a/POMDPPlanners/environments/carla_pomdp/carla_model_pomdp.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_model_pomdp.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: MIT
+
+"""Abstract planner-side generative-model interface for the CARLA world.
+
+:class:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp.CarlaPOMDP` is a
+forward-only *world* (no densities, no state injection). A planner instead carries a
+generative *model* as ``policy.environment`` — one that can sample transitions from an
+arbitrary state, score an observation against a state, and supply a reward. This module
+defines the **interface** that model must satisfy: :class:`CarlaModelPOMDP` owns only the
+CARLA state/observation *schema* (agent-slot layout, discrete action set, observation-dict
+hashing/equality) and leaves every dynamic quantity — transition, observation, reward,
+terminal — abstract for a study- or task-specific subclass (e.g. a learned model) to fill
+in.
+
+A runnable reference implementation with a fixed factored observation model lives in
+:mod:`~POMDPPlanners.environments.carla_pomdp.carla_factored_model_pomdp`.
+
+The schema (state/observation layout, action presets) is imported from
+:mod:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp` so world and model agree by
+construction.
+
+Classes:
+    CarlaModelPOMDP: Abstract generative-model interface over the CARLA schema.
+"""
+
+from abc import abstractmethod
+from collections.abc import Hashable
+from typing import Any, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.environment import DiscreteActionsEnvironment, SpaceInfo, SpaceType
+
+from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
+    AGENT_SLOT_WIDTH,
+    DEFAULT_ACTION_PRESETS,
+    DEFAULT_MAX_TRACKED_AGENTS,
+    EGO_STATE_WIDTH,
+)
+
+
+class CarlaModelPOMDP(DiscreteActionsEnvironment):
+    """Abstract generative-model interface paired with the forward-only CARLA world.
+
+    Concrete subclasses supply the dynamics — :meth:`sample_next_state`,
+    :meth:`transition_log_probability`, :meth:`sample_observation`,
+    :meth:`observation_log_probability`, :meth:`reward`, :meth:`is_terminal`, and the
+    initial-distribution hooks — while this base owns the fixed CARLA schema shared by
+    every model: the ego + agent-slot state layout, the discrete action set, and the
+    observation-dict hashing/equality.
+
+    Attributes:
+        action_presets: Discrete ``(throttle, steer, brake)`` control triples; the
+            discrete action set is the indices into this list.
+        max_tracked_agents: Number of fixed agent slots in the state/observation.
+
+    Note:
+        This is an abstract base class and cannot be instantiated directly. See
+        :class:`~POMDPPlanners.environments.carla_pomdp.carla_factored_model_pomdp.FactoredCarlaModelPOMDP`
+        for a concrete reference implementation.
+    """
+
+    def __init__(
+        self,
+        discount_factor: float,
+        action_presets: Optional[Sequence[Tuple[float, float, float]]] = None,
+        max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
+        name: Optional[str] = None,
+    ) -> None:
+        """Initialize the CARLA generative-model interface.
+
+        Args:
+            discount_factor: Discount factor for future rewards (0 < d <= 1).
+            action_presets: Discrete ``(throttle, steer, brake)`` triples. Defaults to
+                :data:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp.DEFAULT_ACTION_PRESETS`.
+            max_tracked_agents: Number of fixed agent slots carried in the state and
+                observation. Defaults to
+                :data:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp.DEFAULT_MAX_TRACKED_AGENTS`.
+            name: Environment identifier. Defaults to the class name.
+        """
+        presets = action_presets if action_presets is not None else DEFAULT_ACTION_PRESETS
+        self.action_presets: List[Tuple[float, float, float]] = [
+            (float(throttle), float(steer), float(brake)) for throttle, steer, brake in presets
+        ]
+        self.max_tracked_agents = max_tracked_agents
+        super().__init__(
+            discount_factor=discount_factor,
+            name=name if name is not None else type(self).__name__,
+            space_info=SpaceInfo(
+                action_space=SpaceType.DISCRETE,
+                observation_space=SpaceType.CONTINUOUS,
+            ),
+        )
+
+    # ── Schema (concrete, shared by every model) ────────────────────────
+    def get_actions(self) -> List[int]:
+        """Discrete action set: indices into ``action_presets``."""
+        return list(range(len(self.action_presets)))
+
+    def is_equal_observation(self, observation1: Any, observation2: Any) -> bool:
+        return np.array_equal(
+            np.asarray(observation1["agents"]), np.asarray(observation2["agents"])
+        ) and np.array_equal(np.asarray(observation1["gnss"]), np.asarray(observation2["gnss"]))
+
+    def hash_observation(self, observation: Any) -> Hashable:
+        return tuple((key, np.asarray(observation[key]).tobytes()) for key in sorted(observation))
+
+    def hash_action(self, action: Any) -> Hashable:
+        return action
+
+    def _state_agent_rows(self, state: np.ndarray) -> np.ndarray:
+        return state[EGO_STATE_WIDTH:].reshape(self.max_tracked_agents, AGENT_SLOT_WIDTH)
+
+    # ── Dynamics (abstract — the interface a model must implement) ───────
+    @abstractmethod
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        """Sample ``n_samples`` next states for ``(state, action)``."""
+
+    @abstractmethod
+    def transition_log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+        """Log-density of ``next_states`` under the transition model for ``(state, action)``."""
+
+    @abstractmethod
+    def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> Any:
+        """Sample ``n_samples`` observations for a resulting ``next_state``."""
+
+    @abstractmethod
+    def observation_log_probability(
+        self, next_state: Any, action: Any, observations: Any
+    ) -> np.ndarray:
+        """Log-density of ``observations`` under the observation model given ``next_state``."""

--- a/POMDPPlanners/environments/carla_pomdp/carla_pomdp.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_pomdp.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MIT
 
+# pylint: disable=too-many-lines  # Multi-agent traffic + perception grew the module.
+
 """CARLA POMDP world environment.
 
 This module adapts the `CARLA <https://carla.org/>`_ autonomous-driving
@@ -20,11 +22,58 @@ called.
 
 Unlike :class:`~POMDPPlanners.environments.gym_pomdp.gym_pomdp.GymPOMDP` (which is
 fully observed: observation equals state), CARLA is genuinely partially observed.
-The **state** is the ego vehicle's ground-truth kinematics ``[x, y, yaw, vx, vy]``
-read straight from the simulator, while the **observation** is a native CARLA
-sensor payload (GNSS ``[lat, lon, alt]`` by default). Any measurement noise is
-CARLA's own, configured through the sensor blueprint attributes in
-``sensor_config`` — the wrapper adds none.
+
+The world is populated each reset with surrounding autopilot traffic and walking
+pedestrians (via CARLA's Traffic Manager), so it poses a genuine multi-agent
+perception problem rather than an empty course.
+
+The **state** is the ego vehicle's ground-truth kinematics and lane pose,
+``[x, y, yaw, vx, vy, lat, heading_err]``, **followed by fixed slots for the
+``max_tracked_agents`` nearest other vehicles** (ground truth). Each agent slot is
+``[present, rel_x, rel_y, rel_yaw, rel_speed]`` expressed in the ego frame
+(``rel_x`` forward, ``rel_y`` left, ``rel_yaw`` in **radians**, ``rel_speed`` in
+m/s); ``present`` is ``1`` for a filled slot and ``0`` for padding. The ego part
+is read straight from the simulator, where:
+
+- ``x``, ``y``: ego position in the CARLA map (world) frame, in metres, read from
+  the actor transform's location.
+- ``yaw``: ego heading about the world Z axis, in **degrees** (CARLA convention),
+  read from the actor transform's rotation.
+- ``vx``, ``vy``: ego linear-velocity components in the world frame, in metres per
+  second, read from the actor's velocity vector.
+- ``lat``: signed lateral offset from the centre of the nearest driving lane, in
+  metres (positive to the lane's left), from the CARLA map's lane geometry.
+- ``heading_err``: ego heading minus the lane direction, wrapped to
+  ``[-pi, pi]``, in **radians**.
+
+(The vertical axis ``z`` and roll/pitch are intentionally omitted; the ego is
+modelled on the ground plane.)
+
+The lane-relative terms (``lat``, ``heading_err``) drive a gym-carla-style
+driving-quality reward: it rewards longitudinal progress along the lane while
+penalising overspeed, drifting out of lane, and harsh / high-speed steering, plus
+a per-step time cost and a terminal collision penalty. See
+:data:`REWARD_SPEED_WEIGHT` and the sibling weights for the fixed coefficients.
+
+The **observation** is a multi-modal dict of native CARLA sensor payloads:
+
+- ``"gnss"``: ``[lat, lon, alt]`` (always present) — latitude and longitude in
+  **degrees** and altitude in metres, from a ``sensor.other.gnss`` reading.
+- ``"agents"`` (always present): the ``max_tracked_agents`` agent slots of the
+  state flattened, but with any agent that is **out of ``perception_range`` or
+  geometrically occluded** by another vehicle zeroed to an empty (``present == 0``)
+  slot. Slot indices align with the state, so a nearby agent the ego cannot see is
+  exactly a slot that is filled in the state yet empty here — the hidden variable
+  the belief must reason about.
+- ``"camera"`` (present iff ``include_camera``): a front-facing RGB image,
+  ``(H, W, 3)`` ``uint8``, from a ``sensor.camera.rgb``.
+- ``"lidar"`` (present iff ``include_lidar``): a point cloud, ``(N, 4)`` ``float32``
+  with rows ``[x, y, z, intensity]`` in the LiDAR **sensor** frame (metres;
+  ``intensity`` normalised to ``[0, 1]``), from a ``sensor.lidar.ray_cast``. ``N``
+  varies per tick.
+
+Any measurement noise is CARLA's own, configured through the sensor blueprint
+attributes — the wrapper adds none.
 
 Classes:
     CarlaPOMDP: Forward-only adapter exposing a CARLA session as a world Environment.
@@ -33,7 +82,7 @@ Classes:
 from collections.abc import Hashable
 from pathlib import Path
 from queue import Queue
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 import numpy as np
 
@@ -54,11 +103,160 @@ DEFAULT_ACTION_PRESETS: Tuple[Tuple[float, float, float], ...] = (
 _ROLE_NEXT_STATE = "next_state"
 _ROLE_REWARD = "reward"
 
+# Fixed gym-carla-style reward term weights. The collision weight is the tunable
+# ``collision_penalty`` constructor argument; these shape the driving-quality
+# terms and are held fixed so the reward is a single well-defined objective.
+REWARD_SPEED_WEIGHT = 1.0  # reward per m/s of along-lane (longitudinal) progress
+REWARD_FAST_PENALTY = 10.0  # penalty when longitudinal speed exceeds desired_speed
+REWARD_OUT_PENALTY = 1.0  # penalty when |lat| exceeds out_lane_thresh
+REWARD_STEER_WEIGHT = 5.0  # penalty on squared steering (harsh-steer smoothness)
+REWARD_LAT_WEIGHT = 0.2  # penalty on |steer| * longitudinal_speed**2 (fast turns)
+REWARD_STEP_COST = 0.1  # constant per-step time cost
+
+
+def _wrap_to_pi(angle: float) -> float:
+    """Wrap an angle in radians to the ``[-pi, pi]`` interval."""
+    return (angle + np.pi) % (2.0 * np.pi) - np.pi
+
+
+def driving_quality_reward(
+    next_state: np.ndarray,
+    steer: float,
+    terminated: bool,
+    desired_speed: float,
+    out_lane_thresh: float,
+    collision_penalty: float,
+) -> float:
+    """Score a transition with a gym-carla-style driving-quality reward.
+
+    Rewards along-lane progress and penalises overspeed, drifting out of lane, harsh /
+    high-speed steering, each elapsed step, and a terminal collision. Shared by the
+    :class:`CarlaPOMDP` world and the planner-side factored model so the two score a
+    transition identically by construction.
+
+    Args:
+        next_state: Resulting ego state ``[x, y, yaw(deg), vx, vy, lat, heading_err]``.
+        steer: Steering command applied on the transition (from the action preset).
+        terminated: Whether the transition ended in a terminal collision.
+        desired_speed: Target longitudinal speed (m/s); exceeding it is penalised.
+        out_lane_thresh: Lateral offset (m) beyond which the ego is treated as out of lane.
+        collision_penalty: Penalty scale applied on a terminal collision.
+
+    Returns:
+        The scalar reward for the transition.
+    """
+    ego_yaw = float(np.radians(next_state[2]))
+    vel_x, vel_y = float(next_state[3]), float(next_state[4])
+    lateral, heading_err = float(next_state[5]), float(next_state[6])
+    lane_yaw = ego_yaw - heading_err
+    lspeed_lon = vel_x * np.cos(lane_yaw) + vel_y * np.sin(lane_yaw)
+
+    r_fast = -1.0 if lspeed_lon > desired_speed else 0.0
+    r_out = -1.0 if abs(lateral) > out_lane_thresh else 0.0
+    r_collision = -1.0 if terminated else 0.0
+    r_steer = -(steer**2)
+    r_lat = -abs(steer) * lspeed_lon**2
+
+    return float(
+        collision_penalty * r_collision
+        + REWARD_SPEED_WEIGHT * lspeed_lon
+        + REWARD_FAST_PENALTY * r_fast
+        + REWARD_OUT_PENALTY * r_out
+        + REWARD_STEER_WEIGHT * r_steer
+        + REWARD_LAT_WEIGHT * r_lat
+        - REWARD_STEP_COST
+    )
+
+
+# Surrounding-traffic / perception defaults.
+DEFAULT_NUM_VEHICLES = 30  # other autopilot vehicles spawned into the world
+DEFAULT_NUM_WALKERS = 10  # pedestrians spawned into the world
+DEFAULT_MAX_TRACKED_AGENTS = 5  # nearest other vehicles carried in state/observation
+DEFAULT_PERCEPTION_RANGE = 50.0  # metres beyond which another agent is undetectable
+DEFAULT_OCCLUSION_RADIUS = 1.5  # metres; a vehicle nearer than this to the ego->target
+# sight line is treated as blocking (geometric occlusion among vehicles)
+DEFAULT_TRAFFIC_MANAGER_PORT = 8000  # CARLA Traffic Manager RPC port
+
+# State/observation layout for other agents. Each tracked agent occupies a fixed
+# slot ``[present, rel_x, rel_y, rel_yaw, rel_speed]`` expressed in the ego frame
+# (``rel_x`` forward, ``rel_y`` left, ``rel_yaw`` in radians, ``rel_speed`` in m/s).
+EGO_STATE_WIDTH = 7  # [x, y, yaw, vx, vy, lat, heading_err]
+AGENT_SLOT_WIDTH = 5  # [present, rel_x, rel_y, rel_yaw, rel_speed]
+
+
+def _relative_agent_row(
+    ego_x: float,
+    ego_y: float,
+    ego_yaw_rad: float,
+    other_x: float,
+    other_y: float,
+    other_yaw_rad: float,
+    other_speed: float,
+) -> np.ndarray:
+    """Express another agent's pose/speed in the ego frame as a present slot row.
+
+    Returns ``[1.0, rel_x, rel_y, rel_yaw, rel_speed]`` with ``rel_x`` pointing
+    along the ego heading, ``rel_y`` to its left, and ``rel_yaw`` wrapped to
+    ``[-pi, pi]``.
+    """
+    delta_x = other_x - ego_x
+    delta_y = other_y - ego_y
+    cos_yaw = np.cos(ego_yaw_rad)
+    sin_yaw = np.sin(ego_yaw_rad)
+    rel_x = float(cos_yaw * delta_x + sin_yaw * delta_y)
+    rel_y = float(-sin_yaw * delta_x + cos_yaw * delta_y)
+    rel_yaw = float(_wrap_to_pi(other_yaw_rad - ego_yaw_rad))
+    return np.array([1.0, rel_x, rel_y, rel_yaw, float(other_speed)])
+
+
+def _segment_occludes(
+    ego_x: float,
+    ego_y: float,
+    target_x: float,
+    target_y: float,
+    blocker_x: float,
+    blocker_y: float,
+    radius: float,
+) -> bool:
+    """Whether a blocker vehicle lies on the ego->target sight line within ``radius``.
+
+    Projects the blocker onto the ego->target segment; it occludes when the
+    projection falls strictly between the endpoints and its perpendicular distance
+    to the line is below ``radius``.
+    """
+    seg_x = target_x - ego_x
+    seg_y = target_y - ego_y
+    seg_len_sq = seg_x * seg_x + seg_y * seg_y
+    if seg_len_sq == 0.0:
+        return False
+    param = ((blocker_x - ego_x) * seg_x + (blocker_y - ego_y) * seg_y) / seg_len_sq
+    if param <= 0.0 or param >= 1.0:
+        return False
+    perp_x = ego_x + param * seg_x - blocker_x
+    perp_y = ego_y + param * seg_y - blocker_y
+    return float(np.hypot(perp_x, perp_y)) < radius
+
+
 # Default chase RGB camera resolution / field of view (blueprint attributes).
 DEFAULT_CAMERA_CONFIG: Dict[str, str] = {
     "image_size_x": "640",
     "image_size_y": "480",
     "fov": "90",
+}
+
+# Default front-facing observation RGB camera blueprint attributes.
+DEFAULT_OBSERVATION_CAMERA_CONFIG: Dict[str, str] = {
+    "image_size_x": "128",
+    "image_size_y": "128",
+    "fov": "90",
+}
+
+# Default roof-mounted LiDAR blueprint attributes.
+DEFAULT_LIDAR_CONFIG: Dict[str, str] = {
+    "channels": "32",
+    "range": "50.0",
+    "points_per_second": "100000",
+    "rotation_frequency": "20.0",
 }
 
 
@@ -82,18 +280,47 @@ class _CarlaSession:
         timeout: float,
         record_camera: bool = False,
         camera_config: Optional[Dict[str, Any]] = None,
+        include_camera: bool = True,
+        include_lidar: bool = True,
+        observation_camera_config: Optional[Dict[str, Any]] = None,
+        lidar_config: Optional[Dict[str, Any]] = None,
+        num_vehicles: int = DEFAULT_NUM_VEHICLES,
+        num_walkers: int = DEFAULT_NUM_WALKERS,
+        max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
+        perception_range: float = DEFAULT_PERCEPTION_RANGE,
+        occlusion_radius: float = DEFAULT_OCCLUSION_RADIUS,
+        traffic_manager_port: int = DEFAULT_TRAFFIC_MANAGER_PORT,
+        randomize_spawn: bool = True,
+        observation_extractor: Optional[Callable[[Dict[str, np.ndarray]], Any]] = None,
     ) -> None:
         import carla  # pylint: disable=import-outside-toplevel,import-error
 
         self._carla = carla
+        self._observation_extractor = observation_extractor
         self._sensor_config = sensor_config
         self._vehicle_filter = vehicle_filter
+        self._num_vehicles = num_vehicles
+        self._num_walkers = num_walkers
+        self._max_tracked_agents = max_tracked_agents
+        self._perception_range = perception_range
+        self._occlusion_radius = occlusion_radius
+        self._traffic_manager_port = traffic_manager_port
+        self._randomize_spawn = randomize_spawn
         self._record_camera = record_camera
         self._camera_config = camera_config if camera_config is not None else {}
+        self._include_camera = include_camera
+        self._include_lidar = include_lidar
+        self._obs_camera_config = (
+            observation_camera_config if observation_camera_config is not None else {}
+        )
+        self._lidar_config = lidar_config if lidar_config is not None else {}
+        self._camera_width = int(self._obs_camera_config.get("image_size_x", 128))
+        self._camera_height = int(self._obs_camera_config.get("image_size_y", 128))
         client = carla.Client(host, port)
         client.set_timeout(timeout)
         self._client = client
         self._world = client.load_world(town)
+        self._map = self._world.get_map()
         self._apply_synchronous_settings(fixed_delta_seconds)
 
         self._vehicle: Optional[Any] = None
@@ -102,29 +329,50 @@ class _CarlaSession:
         self._camera_sensor: Optional[Any] = None
         self._camera_queue: Optional["Queue[Any]"] = None
         self._frames: List[np.ndarray] = []
+        self._obs_camera_sensor: Optional[Any] = None
+        self._lidar_sensor: Optional[Any] = None
         self._latest_gnss: Optional[np.ndarray] = None
+        self._latest_camera: Optional[np.ndarray] = None
+        self._latest_lidar: Optional[np.ndarray] = None
         self._collided: bool = False
+        self._traffic_vehicles: List[Any] = []
+        self._walkers: List[Any] = []
+        self._walker_controllers: List[Any] = []
+        self._rng = np.random.default_rng()
 
     @property
     def frames(self) -> List[np.ndarray]:
         """RGB chase-camera frames captured so far, one ``(H, W, 3)`` array per tick."""
         return self._frames
 
-    def reset(self, seed: Optional[int] = None) -> Tuple[np.ndarray, np.ndarray]:
-        """Respawn the ego vehicle and sensors, tick once, and read the start."""
+    def reset(self, seed: Optional[int] = None) -> Tuple[np.ndarray, Dict[str, np.ndarray]]:
+        """Respawn the ego, surrounding traffic, and sensors, tick once, read start."""
         if seed is not None:
-            self._world.get_settings()  # touch settings so a seed hook can attach
+            self._rng = np.random.default_rng(seed)
         self._teardown_actors()
         self._frames = []
+        self._randomize_weather()
         self._spawn_actors()
+        self._spawn_traffic()
         self._collided = False
         self._world.tick()
         self._capture_frame()
         return self._read_state(), self._read_observation()
 
+    def _randomize_weather(self) -> None:
+        presets = [
+            attr
+            for attr in dir(self._carla.WeatherParameters)
+            if not attr.startswith("_") and attr != "values"
+        ]
+        if not presets:
+            return
+        choice = presets[int(self._rng.integers(len(presets)))]
+        self._world.set_weather(getattr(self._carla.WeatherParameters, choice))
+
     def step(
         self, throttle: float, steer: float, brake: float
-    ) -> Tuple[np.ndarray, np.ndarray, bool]:
+    ) -> Tuple[np.ndarray, Dict[str, np.ndarray], bool]:
         """Apply a control, advance one fixed tick, and read the outcome."""
         control = self._carla.VehicleControl(throttle=throttle, steer=steer, brake=brake)
         self._vehicle.apply_control(control)
@@ -141,12 +389,62 @@ class _CarlaSession:
     def _spawn_actors(self) -> None:
         blueprint_library = self._world.get_blueprint_library()
         vehicle_bp = blueprint_library.filter(self._vehicle_filter)[0]
-        spawn_point = self._world.get_map().get_spawn_points()[0]
-        self._vehicle = self._world.spawn_actor(vehicle_bp, spawn_point)
+        spawn_points = self._map.get_spawn_points()
+        index = int(self._rng.integers(len(spawn_points))) if self._randomize_spawn else 0
+        self._vehicle = self._world.spawn_actor(vehicle_bp, spawn_points[index])
         self._gnss_sensor = self._attach_gnss(blueprint_library)
         self._collision_sensor = self._attach_collision(blueprint_library)
         if self._record_camera:
             self._camera_sensor = self._attach_camera(blueprint_library)
+        if self._include_camera:
+            self._obs_camera_sensor = self._attach_observation_camera(blueprint_library)
+        if self._include_lidar:
+            self._lidar_sensor = self._attach_lidar(blueprint_library)
+
+    def _spawn_traffic(self) -> None:
+        """Populate the world with autopilot vehicles and walking pedestrians."""
+        self._spawn_traffic_vehicles()
+        self._spawn_walkers()
+
+    def _spawn_traffic_vehicles(self) -> None:
+        blueprint_library = self._world.get_blueprint_library()
+        vehicle_bps = blueprint_library.filter("vehicle.*")
+        traffic_manager = self._client.get_trafficmanager(self._traffic_manager_port)
+        traffic_manager.set_synchronous_mode(True)
+        spawn_points = self._map.get_spawn_points()
+        ego_location = self._vehicle.get_location()
+        candidates = [
+            point for point in spawn_points if point.location.distance(ego_location) > 1.0
+        ]
+        order = self._rng.permutation(len(candidates))
+        for point_index in order[: self._num_vehicles]:
+            blueprint = vehicle_bps[int(self._rng.integers(len(vehicle_bps)))]
+            vehicle: Any = self._world.try_spawn_actor(blueprint, candidates[int(point_index)])
+            if vehicle is None:
+                continue
+            vehicle.set_autopilot(True, traffic_manager.get_port())
+            self._traffic_vehicles.append(vehicle)
+
+    def _spawn_walkers(self) -> None:
+        blueprint_library = self._world.get_blueprint_library()
+        walker_bps = blueprint_library.filter("walker.pedestrian.*")
+        controller_bp = blueprint_library.find("controller.ai.walker")
+        for _ in range(self._num_walkers):
+            location = self._world.get_random_location_from_navigation()
+            if location is None:
+                continue
+            blueprint = walker_bps[int(self._rng.integers(len(walker_bps)))]
+            transform = self._carla.Transform(location)
+            walker: Any = self._world.try_spawn_actor(blueprint, transform)
+            if walker is None:
+                continue
+            controller: Any = self._world.spawn_actor(
+                controller_bp, self._carla.Transform(), attach_to=walker
+            )
+            controller.start()
+            controller.go_to_location(self._world.get_random_location_from_navigation())
+            self._walkers.append(walker)
+            self._walker_controllers.append(controller)
 
     def _attach_gnss(self, blueprint_library: Any) -> Any:
         gnss_bp = blueprint_library.find("sensor.other.gnss")
@@ -180,6 +478,26 @@ class _CarlaSession:
         sensor.listen(self._camera_queue.put)
         return sensor
 
+    def _attach_observation_camera(self, blueprint_library: Any) -> Any:
+        camera_bp = blueprint_library.find("sensor.camera.rgb")
+        for attribute, value in self._obs_camera_config.items():
+            camera_bp.set_attribute(attribute, str(value))
+        # Front-facing view: ahead of and above the ego, no rotation.
+        transform = self._carla.Transform(self._carla.Location(x=1.5, z=2.4))
+        sensor: Any = self._world.spawn_actor(camera_bp, transform, attach_to=self._vehicle)
+        sensor.listen(self._on_camera)
+        return sensor
+
+    def _attach_lidar(self, blueprint_library: Any) -> Any:
+        lidar_bp = blueprint_library.find("sensor.lidar.ray_cast")
+        for attribute, value in self._lidar_config.items():
+            lidar_bp.set_attribute(attribute, str(value))
+        # Roof-mounted, centered on the ego.
+        transform = self._carla.Transform(self._carla.Location(z=2.4))
+        sensor: Any = self._world.spawn_actor(lidar_bp, transform, attach_to=self._vehicle)
+        sensor.listen(self._on_lidar)
+        return sensor
+
     def _capture_frame(self) -> None:
         """Pull the RGB frame CARLA rendered for the tick just executed."""
         if not self._record_camera or self._camera_queue is None:
@@ -195,6 +513,15 @@ class _CarlaSession:
             [measurement.latitude, measurement.longitude, measurement.altitude]
         )
 
+    def _on_camera(self, image: Any) -> None:
+        buffer = np.frombuffer(image.raw_data, dtype=np.uint8)
+        bgra = np.reshape(buffer, (image.height, image.width, 4))
+        # CARLA stores BGRA; take B,G,R reversed to RGB and drop alpha.
+        self._latest_camera = np.ascontiguousarray(bgra[:, :, 2::-1])
+
+    def _on_lidar(self, data: Any) -> None:
+        self._latest_lidar = np.frombuffer(data.raw_data, dtype=np.float32).reshape(-1, 4)
+
     def _on_collision(self, event: Any) -> None:
         del event
         self._collided = True
@@ -202,36 +529,157 @@ class _CarlaSession:
     def _read_state(self) -> np.ndarray:
         transform = self._vehicle.get_transform()
         velocity = self._vehicle.get_velocity()
-        return np.array(
+        lateral, heading_err = self._lane_geometry(transform.location, transform.rotation.yaw)
+        ego = np.array(
             [
                 transform.location.x,
                 transform.location.y,
                 transform.rotation.yaw,
                 velocity.x,
                 velocity.y,
+                lateral,
+                heading_err,
             ]
         )
+        agent_rows = self._agent_rows(detected_only=False)
+        return np.concatenate([ego, agent_rows.reshape(-1)])
 
-    def _read_observation(self) -> np.ndarray:
+    def _nearest_agents(self) -> List[Any]:
+        """The ``max_tracked_agents`` other vehicles nearest the ego, by true distance."""
+        ego_location = self._vehicle.get_location()
+        others = [
+            actor
+            for actor in self._world.get_actors().filter("vehicle.*")
+            if actor.id != self._vehicle.id
+        ]
+        others.sort(key=lambda actor: actor.get_location().distance(ego_location))
+        return others[: self._max_tracked_agents]
+
+    def _agent_rows(self, detected_only: bool) -> np.ndarray:
+        """Fixed ``(K, AGENT_SLOT_WIDTH)`` matrix of nearest-agent slots in ego frame.
+
+        When ``detected_only`` is set, agents that are out of range or occluded are
+        left as empty (``present == 0``) slots, so the same slot index that carries
+        an agent in the ground-truth state is hidden in the observation.
+        """
+        rows = np.zeros((self._max_tracked_agents, AGENT_SLOT_WIDTH))
+        ego_transform = self._vehicle.get_transform()
+        ego_location = ego_transform.location
+        ego_x, ego_y = ego_location.x, ego_location.y
+        ego_yaw = np.radians(ego_transform.rotation.yaw)
+        nearest = self._nearest_agents()
+        for slot, actor in enumerate(nearest):
+            if detected_only and not self._is_detected(ego_location, actor, nearest):
+                continue
+            other_transform = actor.get_transform()
+            other_velocity = actor.get_velocity()
+            rows[slot] = _relative_agent_row(
+                ego_x,
+                ego_y,
+                ego_yaw,
+                other_transform.location.x,
+                other_transform.location.y,
+                np.radians(other_transform.rotation.yaw),
+                float(np.hypot(other_velocity.x, other_velocity.y)),
+            )
+        return rows
+
+    def _is_detected(self, ego_location: Any, actor: Any, nearest: List[Any]) -> bool:
+        """Whether ``actor`` is within perception range and not occluded by a vehicle."""
+        target = actor.get_location()
+        if target.distance(ego_location) > self._perception_range:
+            return False
+        for blocker in nearest:
+            if blocker.id == actor.id:
+                continue
+            blocker_location = blocker.get_location()
+            if _segment_occludes(
+                ego_location.x,
+                ego_location.y,
+                target.x,
+                target.y,
+                blocker_location.x,
+                blocker_location.y,
+                self._occlusion_radius,
+            ):
+                return False
+        return True
+
+    def _lane_geometry(self, location: Any, yaw_deg: float) -> Tuple[float, float]:
+        """Signed lateral offset (m) and heading error (rad) w.r.t. the driving lane.
+
+        Projects the ego onto the centre of the nearest driving lane via the CARLA
+        map, then returns how far it sits to the side of that lane centre and how
+        far its heading deviates from the lane direction (wrapped to ``[-pi, pi]``).
+        """
+        waypoint = self._map.get_waypoint(
+            location, project_to_road=True, lane_type=self._carla.LaneType.Driving
+        )
+        lane_transform = waypoint.transform
+        lane_yaw = np.radians(lane_transform.rotation.yaw)
+        delta_x = location.x - lane_transform.location.x
+        delta_y = location.y - lane_transform.location.y
+        lateral = float(-np.sin(lane_yaw) * delta_x + np.cos(lane_yaw) * delta_y)
+        heading_err = float(_wrap_to_pi(np.radians(yaw_deg) - lane_yaw))
+        return lateral, heading_err
+
+    def _read_observation(self) -> Dict[str, np.ndarray]:
+        observation: Dict[str, np.ndarray] = {
+            "gnss": self._read_gnss(),
+            "agents": self._agent_rows(detected_only=True).reshape(-1),
+        }
+        if self._include_camera:
+            observation["camera"] = self._read_camera()
+        if self._include_lidar:
+            observation["lidar"] = self._read_lidar()
+        if self._observation_extractor is not None:
+            return self._observation_extractor(observation)
+        return observation
+
+    def _read_gnss(self) -> np.ndarray:
         if self._latest_gnss is None:
             return np.zeros(3)
         return self._latest_gnss
 
+    def _read_camera(self) -> np.ndarray:
+        if self._latest_camera is None:
+            return np.zeros((self._camera_height, self._camera_width, 3), dtype=np.uint8)
+        return self._latest_camera
+
+    def _read_lidar(self) -> np.ndarray:
+        if self._latest_lidar is None:
+            return np.zeros((0, 4), dtype=np.float32)
+        return self._latest_lidar
+
     def _teardown_actors(self) -> None:
+        for controller in self._walker_controllers:
+            controller.stop()
         for actor in (
+            *self._walker_controllers,
+            *self._walkers,
+            *self._traffic_vehicles,
             self._camera_sensor,
+            self._obs_camera_sensor,
+            self._lidar_sensor,
             self._collision_sensor,
             self._gnss_sensor,
             self._vehicle,
         ):
             if actor is not None:
                 actor.destroy()
+        self._traffic_vehicles = []
+        self._walkers = []
+        self._walker_controllers = []
         self._vehicle = None
         self._gnss_sensor = None
         self._collision_sensor = None
         self._camera_sensor = None
         self._camera_queue = None
+        self._obs_camera_sensor = None
+        self._lidar_sensor = None
         self._latest_gnss = None
+        self._latest_camera = None
+        self._latest_lidar = None
 
 
 class CarlaPOMDP(Environment):
@@ -243,7 +691,9 @@ class CarlaPOMDP(Environment):
     POMDPPlanners episode loop requests those three quantities through separate
     method calls while CARLA produces them atomically. The state is the ego
     vehicle's ground-truth kinematics; the observation is a native CARLA sensor
-    payload (GNSS by default), so the world is genuinely partially observed.
+    payload (GNSS by default), so the world is genuinely partially observed. See
+    the module docstring for the exact state and observation variables, units,
+    and frames.
 
     Note:
         This is a *world* environment, not a generative model. It cannot sample a
@@ -270,7 +720,8 @@ class CarlaPOMDP(Environment):
             env = CarlaPOMDP(discount_factor=0.95, town="Town03")
             state = env.initial_state_dist().sample()[0]
             next_state, observation, reward = env.sample_next_step(state, 0)
-            # state is [x, y, yaw, vx, vy]; observation is a GNSS reading.
+            # state is [ego(7), nearest-agent slots...]; observation is a
+            # gnss/agents/camera/lidar dict hiding out-of-range / occluded agents.
     """
 
     def __init__(
@@ -283,8 +734,22 @@ class CarlaPOMDP(Environment):
         action_presets: Optional[Sequence[Tuple[float, float, float]]] = None,
         record_camera: bool = False,
         camera_config: Optional[Dict[str, Any]] = None,
+        include_camera: bool = True,
+        include_lidar: bool = True,
+        observation_camera_config: Optional[Dict[str, Any]] = None,
+        lidar_config: Optional[Dict[str, Any]] = None,
         fixed_delta_seconds: float = 0.05,
         collision_penalty: float = 100.0,
+        desired_speed: float = 8.0,
+        out_lane_thresh: float = 2.0,
+        num_vehicles: int = DEFAULT_NUM_VEHICLES,
+        num_walkers: int = DEFAULT_NUM_WALKERS,
+        max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
+        perception_range: float = DEFAULT_PERCEPTION_RANGE,
+        occlusion_radius: float = DEFAULT_OCCLUSION_RADIUS,
+        traffic_manager_port: int = DEFAULT_TRAFFIC_MANAGER_PORT,
+        randomize_spawn: bool = True,
+        observation_extractor: Optional[Callable[[Dict[str, np.ndarray]], Any]] = None,
         vehicle_filter: str = "vehicle.tesla.model3",
         timeout: float = 10.0,
         seed: Optional[int] = None,
@@ -310,9 +775,45 @@ class CarlaPOMDP(Environment):
                 render cost, so it defaults to False.
             camera_config: RGB camera blueprint attributes (e.g. ``image_size_x``)
                 overriding :data:`DEFAULT_CAMERA_CONFIG`. Defaults to none.
+            include_camera: If True, attach a front-facing RGB observation camera
+                and include its frame under the ``"camera"`` observation key.
+                Defaults to True.
+            include_lidar: If True, attach a roof-mounted LiDAR and include its
+                point cloud under the ``"lidar"`` observation key. Defaults to True.
+            observation_camera_config: Front camera blueprint attributes overriding
+                :data:`DEFAULT_OBSERVATION_CAMERA_CONFIG`. Defaults to none.
+            lidar_config: LiDAR blueprint attributes overriding
+                :data:`DEFAULT_LIDAR_CONFIG`. Defaults to none.
             fixed_delta_seconds: Synchronous-mode tick length. Defaults to 0.05.
             collision_penalty: Reward penalty applied on a terminal collision.
                 Defaults to 100.0.
+            desired_speed: Target longitudinal speed in m/s; exceeding it incurs the
+                overspeed penalty. Defaults to 8.0.
+            out_lane_thresh: Lateral offset in metres beyond which the ego is treated
+                as out of lane and penalised. Defaults to 2.0.
+            num_vehicles: Number of autopilot traffic vehicles spawned into the
+                world each reset. Defaults to :data:`DEFAULT_NUM_VEHICLES`.
+            num_walkers: Number of walking pedestrians spawned into the world each
+                reset. Defaults to :data:`DEFAULT_NUM_WALKERS`.
+            max_tracked_agents: Number of nearest other vehicles carried as fixed
+                slots in the state and observation. Defaults to
+                :data:`DEFAULT_MAX_TRACKED_AGENTS`.
+            perception_range: Metres beyond which another agent is undetectable and
+                hidden from the observation. Defaults to
+                :data:`DEFAULT_PERCEPTION_RANGE`.
+            occlusion_radius: Metres from the ego->target sight line within which a
+                vehicle blocks (occludes) the target. Defaults to
+                :data:`DEFAULT_OCCLUSION_RADIUS`.
+            traffic_manager_port: CARLA Traffic Manager RPC port used to drive the
+                traffic vehicles. Defaults to :data:`DEFAULT_TRAFFIC_MANAGER_PORT`.
+            randomize_spawn: If True, sample a random ego spawn point (and weather)
+                each reset instead of a fixed one. Defaults to True.
+            observation_extractor: Optional callable applied to the full
+                ``{gnss, agents, camera, lidar}`` observation dict each step,
+                returning the observation actually emitted (e.g. a subset of the
+                keys or a flattened vector). Must be a picklable (module-level)
+                callable, since the environment is pickled for distributed runs.
+                Defaults to None, which emits the full dict unchanged.
             vehicle_filter: Blueprint filter for the ego vehicle. Defaults to
                 ``"vehicle.tesla.model3"``.
             timeout: CARLA client timeout in seconds. Defaults to 10.0.
@@ -335,8 +836,26 @@ class CarlaPOMDP(Environment):
         self.camera_config: Dict[str, Any] = dict(DEFAULT_CAMERA_CONFIG)
         if camera_config:
             self.camera_config.update(camera_config)
+        self.include_camera = include_camera
+        self.include_lidar = include_lidar
+        self.observation_camera_config: Dict[str, Any] = dict(DEFAULT_OBSERVATION_CAMERA_CONFIG)
+        if observation_camera_config:
+            self.observation_camera_config.update(observation_camera_config)
+        self.lidar_config: Dict[str, Any] = dict(DEFAULT_LIDAR_CONFIG)
+        if lidar_config:
+            self.lidar_config.update(lidar_config)
         self.fixed_delta_seconds = fixed_delta_seconds
         self.collision_penalty = collision_penalty
+        self.desired_speed = desired_speed
+        self.out_lane_thresh = out_lane_thresh
+        self.num_vehicles = num_vehicles
+        self.num_walkers = num_walkers
+        self.max_tracked_agents = max_tracked_agents
+        self.perception_range = perception_range
+        self.occlusion_radius = occlusion_radius
+        self.traffic_manager_port = traffic_manager_port
+        self.randomize_spawn = randomize_spawn
+        self.observation_extractor = observation_extractor
         self.vehicle_filter = vehicle_filter
         self.timeout = timeout
         self.seed = seed
@@ -344,7 +863,7 @@ class CarlaPOMDP(Environment):
         # Live-session state: rebuilt lazily and never serialized.
         self._session: Optional[Any] = None
         self._live_state: Optional[np.ndarray] = None
-        self._latest_obs: Optional[np.ndarray] = None
+        self._latest_obs: Optional[Dict[str, np.ndarray]] = None
         self._terminated: bool = False
         self._seeded: bool = False
         self._pending: Optional[Dict[str, Any]] = None
@@ -403,6 +922,18 @@ class CarlaPOMDP(Environment):
                 timeout=self.timeout,
                 record_camera=self.record_camera,
                 camera_config=self.camera_config,
+                include_camera=self.include_camera,
+                include_lidar=self.include_lidar,
+                observation_camera_config=self.observation_camera_config,
+                lidar_config=self.lidar_config,
+                num_vehicles=self.num_vehicles,
+                num_walkers=self.num_walkers,
+                max_tracked_agents=self.max_tracked_agents,
+                perception_range=self.perception_range,
+                occlusion_radius=self.occlusion_radius,
+                traffic_manager_port=self.traffic_manager_port,
+                randomize_spawn=self.randomize_spawn,
+                observation_extractor=self.observation_extractor,
             )
         return self._session
 
@@ -415,7 +946,7 @@ class CarlaPOMDP(Environment):
             state, observation = session.reset()
         state = np.asarray(state)
         self._live_state = state
-        self._latest_obs = np.asarray(observation)
+        self._latest_obs = observation
         self._terminated = False
         self._pending = None
         self._served_roles = set()
@@ -427,10 +958,21 @@ class CarlaPOMDP(Environment):
     def _states_equal(self, state_a: Any, state_b: Any) -> bool:
         return np.array_equal(np.asarray(state_a), np.asarray(state_b))
 
-    def _compute_reward(self, next_state: np.ndarray, terminated: bool) -> float:
-        speed = float(np.hypot(next_state[3], next_state[4]))
-        penalty = self.collision_penalty if terminated else 0.0
-        return speed - penalty
+    def _compute_reward(self, next_state: np.ndarray, action: Any, terminated: bool) -> float:
+        """Score a transition with a gym-carla-style driving-quality reward.
+
+        Rewards along-lane progress and penalises overspeed, drifting out of lane,
+        harsh / high-speed steering, each elapsed step, and a terminal collision.
+        """
+        _, steer, _ = self._to_control(action)
+        return driving_quality_reward(
+            next_state,
+            steer,
+            terminated,
+            self.desired_speed,
+            self.out_lane_thresh,
+            self.collision_penalty,
+        )
 
     def _ensure_stepped(self, state: Any, action: Any, role: str) -> Dict[str, Any]:
         """Advance the world one tick for ``(state, action)`` (once) and cache it.
@@ -465,14 +1007,13 @@ class CarlaPOMDP(Environment):
         throttle, steer, brake = self._to_control(action)
         next_state, observation, terminated = session.step(throttle, steer, brake)
         next_state = np.asarray(next_state)
-        observation = np.asarray(observation)
         done = bool(terminated)
         pending = {
             "state": np.asarray(state).copy(),
             "action": action,
             "next_state": next_state,
             "observation": observation,
-            "reward": self._compute_reward(next_state, done),
+            "reward": self._compute_reward(next_state, action, done),
             "terminated": done,
         }
         self._pending = pending
@@ -488,7 +1029,7 @@ class CarlaPOMDP(Environment):
             raise ValueError("CarlaPOMDP is forward-only and only supports n_samples=1")
         return self._ensure_stepped(state, action, _ROLE_NEXT_STATE)["next_state"]
 
-    def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+    def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> Any:
         del action
         if n_samples != 1:
             raise ValueError("CarlaPOMDP is forward-only and only supports n_samples=1")
@@ -529,20 +1070,33 @@ class CarlaPOMDP(Environment):
         parent = self
 
         class InitialObservation(Distribution):
-            def sample(self, n_samples: int = 1) -> List[np.ndarray]:
+            def sample(self, n_samples: int = 1) -> List[Any]:
                 # pylint: disable=protected-access
                 observation = parent._latest_obs
                 if observation is None:
                     parent._reset()
                     observation = parent._latest_obs
-                return [np.asarray(observation) for _ in range(n_samples)]
+                assert observation is not None
+                return [dict(observation) for _ in range(n_samples)]
 
         return InitialObservation()
 
     def is_equal_observation(self, observation1: Any, observation2: Any) -> bool:
+        is_dict1 = isinstance(observation1, dict)
+        is_dict2 = isinstance(observation2, dict)
+        if is_dict1 and is_dict2:
+            if observation1.keys() != observation2.keys():
+                return False
+            return all(np.array_equal(observation1[key], observation2[key]) for key in observation1)
+        if is_dict1 or is_dict2:
+            return False
         return np.array_equal(np.asarray(observation1), np.asarray(observation2))
 
     def hash_observation(self, observation: Any) -> Hashable:
+        if isinstance(observation, dict):
+            return tuple(
+                (key, np.asarray(observation[key]).tobytes()) for key in sorted(observation)
+            )
         array = np.asarray(observation)
         return array.tobytes()
 

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_model_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_model_pomdp.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the CARLA generative-model interface and its factored reference impl.
+
+Covers the abstract :class:`CarlaModelPOMDP` interface contract, the concrete
+:class:`FactoredCarlaModelPOMDP` factored observation model / identity transition /
+shared reward, and the intended learned-dynamics subclassing pattern. All tests run on
+hand-built state arrays with no CARLA server.
+"""
+
+from typing import Any, List
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.carla_pomdp.carla_model_pomdp import CarlaModelPOMDP
+from POMDPPlanners.environments.carla_pomdp.carla_factored_model_pomdp import (
+    FactoredCarlaModelPOMDP,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
+    AGENT_SLOT_WIDTH,
+    DEFAULT_MAX_TRACKED_AGENTS,
+    EGO_STATE_WIDTH,
+    driving_quality_reward,
+)
+
+
+def _make_state(
+    agent_rows: List[np.ndarray],
+    ego: Any = None,
+    max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
+) -> np.ndarray:
+    """Assemble a CARLA state vector from an ego part and filled agent slots."""
+    ego_part = np.zeros(EGO_STATE_WIDTH) if ego is None else np.asarray(ego, dtype=float)
+    rows = np.zeros((max_tracked_agents, AGENT_SLOT_WIDTH))
+    for index, row in enumerate(agent_rows):
+        rows[index] = row
+    return np.concatenate([ego_part, rows.reshape(-1)])
+
+
+def test_base_interface_cannot_be_instantiated():
+    """Test that the abstract CarlaModelPOMDP interface cannot be instantiated.
+
+    Purpose: Validates CarlaModelPOMDP is an abstract interface, not a usable class
+
+    Given: The abstract CarlaModelPOMDP base with unimplemented dynamics methods
+    When: Direct instantiation is attempted
+    Then: A TypeError is raised for the remaining abstract methods
+
+    Test type: unit
+    """
+    with pytest.raises(TypeError):
+        CarlaModelPOMDP(discount_factor=0.95)  # type: ignore[abstract]
+
+
+def test_get_actions_indexes_presets():
+    """Test that the discrete action set is the indices into the control presets.
+
+    Purpose: Validates the schema-level discrete action enumeration
+
+    Given: A factored model built with three control presets
+    When: get_actions is called
+    Then: It returns [0, 1, 2], one index per preset
+
+    Test type: unit
+    """
+    env = FactoredCarlaModelPOMDP(
+        discount_factor=0.95,
+        action_presets=[(0.5, 0.0, 0.0), (0.3, -0.5, 0.0), (0.0, 0.0, 1.0)],
+    )
+    assert env.get_actions() == [0, 1, 2]
+
+
+def test_sample_next_state_identity_single_and_batch():
+    """Test the identity-transition placeholder honours the n_samples convention.
+
+    Purpose: Validates the placeholder returns a single state for n_samples=1 and a
+        stacked batch otherwise, matching the repo convention
+
+    Given: A factored model and a hand-built state vector
+    When: sample_next_state is called with n_samples 1 and 3
+    Then: n_samples=1 returns the single unchanged state (1-D); n_samples=3 returns a
+        (3, D) stack of copies
+
+    Test type: unit
+    """
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95)
+    state = _make_state([np.array([1.0, 3.0, 0.0, 0.0, 4.0])])
+
+    single = env.sample_next_state(state, action=0)
+    assert single.shape == state.shape
+    np.testing.assert_array_equal(single, state)
+
+    batch = env.sample_next_state(state, action=0, n_samples=3)
+    assert batch.shape == (3, state.shape[0])
+    for row in batch:
+        np.testing.assert_array_equal(row, state)
+
+
+def test_transition_log_probability_raises():
+    """Test that the placeholder transition density raises NotImplementedError.
+
+    Purpose: Validates the transition density is an explicit, documented stub
+
+    Given: A factored model with a placeholder identity transition
+    When: transition_log_probability is called
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95)
+    state = _make_state([])
+    with pytest.raises(NotImplementedError):
+        env.transition_log_probability(state, action=0, next_states=state)
+
+
+def test_is_terminal_always_false():
+    """Test that the model reports no terminal states.
+
+    Purpose: Validates the model's is_terminal is a constant False
+
+    Given: A factored model and an arbitrary state
+    When: is_terminal is called
+    Then: It returns False
+
+    Test type: unit
+    """
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95)
+    assert env.is_terminal(_make_state([])) is False
+
+
+def test_initial_distributions_raise():
+    """Test that the initial-distribution hooks direct seeding to the world.
+
+    Purpose: Validates the model refuses to synthesise an initial belief itself
+
+    Given: A factored model paired with a forward-only world
+    When: initial_state_dist or initial_observation_dist is called
+    Then: NotImplementedError is raised in both cases
+
+    Test type: unit
+    """
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95)
+    with pytest.raises(NotImplementedError):
+        env.initial_state_dist()
+    with pytest.raises(NotImplementedError):
+        env.initial_observation_dist()
+
+
+def test_sample_observation_keys_and_hides_unseen():
+    """Test that sampled observations expose the schema keys and hide unseen agents.
+
+    Purpose: Validates the factored observation zeroes out-of-range/occluded agents
+
+    Given: A state with one in-range agent and one agent beyond perception range
+    When: sample_observation is called (no pose noise via zero pose_std is not used;
+        instead we inspect the present flags which noise does not touch)
+    Then: The observation has 'gnss' and 'agents' keys; the near agent's slot is present
+        and the far agent's slot is zeroed
+
+    Test type: unit
+    """
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95, perception_range=50.0)
+    near = np.array([1.0, 10.0, 0.0, 0.0, 0.0])
+    far = np.array([1.0, 100.0, 0.0, 0.0, 0.0])
+    state = _make_state([near, far])
+
+    observation = env.sample_observation(state, action=0)
+    assert sorted(observation) == ["agents", "gnss"]
+    obs_rows = observation["agents"].reshape(DEFAULT_MAX_TRACKED_AGENTS, AGENT_SLOT_WIDTH)
+    assert obs_rows[0, 0] == 1.0  # near agent detected
+    assert obs_rows[1, 0] == 0.0  # far agent hidden
+
+
+def test_observation_log_probability_prefers_matching_observation():
+    """Test that a matching observation scores higher than a mismatched one.
+
+    Purpose: Validates the factored observation likelihood ranks the truthful reading
+        above a corrupted one
+
+    Given: A state with a single detected agent and its clean rendered observation
+    When: observation_log_probability is scored for the clean observation vs a
+        pose-shifted one
+    Then: The clean observation has the higher log-probability
+
+    Test type: unit
+    """
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95)
+    state = _make_state([np.array([1.0, 10.0, 1.0, 0.2, 3.0])])
+    clean = env._render_observation(state, noisy=False)  # pylint: disable=protected-access
+
+    mismatched = {
+        "gnss": clean["gnss"].copy(),
+        "agents": clean["agents"].copy(),
+    }
+    mismatched["agents"][1] += 5.0  # shift the detected agent's rel_x far from truth
+
+    clean_lp = env.observation_log_probability(state, action=0, observations=clean)[0]
+    mismatched_lp = env.observation_log_probability(state, action=0, observations=mismatched)[0]
+    assert clean_lp > mismatched_lp
+
+
+def test_observation_log_probability_penalizes_seeing_an_occluded_agent():
+    """Test that observing an occluded agent is scored as near-impossible.
+
+    Purpose: Validates the occlusion gating in the observation likelihood
+
+    Given: A target agent occluded by a blocker on the ego->target sight line
+    When: observation_log_probability scores an observation that (wrongly) reports the
+        occluded target as detected vs one that correctly omits it
+    Then: The correct (omitted) observation scores far higher than the impossible one
+
+    Test type: unit
+    """
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95, occlusion_radius=1.5)
+    target = np.array([1.0, 10.0, 0.0, 0.0, 0.0])
+    blocker = np.array([1.0, 5.0, 0.0, 0.0, 0.0])
+    state = _make_state([target, blocker])
+
+    rows = np.zeros((DEFAULT_MAX_TRACKED_AGENTS, AGENT_SLOT_WIDTH))
+    rows[1] = blocker  # only the visible blocker is reported
+    omitted = {"gnss": state[:2].copy(), "agents": rows.reshape(-1)}
+
+    wrongly_seen = {"gnss": state[:2].copy(), "agents": rows.reshape(-1).copy()}
+    wrongly_seen["agents"][:AGENT_SLOT_WIDTH] = target  # report the occluded target
+
+    omitted_lp = env.observation_log_probability(state, action=0, observations=omitted)[0]
+    seen_lp = env.observation_log_probability(state, action=0, observations=wrongly_seen)[0]
+    assert omitted_lp > seen_lp + 40.0  # the impossible reading is floored at _LOG_EPS
+
+
+def test_reward_matches_shared_driving_quality_reward():
+    """Test that the model reward equals the shared world reward for the same state.
+
+    Purpose: Validates world and model score a transition identically by construction
+
+    Given: A resulting ego state with longitudinal speed and a steering action preset
+    When: The model reward is computed for that next_state
+    Then: It equals driving_quality_reward called with the preset's steer and the model's
+        reward parameters
+
+    Test type: unit
+    """
+    env = FactoredCarlaModelPOMDP(
+        discount_factor=0.95,
+        action_presets=[(0.5, 0.0, 0.0), (0.3, -0.5, 0.0)],
+        desired_speed=8.0,
+        out_lane_thresh=2.0,
+        collision_penalty=100.0,
+    )
+    next_state = _make_state([], ego=[0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0])
+
+    reward = env.reward(state=_make_state([]), action=1, next_state=next_state)
+    expected = driving_quality_reward(next_state, -0.5, False, 8.0, 2.0, 100.0)
+    assert reward == pytest.approx(expected)
+
+
+def test_reward_falls_back_to_state_when_next_state_is_none():
+    """Test that reward scores the current state when no next_state is supplied.
+
+    Purpose: Validates the belief-expectation reward path (reward_batch passes only
+        state, action) is supported
+
+    Given: A model and a state carrying longitudinal speed
+    When: reward is called with next_state=None
+    Then: It equals the reward computed from that state as the resulting state
+
+    Test type: unit
+    """
+    env = FactoredCarlaModelPOMDP(
+        discount_factor=0.95,
+        action_presets=[(0.5, 0.0, 0.0), (0.3, -0.5, 0.0)],
+    )
+    state = _make_state([], ego=[0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0])
+
+    reward = env.reward(state=state, action=1)
+    expected = driving_quality_reward(state, -0.5, False, 8.0, 2.0, 100.0)
+    assert reward == pytest.approx(expected)
+
+
+def test_hash_and_equal_observation():
+    """Test observation hashing and equality over the CARLA observation dict.
+
+    Purpose: Validates the schema-level equality/hash agree for identical observations
+        and differ for distinct ones
+
+    Given: Two identical observations and one with a different agents payload
+    When: is_equal_observation and hash_observation are applied
+    Then: Identical observations compare equal and hash equal; the distinct one differs
+
+    Test type: unit
+    """
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95)
+    obs_a = {"gnss": np.array([1.0, 2.0]), "agents": np.zeros(AGENT_SLOT_WIDTH)}
+    obs_b = {"gnss": np.array([1.0, 2.0]), "agents": np.zeros(AGENT_SLOT_WIDTH)}
+    obs_c = {"gnss": np.array([1.0, 2.0]), "agents": np.ones(AGENT_SLOT_WIDTH)}
+
+    assert env.is_equal_observation(obs_a, obs_b)
+    assert env.hash_observation(obs_a) == env.hash_observation(obs_b)
+    assert not env.is_equal_observation(obs_a, obs_c)
+    assert env.hash_observation(obs_a) != env.hash_observation(obs_c)
+
+
+def test_config_id_stable_and_sensitive_to_params():
+    """Test the deterministic config id is stable and parameter-sensitive.
+
+    Purpose: Validates config_id round-trips schema/model attributes for caching
+
+    Given: Two identically configured models and one with a different detect_prob
+    When: config_id is read from each
+    Then: The identical models share a config_id; the differing model has a distinct one
+
+    Test type: configuration
+    """
+    env_a = FactoredCarlaModelPOMDP(discount_factor=0.95, detect_prob=0.95)
+    env_b = FactoredCarlaModelPOMDP(discount_factor=0.95, detect_prob=0.95)
+    env_c = FactoredCarlaModelPOMDP(discount_factor=0.95, detect_prob=0.5)
+
+    assert env_a.config_id == env_b.config_id
+    assert env_a.config_id != env_c.config_id
+
+
+def test_learned_dynamics_subclass_plugs_into_sample_next_step():
+    """Test the intended pattern: override transition/reward, keep the factored obs model.
+
+    Purpose: Validates the interface supports a study-specific (e.g. learned) model that
+        replaces dynamics while reusing the factored observation and CARLA schema
+
+    Given: A subclass overriding sample_next_state (a fixed drift) and reward (constant)
+    When: sample_next_step is driven from a hand-built state
+    Then: The next_state reflects the overridden transition, the observation carries the
+        schema keys, and the reward is the overridden constant
+
+    Test type: integration
+    """
+
+    class DriftModel(FactoredCarlaModelPOMDP):
+        def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+            del action
+            nxt = np.asarray(state, dtype=float).copy()
+            nxt[0] += 1.0  # deterministic forward drift in ego x
+            if n_samples == 1:
+                return nxt
+            return np.stack([nxt for _ in range(n_samples)])
+
+        def reward(self, state: Any, action: Any, next_state: Any = None) -> float:
+            del state, action, next_state
+            return 2.0
+
+    env = DriftModel(discount_factor=0.95)
+    state = _make_state([np.array([1.0, 10.0, 0.0, 0.0, 0.0])])
+
+    next_state, observation, reward = env.sample_next_step(state, action=0)
+    assert next_state[0] == state[0] + 1.0
+    assert sorted(observation) == ["agents", "gnss"]
+    assert reward == 2.0
+
+
+def test_factored_model_docstring_example():
+    """Test the usage example from the FactoredCarlaModelPOMDP docstring.
+
+    Purpose: Validates the class docstring example executes and behaves as documented
+
+    Given: The exact setup from the docstring (seeded rng, zero state, first action)
+    When: sample_next_step is called and terminal state is checked
+    Then: The observation has the documented keys and is_terminal is False
+
+    Test type: example
+    """
+    np.random.seed(42)
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95)
+    width = EGO_STATE_WIDTH + env.max_tracked_agents * AGENT_SLOT_WIDTH
+    state = np.zeros(width)
+    action = env.get_actions()[0]
+
+    _, observation, _ = env.sample_next_step(state, action)
+    assert sorted(observation) == ["agents", "gnss"]
+    assert env.is_terminal(state) is False

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
@@ -3,15 +3,16 @@
 """Unit tests for the CarlaPOMDP forward-only world wrapper.
 
 These tests drive CarlaPOMDP against a controllable fake CARLA session (scripted
-reset/step returning a 5-D ground-truth state and a 3-D GNSS observation) injected
+reset/step returning a 7-D ground-truth state and a 3-D GNSS observation) injected
 by monkeypatching ``CarlaPOMDP._get_session``, so they run without a CARLA server
 or the ``carla`` package installed. They mirror the GymPOMDP suite and add the
 CARLA-specific assertion that the observation differs from the state.
 """
 
-# pylint: disable=protected-access  # Tests inspect the live-session internals
+# pylint: disable=protected-access,too-many-lines  # Tests inspect live-session internals
 
 import pickle
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 from pathlib import Path
 
@@ -22,18 +23,34 @@ from POMDPPlanners.core.belief import Belief
 from POMDPPlanners.core.belief.belief_utils import get_initial_belief
 from POMDPPlanners.core.environment import Environment, SpaceType
 from POMDPPlanners.core.policy import Policy, PolicyRunData, PolicySpaceInfo
-from POMDPPlanners.environments.carla_pomdp import CarlaPOMDP, carla_video
+from POMDPPlanners.environments.carla_pomdp import CarlaPOMDP, carla_pomdp, carla_video
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
 from POMDPPlanners.simulations.episodes import EpisodeRunner
 
 
-class FakeCarlaSession:
-    """Scripted CARLA-like session: 5-D ground-truth state, 3-D GNSS observation.
+def _make_observation(latitude: float) -> Dict[str, np.ndarray]:
+    """Build a multi-modal gnss/camera/lidar observation dict for the fakes."""
+    return {
+        "gnss": np.array([latitude, 2.0, 0.0]),
+        "camera": np.zeros((128, 128, 3), dtype=np.uint8),
+        "lidar": np.zeros((10, 4), dtype=np.float32),
+    }
 
-    The state is ``[x, y, yaw, vx, vy]`` with ``vx`` advancing each tick so the
-    ego speed equals the step index; the observation is a distinct 3-D GNSS
-    ``[lat, lon, alt]`` vector. The episode terminates once three ticks have been
-    taken, so terminal behavior is deterministic.
+
+def _gnss_only_extractor(observation: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+    """Observation extractor that keeps only the ``gnss`` modality."""
+    return {"gnss": observation["gnss"]}
+
+
+class FakeCarlaSession:
+    """Scripted CARLA-like session: 7-D ground-truth state, multi-modal observation.
+
+    The state is ``[x, y, yaw, vx, vy, lat, heading_err]`` with ``vx`` advancing
+    each tick so the ego speed equals the step index and the ego kept perfectly on
+    the lane centre (``lat == 0`` and ``heading_err == 0``); the observation is a
+    distinct dict with a 3-D GNSS ``[lat, lon, alt]`` vector plus camera and lidar
+    arrays. The episode terminates once three ticks have been taken, so terminal
+    behavior is deterministic.
     """
 
     def __init__(self) -> None:
@@ -42,24 +59,22 @@ class FakeCarlaSession:
         self.last_control: Optional[Tuple[float, float, float]] = None
         self._t = 0
 
-    def reset(self, seed: Optional[int] = None) -> Tuple[np.ndarray, np.ndarray]:
+    def reset(self, seed: Optional[int] = None) -> Tuple[np.ndarray, Dict[str, np.ndarray]]:
         del seed
         self.reset_calls += 1
         self._t = 0
-        state = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
-        observation = np.array([48.0, 2.0, 0.0])
-        return state, observation
+        state = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        return state, _make_observation(48.0)
 
     def step(
         self, throttle: float, steer: float, brake: float
-    ) -> Tuple[np.ndarray, np.ndarray, bool]:
+    ) -> Tuple[np.ndarray, Dict[str, np.ndarray], bool]:
         self.step_calls += 1
         self.last_control = (throttle, steer, brake)
         self._t += 1
-        state = np.array([float(self._t), 0.0, 0.0, float(self._t), 0.0])
-        observation = np.array([48.0 + self._t, 2.0, 0.0])
+        state = np.array([float(self._t), 0.0, 0.0, float(self._t), 0.0, 0.0, 0.0])
         terminated = self._t >= 3
-        return state, observation, terminated
+        return state, _make_observation(48.0 + self._t), terminated
 
 
 class FixedActionPolicy(Policy):
@@ -143,9 +158,9 @@ def test_step_called_once_across_reward_next_state_observation(
     observation = world.sample_observation(next_state, 0)
 
     assert fake_session.step_calls - before == 1
-    assert reward == 1.0
-    assert np.array_equal(next_state, np.array([1.0, 0.0, 0.0, 1.0, 0.0]))
-    assert np.array_equal(observation, np.array([49.0, 2.0, 0.0]))
+    assert reward == pytest.approx(0.9)
+    assert np.array_equal(next_state, np.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
+    assert np.array_equal(observation["gnss"], np.array([49.0, 2.0, 0.0]))
 
 
 def test_call_order_independence_next_state_before_reward(
@@ -168,8 +183,8 @@ def test_call_order_independence_next_state_before_reward(
     reward = world.reward(state, 0)
 
     assert fake_session.step_calls - before == 1
-    assert np.array_equal(next_state, np.array([1.0, 0.0, 0.0, 1.0, 0.0]))
-    assert reward == 1.0
+    assert np.array_equal(next_state, np.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]))
+    assert reward == pytest.approx(0.9)
 
 
 def test_observation_differs_from_ground_truth_state(world: CarlaPOMDP) -> None:
@@ -179,7 +194,7 @@ def test_observation_differs_from_ground_truth_state(world: CarlaPOMDP) -> None:
 
     Given: A CarlaPOMDP world at its live state
     When: A step is sampled and both next state and observation are read
-    Then: The observation is the 3-D GNSS vector, not the 5-D ground-truth state
+    Then: The observation is the multi-modal sensor dict, not the 5-D state
 
     Test type: unit
     """
@@ -187,8 +202,8 @@ def test_observation_differs_from_ground_truth_state(world: CarlaPOMDP) -> None:
     next_state = world.sample_next_state(state, 0)
     observation = world.sample_observation(next_state, 0)
 
-    assert next_state.shape == (5,)
-    assert observation.shape == (3,)
+    assert next_state.shape == (7,)
+    assert observation["gnss"].shape == (3,)
     assert not world.is_equal_observation(observation, next_state)
 
 
@@ -230,7 +245,7 @@ def test_initial_state_dist_sample_triggers_reset(fake_session: FakeCarlaSession
 
     assert fake_session.reset_calls - before == 1
     assert len(samples) == 1
-    assert np.array_equal(samples[0], np.zeros(5))
+    assert np.array_equal(samples[0], np.zeros(7))
 
 
 def test_initial_observation_dist_returns_sensor_reading(world: CarlaPOMDP) -> None:
@@ -246,7 +261,7 @@ def test_initial_observation_dist_returns_sensor_reading(world: CarlaPOMDP) -> N
     """
     samples = world.initial_observation_dist().sample()
     assert len(samples) == 1
-    assert np.array_equal(samples[0], np.array([48.0, 2.0, 0.0]))
+    assert np.array_equal(samples[0]["gnss"], np.array([48.0, 2.0, 0.0]))
 
 
 def test_action_preset_index_maps_to_vehicle_control(world: CarlaPOMDP) -> None:
@@ -305,7 +320,7 @@ def test_forward_only_guard_raises_on_mismatched_state(world: CarlaPOMDP) -> Non
 
     Test type: unit
     """
-    arbitrary_state = np.array([99.0, 99.0, 0.0, 0.0, 0.0])
+    arbitrary_state = np.array([99.0, 99.0, 0.0, 0.0, 0.0, 0.0, 0.0])
     with pytest.raises(RuntimeError, match="forward-only"):
         world.sample_next_state(arbitrary_state, 0)
 
@@ -322,7 +337,7 @@ def test_sample_observation_rejects_mismatched_next_state(world: CarlaPOMDP) -> 
     Test type: unit
     """
     with pytest.raises(RuntimeError, match="forward-only|live"):
-        world.sample_observation(np.array([7.0, 7.0, 0.0, 0.0, 0.0]), 0)
+        world.sample_observation(np.array([7.0, 7.0, 0.0, 0.0, 0.0, 0.0, 0.0]), 0)
 
 
 def test_sample_next_state_rejects_multiple_samples(world: CarlaPOMDP) -> None:
@@ -396,7 +411,7 @@ def test_two_env_initial_state_drawn_from_world(fake_session: FakeCarlaSession) 
         environment=world, policy=policy, initial_belief=belief, num_steps=2, logger=None
     )
 
-    assert np.array_equal(runner.state, np.zeros(5))
+    assert np.array_equal(runner.state, np.zeros(7))
     assert fake_session.reset_calls >= 1
 
 
@@ -413,21 +428,21 @@ class StationaryThenMovingSession:
         self.step_calls = 0
         self._t = 0
 
-    def reset(self, seed: Optional[int] = None) -> Tuple[np.ndarray, np.ndarray]:
+    def reset(self, seed: Optional[int] = None) -> Tuple[np.ndarray, Dict[str, np.ndarray]]:
         del seed
         self.reset_calls += 1
         self._t = 0
-        return np.array([0.0, 0.0, 0.0, 0.0, 0.0]), np.array([48.0, 2.0, 0.0])
+        return np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]), _make_observation(48.0)
 
     def step(
         self, throttle: float, steer: float, brake: float
-    ) -> Tuple[np.ndarray, np.ndarray, bool]:
+    ) -> Tuple[np.ndarray, Dict[str, np.ndarray], bool]:
         del throttle, steer, brake
         self.step_calls += 1
         self._t += 1
         position = 0.0 if self._t <= 2 else float(self._t - 2)
-        state = np.array([position, 0.0, 0.0, 0.0, 0.0])
-        return state, np.array([48.0, 2.0, 0.0]), False
+        state = np.array([position, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        return state, _make_observation(48.0), False
 
 
 def test_stationary_ego_does_not_freeze_the_world(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -648,14 +663,17 @@ def test_is_equal_observation_true_for_identical_false_for_distinct(world: Carla
 
 
 def test_reward_subtracts_collision_penalty_on_terminal_step(world: CarlaPOMDP) -> None:
-    """The reward is ego speed on live steps and speed minus the penalty on collision.
+    """The reward rewards along-lane progress and subtracts the collision penalty.
 
-    Purpose: Validates the collision-penalty branch of the reward model.
+    Purpose: Validates the driving-quality reward and its collision branch.
 
-    Given: A world whose fake session terminates on the third tick at speed 3
+    Given: A world whose fake session keeps the ego on the lane centre (lat and
+        heading_err both zero), cruising straight (steer 0) at a speed equal to the
+        step index, terminating on the third tick at speed 3
     When: The world is driven forward three steps, reading each reward
-    Then: Non-terminal rewards equal the speed and the terminal reward has the
-        default collision penalty subtracted (3.0 - 100.0 == -97.0)
+    Then: Each non-terminal reward is the along-lane speed minus the per-step cost
+        (speed - 0.1), and the terminal reward additionally subtracts the default
+        collision penalty (3.0 - 0.1 - 100.0 == -97.1)
 
     Test type: unit
     """
@@ -667,6 +685,412 @@ def test_reward_subtracts_collision_penalty_on_terminal_step(world: CarlaPOMDP) 
         rewards.append(reward)
         state = next_state
 
-    assert rewards[0] == 1.0
-    assert rewards[1] == 2.0
-    assert rewards[2] == 3.0 - 100.0
+    assert rewards[0] == pytest.approx(1.0 - 0.1)
+    assert rewards[1] == pytest.approx(2.0 - 0.1)
+    assert rewards[2] == pytest.approx(3.0 - 0.1 - 100.0)
+
+
+def test_reward_penalizes_leaving_the_lane(world: CarlaPOMDP) -> None:
+    """A lateral offset beyond the threshold subtracts the out-of-lane penalty.
+
+    Purpose: Validates the out-of-lane term of the driving-quality reward.
+
+    Given: A transition cruising straight at 1 m/s but 3 m off the lane centre,
+        beyond the default 2 m out_lane_thresh
+    When: The reward for that transition is computed (non-terminal, no steering)
+    Then: The reward is the along-lane progress minus the out-of-lane penalty and
+        the per-step cost (1.0 - 1.0 - 0.1 == -0.1)
+
+    Test type: unit
+    """
+    next_state = np.array([0.0, 0.0, 0.0, 1.0, 0.0, 3.0, 0.0])
+
+    reward = world._compute_reward(next_state, 0, terminated=False)
+
+    assert reward == pytest.approx(1.0 - 1.0 - 0.1)
+
+
+def test_reward_penalizes_exceeding_desired_speed(world: CarlaPOMDP) -> None:
+    """Longitudinal speed above desired_speed subtracts the overspeed penalty.
+
+    Purpose: Validates the overspeed term of the driving-quality reward.
+
+    Given: A transition cruising straight along the lane at 10 m/s, above the
+        default 8 m/s desired_speed
+    When: The reward for that transition is computed (non-terminal, no steering)
+    Then: The reward is the along-lane progress minus the overspeed penalty and the
+        per-step cost (10.0 - 10.0 - 0.1 == -0.1)
+
+    Test type: unit
+    """
+    next_state = np.array([0.0, 0.0, 0.0, 10.0, 0.0, 0.0, 0.0])
+
+    reward = world._compute_reward(next_state, 0, terminated=False)
+
+    assert reward == pytest.approx(10.0 - 10.0 - 0.1)
+
+
+def test_reward_penalizes_steering(world: CarlaPOMDP) -> None:
+    """A steering action subtracts the squared-steer and lateral-accel penalties.
+
+    Purpose: Validates the steering smoothness terms of the driving-quality reward.
+
+    Given: A transition at 1 m/s along the lane taken with the steer-left preset
+        (index 1, steer -0.5)
+    When: The reward for that transition is computed (non-terminal)
+    Then: The reward is progress minus 5*steer**2, minus 0.2*|steer|*speed**2, minus
+        the per-step cost (1.0 - 5*0.25 - 0.2*0.5 - 0.1 == -0.45)
+
+    Test type: unit
+    """
+    next_state = np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
+
+    reward = world._compute_reward(next_state, 1, terminated=False)
+
+    assert reward == pytest.approx(1.0 - 5 * 0.25 - 0.2 * 0.5 - 0.1)
+
+
+def test_lane_geometry_returns_signed_offset_and_wrapped_heading_error() -> None:
+    """_lane_geometry projects the ego onto the lane and wraps the heading error.
+
+    Purpose: Validates the lane-relative geometry feeding lat/heading_err in state.
+
+    Given: A session whose CARLA map reports a lane centred at the origin pointing
+        along +x, with the ego 1.5 m to the lane's left
+    When: _lane_geometry is queried for headings of 10 deg and 190 deg
+    Then: The lateral offset is +1.5 m and the heading error equals the ego heading
+        minus the lane direction, wrapped to [-pi, pi]
+
+    Test type: unit
+    """
+    lane_transform = SimpleNamespace(
+        location=SimpleNamespace(x=0.0, y=0.0), rotation=SimpleNamespace(yaw=0.0)
+    )
+    waypoint = SimpleNamespace(transform=lane_transform)
+    session: Any = object.__new__(carla_pomdp._CarlaSession)
+    session._carla = SimpleNamespace(LaneType=SimpleNamespace(Driving="Driving"))
+    session._map = SimpleNamespace(
+        get_waypoint=lambda location, project_to_road, lane_type: waypoint
+    )
+    ego_location = SimpleNamespace(x=0.0, y=1.5)
+
+    lateral, heading_err = session._lane_geometry(ego_location, 10.0)
+    _, wrapped_heading_err = session._lane_geometry(ego_location, 190.0)
+
+    assert lateral == pytest.approx(1.5)
+    assert heading_err == pytest.approx(np.radians(10.0))
+    assert wrapped_heading_err == pytest.approx(np.radians(190.0) - 2 * np.pi)
+
+
+def test_relative_agent_row_expresses_pose_in_ego_frame() -> None:
+    """_relative_agent_row rotates another agent's pose into the ego frame.
+
+    Purpose: Validates the ego-frame transform feeding the agent state/obs slots.
+
+    Given: An ego at the origin heading 90 degrees (north, +y) and another agent
+        10 m north of it heading 90 degrees at 4 m/s
+    When: _relative_agent_row builds the slot row
+    Then: The agent maps to 10 m straight ahead (rel_x), 0 m lateral (rel_y), zero
+        relative heading, its speed, and a set present flag
+
+    Test type: unit
+    """
+    row = carla_pomdp._relative_agent_row(
+        ego_x=0.0,
+        ego_y=0.0,
+        ego_yaw_rad=np.radians(90.0),
+        other_x=0.0,
+        other_y=10.0,
+        other_yaw_rad=np.radians(90.0),
+        other_speed=4.0,
+    )
+
+    assert row[0] == pytest.approx(1.0)
+    assert row[1] == pytest.approx(10.0)
+    assert row[2] == pytest.approx(0.0, abs=1e-9)
+    assert row[3] == pytest.approx(0.0)
+    assert row[4] == pytest.approx(4.0)
+
+
+def test_segment_occludes_only_for_blockers_on_the_sight_line() -> None:
+    """_segment_occludes flags blockers between ego and target near the sight line.
+
+    Purpose: Validates the geometric occlusion test for perception hiding.
+
+    Given: An ego at the origin and a target 30 m ahead along +x
+    When: A blocker sits on the sight line between them, off to the side, and behind
+        the ego
+    Then: Only the on-line, in-between blocker occludes the target
+
+    Test type: unit
+    """
+    on_line = carla_pomdp._segment_occludes(0.0, 0.0, 30.0, 0.0, 15.0, 0.5, 1.5)
+    off_to_side = carla_pomdp._segment_occludes(0.0, 0.0, 30.0, 0.0, 15.0, 5.0, 1.5)
+    behind_ego = carla_pomdp._segment_occludes(0.0, 0.0, 30.0, 0.0, -5.0, 0.0, 1.5)
+
+    assert on_line is True
+    assert off_to_side is False
+    assert behind_ego is False
+
+
+def test_agent_rows_state_keeps_all_nearest_observation_hides_unseen() -> None:
+    """State carries every nearest agent; the observation hides unseen ones.
+
+    Purpose: Validates the core partial-observability gap over other agents.
+
+    Given: An ego with three tracked neighbours — one clearly visible ahead, one
+        directly behind the visible one (occluded), and one beyond perception range
+    When: _agent_rows is built for the state (all) and the observation (detected)
+    Then: The state marks all three present, while the observation keeps only the
+        visible agent and zeroes the occluded and out-of-range slots
+
+    Test type: unit
+    """
+    ego = _fake_actor(0, 0.0, 0.0)
+    visible = _fake_actor(1, 10.0, 0.0)  # 10 m ahead, in range, unobstructed
+    occluded = _fake_actor(2, 30.0, 0.0)  # behind `visible` on the same sight line
+    far = _fake_actor(3, 60.0, 0.0)  # beyond the 50 m perception range
+    session: Any = object.__new__(carla_pomdp._CarlaSession)
+    session._vehicle = ego
+    session._world = _fake_world([ego, visible, occluded, far])
+    session._max_tracked_agents = 3
+    session._perception_range = 50.0
+    session._occlusion_radius = 1.5
+
+    state_rows = session._agent_rows(detected_only=False)
+    observed_rows = session._agent_rows(detected_only=True)
+
+    assert state_rows.shape == (3, carla_pomdp.AGENT_SLOT_WIDTH)
+    assert list(state_rows[:, 0]) == [1.0, 1.0, 1.0]
+    assert state_rows[0][1] == pytest.approx(10.0)  # nearest is the visible agent
+    assert observed_rows[0][0] == 1.0  # visible agent survives
+    assert np.array_equal(observed_rows[1], np.zeros(carla_pomdp.AGENT_SLOT_WIDTH))
+    assert np.array_equal(observed_rows[2], np.zeros(carla_pomdp.AGENT_SLOT_WIDTH))
+
+
+def test_observation_includes_camera_and_lidar(world: CarlaPOMDP) -> None:
+    """A stepped observation is a multi-modal gnss/camera/lidar dict.
+
+    Purpose: Validates the multi-modal observation payload of the CARLA world.
+
+    Given: A CarlaPOMDP world whose fake session returns a dict observation
+    When: A step is sampled and the observation is read
+    Then: The observation is a dict with gnss/camera/lidar; camera is (H, W, 3)
+        uint8 and lidar is (N, 4) float32
+
+    Test type: unit
+    """
+    state = world._live_state
+    next_state = world.sample_next_state(state, 0)
+    observation = world.sample_observation(next_state, 0)
+
+    assert isinstance(observation, dict)
+    assert set(observation) == {"gnss", "camera", "lidar"}
+    assert np.array_equal(observation["gnss"], np.array([49.0, 2.0, 0.0]))
+    assert observation["camera"].shape == (128, 128, 3)
+    assert observation["camera"].dtype == np.uint8
+    assert observation["lidar"].shape[1] == 4
+    assert observation["lidar"].dtype == np.float32
+
+
+def _fake_actor(actor_id: int, x: float, y: float, yaw: float = 0.0, speed: float = 0.0) -> Any:
+    """A SimpleNamespace CARLA actor with transform/location/velocity accessors."""
+    location = SimpleNamespace(
+        x=x, y=y, distance=lambda other, _x=x, _y=y: float(np.hypot(other.x - _x, other.y - _y))
+    )
+    transform = SimpleNamespace(location=location, rotation=SimpleNamespace(yaw=yaw))
+    velocity = SimpleNamespace(x=speed, y=0.0)
+    return SimpleNamespace(
+        id=actor_id,
+        get_location=lambda _loc=location: _loc,
+        get_transform=lambda _tf=transform: _tf,
+        get_velocity=lambda _vel=velocity: _vel,
+    )
+
+
+def _fake_world(actors: List[Any]) -> Any:
+    """A SimpleNamespace CARLA world whose get_actors().filter() returns ``actors``."""
+    return SimpleNamespace(get_actors=lambda: SimpleNamespace(filter=lambda pattern: actors))
+
+
+def _bare_session(
+    include_camera: bool,
+    include_lidar: bool,
+    observation_extractor: Optional[Any] = None,
+) -> Any:
+    """Build a _CarlaSession bypassing __init__ so _read_observation runs sans carla."""
+    session = object.__new__(carla_pomdp._CarlaSession)
+    session._observation_extractor = observation_extractor
+    session._include_camera = include_camera
+    session._include_lidar = include_lidar
+    session._latest_gnss = None
+    session._latest_camera = None
+    session._latest_lidar = None
+    session._camera_height = 128
+    session._camera_width = 128
+    ego = _fake_actor(0, 0.0, 0.0)
+    session._vehicle = ego
+    session._world = _fake_world([ego])
+    session._max_tracked_agents = 5
+    session._perception_range = 50.0
+    session._occlusion_radius = 1.5
+    return session
+
+
+def test_read_observation_omits_disabled_sensor_keys() -> None:
+    """Disabled sensors drop their observation keys; gnss always stays.
+
+    Purpose: Validates include_camera/include_lidar gate their observation keys.
+
+    Given: Sessions configured with camera-only and lidar-only sensor sets
+    When: _read_observation builds the observation dict
+    Then: Only the enabled sensor key appears alongside the always-present gnss and
+        agents keys
+
+    Test type: unit
+    """
+    camera_only = _bare_session(include_camera=True, include_lidar=False)
+    lidar_only = _bare_session(include_camera=False, include_lidar=True)
+
+    assert set(camera_only._read_observation()) == {"gnss", "agents", "camera"}
+    assert set(lidar_only._read_observation()) == {"gnss", "agents", "lidar"}
+
+
+def test_read_observation_falls_back_to_zeros_before_sensor_data() -> None:
+    """Before a sensor callback fires, observation values fall back to zeros.
+
+    Purpose: Validates the zero-filled fallbacks for gnss/camera/lidar.
+
+    Given: A session with both sensors enabled, no other vehicles, and no callback
+        data yet
+    When: _read_observation is called
+    Then: gnss is zeros(3), the agents block is an all-empty K*slot vector, camera is
+        (H, W, 3) uint8 zeros, and lidar is (0, 4) float32
+
+    Test type: unit
+    """
+    session = _bare_session(include_camera=True, include_lidar=True)
+
+    observation = session._read_observation()
+
+    assert np.array_equal(observation["gnss"], np.zeros(3))
+    assert np.array_equal(observation["agents"], np.zeros(5 * carla_pomdp.AGENT_SLOT_WIDTH))
+    assert observation["camera"].shape == (128, 128, 3)
+    assert observation["camera"].dtype == np.uint8
+    assert not observation["camera"].any()
+    assert observation["lidar"].shape == (0, 4)
+    assert observation["lidar"].dtype == np.float32
+
+
+def test_read_observation_applies_observation_extractor() -> None:
+    """A supplied observation extractor replaces the emitted observation.
+
+    Purpose: Validates that _read_observation routes the full dict through the
+        injected observation_extractor and returns its result.
+
+    Given: A bare session with both sensors enabled and a gnss-only extractor
+    When: _read_observation builds the full dict and applies the extractor
+    Then: The returned observation contains only the ``gnss`` key produced by the
+        extractor, dropping agents/camera/lidar
+
+    Test type: unit
+    """
+    session = _bare_session(
+        include_camera=True, include_lidar=True, observation_extractor=_gnss_only_extractor
+    )
+
+    observation = session._read_observation()
+
+    assert set(observation) == {"gnss"}
+    assert np.array_equal(observation["gnss"], np.zeros(3))
+
+
+def test_observation_extractor_forwarded_from_env_to_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CarlaPOMDP stores the extractor and threads it into the session build.
+
+    Purpose: Validates the observation_extractor constructor argument is retained
+        and forwarded to the underlying _CarlaSession by _get_session.
+
+    Given: A CarlaPOMDP constructed with a gnss-only observation extractor and a
+        recording _CarlaSession stub
+    When: The environment builds its session via _get_session
+    Then: The environment exposes the extractor and _CarlaSession receives the same
+        callable in its keyword arguments
+
+    Test type: unit
+    """
+    captured: Dict[str, Any] = {}
+
+    def _recording_session(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "session"
+
+    monkeypatch.setattr(carla_pomdp, "_CarlaSession", _recording_session)
+    env = CarlaPOMDP(discount_factor=0.95, observation_extractor=_gnss_only_extractor)
+
+    assert env.observation_extractor is _gnss_only_extractor
+    assert env._get_session() == "session"
+    assert captured["observation_extractor"] is _gnss_only_extractor
+
+
+def test_include_flags_thread_into_session(fake_session: FakeCarlaSession) -> None:
+    """The CarlaPOMDP include flags configure the underlying session build.
+
+    Purpose: Validates include_camera/include_lidar reach _CarlaSession config.
+
+    Given: A CarlaPOMDP constructed with camera enabled and lidar disabled
+    When: Its public sensor configuration is inspected
+    Then: The include flags and merged config defaults match the constructor args
+
+    Test type: unit
+    """
+    del fake_session
+    env = CarlaPOMDP(discount_factor=0.95, include_camera=True, include_lidar=False)
+
+    assert env.include_camera is True
+    assert env.include_lidar is False
+    assert env.observation_camera_config["image_size_x"] == "128"
+    assert env.lidar_config["channels"] == "32"
+
+
+def test_hash_observation_handles_dict_observations(world: CarlaPOMDP) -> None:
+    """Dict observations hash equal when equal and differ on a changed modality.
+
+    Purpose: Validates dict-aware hash_observation for multi-modal payloads.
+
+    Given: Two equal sensor dicts and a third with a differing camera frame
+    When: hash_observation is computed for each
+    Then: Equal dicts hash equally and the differing dict hashes differently
+
+    Test type: unit
+    """
+    observation = _make_observation(48.0)
+    same = _make_observation(48.0)
+    different = _make_observation(48.0)
+    different["camera"] = np.ones((128, 128, 3), dtype=np.uint8)
+
+    assert world.hash_observation(observation) == world.hash_observation(same)
+    assert world.hash_observation(observation) != world.hash_observation(different)
+
+
+def test_is_equal_observation_handles_dict_observations(world: CarlaPOMDP) -> None:
+    """is_equal_observation compares dict observations modality by modality.
+
+    Purpose: Validates dict-aware equality, including dict/non-dict mismatches.
+
+    Given: Two equal sensor dicts, one with a differing lidar cloud, and an array
+    When: is_equal_observation compares each pairing
+    Then: Equal dicts compare equal; a changed modality and a dict/array mix differ
+
+    Test type: unit
+    """
+    observation = _make_observation(48.0)
+    same = _make_observation(48.0)
+    different = _make_observation(48.0)
+    different["lidar"] = np.ones((10, 4), dtype=np.float32)
+
+    assert world.is_equal_observation(observation, same) is True
+    assert world.is_equal_observation(observation, different) is False
+    assert world.is_equal_observation(observation, np.zeros(3)) is False


### PR DESCRIPTION
## Summary

Adds a planner-side **generative-model interface** for the CARLA POMDP and completes the forward-only world's **multi-agent perception**, keeping world and model consistent by construction.

### Model (planner side)
- **`CarlaModelPOMDP`** — abstract `DiscreteActionsEnvironment` that owns only the CARLA state/observation *schema* (agent-slot layout, discrete action set, observation-dict hashing/equality). Transition, observation, reward and terminal are **abstract**, so a study- or task-specific model (e.g. a learned one) plugs in its own dynamics. Mirrors the existing `BaseLightDarkPOMDP(Environment, ABC)` intermediate-base pattern.
- **`FactoredCarlaModelPOMDP`** — runnable reference model implementing the fixed factored observation model (range/occlusion-gated per-slot detection + GNSS Gaussian) with an identity-transition placeholder for a study to replace.

### World (ground truth)
- `CarlaPOMDP` grows from a single-vehicle GNSS world into a multi-agent perception problem: nearest-agent state slots, range/occlusion-gated observations, camera/lidar observation dict, surrounding autopilot traffic + pedestrians, and a gym-carla driving-quality reward.

### Shared
- Extract `driving_quality_reward()` so the forward-only world and the model score a transition **identically by construction**; `CarlaPOMDP._compute_reward` delegates to it.
- Export `CarlaModelPOMDP` and `FactoredCarlaModelPOMDP` from the package.

## Why abstract methods (not dependency injection)
`Environment` is already the abstract interface every env implements, and `DiscreteActionsEnvironment` already re-declares `reward`/`is_terminal`/`initial_*`/`get_actions` as abstract. Subclassing it gives a reward-abstract, discrete-action interface for free and keeps CARLA consistent with every other environment in the repo.

## Testing
- New `test_carla_model_pomdp.py` (14 tests): abstract-interface contract, factored observation likelihood (match vs mismatch, occlusion penalty, hidden slots), reward parity with the shared function (incl. `next_state=None` belief-expectation path), schema hashing / config id, and the learned-dynamics subclassing pattern.
- Expanded `test_carla_pomdp.py` for the multi-agent world (reward, geometry, sensor dict, occlusion, `observation_extractor`).

**Gate:** `pytest` 62 passed (world + model + doctest); whole-tree `pyright` 0 errors; `pylint` 10.00/10; pre-commit black/pylint/pyright hooks pass.

## Known follow-up (out of scope here)
Planners build the root belief via `env.initial_state_dist()`, but the model's `initial_state_dist` raises by design (the belief is meant to be seeded from the world's initial observation). Wiring that two-env belief seeding is a separate integration task.
