### PR TITLE
refactor(carla): per-channel observation models + encode_observation seam

### DIFF
--- a/POMDPPlanners/core/environment/environment.py
+++ b/POMDPPlanners/core/environment/environment.py
@@ -16,10 +16,11 @@ Classes:
     SpaceInfo: Data class containing space type information
 """
 
+# pylint: disable=too-many-lines  # foundational module; split tracked separately
+
 import importlib
 import inspect
 import logging
-import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -344,6 +345,7 @@ class Environment(ABC):  # pylint: disable=too-many-public-methods
     def __hash__(self) -> int:
         return hash(self.config_id)
 
+    @abstractmethod
     def reward(self, state: Any, action: Any, next_state: Any = None) -> float:
         """Calculate the immediate reward for a state-action(-next_state) tuple.
 
@@ -643,6 +645,29 @@ class Environment(ABC):  # pylint: disable=too-many-public-methods
 
         return next_state, next_observation, reward
 
+    def encode_observation(self, observation: Any) -> Any:
+        """Encode a raw observation into the space the belief and planner use.
+
+        The base implementation is the identity: for environments whose raw and
+        working observations coincide (the classic single-environment case), the
+        observation is returned unchanged. A planner-side model whose working
+        observation is an encoding of a richer raw observation (e.g. an image
+        encoder the user supplies) overrides this to map the world's raw
+        observation into that encoded space.
+
+        This is the *only* method that consumes a raw observation; every other
+        observation method (:meth:`sample_observation`,
+        :meth:`observation_log_probability`, :meth:`hash_observation`,
+        :meth:`is_equal_observation`) operates in the encoded space.
+
+        Args:
+            observation: The raw observation emitted by the world.
+
+        Returns:
+            The observation in the encoded space the belief and planner use.
+        """
+        return observation
+
     def cache_visualization(
         self, history: "List[StepData]", output_dir: Path, episode_index: int
     ) -> None:
@@ -677,9 +702,8 @@ class Environment(ABC):  # pylint: disable=too-many-public-methods
         """
         return []
 
-    def compute_metrics(
-        self, histories: "List[History]"
-    ) -> "List[MetricValue]":  # pylint: disable=unused-argument
+    # pylint: disable-next=unused-argument
+    def compute_metrics(self, histories: "List[History]") -> "List[MetricValue]":
         """Compute environment-specific metrics from episode histories.
 
         This method can be overridden by subclasses to provide custom

--- a/POMDPPlanners/environments/carla_pomdp/carla_belief.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_belief.py
@@ -2,11 +2,12 @@
 
 """Plain particle belief that stamps the observed agent block onto its particles.
 
-Perception lives in the world's observation model: a
-:class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.carla_pipeline.CarlaPerceptionPipeline`
-run inside :class:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp.CarlaPOMDP` turns the raw
-sensors into the *perceived* observation, so the ``agents`` channel the belief receives is
-already the tracked object list. The belief therefore does no perception at all.
+Perception lives on the planner's generative model, not here and not in the world: the
+forward-only :class:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp.CarlaPOMDP` emits a raw,
+ground-truth observation, and the model's
+:meth:`~POMDPPlanners.environments.carla_pomdp.carla_generative_models.carla_model_pomdp.CarlaModelPOMDP.encode_observation`
+degrades it into the *perceived* observation the belief receives, so the ``agents`` channel the
+belief sees is already the tracked object list. The belief therefore does no perception at all.
 
 It still cannot be a bare particle filter, though: a weight-only update can reweight and
 propagate the agents a particle was seeded with, but it can never *acquire* a vehicle that
@@ -50,8 +51,9 @@ class PerceivedAgentsBelief(WeightedParticleBeliefReinvigoration):
     After the standard particle-filter weight update and resample, the reinvigoration step
     writes the current observation's ``agents`` block into every particle's agent slots (plus
     optional per-particle jitter), leaving the ego block to the filter. The belief holds no
-    perception state — perception is the world's observation model — so a plain observation with
-    a perceived ``agents`` block is all it needs.
+    perception state — perception is the planner model's, applied upstream by
+    ``encode_observation`` — so a plain observation with a perceived ``agents`` block is all it
+    needs.
 
     Attributes:
         max_tracked_agents: Number of fixed agent slots carried in each particle.

--- a/POMDPPlanners/environments/carla_pomdp/carla_generative_models/carla_factored_model_pomdp.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_generative_models/carla_factored_model_pomdp.py
@@ -1,21 +1,23 @@
 # SPDX-License-Identifier: MIT
 
-"""Reference concrete CARLA generative model with a fixed factored observation model.
+"""Reference concrete CARLA generative model pairing dynamics with factored perception.
 
 :class:`FactoredCarlaModelPOMDP` implements the
 :class:`~POMDPPlanners.environments.carla_pomdp.carla_generative_models.carla_model_pomdp.CarlaModelPOMDP`
-interface with a fixed, factored observation model (per-slot agent detection with range +
-occlusion gating and additive Gaussian pose noise, plus a Gaussian GNSS reading) and the
-same gym-carla driving-quality reward the world uses. The transition dynamics are a
-documented identity placeholder for a specific study to replace with real (e.g. learned)
-motion.
+interface by holding a
+:class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.FactoredObservationModel`
+perception (per-slot agent detection with range + occlusion gating and additive Gaussian
+pose noise, plus a Gaussian GNSS reading) — the observation methods themselves are inherited
+from the base and driven by that perception — together with the same gym-carla
+driving-quality reward the world uses. The transition dynamics are a documented identity
+placeholder for a specific study to replace with real (e.g. learned) motion.
 
-State/observation layout, geometry helpers, detection constants, and the shared reward are
-imported from :mod:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp` so world and model
-agree by construction.
+State/observation layout and the shared reward are imported from
+:mod:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp` so world and model agree by
+construction.
 
 Classes:
-    FactoredCarlaModelPOMDP: Concrete CARLA model with a factored observation model.
+    FactoredCarlaModelPOMDP: Concrete CARLA model with a factored-perception observation model.
 """
 
 from typing import Any, Optional, Sequence, Tuple
@@ -26,34 +28,32 @@ from POMDPPlanners.core.distributions import Distribution
 from POMDPPlanners.environments.carla_pomdp.carla_generative_models.carla_model_pomdp import (
     CarlaModelPOMDP,
 )
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model import (
+    FactoredObservationModel,
+)
 from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
-    AGENT_SLOT_WIDTH,
     DEFAULT_MAX_TRACKED_AGENTS,
     DEFAULT_OCCLUSION_RADIUS,
     DEFAULT_PERCEPTION_RANGE,
-    _segment_occludes,
     driving_quality_reward,
 )
 
-_LOG_EPS = -50.0  # log-prob floor for impossible / near-zero events
-
 
 class FactoredCarlaModelPOMDP(CarlaModelPOMDP):
-    """Concrete CARLA generative model with a fixed factored observation model.
+    """Concrete CARLA generative model pairing placeholder dynamics with factored perception.
 
-    The observation model is factored per agent slot (detection gated by perception range
-    and geometric occlusion, additive Gaussian pose noise) plus a Gaussian GNSS reading;
-    the reward is the shared gym-carla driving-quality reward. The transition is a
+    The observation model is a
+    :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.FactoredObservationModel`
+    (held as ``self.perception``): factored per agent slot (detection gated by perception
+    range and geometric occlusion, additive Gaussian pose noise) plus a Gaussian GNSS
+    reading. The reward is the shared gym-carla driving-quality reward. The transition is a
     documented identity placeholder to be replaced with real dynamics per study.
 
     Attributes:
-        perception_range: Metres beyond which an agent is undetectable.
-        occlusion_radius: Sight-line blocking radius among agents.
-        pose_std: Std of Gaussian noise on a detected agent's ``[rel_x, rel_y, rel_yaw,
-            rel_speed]`` measurement.
-        gnss_std: Std of Gaussian noise on the ``gnss`` reading.
-        detect_prob: Probability of detecting a visible (in-range, un-occluded) agent;
-            ``1 - detect_prob`` is the miss rate.
+        perception: The
+            :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.FactoredObservationModel`
+            carrying the observation parameters (``perception_range``, ``occlusion_radius``,
+            ``pose_std``, ``gnss_std``, ``detect_prob``).
         desired_speed: Target longitudinal speed (m/s) used by the reward.
         out_lane_thresh: Lateral offset (m) beyond which the reward penalises out-of-lane.
         collision_penalty: Penalty scale applied on a terminal collision in the reward.
@@ -110,18 +110,22 @@ class FactoredCarlaModelPOMDP(CarlaModelPOMDP):
             collision_penalty: Penalty scale for a terminal collision in the reward.
             name: Environment identifier. Defaults to the class name.
         """
-        self.perception_range = perception_range
-        self.occlusion_radius = occlusion_radius
-        self.pose_std = pose_std
-        self.gnss_std = gnss_std
-        self.detect_prob = detect_prob
         self.desired_speed = desired_speed
         self.out_lane_thresh = out_lane_thresh
         self.collision_penalty = collision_penalty
+        perception = FactoredObservationModel(
+            max_tracked_agents=max_tracked_agents,
+            perception_range=perception_range,
+            occlusion_radius=occlusion_radius,
+            pose_std=pose_std,
+            gnss_std=gnss_std,
+            detect_prob=detect_prob,
+        )
         super().__init__(
             discount_factor=discount_factor,
             action_presets=action_presets,
             max_tracked_agents=max_tracked_agents,
+            perception=perception,
             name=name,
         )
 
@@ -139,20 +143,6 @@ class FactoredCarlaModelPOMDP(CarlaModelPOMDP):
         # Placeholder: implement the density matching sample_next_state's motion model.
         del state, action, next_states
         raise NotImplementedError("FactoredCarlaModelPOMDP transition density not yet implemented.")
-
-    # ── Observation model (fixed, factored) ─────────────────────────────
-    def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> Any:
-        del action
-        obs = self._render_observation(np.asarray(next_state, dtype=float), noisy=True)
-        return [obs for _ in range(n_samples)] if n_samples != 1 else obs
-
-    def observation_log_probability(
-        self, next_state: Any, action: Any, observations: Any
-    ) -> np.ndarray:
-        del action
-        state = np.asarray(next_state, dtype=float)
-        obs_list = observations if isinstance(observations, list) else [observations]
-        return np.array([self._log_prob_single(state, obs) for obs in obs_list])
 
     # ── Reward (shared with the world by construction) ───────────────────
     def reward(self, state: Any, action: Any, next_state: Any = None) -> float:
@@ -179,62 +169,3 @@ class FactoredCarlaModelPOMDP(CarlaModelPOMDP):
 
     def initial_observation_dist(self) -> Distribution:
         raise NotImplementedError("Seed the belief from the world's initial observation.")
-
-    # ── Factored observation helpers ─────────────────────────────────────
-    def _visible(self, rows: np.ndarray, slot: int) -> bool:
-        """Whether true agent ``slot`` is in range and not occluded (ego-frame)."""
-        rel_x, rel_y = rows[slot, 1], rows[slot, 2]
-        if self.perception_range is not None and float(np.hypot(rel_x, rel_y)) > (
-            self.perception_range
-        ):
-            return False
-        for other in range(self.max_tracked_agents):
-            if other == slot or rows[other, 0] != 1.0:
-                continue
-            if _segment_occludes(
-                0.0, 0.0, rel_x, rel_y, rows[other, 1], rows[other, 2], self.occlusion_radius
-            ):
-                return False
-        return True
-
-    def _render_observation(self, state: np.ndarray, noisy: bool) -> dict:
-        rows = self._state_agent_rows(state).copy()
-        for slot in range(self.max_tracked_agents):
-            if rows[slot, 0] != 1.0 or not self._visible(rows, slot):
-                rows[slot] = 0.0
-            elif noisy:
-                rows[slot, 1:] += np.random.normal(0.0, self.pose_std, size=AGENT_SLOT_WIDTH - 1)
-        gnss = state[:2].copy()
-        if noisy:
-            gnss = gnss + np.random.normal(0.0, self.gnss_std, size=2)
-        return {"gnss": gnss, "agents": rows.reshape(-1)}
-
-    def _log_prob_single(self, state: np.ndarray, obs: dict) -> float:
-        rows = self._state_agent_rows(state)
-        obs_rows = np.asarray(obs["agents"], dtype=float).reshape(
-            self.max_tracked_agents, AGENT_SLOT_WIDTH
-        )
-        total = self._gnss_log_prob(state, obs)
-        for slot in range(self.max_tracked_agents):
-            total += self._slot_log_prob(rows, obs_rows, slot)
-        return float(total)
-
-    def _gnss_log_prob(self, state: np.ndarray, obs: dict) -> float:
-        gnss = np.asarray(obs["gnss"], dtype=float)[:2]
-        diff = gnss - state[:2]
-        return float(-0.5 * np.sum((diff / self.gnss_std) ** 2) - 2 * np.log(self.gnss_std))
-
-    def _slot_log_prob(self, rows: np.ndarray, obs_rows: np.ndarray, slot: int) -> float:
-        true_present = rows[slot, 0] == 1.0
-        obs_present = obs_rows[slot, 0] == 1.0
-        if not true_present:
-            return 0.0 if not obs_present else _LOG_EPS  # empty state slot -> empty obs slot
-        if not self._visible(rows, slot):
-            return 0.0 if not obs_present else _LOG_EPS  # invisible -> must be missed
-        if not obs_present:
-            return float(np.log(max(1.0 - self.detect_prob, np.exp(_LOG_EPS))))  # a miss
-        diff = obs_rows[slot, 1:] - rows[slot, 1:]
-        gauss = -0.5 * np.sum((diff / self.pose_std) ** 2) - (AGENT_SLOT_WIDTH - 1) * np.log(
-            self.pose_std
-        )
-        return float(np.log(self.detect_prob) + gauss)

--- a/POMDPPlanners/environments/carla_pomdp/carla_generative_models/carla_factored_model_pomdp.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_generative_models/carla_factored_model_pomdp.py
@@ -4,13 +4,15 @@
 
 :class:`FactoredCarlaModelPOMDP` implements the
 :class:`~POMDPPlanners.environments.carla_pomdp.carla_generative_models.carla_model_pomdp.CarlaModelPOMDP`
-interface by holding a
-:class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.FactoredObservationModel`
-perception (per-slot agent detection with range + occlusion gating and additive Gaussian
-pose noise, plus a Gaussian GNSS reading) — the observation methods themselves are inherited
-from the base and driven by that perception — together with the same gym-carla
-driving-quality reward the world uses. The transition dynamics are a documented identity
-placeholder for a specific study to replace with real (e.g. learned) motion.
+interface by composing per-channel observation models — a
+:class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.agent_models.FactoredAgentObservationModel`
+on the ``agents`` channel (per-slot detection with range + occlusion gating and additive Gaussian
+pose noise) and a
+:class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.gnss_models.GnssObservationModel`
+on the ``gnss`` channel — the observation methods themselves are inherited from the base and
+driven by that map, together with the same gym-carla driving-quality reward the world uses. The
+transition dynamics are a documented identity placeholder for a specific study to replace with
+real (e.g. learned) motion.
 
 State/observation layout and the shared reward are imported from
 :mod:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp` so world and model agree by
@@ -20,7 +22,7 @@ Classes:
     FactoredCarlaModelPOMDP: Concrete CARLA model with a factored-perception observation model.
 """
 
-from typing import Any, Optional, Sequence, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -28,8 +30,8 @@ from POMDPPlanners.core.distributions import Distribution
 from POMDPPlanners.environments.carla_pomdp.carla_generative_models.carla_model_pomdp import (
     CarlaModelPOMDP,
 )
-from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model import (
-    FactoredObservationModel,
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models import (
+    build_observation_model,
 )
 from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
     DEFAULT_MAX_TRACKED_AGENTS,
@@ -42,18 +44,18 @@ from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
 class FactoredCarlaModelPOMDP(CarlaModelPOMDP):
     """Concrete CARLA generative model pairing placeholder dynamics with factored perception.
 
-    The observation model is a
-    :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.FactoredObservationModel`
-    (held as ``self.perception``): factored per agent slot (detection gated by perception
-    range and geometric occlusion, additive Gaussian pose noise) plus a Gaussian GNSS
-    reading. The reward is the shared gym-carla driving-quality reward. The transition is a
+    The observation is composed per channel (held as ``self.observation_models``): a
+    :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.agent_models.FactoredAgentObservationModel`
+    on ``agents`` (detection gated by perception range and geometric occlusion, additive Gaussian
+    pose noise) and a
+    :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.gnss_models.GnssObservationModel`
+    on ``gnss``. The reward is the shared gym-carla driving-quality reward. The transition is a
     documented identity placeholder to be replaced with real dynamics per study.
 
     Attributes:
-        perception: The
-            :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.FactoredObservationModel`
-            carrying the observation parameters (``perception_range``, ``occlusion_radius``,
-            ``pose_std``, ``gnss_std``, ``detect_prob``).
+        observation_models: The per-channel ``{channel: CarlaObservationModel}`` map carrying the
+            observation parameters (``perception_range``, ``occlusion_radius``, ``pose_std``,
+            ``gnss_std``, ``detect_prob``).
         desired_speed: Target longitudinal speed (m/s) used by the reward.
         out_lane_thresh: Lateral offset (m) beyond which the reward penalises out-of-lane.
         collision_penalty: Penalty scale applied on a terminal collision in the reward.
@@ -90,6 +92,7 @@ class FactoredCarlaModelPOMDP(CarlaModelPOMDP):
         desired_speed: float = 8.0,
         out_lane_thresh: float = 2.0,
         collision_penalty: float = 100.0,
+        observation: Optional[Dict[str, str]] = None,
         name: Optional[str] = None,
     ) -> None:
         """Initialize the factored CARLA generative model.
@@ -108,24 +111,36 @@ class FactoredCarlaModelPOMDP(CarlaModelPOMDP):
             desired_speed: Target longitudinal speed (m/s) for the reward.
             out_lane_thresh: Lateral offset (m) beyond which the reward penalises.
             collision_penalty: Penalty scale for a terminal collision in the reward.
+            observation: Per-channel model selection ``{channel: registered_name}`` resolved via
+                the observation-model registry. Defaults to
+                ``{"gnss": "gaussian", "agents": "factored"}``.
             name: Environment identifier. Defaults to the class name.
         """
         self.desired_speed = desired_speed
         self.out_lane_thresh = out_lane_thresh
         self.collision_penalty = collision_penalty
-        perception = FactoredObservationModel(
-            max_tracked_agents=max_tracked_agents,
-            perception_range=perception_range,
-            occlusion_radius=occlusion_radius,
-            pose_std=pose_std,
-            gnss_std=gnss_std,
-            detect_prob=detect_prob,
+        selection = (
+            observation if observation is not None else {"gnss": "gaussian", "agents": "factored"}
         )
+        channel_kwargs: Dict[str, Dict[str, Any]] = {
+            "gnss": {"gnss_std": gnss_std},
+            "agents": {
+                "max_tracked_agents": max_tracked_agents,
+                "perception_range": perception_range,
+                "occlusion_radius": occlusion_radius,
+                "pose_std": pose_std,
+                "detect_prob": detect_prob,
+            },
+        }
+        observation_models = {
+            channel: build_observation_model(channel, model_name, **channel_kwargs.get(channel, {}))
+            for channel, model_name in selection.items()
+        }
         super().__init__(
             discount_factor=discount_factor,
             action_presets=action_presets,
             max_tracked_agents=max_tracked_agents,
-            perception=perception,
+            observation_models=observation_models,
             name=name,
         )
 

--- a/POMDPPlanners/environments/carla_pomdp/carla_generative_models/carla_model_pomdp.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_generative_models/carla_model_pomdp.py
@@ -25,12 +25,15 @@ Classes:
 
 from abc import abstractmethod
 from collections.abc import Hashable
-from typing import Any, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
 from POMDPPlanners.core.environment import DiscreteActionsEnvironment, SpaceInfo, SpaceType
 
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model import (
+    CarlaObservationModel,
+)
 from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
     AGENT_SLOT_WIDTH,
     DEFAULT_ACTION_PRESETS,
@@ -43,16 +46,25 @@ class CarlaModelPOMDP(DiscreteActionsEnvironment):
     """Abstract generative-model interface paired with the forward-only CARLA world.
 
     Concrete subclasses supply the dynamics — :meth:`sample_next_state`,
-    :meth:`transition_log_probability`, :meth:`sample_observation`,
-    :meth:`observation_log_probability`, :meth:`reward`, :meth:`is_terminal`, and the
+    :meth:`transition_log_probability`, :meth:`reward`, :meth:`is_terminal`, and the
     initial-distribution hooks — while this base owns the fixed CARLA schema shared by
-    every model: the ego + agent-slot state layout, the discrete action set, and the
-    observation-dict hashing/equality.
+    every model (the ego + agent-slot state layout, the discrete action set, and the
+    observation-dict hashing/equality) *and* the observation model. The observation is
+    produced by running a clean, fully-detected observation (built from the state) through
+    a swappable
+    :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.CarlaObservationModel`
+    perception. Two models differ in their observation only by the perception they hold; a
+    model that scores observations for a belief update needs a perception with a density
+    (``supports_density``). A subclass whose observation model is not a clean-observation
+    transform (e.g. a learned latent decoder) may instead override :meth:`sample_observation`
+    and :meth:`observation_log_probability` directly.
 
     Attributes:
         action_presets: Discrete ``(throttle, steer, brake)`` control triples; the
             discrete action set is the indices into this list.
         max_tracked_agents: Number of fixed agent slots in the state/observation.
+        perception: The swappable observation model applied to the clean observation, or
+            ``None`` for a subclass that overrides the observation methods directly.
 
     Note:
         This is an abstract base class and cannot be instantiated directly. See
@@ -65,6 +77,7 @@ class CarlaModelPOMDP(DiscreteActionsEnvironment):
         discount_factor: float,
         action_presets: Optional[Sequence[Tuple[float, float, float]]] = None,
         max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
+        perception: Optional[CarlaObservationModel] = None,
         name: Optional[str] = None,
     ) -> None:
         """Initialize the CARLA generative-model interface.
@@ -76,6 +89,9 @@ class CarlaModelPOMDP(DiscreteActionsEnvironment):
             max_tracked_agents: Number of fixed agent slots carried in the state and
                 observation. Defaults to
                 :data:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp.DEFAULT_MAX_TRACKED_AGENTS`.
+            perception: The swappable observation model applied to the clean observation.
+                ``None`` (the default) is for subclasses that override the observation
+                methods directly.
             name: Environment identifier. Defaults to the class name.
         """
         presets = action_presets if action_presets is not None else DEFAULT_ACTION_PRESETS
@@ -83,6 +99,7 @@ class CarlaModelPOMDP(DiscreteActionsEnvironment):
             (float(throttle), float(steer), float(brake)) for throttle, steer, brake in presets
         ]
         self.max_tracked_agents = max_tracked_agents
+        self.perception = perception
         super().__init__(
             discount_factor=discount_factor,
             name=name if name is not None else type(self).__name__,
@@ -111,6 +128,55 @@ class CarlaModelPOMDP(DiscreteActionsEnvironment):
     def _state_agent_rows(self, state: np.ndarray) -> np.ndarray:
         return state[EGO_STATE_WIDTH:].reshape(self.max_tracked_agents, AGENT_SLOT_WIDTH)
 
+    def _clean_observation(self, state: Any) -> Dict[str, np.ndarray]:
+        """Build the clean, fully-detected observation from a state (shared schema).
+
+        This is the noise-free ``{gnss, agents}`` observation the perception degrades; both
+        the sampler and the density route the state through it so the two agree by
+        construction.
+        """
+        arr = np.asarray(state, dtype=float)
+        return {
+            "gnss": arr[:2].copy(),
+            "agents": self._state_agent_rows(arr).reshape(-1).copy(),
+        }
+
+    # ── Observation model (perception applied to the clean observation) ──
+    def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> Any:
+        """Sample ``n_samples`` observations by perceiving ``next_state``'s clean reading."""
+        del action
+        perception = self._require_perception()
+        obs = perception.perceive(self._clean_observation(next_state))
+        return [obs for _ in range(n_samples)] if n_samples != 1 else obs
+
+    def observation_log_probability(
+        self, next_state: Any, action: Any, observations: Any
+    ) -> np.ndarray:
+        """Log-density of ``observations`` under the perception given ``next_state``."""
+        del action
+        perception = self._require_density()
+        clean = self._clean_observation(next_state)
+        obs_list = observations if isinstance(observations, list) else [observations]
+        return np.array([perception.log_probability(clean, obs) for obs in obs_list])
+
+    def _require_perception(self) -> CarlaObservationModel:
+        if self.perception is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} has no perception; supply a CarlaObservationModel "
+                "or override sample_observation."
+            )
+        return self.perception
+
+    def _require_density(self) -> CarlaObservationModel:
+        perception = self._require_perception()
+        if not perception.supports_density:
+            raise NotImplementedError(
+                f"{type(perception).__name__} is a sample-only perception with no "
+                "observation density; belief updates need a perception that scores "
+                "observations, or override observation_log_probability."
+            )
+        return perception
+
     # ── Dynamics (abstract — the interface a model must implement) ───────
     @abstractmethod
     def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
@@ -119,13 +185,3 @@ class CarlaModelPOMDP(DiscreteActionsEnvironment):
     @abstractmethod
     def transition_log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
         """Log-density of ``next_states`` under the transition model for ``(state, action)``."""
-
-    @abstractmethod
-    def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> Any:
-        """Sample ``n_samples`` observations for a resulting ``next_state``."""
-
-    @abstractmethod
-    def observation_log_probability(
-        self, next_state: Any, action: Any, observations: Any
-    ) -> np.ndarray:
-        """Log-density of ``observations`` under the observation model given ``next_state``."""

--- a/POMDPPlanners/environments/carla_pomdp/carla_generative_models/carla_model_pomdp.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_generative_models/carla_model_pomdp.py
@@ -49,22 +49,26 @@ class CarlaModelPOMDP(DiscreteActionsEnvironment):
     :meth:`transition_log_probability`, :meth:`reward`, :meth:`is_terminal`, and the
     initial-distribution hooks — while this base owns the fixed CARLA schema shared by
     every model (the ego + agent-slot state layout, the discrete action set, and the
-    observation-dict hashing/equality) *and* the observation model. The observation is
-    produced by running a clean, fully-detected observation (built from the state) through
-    a swappable
-    :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.CarlaObservationModel`
-    perception. Two models differ in their observation only by the perception they hold; a
-    model that scores observations for a belief update needs a perception with a density
-    (``supports_density``). A subclass whose observation model is not a clean-observation
-    transform (e.g. a learned latent decoder) may instead override :meth:`sample_observation`
-    and :meth:`observation_log_probability` directly.
+    observation-dict hashing/equality) *and* the observation model. The observation is factored
+    by channel: this base holds a ``{channel: CarlaObservationModel}`` map
+    (:attr:`observation_models`) and composes it — :meth:`sample_observation` perceives each
+    channel of the clean observation built from the state, :meth:`observation_log_probability`
+    sums the per-channel densities, and :meth:`encode_observation` (the single raw-observation
+    seam) perceives each channel of the forward-only world's raw reading into the same perceived
+    space, so the belief filter and planner search operate on one consistent (encoded)
+    observation. Two models differ in their observation only by the channel models they hold; a
+    model that scores observations for a belief update needs every channel to provide a density
+    (``supports_density``). A subclass whose observation is not a per-channel clean transform
+    (e.g. a learned latent decoder) may instead override :meth:`sample_observation`,
+    :meth:`observation_log_probability` and :meth:`encode_observation` directly.
 
     Attributes:
         action_presets: Discrete ``(throttle, steer, brake)`` control triples; the
             discrete action set is the indices into this list.
         max_tracked_agents: Number of fixed agent slots in the state/observation.
-        perception: The swappable observation model applied to the clean observation, or
-            ``None`` for a subclass that overrides the observation methods directly.
+        observation_models: The per-channel ``{channel: CarlaObservationModel}`` map composed to
+            produce the observation, or ``None`` for a subclass that overrides the observation
+            methods directly.
 
     Note:
         This is an abstract base class and cannot be instantiated directly. See
@@ -77,7 +81,7 @@ class CarlaModelPOMDP(DiscreteActionsEnvironment):
         discount_factor: float,
         action_presets: Optional[Sequence[Tuple[float, float, float]]] = None,
         max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
-        perception: Optional[CarlaObservationModel] = None,
+        observation_models: Optional[Dict[str, CarlaObservationModel]] = None,
         name: Optional[str] = None,
     ) -> None:
         """Initialize the CARLA generative-model interface.
@@ -89,9 +93,9 @@ class CarlaModelPOMDP(DiscreteActionsEnvironment):
             max_tracked_agents: Number of fixed agent slots carried in the state and
                 observation. Defaults to
                 :data:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp.DEFAULT_MAX_TRACKED_AGENTS`.
-            perception: The swappable observation model applied to the clean observation.
-                ``None`` (the default) is for subclasses that override the observation
-                methods directly.
+            observation_models: The per-channel ``{channel: CarlaObservationModel}`` map composed
+                to produce the observation. ``None`` (the default) is for subclasses that override
+                the observation methods directly.
             name: Environment identifier. Defaults to the class name.
         """
         presets = action_presets if action_presets is not None else DEFAULT_ACTION_PRESETS
@@ -99,7 +103,7 @@ class CarlaModelPOMDP(DiscreteActionsEnvironment):
             (float(throttle), float(steer), float(brake)) for throttle, steer, brake in presets
         ]
         self.max_tracked_agents = max_tracked_agents
-        self.perception = perception
+        self.observation_models = observation_models
         super().__init__(
             discount_factor=discount_factor,
             name=name if name is not None else type(self).__name__,
@@ -141,41 +145,78 @@ class CarlaModelPOMDP(DiscreteActionsEnvironment):
             "agents": self._state_agent_rows(arr).reshape(-1).copy(),
         }
 
-    # ── Observation model (perception applied to the clean observation) ──
+    # ── Observation model (per-channel perception composed over the clean observation) ──
+    def encode_observation(self, observation: Any) -> Any:
+        """Perceive the world's raw observation into the belief/planner observation space.
+
+        The forward-only world emits a raw, fully-detected observation; each channel model
+        degrades its channel (per-slot detection gating, occlusion, additive noise) into the
+        perceived observation the belief filter and planner search operate in. This is the
+        single raw-observation seam — every other observation method works in the perceived
+        (encoded) space. A subclass without channel models (``observation_models is None``,
+        e.g. a learned latent model) inherits the identity default.
+
+        Args:
+            observation: The raw ``{gnss, agents}`` observation emitted by the world.
+
+        Returns:
+            The perceived observation the belief and planner consume.
+        """
+        if self.observation_models is None:
+            return super().encode_observation(observation)
+        return {
+            channel: model.perceive(observation[channel])
+            for channel, model in self.observation_models.items()
+        }
+
     def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> Any:
         """Sample ``n_samples`` observations by perceiving ``next_state``'s clean reading."""
         del action
-        perception = self._require_perception()
-        obs = perception.perceive(self._clean_observation(next_state))
+        models = self._require_observation_models()
+        clean = self._clean_observation(next_state)
+        obs = {channel: model.perceive(clean[channel]) for channel, model in models.items()}
         return [obs for _ in range(n_samples)] if n_samples != 1 else obs
 
     def observation_log_probability(
         self, next_state: Any, action: Any, observations: Any
     ) -> np.ndarray:
-        """Log-density of ``observations`` under the perception given ``next_state``."""
+        """Log-density of ``observations`` under the per-channel perception given ``next_state``."""
         del action
-        perception = self._require_density()
+        models = self._require_density_models()
         clean = self._clean_observation(next_state)
         obs_list = observations if isinstance(observations, list) else [observations]
-        return np.array([perception.log_probability(clean, obs) for obs in obs_list])
+        return np.array([self._composed_log_prob(models, clean, obs) for obs in obs_list])
 
-    def _require_perception(self) -> CarlaObservationModel:
-        if self.perception is None:
-            raise NotImplementedError(
-                f"{type(self).__name__} has no perception; supply a CarlaObservationModel "
-                "or override sample_observation."
+    @staticmethod
+    def _composed_log_prob(
+        models: Dict[str, CarlaObservationModel], clean: Dict[str, Any], observation: Any
+    ) -> float:
+        """Sum the per-channel observation log-densities into one scalar."""
+        return float(
+            sum(
+                model.log_probability(clean[channel], observation[channel])
+                for channel, model in models.items()
             )
-        return self.perception
+        )
 
-    def _require_density(self) -> CarlaObservationModel:
-        perception = self._require_perception()
-        if not perception.supports_density:
+    def _require_observation_models(self) -> Dict[str, CarlaObservationModel]:
+        if self.observation_models is None:
             raise NotImplementedError(
-                f"{type(perception).__name__} is a sample-only perception with no "
-                "observation density; belief updates need a perception that scores "
-                "observations, or override observation_log_probability."
+                f"{type(self).__name__} has no observation models; supply a "
+                "{channel: CarlaObservationModel} map or override sample_observation."
             )
-        return perception
+        return self.observation_models
+
+    def _require_density_models(self) -> Dict[str, CarlaObservationModel]:
+        models = self._require_observation_models()
+        sample_only = [channel for channel, model in models.items() if not model.supports_density]
+        if sample_only:
+            raise NotImplementedError(
+                f"Observation channels {sample_only} are sample-only (no density); belief "
+                "updates need every channel to score observations, or override "
+                "observation_log_probability."
+            )
+        return models
 
     # ── Dynamics (abstract — the interface a model must implement) ───────
     @abstractmethod

--- a/POMDPPlanners/environments/carla_pomdp/carla_perception/__init__.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_perception/__init__.py
@@ -13,12 +13,14 @@ user can swap in a different perception model without touching either:
   multi-object tracker that adds velocity and coasts briefly occluded vehicles.
 * :mod:`~POMDPPlanners.environments.carla_pomdp.carla_perception.carla_pipeline` — the swappable
   :class:`PerceptionModel` / :class:`MotionTracker` interfaces and the composed, immutable
-  :class:`CarlaPerceptionPipeline` that :class:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp.CarlaPOMDP`
-  runs inside its observation model.
+  :class:`CarlaPerceptionPipeline`, a standalone whole-observation sensor-fusion stage (raw
+  lidar/camera -> tracked agent block).
 * :mod:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model` — the shared
-  :class:`CarlaObservationModel` interface (clean observation -> perceived observation) that both
-  the world and the generative models plug their perception into, plus the factored reference
-  :class:`FactoredObservationModel`.
+  per-channel :class:`CarlaObservationModel` interface (one clean channel -> one perceived
+  channel) that the planner's generative models compose into a ``{channel: model}`` map.
+* :mod:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models` — the catalog
+  of concrete per-channel models (:class:`GnssObservationModel`,
+  :class:`FactoredAgentObservationModel`) registered for user selection by name.
 
 The public names below are re-exported here so callers can import them straight from the
 subpackage (e.g. ``from ...carla_perception import CarlaPerceptionPipeline``).
@@ -38,7 +40,13 @@ from POMDPPlanners.environments.carla_pomdp.carla_perception.carla_tracking impo
 )
 from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model import (
     CarlaObservationModel,
-    FactoredObservationModel,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models import (
+    FactoredAgentObservationModel,
+    GnssObservationModel,
+    available_observation_models,
+    build_observation_model,
+    register_observation_model,
 )
 from POMDPPlanners.environments.carla_pomdp.carla_perception.carla_pipeline import (
     AlphaBetaTracker,
@@ -61,7 +69,11 @@ __all__ = [
     "TRACK_WIDTH",
     "update_tracks",
     "CarlaObservationModel",
-    "FactoredObservationModel",
+    "FactoredAgentObservationModel",
+    "GnssObservationModel",
+    "available_observation_models",
+    "build_observation_model",
+    "register_observation_model",
     "AlphaBetaTracker",
     "CarlaPerceptionPipeline",
     "Detections",

--- a/POMDPPlanners/environments/carla_pomdp/carla_perception/__init__.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_perception/__init__.py
@@ -15,6 +15,10 @@ user can swap in a different perception model without touching either:
   :class:`PerceptionModel` / :class:`MotionTracker` interfaces and the composed, immutable
   :class:`CarlaPerceptionPipeline` that :class:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp.CarlaPOMDP`
   runs inside its observation model.
+* :mod:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model` — the shared
+  :class:`CarlaObservationModel` interface (clean observation -> perceived observation) that both
+  the world and the generative models plug their perception into, plus the factored reference
+  :class:`FactoredObservationModel`.
 
 The public names below are re-exported here so callers can import them straight from the
 subpackage (e.g. ``from ...carla_perception import CarlaPerceptionPipeline``).
@@ -31,6 +35,10 @@ from POMDPPlanners.environments.carla_pomdp.carla_perception.carla_sensors impor
 from POMDPPlanners.environments.carla_pomdp.carla_perception.carla_tracking import (
     TRACK_WIDTH,
     update_tracks,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model import (
+    CarlaObservationModel,
+    FactoredObservationModel,
 )
 from POMDPPlanners.environments.carla_pomdp.carla_perception.carla_pipeline import (
     AlphaBetaTracker,
@@ -52,6 +60,8 @@ __all__ = [
     "traffic_light_stop_distance",
     "TRACK_WIDTH",
     "update_tracks",
+    "CarlaObservationModel",
+    "FactoredObservationModel",
     "AlphaBetaTracker",
     "CarlaPerceptionPipeline",
     "Detections",

--- a/POMDPPlanners/environments/carla_pomdp/carla_perception/carla_pipeline.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_perception/carla_pipeline.py
@@ -46,9 +46,6 @@ from typing import Any, Optional
 
 import numpy as np
 
-from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model import (
-    CarlaObservationModel,
-)
 from POMDPPlanners.environments.carla_pomdp.carla_perception.carla_sensors import (
     DEFAULT_CORRIDOR_HALFWIDTH,
     camera_looming_cue,
@@ -275,7 +272,7 @@ class AlphaBetaTracker(MotionTracker):
         return update_tracks(tracks, vehicle_positions, dt)
 
 
-class CarlaPerceptionPipeline(CarlaObservationModel):
+class CarlaPerceptionPipeline:
     """Standalone perception + prediction stage: raw observation -> agent slots + obstacle.
 
     Composes a :class:`PerceptionModel` (single-frame) and a :class:`MotionTracker` (temporal),
@@ -283,12 +280,13 @@ class CarlaPerceptionPipeline(CarlaObservationModel):
     particles plus a fused forward-obstacle distance. Immutable: :meth:`process` returns a
     :class:`PerceptionOutput` carrying a successor pipeline with the advanced tracks.
 
-    As a sensor-driven, temporally-stateful stage it is a *sample-only*
-    :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.CarlaObservationModel`
-    (``supports_density = False``): it perceives an observation but exposes no observation
-    density. The world threads its tracker state forward via :meth:`process`; the
-    :meth:`perceive` interface method returns a single perceived observation without carrying
-    the advanced tracks, for callers that only need one reading.
+    It is a whole-observation sensor-fusion stage (fusing lidar/camera into the agent block),
+    not a per-channel
+    :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.CarlaObservationModel`:
+    it perceives a whole observation and exposes no observation density. The world threads its
+    tracker state forward via :meth:`process`; the :meth:`perceive` convenience method returns a
+    single perceived observation without carrying the advanced tracks, for callers that only need
+    one reading.
 
     Attributes:
         max_tracked_agents: Number of agent slots produced in the agent block.

--- a/POMDPPlanners/environments/carla_pomdp/carla_perception/carla_pipeline.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_perception/carla_pipeline.py
@@ -46,6 +46,9 @@ from typing import Any, Optional
 
 import numpy as np
 
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model import (
+    CarlaObservationModel,
+)
 from POMDPPlanners.environments.carla_pomdp.carla_perception.carla_sensors import (
     DEFAULT_CORRIDOR_HALFWIDTH,
     camera_looming_cue,
@@ -272,13 +275,20 @@ class AlphaBetaTracker(MotionTracker):
         return update_tracks(tracks, vehicle_positions, dt)
 
 
-class CarlaPerceptionPipeline:
+class CarlaPerceptionPipeline(CarlaObservationModel):
     """Standalone perception + prediction stage: raw observation -> agent slots + obstacle.
 
     Composes a :class:`PerceptionModel` (single-frame) and a :class:`MotionTracker` (temporal),
     owns the tracker state, and produces the ego-frame agent block a belief stamps onto its
     particles plus a fused forward-obstacle distance. Immutable: :meth:`process` returns a
     :class:`PerceptionOutput` carrying a successor pipeline with the advanced tracks.
+
+    As a sensor-driven, temporally-stateful stage it is a *sample-only*
+    :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.CarlaObservationModel`
+    (``supports_density = False``): it perceives an observation but exposes no observation
+    density. The world threads its tracker state forward via :meth:`process`; the
+    :meth:`perceive` interface method returns a single perceived observation without carrying
+    the advanced tracks, for callers that only need one reading.
 
     Attributes:
         max_tracked_agents: Number of agent slots produced in the agent block.
@@ -361,6 +371,23 @@ class CarlaPerceptionPipeline:
             obstacle_distance=obstacle,
             pipeline=self._successor(tracks),
         )
+
+    def perceive(self, clean_observation: Mapping[str, Any]) -> dict:
+        """Perceive one observation, replacing its ``agents`` block with tracked slots.
+
+        Unlike :meth:`process` this discards the advanced tracker state: it yields a single
+        perceived observation for callers that only need one reading. Use :meth:`process`
+        when the successor pipeline (advanced tracks) must be threaded forward.
+
+        Args:
+            clean_observation: The world's raw observation dict.
+
+        Returns:
+            The perceived observation dict with the tracked ``agents`` block.
+        """
+        perceived = dict(clean_observation)
+        perceived["agents"] = self.process(clean_observation).agent_rows.reshape(-1)
+        return perceived
 
     def _pack_agent_rows(self, tracks: np.ndarray) -> np.ndarray:
         rows = np.zeros((self.max_tracked_agents, AGENT_SLOT_WIDTH))

--- a/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_model.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_model.py
@@ -1,228 +1,80 @@
 # SPDX-License-Identifier: MIT
 
-"""Swappable observation model: a clean observation in, a perceived observation out.
+"""Per-channel observation model: one clean observation channel in, one perceived channel out.
 
-Every CARLA variation — the forward-only world and each planner-side generative model —
-shares one observation *definition* (the ``{gnss, agents}`` schema keyed off the CARLA
-state layout). What differs between them is the **perception**: the transform applied when
-a clean, fully-detected observation is fed through the observation model to yield the
-degraded reading a planner actually sees. This module holds that transform as a single
-swappable interface so the same object can drive the world and the models alike.
+The forward-only world emits a raw, ground-truth observation; the planner-side generative model
+degrades it into the reading a planner actually sees. That degradation is *factored by
+observation channel* — each channel (``gnss``, ``agents``, and, in future, ``image`` / ``lidar``)
+is handled by its own :class:`CarlaObservationModel`, and the generative model composes a
+``{channel: CarlaObservationModel}`` map. This module holds the single-channel interface;
+concrete per-channel models live in the
+:mod:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models` catalog.
 
 Two capabilities, with different reach:
 
-* :meth:`CarlaObservationModel.perceive` — sample a perceived observation from a clean one.
-  Required; used by the world (to emit a reading) and by a model (``sample_observation``).
-* :meth:`CarlaObservationModel.log_probability` — the observation density. Optional; a
-  sample-only perception (e.g. a learned/sensor pipeline) may leave it unimplemented and is
-  still usable as the world's perception, but is rejected by a generative model that must
-  score observations for a belief update.
+* :meth:`CarlaObservationModel.perceive` — sample this channel's perceived value from its clean
+  one. Required; used by a model to generate a tree observation (``sample_observation``) and to
+  encode the world's raw channel (``encode_observation``).
+* :meth:`CarlaObservationModel.log_probability` — this channel's observation density. Optional;
+  a sample-only channel (e.g. a learned encoder) may leave it unimplemented and is still usable
+  to generate observations, but is rejected by a generative model that must score observations
+  for a belief update.
 
 Classes:
-    CarlaObservationModel: Abstract clean-observation -> perceived-observation interface.
-    FactoredObservationModel: Per-slot detection + Gaussian-noise reference perception.
+    CarlaObservationModel: Abstract single-channel clean -> perceived observation interface.
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
-from typing import Any, Optional
-
-import numpy as np
-
-from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
-    AGENT_SLOT_WIDTH,
-    DEFAULT_MAX_TRACKED_AGENTS,
-    DEFAULT_OCCLUSION_RADIUS,
-    DEFAULT_PERCEPTION_RANGE,
-    _segment_occludes,
-)
-
-_LOG_EPS = -50.0  # log-prob floor for impossible / near-zero events
+from typing import Any
 
 
 class CarlaObservationModel(ABC):
-    """Abstract observation model: clean observation -> perceived observation.
+    """Abstract single-channel observation model: clean channel -> perceived channel.
 
-    A concrete perception maps a clean, fully-detected observation (built from a state by
-    the world or a model) to the degraded reading a planner sees. Implementations set
+    A concrete perception maps one observation channel's clean, fully-detected value (built from
+    a state by a model, or taken from the world's raw reading) to the degraded value a planner
+    sees. Implementations declare which channel they handle via :attr:`channel` and set
     :attr:`supports_density` to ``True`` when they also provide :meth:`log_probability`.
 
     Attributes:
-        supports_density: Whether :meth:`log_probability` is implemented. Sample-only
-            perceptions leave this ``False`` and are usable only where sampling is needed.
+        channel: The observation-dict key this model handles (e.g. ``"gnss"`` or ``"agents"``).
+        supports_density: Whether :meth:`log_probability` is implemented. Sample-only channels
+            leave this ``False`` and are usable only where sampling is needed.
 
     Note:
         This is an abstract base class and cannot be instantiated directly.
     """
 
+    channel: str = ""
     supports_density: bool = False
 
     @abstractmethod
-    def perceive(self, clean_observation: Mapping[str, Any]) -> dict:
-        """Sample a perceived observation from a clean, fully-detected one.
+    def perceive(self, clean_channel: Any) -> Any:
+        """Sample this channel's perceived value from its clean, fully-detected value.
 
         Args:
-            clean_observation: The noise-free observation dict (``{gnss, agents}`` in the
-                shared CARLA schema) built from a state.
+            clean_channel: The noise-free value of this channel, built from a state or taken
+                from the world's raw reading.
 
         Returns:
-            The perceived observation dict of the same schema.
+            The perceived value of the same channel.
         """
 
-    def log_probability(
-        self, clean_observation: Mapping[str, Any], observation: Mapping[str, Any]
-    ) -> float:
-        """Log-density of ``observation`` given the clean observation.
+    def log_probability(self, clean_channel: Any, channel_observation: Any) -> float:
+        """Log-density of ``channel_observation`` given the clean channel value.
 
         Args:
-            clean_observation: The noise-free observation dict built from a state.
-            observation: The observation whose likelihood is scored.
+            clean_channel: The noise-free value of this channel built from a state.
+            channel_observation: The channel value whose likelihood is scored.
 
         Returns:
-            The observation log-probability.
+            The channel's observation log-probability.
 
         Raises:
-            NotImplementedError: If this is a sample-only perception without a density.
+            NotImplementedError: If this is a sample-only channel without a density.
         """
-        del clean_observation, observation
+        del clean_channel, channel_observation
         raise NotImplementedError(
-            f"{type(self).__name__} is a sample-only perception with no observation "
-            "density; it cannot back a generative model that scores observations."
+            f"{type(self).__name__} is a sample-only observation model with no density; "
+            "it cannot back a generative model that scores observations."
         )
-
-
-class FactoredObservationModel(CarlaObservationModel):
-    """Reference perception: per-slot detection gating plus additive Gaussian noise.
-
-    Each agent slot is detected only when in perception range and not geometrically
-    occluded by another agent on the ego->target sight line; a detected agent's pose is
-    corrupted with additive Gaussian noise, as is the ``gnss`` reading. Provides both a
-    sampler and a matching density, so it can back a scoring generative model.
-
-    Attributes:
-        max_tracked_agents: Number of fixed agent slots in the observation.
-        perception_range: Metres beyond which an agent is undetectable (``None`` disables
-            the range gate).
-        occlusion_radius: Sight-line blocking radius among agents.
-        pose_std: Std of Gaussian noise on a detected agent's pose measurement.
-        gnss_std: Std of Gaussian noise on the ``gnss`` reading.
-        detect_prob: Probability of detecting a visible agent; ``1 - detect_prob`` is the
-            miss rate scored by the density.
-
-    Example:
-        >>> import numpy as np
-        >>> np.random.seed(0)
-        >>> model = FactoredObservationModel(max_tracked_agents=1, perception_range=50.0)
-        >>> clean = {"gnss": np.zeros(2), "agents": np.array([1.0, 10.0, 0.0, 0.0, 0.0])}
-        >>> float(model.perceive(clean)["agents"][0])  # near agent detected
-        1.0
-    """
-
-    supports_density = True
-
-    def __init__(
-        self,
-        max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
-        perception_range: Optional[float] = DEFAULT_PERCEPTION_RANGE,
-        occlusion_radius: float = DEFAULT_OCCLUSION_RADIUS,
-        pose_std: float = 0.5,
-        gnss_std: float = 1e-5,
-        detect_prob: float = 0.95,
-    ) -> None:
-        """Initialize the factored perception.
-
-        Args:
-            max_tracked_agents: Number of fixed agent slots in the observation.
-            perception_range: Metres beyond which an agent is undetectable, or ``None``.
-            occlusion_radius: Sight-line blocking radius among agents.
-            pose_std: Std of Gaussian noise on a detected agent's pose measurement.
-            gnss_std: Std of Gaussian noise on the ``gnss`` reading.
-            detect_prob: Probability of detecting a visible agent.
-        """
-        self.max_tracked_agents = max_tracked_agents
-        self.perception_range = perception_range
-        self.occlusion_radius = occlusion_radius
-        self.pose_std = pose_std
-        self.gnss_std = gnss_std
-        self.detect_prob = detect_prob
-
-    def perceive(self, clean_observation: Mapping[str, Any]) -> dict:
-        return self.render(clean_observation, noisy=True)
-
-    def render(self, clean_observation: Mapping[str, Any], noisy: bool) -> dict:
-        """Gate the clean observation per slot, optionally adding Gaussian noise.
-
-        Args:
-            clean_observation: The noise-free ``{gnss, agents}`` observation.
-            noisy: When True, add pose and GNSS Gaussian noise (the sampler path); when
-                False, return the gated but noise-free observation.
-
-        Returns:
-            The perceived observation dict.
-        """
-        rows = self._agent_rows(clean_observation).copy()
-        for slot in range(self.max_tracked_agents):
-            if rows[slot, 0] != 1.0 or not self._visible(rows, slot):
-                rows[slot] = 0.0
-            elif noisy:
-                rows[slot, 1:] += np.random.normal(0.0, self.pose_std, size=AGENT_SLOT_WIDTH - 1)
-        gnss = np.asarray(clean_observation["gnss"], dtype=float)[:2].copy()
-        if noisy:
-            gnss = gnss + np.random.normal(0.0, self.gnss_std, size=2)
-        return {"gnss": gnss, "agents": rows.reshape(-1)}
-
-    def log_probability(
-        self, clean_observation: Mapping[str, Any], observation: Mapping[str, Any]
-    ) -> float:
-        rows = self._agent_rows(clean_observation)
-        obs_rows = np.asarray(observation["agents"], dtype=float).reshape(
-            self.max_tracked_agents, AGENT_SLOT_WIDTH
-        )
-        total = self._gnss_log_prob(clean_observation, observation)
-        for slot in range(self.max_tracked_agents):
-            total += self._slot_log_prob(rows, obs_rows, slot)
-        return float(total)
-
-    def _agent_rows(self, observation: Mapping[str, Any]) -> np.ndarray:
-        return np.asarray(observation["agents"], dtype=float).reshape(
-            self.max_tracked_agents, AGENT_SLOT_WIDTH
-        )
-
-    def _visible(self, rows: np.ndarray, slot: int) -> bool:
-        """Whether true agent ``slot`` is in range and not occluded (ego-frame)."""
-        rel_x, rel_y = rows[slot, 1], rows[slot, 2]
-        if self.perception_range is not None and float(np.hypot(rel_x, rel_y)) > (
-            self.perception_range
-        ):
-            return False
-        for other in range(self.max_tracked_agents):
-            if other == slot or rows[other, 0] != 1.0:
-                continue
-            if _segment_occludes(
-                0.0, 0.0, rel_x, rel_y, rows[other, 1], rows[other, 2], self.occlusion_radius
-            ):
-                return False
-        return True
-
-    def _gnss_log_prob(
-        self, clean_observation: Mapping[str, Any], observation: Mapping[str, Any]
-    ) -> float:
-        truth = np.asarray(clean_observation["gnss"], dtype=float)[:2]
-        gnss = np.asarray(observation["gnss"], dtype=float)[:2]
-        diff = gnss - truth
-        return float(-0.5 * np.sum((diff / self.gnss_std) ** 2) - 2 * np.log(self.gnss_std))
-
-    def _slot_log_prob(self, rows: np.ndarray, obs_rows: np.ndarray, slot: int) -> float:
-        true_present = rows[slot, 0] == 1.0
-        obs_present = obs_rows[slot, 0] == 1.0
-        if not true_present:
-            return 0.0 if not obs_present else _LOG_EPS  # empty state slot -> empty obs slot
-        if not self._visible(rows, slot):
-            return 0.0 if not obs_present else _LOG_EPS  # invisible -> must be missed
-        if not obs_present:
-            return float(np.log(max(1.0 - self.detect_prob, np.exp(_LOG_EPS))))  # a miss
-        diff = obs_rows[slot, 1:] - rows[slot, 1:]
-        gauss = -0.5 * np.sum((diff / self.pose_std) ** 2) - (AGENT_SLOT_WIDTH - 1) * np.log(
-            self.pose_std
-        )
-        return float(np.log(self.detect_prob) + gauss)

--- a/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_model.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_model.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: MIT
+
+"""Swappable observation model: a clean observation in, a perceived observation out.
+
+Every CARLA variation — the forward-only world and each planner-side generative model —
+shares one observation *definition* (the ``{gnss, agents}`` schema keyed off the CARLA
+state layout). What differs between them is the **perception**: the transform applied when
+a clean, fully-detected observation is fed through the observation model to yield the
+degraded reading a planner actually sees. This module holds that transform as a single
+swappable interface so the same object can drive the world and the models alike.
+
+Two capabilities, with different reach:
+
+* :meth:`CarlaObservationModel.perceive` — sample a perceived observation from a clean one.
+  Required; used by the world (to emit a reading) and by a model (``sample_observation``).
+* :meth:`CarlaObservationModel.log_probability` — the observation density. Optional; a
+  sample-only perception (e.g. a learned/sensor pipeline) may leave it unimplemented and is
+  still usable as the world's perception, but is rejected by a generative model that must
+  score observations for a belief update.
+
+Classes:
+    CarlaObservationModel: Abstract clean-observation -> perceived-observation interface.
+    FactoredObservationModel: Per-slot detection + Gaussian-noise reference perception.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from typing import Any, Optional
+
+import numpy as np
+
+from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
+    AGENT_SLOT_WIDTH,
+    DEFAULT_MAX_TRACKED_AGENTS,
+    DEFAULT_OCCLUSION_RADIUS,
+    DEFAULT_PERCEPTION_RANGE,
+    _segment_occludes,
+)
+
+_LOG_EPS = -50.0  # log-prob floor for impossible / near-zero events
+
+
+class CarlaObservationModel(ABC):
+    """Abstract observation model: clean observation -> perceived observation.
+
+    A concrete perception maps a clean, fully-detected observation (built from a state by
+    the world or a model) to the degraded reading a planner sees. Implementations set
+    :attr:`supports_density` to ``True`` when they also provide :meth:`log_probability`.
+
+    Attributes:
+        supports_density: Whether :meth:`log_probability` is implemented. Sample-only
+            perceptions leave this ``False`` and are usable only where sampling is needed.
+
+    Note:
+        This is an abstract base class and cannot be instantiated directly.
+    """
+
+    supports_density: bool = False
+
+    @abstractmethod
+    def perceive(self, clean_observation: Mapping[str, Any]) -> dict:
+        """Sample a perceived observation from a clean, fully-detected one.
+
+        Args:
+            clean_observation: The noise-free observation dict (``{gnss, agents}`` in the
+                shared CARLA schema) built from a state.
+
+        Returns:
+            The perceived observation dict of the same schema.
+        """
+
+    def log_probability(
+        self, clean_observation: Mapping[str, Any], observation: Mapping[str, Any]
+    ) -> float:
+        """Log-density of ``observation`` given the clean observation.
+
+        Args:
+            clean_observation: The noise-free observation dict built from a state.
+            observation: The observation whose likelihood is scored.
+
+        Returns:
+            The observation log-probability.
+
+        Raises:
+            NotImplementedError: If this is a sample-only perception without a density.
+        """
+        del clean_observation, observation
+        raise NotImplementedError(
+            f"{type(self).__name__} is a sample-only perception with no observation "
+            "density; it cannot back a generative model that scores observations."
+        )
+
+
+class FactoredObservationModel(CarlaObservationModel):
+    """Reference perception: per-slot detection gating plus additive Gaussian noise.
+
+    Each agent slot is detected only when in perception range and not geometrically
+    occluded by another agent on the ego->target sight line; a detected agent's pose is
+    corrupted with additive Gaussian noise, as is the ``gnss`` reading. Provides both a
+    sampler and a matching density, so it can back a scoring generative model.
+
+    Attributes:
+        max_tracked_agents: Number of fixed agent slots in the observation.
+        perception_range: Metres beyond which an agent is undetectable (``None`` disables
+            the range gate).
+        occlusion_radius: Sight-line blocking radius among agents.
+        pose_std: Std of Gaussian noise on a detected agent's pose measurement.
+        gnss_std: Std of Gaussian noise on the ``gnss`` reading.
+        detect_prob: Probability of detecting a visible agent; ``1 - detect_prob`` is the
+            miss rate scored by the density.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(0)
+        >>> model = FactoredObservationModel(max_tracked_agents=1, perception_range=50.0)
+        >>> clean = {"gnss": np.zeros(2), "agents": np.array([1.0, 10.0, 0.0, 0.0, 0.0])}
+        >>> float(model.perceive(clean)["agents"][0])  # near agent detected
+        1.0
+    """
+
+    supports_density = True
+
+    def __init__(
+        self,
+        max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
+        perception_range: Optional[float] = DEFAULT_PERCEPTION_RANGE,
+        occlusion_radius: float = DEFAULT_OCCLUSION_RADIUS,
+        pose_std: float = 0.5,
+        gnss_std: float = 1e-5,
+        detect_prob: float = 0.95,
+    ) -> None:
+        """Initialize the factored perception.
+
+        Args:
+            max_tracked_agents: Number of fixed agent slots in the observation.
+            perception_range: Metres beyond which an agent is undetectable, or ``None``.
+            occlusion_radius: Sight-line blocking radius among agents.
+            pose_std: Std of Gaussian noise on a detected agent's pose measurement.
+            gnss_std: Std of Gaussian noise on the ``gnss`` reading.
+            detect_prob: Probability of detecting a visible agent.
+        """
+        self.max_tracked_agents = max_tracked_agents
+        self.perception_range = perception_range
+        self.occlusion_radius = occlusion_radius
+        self.pose_std = pose_std
+        self.gnss_std = gnss_std
+        self.detect_prob = detect_prob
+
+    def perceive(self, clean_observation: Mapping[str, Any]) -> dict:
+        return self.render(clean_observation, noisy=True)
+
+    def render(self, clean_observation: Mapping[str, Any], noisy: bool) -> dict:
+        """Gate the clean observation per slot, optionally adding Gaussian noise.
+
+        Args:
+            clean_observation: The noise-free ``{gnss, agents}`` observation.
+            noisy: When True, add pose and GNSS Gaussian noise (the sampler path); when
+                False, return the gated but noise-free observation.
+
+        Returns:
+            The perceived observation dict.
+        """
+        rows = self._agent_rows(clean_observation).copy()
+        for slot in range(self.max_tracked_agents):
+            if rows[slot, 0] != 1.0 or not self._visible(rows, slot):
+                rows[slot] = 0.0
+            elif noisy:
+                rows[slot, 1:] += np.random.normal(0.0, self.pose_std, size=AGENT_SLOT_WIDTH - 1)
+        gnss = np.asarray(clean_observation["gnss"], dtype=float)[:2].copy()
+        if noisy:
+            gnss = gnss + np.random.normal(0.0, self.gnss_std, size=2)
+        return {"gnss": gnss, "agents": rows.reshape(-1)}
+
+    def log_probability(
+        self, clean_observation: Mapping[str, Any], observation: Mapping[str, Any]
+    ) -> float:
+        rows = self._agent_rows(clean_observation)
+        obs_rows = np.asarray(observation["agents"], dtype=float).reshape(
+            self.max_tracked_agents, AGENT_SLOT_WIDTH
+        )
+        total = self._gnss_log_prob(clean_observation, observation)
+        for slot in range(self.max_tracked_agents):
+            total += self._slot_log_prob(rows, obs_rows, slot)
+        return float(total)
+
+    def _agent_rows(self, observation: Mapping[str, Any]) -> np.ndarray:
+        return np.asarray(observation["agents"], dtype=float).reshape(
+            self.max_tracked_agents, AGENT_SLOT_WIDTH
+        )
+
+    def _visible(self, rows: np.ndarray, slot: int) -> bool:
+        """Whether true agent ``slot`` is in range and not occluded (ego-frame)."""
+        rel_x, rel_y = rows[slot, 1], rows[slot, 2]
+        if self.perception_range is not None and float(np.hypot(rel_x, rel_y)) > (
+            self.perception_range
+        ):
+            return False
+        for other in range(self.max_tracked_agents):
+            if other == slot or rows[other, 0] != 1.0:
+                continue
+            if _segment_occludes(
+                0.0, 0.0, rel_x, rel_y, rows[other, 1], rows[other, 2], self.occlusion_radius
+            ):
+                return False
+        return True
+
+    def _gnss_log_prob(
+        self, clean_observation: Mapping[str, Any], observation: Mapping[str, Any]
+    ) -> float:
+        truth = np.asarray(clean_observation["gnss"], dtype=float)[:2]
+        gnss = np.asarray(observation["gnss"], dtype=float)[:2]
+        diff = gnss - truth
+        return float(-0.5 * np.sum((diff / self.gnss_std) ** 2) - 2 * np.log(self.gnss_std))
+
+    def _slot_log_prob(self, rows: np.ndarray, obs_rows: np.ndarray, slot: int) -> float:
+        true_present = rows[slot, 0] == 1.0
+        obs_present = obs_rows[slot, 0] == 1.0
+        if not true_present:
+            return 0.0 if not obs_present else _LOG_EPS  # empty state slot -> empty obs slot
+        if not self._visible(rows, slot):
+            return 0.0 if not obs_present else _LOG_EPS  # invisible -> must be missed
+        if not obs_present:
+            return float(np.log(max(1.0 - self.detect_prob, np.exp(_LOG_EPS))))  # a miss
+        diff = obs_rows[slot, 1:] - rows[slot, 1:]
+        gauss = -0.5 * np.sum((diff / self.pose_std) ** 2) - (AGENT_SLOT_WIDTH - 1) * np.log(
+            self.pose_std
+        )
+        return float(np.log(self.detect_prob) + gauss)

--- a/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_models/__init__.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_models/__init__.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+
+"""Catalog of per-channel CARLA observation models, registered for user selection.
+
+Each observation channel has its own module of concrete
+:class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.CarlaObservationModel`
+implementations (``gnss_models``, ``agent_models``, and the ``image_models`` / ``lidar_models``
+placeholders for future modalities). Importing a channel module runs its
+``@register_observation_model`` decorators, so a planner environment can resolve a per-channel
+selection like ``{"gnss": "gaussian", "agents": "factored"}`` into instances via
+:func:`build_observation_model`.
+
+To add a modality: create/extend its ``<channel>_models.py``, register the class, and import it
+here so registration runs on import.
+
+Functions:
+    register_observation_model: Decorator registering a factory under ``(channel, name)``.
+    build_observation_model: Instantiate the model registered under ``(channel, name)``.
+    available_observation_models: List the names registered for a channel.
+
+Classes:
+    GnssObservationModel: Additive-Gaussian-noise GNSS reading with a matching density.
+    FactoredAgentObservationModel: Per-slot detection + occlusion gating + Gaussian pose noise.
+"""
+
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.registry import (
+    available_observation_models,
+    build_observation_model,
+    register_observation_model,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.gnss_models import (
+    GnssObservationModel,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.agent_models import (
+    FactoredAgentObservationModel,
+)
+
+__all__ = [
+    "register_observation_model",
+    "build_observation_model",
+    "available_observation_models",
+    "GnssObservationModel",
+    "FactoredAgentObservationModel",
+]

--- a/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_models/agent_models.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_models/agent_models.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: MIT
+
+"""Agent-channel observation models.
+
+Catalog of per-channel models for the ``agents`` observation channel (the fixed agent-slot
+block). Add new agent-perception models here and register them with
+:func:`register_observation_model` so they can be selected by name.
+
+Classes:
+    FactoredAgentObservationModel: Per-slot detection + occlusion gating + Gaussian pose noise.
+"""
+
+from typing import Any, Optional
+
+import numpy as np
+
+from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
+    AGENT_SLOT_WIDTH,
+    DEFAULT_MAX_TRACKED_AGENTS,
+    DEFAULT_OCCLUSION_RADIUS,
+    DEFAULT_PERCEPTION_RANGE,
+    _segment_occludes,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model import (
+    CarlaObservationModel,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.registry import (
+    register_observation_model,
+)
+
+_LOG_EPS = -50.0  # log-prob floor for impossible / near-zero events
+
+
+@register_observation_model("agents", "factored")
+class FactoredAgentObservationModel(CarlaObservationModel):
+    """Reference agent perception: per-slot detection gating plus additive Gaussian pose noise.
+
+    Each agent slot is detected only when in perception range and not geometrically occluded by
+    another agent on the ego->target sight line; a detected agent's pose is corrupted with
+    additive Gaussian noise. Provides both a sampler and a matching density, so it can back a
+    scoring generative model.
+
+    Attributes:
+        max_tracked_agents: Number of fixed agent slots in the ``agents`` block.
+        perception_range: Metres beyond which an agent is undetectable (``None`` disables the
+            range gate).
+        occlusion_radius: Sight-line blocking radius among agents.
+        pose_std: Std of Gaussian noise on a detected agent's pose measurement.
+        detect_prob: Probability of detecting a visible agent; ``1 - detect_prob`` is the miss
+            rate scored by the density.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(0)
+        >>> model = FactoredAgentObservationModel(max_tracked_agents=1, perception_range=50.0)
+        >>> agents = np.array([1.0, 10.0, 0.0, 0.0, 0.0])
+        >>> float(model.perceive(agents)[0])  # near agent detected
+        1.0
+    """
+
+    channel = "agents"
+    supports_density = True
+
+    def __init__(
+        self,
+        max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
+        perception_range: Optional[float] = DEFAULT_PERCEPTION_RANGE,
+        occlusion_radius: float = DEFAULT_OCCLUSION_RADIUS,
+        pose_std: float = 0.5,
+        detect_prob: float = 0.95,
+    ) -> None:
+        """Initialize the factored agent perception.
+
+        Args:
+            max_tracked_agents: Number of fixed agent slots in the ``agents`` block.
+            perception_range: Metres beyond which an agent is undetectable, or ``None``.
+            occlusion_radius: Sight-line blocking radius among agents.
+            pose_std: Std of Gaussian noise on a detected agent's pose measurement.
+            detect_prob: Probability of detecting a visible agent.
+        """
+        self.max_tracked_agents = max_tracked_agents
+        self.perception_range = perception_range
+        self.occlusion_radius = occlusion_radius
+        self.pose_std = pose_std
+        self.detect_prob = detect_prob
+
+    def perceive(self, clean_channel: Any) -> np.ndarray:
+        return self.render(clean_channel, noisy=True)
+
+    def render(self, clean_channel: Any, noisy: bool) -> np.ndarray:
+        """Gate the clean agent block per slot, optionally adding Gaussian pose noise.
+
+        Args:
+            clean_channel: The noise-free flat ``agents`` block.
+            noisy: When True, add pose Gaussian noise (the sampler path); when False, return the
+                gated but noise-free block.
+
+        Returns:
+            The perceived flat ``agents`` block.
+        """
+        rows = self._agent_rows(clean_channel).copy()
+        for slot in range(self.max_tracked_agents):
+            if rows[slot, 0] != 1.0 or not self._visible(rows, slot):
+                rows[slot] = 0.0
+            elif noisy:
+                rows[slot, 1:] += np.random.normal(0.0, self.pose_std, size=AGENT_SLOT_WIDTH - 1)
+        return rows.reshape(-1)
+
+    def log_probability(self, clean_channel: Any, channel_observation: Any) -> float:
+        rows = self._agent_rows(clean_channel)
+        obs_rows = np.asarray(channel_observation, dtype=float).reshape(
+            self.max_tracked_agents, AGENT_SLOT_WIDTH
+        )
+        total = 0.0
+        for slot in range(self.max_tracked_agents):
+            total += self._slot_log_prob(rows, obs_rows, slot)
+        return float(total)
+
+    def _agent_rows(self, channel_value: Any) -> np.ndarray:
+        return np.asarray(channel_value, dtype=float).reshape(
+            self.max_tracked_agents, AGENT_SLOT_WIDTH
+        )
+
+    def _visible(self, rows: np.ndarray, slot: int) -> bool:
+        """Whether true agent ``slot`` is in range and not occluded (ego-frame)."""
+        rel_x, rel_y = rows[slot, 1], rows[slot, 2]
+        if self.perception_range is not None and float(np.hypot(rel_x, rel_y)) > (
+            self.perception_range
+        ):
+            return False
+        for other in range(self.max_tracked_agents):
+            if other == slot or rows[other, 0] != 1.0:
+                continue
+            if _segment_occludes(
+                0.0, 0.0, rel_x, rel_y, rows[other, 1], rows[other, 2], self.occlusion_radius
+            ):
+                return False
+        return True
+
+    def _slot_log_prob(self, rows: np.ndarray, obs_rows: np.ndarray, slot: int) -> float:
+        true_present = rows[slot, 0] == 1.0
+        obs_present = obs_rows[slot, 0] == 1.0
+        if not true_present:
+            return 0.0 if not obs_present else _LOG_EPS  # empty state slot -> empty obs slot
+        if not self._visible(rows, slot):
+            return 0.0 if not obs_present else _LOG_EPS  # invisible -> must be missed
+        if not obs_present:
+            return float(np.log(max(1.0 - self.detect_prob, np.exp(_LOG_EPS))))  # a miss
+        diff = obs_rows[slot, 1:] - rows[slot, 1:]
+        gauss = -0.5 * np.sum((diff / self.pose_std) ** 2) - (AGENT_SLOT_WIDTH - 1) * np.log(
+            self.pose_std
+        )
+        return float(np.log(self.detect_prob) + gauss)

--- a/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_models/gnss_models.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_models/gnss_models.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+
+"""GNSS-channel observation models.
+
+Catalog of per-channel models for the ``gnss`` observation channel. Add new GNSS models here
+and register them with :func:`register_observation_model` so they can be selected by name.
+
+Classes:
+    GnssObservationModel: Additive-Gaussian-noise GNSS reading with a matching density.
+"""
+
+from typing import Any
+
+import numpy as np
+
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model import (
+    CarlaObservationModel,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.registry import (
+    register_observation_model,
+)
+
+
+@register_observation_model("gnss", "gaussian")
+class GnssObservationModel(CarlaObservationModel):
+    """GNSS channel corrupted by additive Gaussian noise, with a matching density.
+
+    Attributes:
+        gnss_std: Std of the zero-mean Gaussian noise added to the 2-D ``gnss`` reading.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(0)
+        >>> model = GnssObservationModel(gnss_std=1e-5)
+        >>> perceived = model.perceive(np.zeros(2))
+        >>> perceived.shape
+        (2,)
+    """
+
+    channel = "gnss"
+    supports_density = True
+
+    def __init__(self, gnss_std: float = 1e-5) -> None:
+        """Initialize the GNSS observation model.
+
+        Args:
+            gnss_std: Std of Gaussian noise on the ``gnss`` reading.
+        """
+        self.gnss_std = gnss_std
+
+    def perceive(self, clean_channel: Any) -> np.ndarray:
+        gnss = np.asarray(clean_channel, dtype=float)[:2].copy()
+        return gnss + np.random.normal(0.0, self.gnss_std, size=2)
+
+    def log_probability(self, clean_channel: Any, channel_observation: Any) -> float:
+        truth = np.asarray(clean_channel, dtype=float)[:2]
+        gnss = np.asarray(channel_observation, dtype=float)[:2]
+        diff = gnss - truth
+        return float(-0.5 * np.sum((diff / self.gnss_std) ** 2) - 2 * np.log(self.gnss_std))

--- a/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_models/image_models.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_models/image_models.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+
+"""Image-channel observation models (catalog placeholder).
+
+Register per-channel models for a future ``image`` observation channel here, with
+:func:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.registry.register_observation_model`
+(``@register_observation_model("image", "<name>")``), then import the new class from this
+subpackage's ``__init__`` so registration runs on import.
+
+The CARLA world does not yet emit an ``image`` channel, so this catalog is intentionally empty.
+When raw camera frames enter the observation schema, add an encoder here (e.g. a learned CNN
+feature map). An encoder that only samples (no tractable density) sets ``supports_density =
+False``: it is usable by sampling planners but rejected by beliefs that score observations.
+"""

--- a/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_models/lidar_models.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_models/lidar_models.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+
+"""Lidar-channel observation models (catalog placeholder).
+
+Register per-channel models for a future ``lidar`` observation channel here, with
+:func:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.registry.register_observation_model`
+(``@register_observation_model("lidar", "<name>")``), then import the new class from this
+subpackage's ``__init__`` so registration runs on import.
+
+The CARLA world does not yet emit a ``lidar`` channel, so this catalog is intentionally empty.
+When raw point clouds enter the observation schema, add an encoder here (e.g. a voxel or
+range-image feature encoder). An encoder that only samples (no tractable density) sets
+``supports_density = False``: it is usable by sampling planners but rejected by beliefs that
+score observations.
+"""

--- a/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_models/registry.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_perception/observation_models/registry.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MIT
+
+"""Registry of per-channel CARLA observation models keyed by ``(channel, name)``.
+
+Concrete per-channel models register themselves with the :func:`register_observation_model`
+decorator so a user can select, per observation channel, which model the planner's generative
+environment holds — e.g. ``{"gnss": "gaussian", "agents": "factored"}``. The environment
+resolves the selection into instances via :func:`build_observation_model`.
+
+Functions:
+    register_observation_model: Decorator registering a factory under ``(channel, name)``.
+    build_observation_model: Instantiate the model registered under ``(channel, name)``.
+    available_observation_models: List the names registered for a channel.
+"""
+
+from typing import Any, Callable, Dict, List, TypeVar
+
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model import (
+    CarlaObservationModel,
+)
+
+ObservationModelFactory = Callable[..., CarlaObservationModel]
+_FactoryT = TypeVar("_FactoryT", bound=ObservationModelFactory)
+
+_REGISTRY: Dict[str, Dict[str, ObservationModelFactory]] = {}
+
+
+def register_observation_model(channel: str, name: str) -> Callable[[_FactoryT], _FactoryT]:
+    """Register an observation-model factory under ``(channel, name)`` for user selection.
+
+    Args:
+        channel: The observation-dict key the model handles (e.g. ``"gnss"``, ``"agents"``).
+        name: The catalog name the user selects the model by within that channel.
+
+    Returns:
+        A decorator that registers the factory (a class or callable returning a
+        :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model.CarlaObservationModel`)
+        and returns it unchanged (its type is preserved).
+    """
+
+    def decorator(factory: _FactoryT) -> _FactoryT:
+        _REGISTRY.setdefault(channel, {})[name] = factory
+        return factory
+
+    return decorator
+
+
+def build_observation_model(channel: str, name: str, **kwargs: Any) -> CarlaObservationModel:
+    """Instantiate the observation model registered under ``(channel, name)``.
+
+    Args:
+        channel: The observation-dict key to resolve the model for.
+        name: The registered catalog name within that channel.
+        **kwargs: Forwarded to the registered factory.
+
+    Returns:
+        The instantiated per-channel observation model.
+
+    Raises:
+        KeyError: If no model is registered under ``(channel, name)``.
+    """
+    channel_models = _REGISTRY.get(channel, {})
+    if name not in channel_models:
+        raise KeyError(
+            f"No observation model '{name}' registered for channel '{channel}'; "
+            f"available: {sorted(channel_models)}."
+        )
+    return channel_models[name](**kwargs)
+
+
+def available_observation_models(channel: str) -> List[str]:
+    """Return the catalog names registered for ``channel``, sorted."""
+    return sorted(_REGISTRY.get(channel, {}))

--- a/POMDPPlanners/environments/carla_pomdp/carla_pomdp.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_pomdp.py
@@ -68,11 +68,9 @@ The **observation** is a multi-modal dict of native CARLA sensor payloads:
 - ``"gnss"``: ``[lat, lon, alt]`` (always present) — latitude and longitude in
   **degrees** and altitude in metres, from a ``sensor.other.gnss`` reading.
 - ``"agents"`` (always present): the ``max_tracked_agents`` agent slots of the
-  state flattened, but with any agent that is **out of ``perception_range`` or
-  geometrically occluded** by another vehicle zeroed to an empty (``present == 0``)
-  slot. Slot indices align with the state, so a nearby agent the ego cannot see is
-  exactly a slot that is filled in the state yet empty here — the hidden variable
-  the belief must reason about.
+  state flattened, reported **raw** at their true ego-frame poses. The world applies
+  no perception, so this is the ground-truth channel; range-gating, occlusion and
+  sensor noise are the planner model's observation model, not the world's.
 - ``"camera"`` (present iff ``include_camera``): a front-facing RGB image,
   ``(H, W, 3)`` ``uint8``, from a ``sensor.camera.rgb``.
 - ``"lidar"`` (present iff ``include_lidar``): a point cloud, ``(N, 4)`` ``float32``
@@ -96,7 +94,7 @@ from collections.abc import Hashable
 from enum import Enum
 from pathlib import Path
 from queue import Queue
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 import numpy as np
 
@@ -104,11 +102,6 @@ from POMDPPlanners.core.distributions import Distribution
 from POMDPPlanners.core.environment import Environment, SpaceInfo, SpaceType
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.utils.statistics_utils import confidence_interval
-
-if TYPE_CHECKING:  # avoid a runtime import cycle (the pipeline imports this module's schema)
-    from POMDPPlanners.environments.carla_pomdp.carla_perception import (
-        CarlaPerceptionPipeline,
-    )
 
 # Default discrete control presets as ``(throttle, steer, brake)`` triples.
 DEFAULT_ACTION_PRESETS: Tuple[Tuple[float, float, float], ...] = (
@@ -348,8 +341,6 @@ class _CarlaSession:
         num_vehicles: int = DEFAULT_NUM_VEHICLES,
         num_walkers: int = DEFAULT_NUM_WALKERS,
         max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
-        perception_range: Optional[float] = DEFAULT_PERCEPTION_RANGE,
-        occlusion_radius: float = DEFAULT_OCCLUSION_RADIUS,
         traffic_manager_port: int = DEFAULT_TRAFFIC_MANAGER_PORT,
         randomize_spawn: bool = True,
         observation_extractor: Optional[Callable[[Dict[str, np.ndarray]], Any]] = None,
@@ -363,8 +354,6 @@ class _CarlaSession:
         self._num_vehicles = num_vehicles
         self._num_walkers = num_walkers
         self._max_tracked_agents = max_tracked_agents
-        self._perception_range = perception_range
-        self._occlusion_radius = occlusion_radius
         self._traffic_manager_port = traffic_manager_port
         self._randomize_spawn = randomize_spawn
         self._record_camera = record_camera
@@ -609,7 +598,7 @@ class _CarlaSession:
                 heading_err,
             ]
         )
-        agent_rows = self._agent_rows(detected_only=False)
+        agent_rows = self._agent_rows()
         return np.concatenate([ego, agent_rows.reshape(-1), self._read_state_traffic_light()])
 
     def _read_state_traffic_light(self) -> np.ndarray:
@@ -670,12 +659,12 @@ class _CarlaSession:
         others.sort(key=lambda actor: actor.get_location().distance(ego_location))
         return others[: self._max_tracked_agents]
 
-    def _agent_rows(self, detected_only: bool) -> np.ndarray:
-        """Fixed ``(K, AGENT_SLOT_WIDTH)`` matrix of nearest-agent slots in ego frame.
+    def _agent_rows(self) -> np.ndarray:
+        """Fixed ``(K, AGENT_SLOT_WIDTH)`` matrix of the nearest-agent slots in ego frame.
 
-        When ``detected_only`` is set, agents that are out of range or occluded are
-        left as empty (``present == 0``) slots, so the same slot index that carries
-        an agent in the ground-truth state is hidden in the observation.
+        Every nearest agent is reported at its true ego-frame pose; the world applies no
+        perception. Range-gating and occlusion are the planner model's observation model,
+        so the world's ``agents`` block is the raw ground-truth channel.
         """
         rows = np.zeros((self._max_tracked_agents, AGENT_SLOT_WIDTH))
         ego_transform = self._vehicle.get_transform()
@@ -684,8 +673,6 @@ class _CarlaSession:
         ego_yaw = np.radians(ego_transform.rotation.yaw)
         nearest = self._nearest_agents()
         for slot, actor in enumerate(nearest):
-            if detected_only and not self._is_detected(ego_location, actor, nearest):
-                continue
             other_transform = actor.get_transform()
             other_velocity = actor.get_velocity()
             rows[slot] = _relative_agent_row(
@@ -698,29 +685,6 @@ class _CarlaSession:
                 float(np.hypot(other_velocity.x, other_velocity.y)),
             )
         return rows
-
-    def _is_detected(self, ego_location: Any, actor: Any, nearest: List[Any]) -> bool:
-        """Whether ``actor`` is within perception range and not occluded by a vehicle."""
-        target = actor.get_location()
-        if self._perception_range is not None and (
-            target.distance(ego_location) > self._perception_range
-        ):
-            return False
-        for blocker in nearest:
-            if blocker.id == actor.id:
-                continue
-            blocker_location = blocker.get_location()
-            if _segment_occludes(
-                ego_location.x,
-                ego_location.y,
-                target.x,
-                target.y,
-                blocker_location.x,
-                blocker_location.y,
-                self._occlusion_radius,
-            ):
-                return False
-        return True
 
     def _lane_geometry(self, location: Any, yaw_deg: float) -> Tuple[float, float]:
         """Signed lateral offset (m) and heading error (rad) w.r.t. the driving lane.
@@ -743,7 +707,7 @@ class _CarlaSession:
     def _read_observation(self) -> Dict[str, np.ndarray]:
         observation: Dict[str, np.ndarray] = {
             "gnss": self._read_gnss(),
-            "agents": self._agent_rows(detected_only=True).reshape(-1),
+            "agents": self._agent_rows().reshape(-1),
         }
         if self._include_traffic_light:
             observation["traffic_light"] = self._read_traffic_light()
@@ -890,12 +854,9 @@ class CarlaPOMDP(Environment):
         num_vehicles: int = DEFAULT_NUM_VEHICLES,
         num_walkers: int = DEFAULT_NUM_WALKERS,
         max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
-        perception_range: Optional[float] = DEFAULT_PERCEPTION_RANGE,
-        occlusion_radius: float = DEFAULT_OCCLUSION_RADIUS,
         traffic_manager_port: int = DEFAULT_TRAFFIC_MANAGER_PORT,
         randomize_spawn: bool = True,
         observation_extractor: Optional[Callable[[Dict[str, np.ndarray]], Any]] = None,
-        perception_pipeline: Optional["CarlaPerceptionPipeline"] = None,
         vehicle_filter: str = "vehicle.tesla.model3",
         timeout: float = 10.0,
         seed: Optional[int] = None,
@@ -947,13 +908,6 @@ class CarlaPOMDP(Environment):
             max_tracked_agents: Number of nearest other vehicles carried as fixed
                 slots in the state and observation. Defaults to
                 :data:`DEFAULT_MAX_TRACKED_AGENTS`.
-            perception_range: Metres beyond which another agent is undetectable and
-                hidden from the observation, or ``None`` to disable the range gate entirely
-                (every nearest-tracked agent stays visible regardless of distance). Defaults
-                to :data:`DEFAULT_PERCEPTION_RANGE`.
-            occlusion_radius: Metres from the ego->target sight line within which a
-                vehicle blocks (occludes) the target. Defaults to
-                :data:`DEFAULT_OCCLUSION_RADIUS`.
             traffic_manager_port: CARLA Traffic Manager RPC port used to drive the
                 traffic vehicles. Defaults to :data:`DEFAULT_TRAFFIC_MANAGER_PORT`.
             randomize_spawn: If True, sample a random ego spawn point (and weather)
@@ -964,15 +918,6 @@ class CarlaPOMDP(Environment):
                 keys or a flattened vector). Must be a picklable (module-level)
                 callable, since the environment is pickled for distributed runs.
                 Defaults to None, which emits the full dict unchanged.
-            perception_pipeline: Optional
-                :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.carla_pipeline.CarlaPerceptionPipeline`
-                run on every emitted observation: it replaces the raw ``agents`` block with the
-                *perceived* object list (vehicles clustered/tracked from the lidar, a fused
-                forward hazard and a camera-inferred traffic light folded in), so the world emits
-                the same perceived observation the planner's model scores. Its tracker state is
-                advanced once per real step and reset each episode. The pipeline's
-                ``max_tracked_agents`` must equal this world's. Defaults to None (the raw
-                ground-truth-detected ``agents`` block is emitted unchanged).
             vehicle_filter: Blueprint filter for the ego vehicle. Defaults to
                 ``"vehicle.tesla.model3"``.
             timeout: CARLA client timeout in seconds. Defaults to 10.0.
@@ -1011,19 +956,12 @@ class CarlaPOMDP(Environment):
         self.num_vehicles = num_vehicles
         self.num_walkers = num_walkers
         self.max_tracked_agents = max_tracked_agents
-        self.perception_range = perception_range
-        self.occlusion_radius = occlusion_radius
         self.traffic_manager_port = traffic_manager_port
         self.randomize_spawn = randomize_spawn
         self.observation_extractor = observation_extractor
-        self.perception_pipeline = perception_pipeline
         self.vehicle_filter = vehicle_filter
         self.timeout = timeout
         self.seed = seed
-
-        # Live perception state: the pipeline advanced across ticks (reset each episode to the
-        # configured base), kept separate from the picklable base config above.
-        self._perception_pipeline: Optional["CarlaPerceptionPipeline"] = perception_pipeline
 
         # Live-session state: rebuilt lazily and never serialized.
         self._session: Optional[Any] = None
@@ -1062,7 +1000,6 @@ class CarlaPOMDP(Environment):
         state["_seeded"] = False
         state["_pending"] = None
         state["_served_roles"] = set()
-        state["_perception_pipeline"] = self.perception_pipeline  # drop advanced tracker state
         return state
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
@@ -1074,7 +1011,6 @@ class CarlaPOMDP(Environment):
         self._seeded = False
         self._pending = None
         self._served_roles = set()
-        self._perception_pipeline = self.perception_pipeline
 
     # ── Live simulator management ───────────────────────────────────────
     def _get_session(self) -> Any:
@@ -1097,8 +1033,6 @@ class CarlaPOMDP(Environment):
                 num_vehicles=self.num_vehicles,
                 num_walkers=self.num_walkers,
                 max_tracked_agents=self.max_tracked_agents,
-                perception_range=self.perception_range,
-                occlusion_radius=self.occlusion_radius,
                 traffic_manager_port=self.traffic_manager_port,
                 randomize_spawn=self.randomize_spawn,
                 observation_extractor=self.observation_extractor,
@@ -1107,7 +1041,6 @@ class CarlaPOMDP(Environment):
 
     def _reset(self) -> np.ndarray:
         session = self._get_session()
-        self._perception_pipeline = self.perception_pipeline  # fresh tracker state per episode
         if self.seed is not None and not self._seeded:
             state, observation = session.reset(seed=self.seed)
             self._seeded = True
@@ -1115,27 +1048,11 @@ class CarlaPOMDP(Environment):
             state, observation = session.reset()
         state = np.asarray(state)
         self._live_state = state
-        self._latest_obs = self._perceive(observation)
+        self._latest_obs = observation
         self._terminated = False
         self._pending = None
         self._served_roles = set()
         return state
-
-    def _perceive(self, observation: Any) -> Any:
-        """Emit the perceived observation, advancing the perception pipeline one step.
-
-        When no pipeline is configured the raw session observation is returned unchanged.
-        Otherwise the pipeline replaces the ``agents`` block with the perceived, tracked object
-        list (obstacles and traffic lights folded in) and its advanced successor is carried
-        forward, so the world emits the same perceived observation the planner's model scores.
-        """
-        if self._perception_pipeline is None or not isinstance(observation, dict):
-            return observation
-        output = self._perception_pipeline.process(observation)
-        self._perception_pipeline = output.pipeline
-        perceived = dict(observation)
-        perceived["agents"] = output.agent_rows.reshape(-1)
-        return perceived
 
     def _to_control(self, action: Any) -> Tuple[float, float, float]:
         return self.action_presets[int(action)]
@@ -1192,7 +1109,6 @@ class CarlaPOMDP(Environment):
         throttle, steer, brake = self._to_control(action)
         next_state, observation, terminated = session.step(throttle, steer, brake)
         next_state = np.asarray(next_state)
-        observation = self._perceive(observation)
         done = bool(terminated)
         pending = {
             "state": np.asarray(state).copy(),

--- a/POMDPPlanners/simulations/episodes.py
+++ b/POMDPPlanners/simulations/episodes.py
@@ -168,10 +168,14 @@ class EpisodeRunner:
         """Execute one action: compute reward, sample transition, update belief."""
         reward = self._compute_reward(action)
         next_state = self._sample_next_state(action)
-        observation = self._sample_observation(next_state=next_state, action=action)
+        raw_observation = self._sample_observation(next_state=next_state, action=action)
+        # The world emits a raw observation; the planner's model encodes it into the
+        # space the belief filter and planner search operate in (identity by default).
+        # History keeps the raw observation; only the belief update sees the encoded one.
+        encoded_observation = self.model_environment.encode_observation(raw_observation)
 
-        self._record_step(action, next_state, observation, reward)
-        self._update_belief(action, observation, next_state)
+        self._record_step(action, next_state, raw_observation, reward)
+        self._update_belief(action, encoded_observation, next_state)
 
         self.state = next_state
 

--- a/POMDPPlanners/tests/test_core/test_environment/test_environment.py
+++ b/POMDPPlanners/tests/test_core/test_environment/test_environment.py
@@ -537,3 +537,43 @@ class TestHashObservationDefault:
         """
         assert base_environment.hash_observation("a") == base_environment.hash_observation("a")
         assert base_environment.hash_observation("a") != base_environment.hash_observation("b")
+
+
+class TestEncodeObservationDefault:
+    """Default ``Environment.encode_observation`` behaviour."""
+
+    def test_returns_observation_unchanged(self, base_environment: MockEnvironment):
+        """Default encode_observation is the identity.
+
+        Purpose: Validates that an environment without an encoder leaves observations untouched
+
+        Given: MockEnvironment instance and an arbitrary observation
+        When: encode_observation is called with that observation
+        Then: The same observation object is returned unchanged
+
+        Test type: unit
+        """
+        observation = np.array([1.0, 2.0, 3.0])
+        assert base_environment.encode_observation(observation) is observation
+        assert base_environment.encode_observation("o1") == "o1"
+        assert base_environment.encode_observation(7) == 7
+
+    def test_override_maps_raw_to_encoded(self):
+        """A subclass override maps a raw observation into an encoded space.
+
+        Purpose: Validates that encode_observation is the single seam a model overrides
+
+        Given: An Environment subclass whose encode_observation doubles the observation
+        When: encode_observation is called with a raw observation
+        Then: The encoded (doubled) observation is returned
+
+        Test type: unit
+        """
+
+        class EncodingEnvironment(MockEnvironment):
+            def encode_observation(self, observation: Any) -> Any:
+                return np.asarray(observation) * 2
+
+        env = EncodingEnvironment(discount_factor=0.9)
+        encoded = env.encode_observation(np.array([1.0, 2.0, 3.0]))
+        assert np.array_equal(encoded, np.array([2.0, 4.0, 6.0]))

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_generative_models/test_carla_model_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_generative_models/test_carla_model_pomdp.py
@@ -18,7 +18,9 @@ from POMDPPlanners.environments.carla_pomdp.carla_generative_models import (
     FactoredCarlaModelPOMDP,
 )
 from POMDPPlanners.environments.carla_pomdp.carla_perception import (
-    FactoredObservationModel,
+    CarlaObservationModel,
+    FactoredAgentObservationModel,
+    GnssObservationModel,
 )
 from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
     AGENT_SLOT_WIDTH,
@@ -213,10 +215,13 @@ def test_observation_log_probability_prefers_matching_observation():
     """
     env = FactoredCarlaModelPOMDP(discount_factor=0.95)
     state = _make_state([np.array([1.0, 10.0, 1.0, 0.2, 3.0])])
-    assert isinstance(env.perception, FactoredObservationModel)
-    clean = env.perception.render(
-        env._clean_observation(state), noisy=False  # pylint: disable=protected-access
-    )
+    agent_model = env.observation_models["agents"]
+    assert isinstance(agent_model, FactoredAgentObservationModel)
+    clean_state = env._clean_observation(state)  # pylint: disable=protected-access
+    clean = {
+        "gnss": clean_state["gnss"],
+        "agents": agent_model.render(clean_state["agents"], noisy=False),
+    }
 
     mismatched = {
         "gnss": clean["gnss"].copy(),
@@ -383,6 +388,124 @@ def test_learned_dynamics_subclass_plugs_into_sample_next_step():
     assert next_state[0] == state[0] + 1.0
     assert sorted(observation) == ["agents", "gnss"]
     assert reward == 2.0
+
+
+def test_encode_observation_perceives_raw_world_observation():
+    """encode_observation degrades the world's raw observation through the model's perception.
+
+    Purpose: Validates the raw-observation seam gates unseen agents like sample_observation
+
+    Given: A model with a 50 m perception range and a raw world observation holding a near
+        (in-range) agent and a far (out-of-range) agent, both flagged present
+    When: encode_observation is called on that raw observation
+    Then: The returned perceived observation keeps the near agent's slot present, zeroes the
+        far agent's slot (range-gated), and preserves the schema keys
+
+    Test type: unit
+    """
+    np.random.seed(0)
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95, perception_range=50.0)
+    rows = np.zeros((DEFAULT_MAX_TRACKED_AGENTS, AGENT_SLOT_WIDTH))
+    rows[0] = np.array([1.0, 10.0, 0.0, 0.0, 0.0])  # near, in range
+    rows[1] = np.array([1.0, 100.0, 0.0, 0.0, 0.0])  # far, beyond the range gate
+    raw = {"gnss": np.zeros(2), "agents": rows.reshape(-1)}
+
+    perceived = env.encode_observation(raw)
+    assert sorted(perceived) == ["agents", "gnss"]
+    obs_rows = perceived["agents"].reshape(DEFAULT_MAX_TRACKED_AGENTS, AGENT_SLOT_WIDTH)
+    assert obs_rows[0, 0] == 1.0  # near agent kept
+    assert obs_rows[1, 0] == 0.0  # far agent gated out
+
+
+def test_encode_observation_identity_without_perception():
+    """A model without a clean-observation perception encodes the raw observation as identity.
+
+    Purpose: Validates the encode_observation fallback for models without channel models
+
+    Given: A factored model whose observation-model map has been cleared (``None``)
+    When: encode_observation is called with a raw observation
+    Then: The same observation object is returned unchanged (the base identity default)
+
+    Test type: unit
+    """
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95)
+    env.observation_models = None  # emulate a subclass that overrides the observation methods
+    raw = {"gnss": np.zeros(2), "agents": np.zeros(DEFAULT_MAX_TRACKED_AGENTS * AGENT_SLOT_WIDTH)}
+    assert env.encode_observation(raw) is raw
+
+
+def test_observation_selection_resolves_channel_models_via_registry():
+    """The ``observation`` selection resolves per-channel models from the registry.
+
+    Purpose: Validates user-selectable per-channel observation models at env init
+
+    Given: A factored model constructed with an explicit gnss/agents selection
+    When: The env's observation_models map is inspected
+    Then: Each channel holds the registered model type for its selected name
+
+    Test type: integration
+    """
+    env = FactoredCarlaModelPOMDP(
+        discount_factor=0.95,
+        observation={"gnss": "gaussian", "agents": "factored"},
+    )
+    assert isinstance(env.observation_models["gnss"], GnssObservationModel)
+    assert isinstance(env.observation_models["agents"], FactoredAgentObservationModel)
+
+
+def test_observation_log_probability_composes_per_channel_densities():
+    """The env's observation density is the sum of the per-channel densities.
+
+    Purpose: Validates the base composes channel models by summing their log-densities
+
+    Given: A factored model, a state, and a perceived observation sampled from it
+    When: observation_log_probability is computed for that observation
+    Then: It equals the sum of each channel model's log_probability on its channel
+
+    Test type: unit
+    """
+    np.random.seed(0)
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95)
+    state = _make_state([np.array([1.0, 10.0, 1.0, 0.2, 3.0])])
+    clean = env._clean_observation(state)  # pylint: disable=protected-access
+    observation = env.sample_observation(state, action=0)
+
+    total = env.observation_log_probability(state, action=0, observations=observation)[0]
+    per_channel = sum(
+        model.log_probability(clean[channel], observation[channel])
+        for channel, model in env.observation_models.items()
+    )
+    assert total == pytest.approx(per_channel)
+
+
+def test_observation_log_probability_rejects_a_sample_only_channel():
+    """A channel without a density makes the belief-scoring path raise.
+
+    Purpose: Validates the density requirement spans every composed channel
+
+    Given: A factored model whose gnss channel is swapped for a sample-only model
+    When: observation_log_probability is called
+    Then: NotImplementedError is raised naming the sample-only channel
+
+    Test type: unit
+    """
+
+    class _SampleOnlyGnss(CarlaObservationModel):
+        channel = "gnss"
+        supports_density = False
+
+        def perceive(self, clean_channel: Any) -> np.ndarray:
+            return np.asarray(clean_channel, dtype=float)
+
+    env = FactoredCarlaModelPOMDP(discount_factor=0.95)
+    assert env.observation_models is not None
+    models = dict(env.observation_models)
+    models["gnss"] = _SampleOnlyGnss()
+    env.observation_models = models
+    state = _make_state([])
+    observation = env.sample_observation(state, action=0)
+    with pytest.raises(NotImplementedError, match="sample-only"):
+        env.observation_log_probability(state, action=0, observations=observation)
 
 
 def test_factored_model_docstring_example():

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_generative_models/test_carla_model_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_generative_models/test_carla_model_pomdp.py
@@ -17,6 +17,9 @@ from POMDPPlanners.environments.carla_pomdp.carla_generative_models import (
     CarlaModelPOMDP,
     FactoredCarlaModelPOMDP,
 )
+from POMDPPlanners.environments.carla_pomdp.carla_perception import (
+    FactoredObservationModel,
+)
 from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
     AGENT_SLOT_WIDTH,
     DEFAULT_MAX_TRACKED_AGENTS,
@@ -210,7 +213,10 @@ def test_observation_log_probability_prefers_matching_observation():
     """
     env = FactoredCarlaModelPOMDP(discount_factor=0.95)
     state = _make_state([np.array([1.0, 10.0, 1.0, 0.2, 3.0])])
-    clean = env._render_observation(state, noisy=False)  # pylint: disable=protected-access
+    assert isinstance(env.perception, FactoredObservationModel)
+    clean = env.perception.render(
+        env._clean_observation(state), noisy=False  # pylint: disable=protected-access
+    )
 
     mismatched = {
         "gnss": clean["gnss"].copy(),

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_perception/test_observation_models/__init__.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_perception/test_observation_models/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_perception/test_observation_models/test_agent_models.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_perception/test_observation_models/test_agent_models.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the agent-channel observation model (agent_models.py)."""
+
+import numpy as np
+
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models import (
+    FactoredAgentObservationModel,
+)
+
+
+def test_perceive_gates_out_of_range_agent():
+    """perceive keeps a near agent and zeroes an out-of-range one.
+
+    Purpose: Validates the range gate on the agents channel
+
+    Given: A model with a 50 m range and a near + far agent (both present)
+    When: perceive is called on the flat agents block
+    Then: The near slot stays present and the far slot is zeroed
+
+    Test type: unit
+    """
+    np.random.seed(0)
+    model = FactoredAgentObservationModel(max_tracked_agents=2, perception_range=50.0)
+    rows = np.zeros((2, 5))
+    rows[0] = np.array([1.0, 10.0, 0.0, 0.0, 0.0])
+    rows[1] = np.array([1.0, 100.0, 0.0, 0.0, 0.0])
+    out = model.perceive(rows.reshape(-1)).reshape(2, 5)
+    assert out[0, 0] == 1.0
+    assert out[1, 0] == 0.0
+
+
+def test_render_noiseless_preserves_pose():
+    """render(noisy=False) gates without perturbing a detected pose.
+
+    Purpose: Validates the noise-free rendering path used to build clean observations
+
+    Given: A model with no range gate and a single detected agent with a nonzero pose
+    When: render is called with noisy=False
+    Then: The agent's pose is returned unchanged
+
+    Test type: unit
+    """
+    model = FactoredAgentObservationModel(max_tracked_agents=1, perception_range=None, pose_std=0.5)
+    rows = np.array([[1.0, 10.0, 1.0, 0.2, 3.0]])
+    out = model.render(rows.reshape(-1), noisy=False).reshape(1, 5)
+    assert np.allclose(out[0], rows[0])
+
+
+def test_log_probability_penalizes_seeing_an_occluded_agent():
+    """Reporting an occluded agent is scored as near-impossible.
+
+    Purpose: Validates occlusion gating in the agent-channel density
+
+    Given: A target occluded by a blocker on the ego->target sight line
+    When: log_probability scores an observation that (wrongly) reports the occluded target
+        vs one that correctly omits it
+    Then: The correctly-omitted observation scores far higher
+
+    Test type: unit
+    """
+    model = FactoredAgentObservationModel(max_tracked_agents=2, occlusion_radius=1.5)
+    target = np.array([1.0, 10.0, 0.0, 0.0, 0.0])
+    blocker = np.array([1.0, 5.0, 0.0, 0.0, 0.0])
+    clean = np.stack([target, blocker]).reshape(-1)
+
+    omitted = np.zeros((2, 5))
+    omitted[1] = blocker
+    seen = omitted.copy()
+    seen[0] = target
+
+    lp_omitted = model.log_probability(clean, omitted.reshape(-1))
+    lp_seen = model.log_probability(clean, seen.reshape(-1))
+    assert lp_omitted > lp_seen + 40.0

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_perception/test_observation_models/test_gnss_models.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_perception/test_observation_models/test_gnss_models.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the GNSS-channel observation model (gnss_models.py)."""
+
+import numpy as np
+
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models import (
+    GnssObservationModel,
+)
+
+
+def test_perceive_returns_two_vector():
+    """perceive returns a 2-D GNSS reading.
+
+    Purpose: Validates the GNSS sampler shape and channel handling
+
+    Given: A GnssObservationModel and a clean 2-D reading
+    When: perceive is called
+    Then: A length-2 array is returned
+
+    Test type: unit
+    """
+    np.random.seed(0)
+    model = GnssObservationModel(gnss_std=1e-5)
+    perceived = model.perceive(np.array([1.0, 2.0]))
+    assert perceived.shape == (2,)
+
+
+def test_log_probability_prefers_the_truth():
+    """The density scores the true reading above a shifted one.
+
+    Purpose: Validates the GNSS Gaussian density ranks the truthful reading higher
+
+    Given: A GnssObservationModel and a clean 2-D reading
+    When: log_probability scores the truth vs a 3 m-shifted reading
+    Then: The truthful reading has the higher log-probability
+
+    Test type: unit
+    """
+    model = GnssObservationModel(gnss_std=0.5)
+    truth = np.array([1.0, 2.0])
+    assert model.log_probability(truth, truth) > model.log_probability(truth, truth + 3.0)

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_perception/test_observation_models/test_registry.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_perception/test_observation_models/test_registry.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the per-channel observation-model registry (registry.py)."""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_model import (
+    CarlaObservationModel,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models import (
+    GnssObservationModel,
+    available_observation_models,
+    build_observation_model,
+    register_observation_model,
+)
+
+
+def test_default_models_are_registered():
+    """The shipped catalog registers the gnss/agents reference models.
+
+    Purpose: Validates importing the catalog populates the registry per channel
+
+    Given: The observation_models subpackage has been imported
+    When: available_observation_models is queried per channel
+    Then: The gnss 'gaussian' and agents 'factored' entries are present
+
+    Test type: unit
+    """
+    assert "gaussian" in available_observation_models("gnss")
+    assert "factored" in available_observation_models("agents")
+
+
+def test_build_resolves_registered_model_with_kwargs():
+    """build_observation_model instantiates the registered factory with kwargs.
+
+    Purpose: Validates name resolution and kwargs forwarding
+
+    Given: The registered gnss 'gaussian' model
+    When: build_observation_model is called with a gnss_std kwarg
+    Then: A GnssObservationModel carrying that gnss_std is returned
+
+    Test type: unit
+    """
+    model = build_observation_model("gnss", "gaussian", gnss_std=0.1)
+    assert isinstance(model, GnssObservationModel)
+    assert model.gnss_std == 0.1
+
+
+def test_build_unknown_name_raises_keyerror():
+    """Resolving an unregistered name raises a descriptive KeyError.
+
+    Purpose: Validates the error path for an unknown selection
+
+    Given: No model registered as gnss 'no-such-model'
+    When: build_observation_model is called for it
+    Then: KeyError is raised naming the missing model
+
+    Test type: unit
+    """
+    with pytest.raises(KeyError, match="no-such-model"):
+        build_observation_model("gnss", "no-such-model")
+
+
+def test_register_decorator_adds_a_selectable_model():
+    """The decorator registers a new model that build/available then expose.
+
+    Purpose: Validates user-extensibility via the registration decorator
+
+    Given: A custom sample-only gnss model registered under a fresh name
+    When: available_observation_models and build_observation_model are used
+    Then: The name is listed and the built instance is the custom class
+
+    Test type: unit
+    """
+
+    @register_observation_model("gnss", "test_identity_gnss")
+    class _IdentityGnss(CarlaObservationModel):
+        channel = "gnss"
+        supports_density = False
+
+        def perceive(self, clean_channel: Any) -> np.ndarray:
+            return np.asarray(clean_channel, dtype=float)
+
+    assert "test_identity_gnss" in available_observation_models("gnss")
+    assert isinstance(build_observation_model("gnss", "test_identity_gnss"), _IdentityGnss)

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
@@ -25,9 +25,6 @@ from POMDPPlanners.core.environment import Environment, SpaceType
 from POMDPPlanners.core.policy import Policy, PolicyRunData, PolicySpaceInfo
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.environments.carla_pomdp import CarlaPOMDP, carla_pomdp, carla_video
-from POMDPPlanners.environments.carla_pomdp.carla_perception import (
-    CarlaPerceptionPipeline,
-)
 from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
     AGENT_SLOT_WIDTH,
     DEFAULT_MAX_TRACKED_AGENTS,
@@ -841,39 +838,36 @@ def test_segment_occludes_only_for_blockers_on_the_sight_line() -> None:
     assert behind_ego is False
 
 
-def test_agent_rows_state_keeps_all_nearest_observation_hides_unseen() -> None:
-    """State carries every nearest agent; the observation hides unseen ones.
+def test_agent_rows_reports_every_nearest_agent_raw() -> None:
+    """The world reports every nearest agent at its true pose; it never hides any.
 
-    Purpose: Validates the core partial-observability gap over other agents.
+    Purpose: Validates the world emits the raw ground-truth agents channel — range-gating
+        and occlusion belong to the planner model, not the world.
 
-    Given: An ego with three tracked neighbours — one clearly visible ahead, one
-        directly behind the visible one (occluded), and one beyond perception range
-    When: _agent_rows is built for the state (all) and the observation (detected)
-    Then: The state marks all three present, while the observation keeps only the
-        visible agent and zeroes the occluded and out-of-range slots
+    Given: An ego with three tracked neighbours, including one directly behind another on
+        the same sight line and one far away that a perception model would drop
+    When: _agent_rows builds the agent matrix
+    Then: All three slots are present at their true ego-frame poses, with the nearest first;
+        no slot is zeroed for range or occlusion
 
     Test type: unit
     """
     ego = _fake_actor(0, 0.0, 0.0)
-    visible = _fake_actor(1, 10.0, 0.0)  # 10 m ahead, in range, unobstructed
-    occluded = _fake_actor(2, 30.0, 0.0)  # behind `visible` on the same sight line
-    far = _fake_actor(3, 60.0, 0.0)  # beyond the 50 m perception range
+    near = _fake_actor(1, 10.0, 0.0)  # 10 m ahead
+    behind = _fake_actor(2, 30.0, 0.0)  # behind `near` on the same sight line
+    far = _fake_actor(3, 60.0, 0.0)  # far away
     session: Any = object.__new__(carla_pomdp._CarlaSession)
     session._vehicle = ego
-    session._world = _fake_world([ego, visible, occluded, far])
+    session._world = _fake_world([ego, near, behind, far])
     session._max_tracked_agents = 3
-    session._perception_range = 50.0
-    session._occlusion_radius = 1.5
 
-    state_rows = session._agent_rows(detected_only=False)
-    observed_rows = session._agent_rows(detected_only=True)
+    rows = session._agent_rows()
 
-    assert state_rows.shape == (3, carla_pomdp.AGENT_SLOT_WIDTH)
-    assert list(state_rows[:, 0]) == [1.0, 1.0, 1.0]
-    assert state_rows[0][1] == pytest.approx(10.0)  # nearest is the visible agent
-    assert observed_rows[0][0] == 1.0  # visible agent survives
-    assert np.array_equal(observed_rows[1], np.zeros(carla_pomdp.AGENT_SLOT_WIDTH))
-    assert np.array_equal(observed_rows[2], np.zeros(carla_pomdp.AGENT_SLOT_WIDTH))
+    assert rows.shape == (3, carla_pomdp.AGENT_SLOT_WIDTH)
+    assert list(rows[:, 0]) == [1.0, 1.0, 1.0]  # all present, none hidden
+    assert rows[0][1] == pytest.approx(10.0)  # nearest first
+    assert rows[1][1] == pytest.approx(30.0)
+    assert rows[2][1] == pytest.approx(60.0)
 
 
 def test_observation_includes_camera_and_lidar(world: CarlaPOMDP) -> None:
@@ -952,8 +946,6 @@ def _bare_session(
     session._vehicle = ego
     session._world = _fake_world([ego])
     session._max_tracked_agents = 5
-    session._perception_range = 50.0
-    session._occlusion_radius = 1.5
     return session
 
 
@@ -1556,49 +1548,19 @@ class _LidarVehicleSession:
         return state, self._observation(), self._t >= 3
 
 
-def test_perception_pipeline_emits_perceived_agents_from_lidar(
+def test_world_emits_raw_agents_never_perceived(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A configured perception pipeline replaces the emitted agents with lidar detections.
+    """The world emits the session's raw agents block unchanged; it never perceives.
 
-    Purpose: Validates the world's observation model runs perception so agents are inferred.
+    Purpose: Validates perception lives only on the planner's generative model, so the world
+        passes its raw (ground-truth) agents channel through untouched even when the sensors
+        would support a perceived detection.
 
-    Given: A world with a CarlaPerceptionPipeline and a session whose lidar shows a vehicle 8 m
-        ahead but whose ground-truth agents channel is empty
+    Given: A world and a session whose lidar shows a vehicle 8 m ahead but whose ground-truth
+        agents channel is all-empty
     When: a step is taken and the observation is read
-    Then: the emitted agents block marks a present agent near 8 m (perceived from the lidar)
-
-    Test type: integration
-    """
-    session = _LidarVehicleSession()
-    monkeypatch.setattr(CarlaPOMDP, "_get_session", lambda self: session)
-    pipeline = CarlaPerceptionPipeline(
-        max_tracked_agents=DEFAULT_MAX_TRACKED_AGENTS,
-        sensor_fusion=False,
-        stop_for_traffic_lights=False,
-    )
-    world = CarlaPOMDP(discount_factor=0.95, perception_pipeline=pipeline)
-    world.initial_state_dist().sample()  # reset to establish the live state
-    state = world._live_state
-
-    next_state = world.sample_next_state(state, 0)
-    observation = world.sample_observation(next_state, 0)
-
-    rows = np.asarray(observation["agents"]).reshape(DEFAULT_MAX_TRACKED_AGENTS, AGENT_SLOT_WIDTH)
-    assert rows[0, 0] == 1.0
-    assert abs(rows[0, 1] - 8.0) < 1.0
-
-
-def test_no_perception_pipeline_emits_raw_agents_unchanged(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Without a pipeline the world emits the session's raw agents block unchanged.
-
-    Purpose: Validates perception is opt-in; the default world passes the oracle agents through.
-
-    Given: A world with no perception pipeline and a session with an all-empty agents channel
-    When: a step is taken and the observation is read
-    Then: the emitted agents block is the raw (empty) channel, not a perceived one
+    Then: the emitted agents block is the raw (empty) channel, not a lidar-perceived one
 
     Test type: integration
     """
@@ -1612,29 +1574,3 @@ def test_no_perception_pipeline_emits_raw_agents_unchanged(
     observation = world.sample_observation(next_state, 0)
 
     assert np.all(np.asarray(observation["agents"]) == 0.0)
-
-
-def test_perception_pipeline_base_is_never_mutated(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Advancing perception never mutates the configured base pipeline.
-
-    Purpose: Validates per-episode perception state cannot leak, since each reset re-seeds the
-    live pipeline from an immutable, empty-tracked base.
-
-    Given: A world whose live pipeline has tracked a vehicle over several steps
-    When: the configured base pipeline is inspected
-    Then: it is the same object with empty tracker state (only the live successor advanced)
-
-    Test type: integration
-    """
-    session = _LidarVehicleSession()
-    monkeypatch.setattr(CarlaPOMDP, "_get_session", lambda self: session)
-    pipeline = CarlaPerceptionPipeline(max_tracked_agents=DEFAULT_MAX_TRACKED_AGENTS)
-    world = CarlaPOMDP(discount_factor=0.95, perception_pipeline=pipeline)
-    world.initial_state_dist().sample()  # reset to establish the live state
-    world.sample_next_state(world._live_state, 0)  # advance so the live pipeline accrues a track
-
-    assert world.perception_pipeline is pipeline  # base handle unchanged
-    assert pipeline.tracks.shape[0] == 0  # base never accumulates tracks -> reset re-seeds clean
-    assert world._perception_pipeline is not pipeline  # the live pipeline advanced off the base

--- a/POMDPPlanners/tests/test_simulations/test_episodes.py
+++ b/POMDPPlanners/tests/test_simulations/test_episodes.py
@@ -196,6 +196,72 @@ def test_two_env_belief_update_runs_on_model() -> None:
     assert len(history.history) > 0
 
 
+class EncodingSpyModel(SpyTiger):
+    """A model whose ``encode_observation`` tags observations.
+
+    Tagging lets a test tell apart the raw observation the world emitted (recorded
+    in history) from the encoded observation the belief update consumes. The
+    belief-update likelihood entry point (``observation_log_probability_per_state``)
+    records the observation it was handed, then strips the tag before delegating so
+    the underlying Tiger scoring still works.
+    """
+
+    def __init__(self, discount_factor: float = 0.95) -> None:
+        super().__init__(discount_factor=discount_factor)
+        self.encoded_inputs: List[Any] = []
+        self.belief_observations: List[Any] = []
+
+    def encode_observation(self, observation: Any) -> Any:
+        self.encoded_inputs.append(observation)
+        return ("encoded", observation)
+
+    def observation_log_probability_per_state(
+        self, next_states: Any, action: Any, observation: Any
+    ) -> Any:
+        self.belief_observations.append(observation)
+        raw = (
+            observation[1]
+            if isinstance(observation, tuple) and observation[0] == "encoded"
+            else observation
+        )
+        assert isinstance(raw, str)  # decoded Tiger observation; narrows for the typed super call
+        return super().observation_log_probability_per_state(next_states, action, raw)
+
+
+def test_two_env_history_records_raw_and_belief_receives_encoded() -> None:
+    """History keeps the raw observation while the belief update consumes the encoded one.
+
+    Purpose: Validates the encode_observation seam routes raw to history and encoded to belief
+
+    Given: A world emitting raw Tiger observations and a model whose encode_observation
+        tags each observation
+    When: An episode is run through EpisodeRunner
+    Then: Each recorded history observation is the raw (untagged) world observation,
+        encode_observation saw those exact raw observations, and the belief update was
+        handed the encoded (tagged) form corresponding to each
+
+    Test type: integration
+    """
+    model = EncodingSpyModel(discount_factor=0.95)
+    world = SpyTiger(discount_factor=0.95)
+    policy = FixedActionPolicy(environment=model, discount_factor=0.95)
+    belief = get_initial_belief(model, n_particles=5)
+
+    history = EpisodeRunner(
+        environment=world, policy=policy, initial_belief=belief, num_steps=3, logger=None
+    ).run()
+
+    steps = [step for step in history.history if step.observation is not None]
+    assert steps  # sanity: the episode produced non-terminal steps
+    # History keeps the raw world observation, never the encoded tag.
+    for step in steps:
+        assert not (isinstance(step.observation, tuple) and step.observation[0] == "encoded")
+    # encode_observation was applied to exactly those raw observations.
+    assert model.encoded_inputs == [step.observation for step in steps]
+    # The belief update was fed the encoded form corresponding to each raw observation.
+    assert model.belief_observations == [("encoded", step.observation) for step in steps]
+
+
 def test_two_env_discount_mismatch_raises() -> None:
     """A world/model discount-factor mismatch is rejected at construction.
 

--- a/carla_pomcpow_example.py
+++ b/carla_pomcpow_example.py
@@ -212,14 +212,14 @@ def seed_belief(model: CarlaModelPOMDP, n_particles: int, initial_observation: d
     world's initial observation and use a plain filter.
 
     For the factored/kinematic model each particle is ego near the origin with jitter, with
-    its agent block seeded from the world's first *perceived* ``agents`` (so the planner sees
-    the traffic in view at step 0). The belief is a
+    its agent block seeded from the world's first raw ``agents`` (so the planner sees the
+    traffic in view at step 0). The belief is a
     :class:`~POMDPPlanners.environments.carla_pomdp.carla_belief.PerceivedAgentsBelief`, which on
-    every update stamps each particle's agent block with the observation's perceived ``agents``
-    block — the perception itself is done by the world's observation model (see
-    :func:`build_world`), not the belief. Without this stamping a plain particle filter could
-    never acquire a vehicle that appears mid-episode; the perceived traffic and signals are used
-    by the planner, not a reactive override.
+    every update stamps each particle's agent block with the observation's ``agents`` block —
+    perception itself is the planner model's, applied by its ``encode_observation`` (see
+    :func:`build_model`), not the world or the belief. Without this stamping a plain particle
+    filter could never acquire a vehicle that appears mid-episode; the perceived traffic and
+    signals are used by the planner, not a reactive override.
     """
     log_weights = np.log(np.ones(n_particles) / n_particles)
     if isinstance(model, DreamerCarlaModelPOMDP):

--- a/carla_pomcpow_example.py
+++ b/carla_pomcpow_example.py
@@ -54,12 +54,8 @@ import numpy as np
 
 from POMDPPlanners.core.belief import Belief, WeightedParticleBelief
 from POMDPPlanners.environments.carla_pomdp.carla_belief import PerceivedAgentsBelief
-from POMDPPlanners.environments.carla_pomdp.carla_perception import (
-    CarlaPerceptionPipeline,
-)
 from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
     AGENT_SLOT_WIDTH,
-    DEFAULT_MAX_TRACKED_AGENTS,
     EGO_STATE_WIDTH,
     CarlaPOMDP,
 )
@@ -81,22 +77,13 @@ DT = 0.05
 
 
 def build_world(seed: int, host: str, port: int) -> CarlaPOMDP:
-    """Construct the forward-only CARLA world with onboard perception and chase-camera recording.
+    """Construct the forward-only CARLA world with chase-camera recording.
 
-    The world's observation model runs a
-    :class:`~POMDPPlanners.environments.carla_pomdp.carla_perception.carla_pipeline.CarlaPerceptionPipeline`,
-    so the emitted ``agents`` block is the *perceived* object list — vehicles clustered and
-    tracked from the lidar, a fused lidar/camera forward hazard and a camera-inferred red/amber
-    light folded in — rather than a ground-truth oracle. The planner's model scores that same
-    perceived observation.
+    The world emits the raw ``{gnss, agents}`` observation unchanged — the ``agents`` block is
+    the ground-truth channel, not a perceived one. Perception lives solely on the planner's
+    generative model, which degrades this same raw observation through its own observation model;
+    the world and the model therefore share one raw observation by construction.
     """
-    pipeline = CarlaPerceptionPipeline(
-        max_tracked_agents=DEFAULT_MAX_TRACKED_AGENTS,
-        sensor_fusion=True,
-        stop_for_traffic_lights=True,
-        obstacle_detection_range=30.0,
-        dt=DT,
-    )
     return CarlaPOMDP(
         discount_factor=GAMMA,
         record_camera=True,
@@ -105,7 +92,6 @@ def build_world(seed: int, host: str, port: int) -> CarlaPOMDP:
         num_vehicles=80,  # heavy surrounding traffic (default is 30)
         num_walkers=0,  # walker-AI spawn segfaults native CARLA on Town02; vehicles suffice
         randomize_spawn=False,  # deterministic, known-busy ego spawn point
-        perception_pipeline=pipeline,
         seed=seed,
         host=host,
         port=port,


### PR DESCRIPTION
## Summary

Two related changes that make CARLA perception a swappable, per-channel, user-selectable component and give the belief a consistent observation to filter on.

### 1. `encode_observation` seam (core)
- Adds `Environment.encode_observation` — identity by default — as the single seam mapping a world's **raw** observation into the space the belief and planner use.
- The episode runner now records the **raw** observation in history but feeds the **encoded** observation to the belief update. Identity default keeps every existing single-environment env unchanged.

### 2. Per-channel CARLA observation models (carla)
- Replaces the monolithic `FactoredObservationModel` with a **per-channel** `CarlaObservationModel` interface (`perceive` / `log_probability` over one observation channel).
- The generative model composes a `{channel: model}` map: `encode_observation`/`sample_observation` perceive each channel; `observation_log_probability` sums the per-channel densities.
- Split the reference perception into `GnssObservationModel` + `FactoredAgentObservationModel`, catalogued in a new `carla_perception.observation_models` subpackage and **registered** so a user selects models per channel at env init:
  ```python
  FactoredCarlaModelPOMDP(observation={"agents": "factored", "gnss": "gaussian"})
  ```
- `image_models.py` / `lidar_models.py` placeholders establish the file-per-modality convention for future channels.
- Decouples `CarlaPerceptionPipeline` from the per-channel interface (it is a whole-observation sensor-fusion stage, not a per-channel model).
- Docs updated across the perception stack (world emits raw; perception lives on the model, applied via `encode_observation`).

## Behavioral note
CARLA two-env runs now filter on the **perceived** observation (occlusion/range gating + noise) instead of the raw ground truth — the correct POMDP semantics, and consistent with the observation likelihood. Experiment results will differ accordingly.

## Testing
- Full suite: **3924 passed**, 22 skipped, 10 xfailed. The single failure (`test_run_progress/test_watcher.py::test_main_no_webhook_logs_and_returns_zero`) is **pre-existing and unrelated** (Slack webhook watcher).
- Whole-tree `pyright POMDPPlanners/`: 0 errors. `pylint`: 10.00/10 on all changed files. CARLA doctests pass.
- New coverage: registry (register/build/available/unknown), per-channel gnss/agent models, env-level per-channel composition + density-requirement + user selection.

## Not covered (follow-up)
No smoke test drives a CARLA planner env through a real planner (POMCPOW/PFT-DPW) — the model is unit-tested directly but never exercised through a planner's tree + belief loop. A server-free smoke test would close that gap.