### PR TITLE
feat: opt-in hazard-terminates-episode flags across all hazard envs

### DIFF
--- a/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_cpp/continuous_laser_tag.cpp
@@ -1329,7 +1329,8 @@ double cont_simulate_rollout(
     double tag_penalty, double step_cost,
     const py::array_t<double, py::array::c_style | py::array::forcecast> &dangerous_areas,
     double dangerous_area_radius, double dangerous_area_penalty,
-    int opponent_policy_code = kPolicyEvade) {
+    int opponent_policy_code = kPolicyEvade,
+    bool is_dangerous_area_hit_terminal = false) {
     // Validate shapes.
     if (initial_state.ndim() != 1 || initial_state.shape(0) != static_cast<py::ssize_t>(kStateDim)) {
         throw std::invalid_argument("initial_state must have shape (5,)");
@@ -1388,6 +1389,22 @@ double cont_simulate_rollout(
         // Check terminal before acting.
         if (state[4] != 0.0) {
             break;
+        }
+        // Geometric-gate terminal: the robot standing inside a dangerous area
+        // ends the episode when the opt-in flag is set (mirrors is_terminal).
+        if (is_dangerous_area_hit_terminal && !danger_areas_vec.empty()) {
+            bool robot_in_danger = false;
+            for (const auto &area : danger_areas_vec) {
+                const double ddx = state[0] - area.first;
+                const double ddy = state[1] - area.second;
+                if (ddx * ddx + ddy * ddy <= da_r_sq) {
+                    robot_in_danger = true;
+                    break;
+                }
+            }
+            if (robot_in_danger) {
+                break;
+            }
         }
         const double action[3] = {act_view(step, 0), act_view(step, 1), act_view(step, 2)};  // NOLINT
 
@@ -1754,7 +1771,8 @@ double simulate_rollout_discrete(
     double transition_error_prob,
     int reward_variant_code,
     double penalty_decay,
-    int opponent_policy_code = kPolicyEvade) {
+    int opponent_policy_code = kPolicyEvade,
+    bool is_dangerous_area_hit_terminal = false) {
 
     if (initial_state.ndim() != 1 || initial_state.shape(0) != 5) {
         throw std::invalid_argument("initial_state must have shape (5,)");
@@ -1782,6 +1800,12 @@ double simulate_rollout_discrete(
     int depth = initial_depth;
 
     while (depth < max_depth && state[4] == 0.0) {
+        // Geometric-gate terminal: the robot standing inside a dangerous area
+        // ends the episode when the opt-in flag is set (mirrors is_terminal).
+        if (is_dangerous_area_hit_terminal &&
+            disc_is_dangerous(static_cast<int>(state[0]), static_cast<int>(state[1]), env)) {
+            break;
+        }
         const int action = action_dist(rng.engine());
 
         // Reward computed on current state before transition.
@@ -2754,6 +2778,7 @@ PYBIND11_MODULE(_native, m) {
         py::arg("tag_radius"), py::arg("tag_reward"), py::arg("tag_penalty"),
         py::arg("step_cost"), py::arg("dangerous_areas"), py::arg("dangerous_area_radius"),
         py::arg("dangerous_area_penalty"), py::arg("opponent_policy_code") = 0,
+        py::arg("is_dangerous_area_hit_terminal") = false,
         "Run a full random rollout for ContinuousLaserTagPOMDP in one C++ frame.\n\n"
         "``actions_buffer`` must be shape (N, 3) float64 with N >= max_depth - start_depth.\n"
         "``opponent_policy_code`` selects the opponent behaviour: 0 = EVADE (away from\n"
@@ -2774,6 +2799,7 @@ PYBIND11_MODULE(_native, m) {
         py::arg("reward_variant_code") = 0,
         py::arg("penalty_decay") = 1.0,
         py::arg("opponent_policy_code") = 0,
+        py::arg("is_dangerous_area_hit_terminal") = false,
         "Run a full random-action rollout for the discrete LaserTagPOMDP in one C++ frame.\n\n"
         "Actions are drawn uniformly from {0,1,2,3,4} using pomdp_native::default_rng().\n"
         "Seed via set_seed() before calling to obtain reproducible trajectories.\n"

--- a/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/laser_tag_pomdp/_native.pyi
@@ -152,6 +152,7 @@ def simulate_rollout_discrete(
     reward_variant_code: int = ...,
     penalty_decay: float = ...,
     opponent_policy_code: int = ...,
+    is_dangerous_area_hit_terminal: bool = ...,
 ) -> float:
     """Run a full random-action rollout for the discrete LaserTagPOMDP in one C++ frame.
 
@@ -281,6 +282,7 @@ def cont_simulate_rollout(
     dangerous_area_radius: float,
     dangerous_area_penalty: float,
     opponent_policy_code: int = ...,
+    is_dangerous_area_hit_terminal: bool = ...,
 ) -> float:
     """Run a full random rollout for ContinuousLaserTagPOMDP in one C++ frame.
 

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -178,6 +178,7 @@ class ContinuousLaserTagPOMDP(Environment):
         dangerous_area_radius: float = 1.0,
         dangerous_area_penalty: float = 5.0,
         dangerous_area_hit_probability: float = 1.0,
+        is_dangerous_area_hit_terminal: bool = False,
         output_dir: Optional[Path] = None,
         debug: bool = False,
         use_queue_logger: bool = False,
@@ -211,6 +212,12 @@ class ContinuousLaserTagPOMDP(Environment):
                 matching legacy behavior).  Values below ``1.0`` make the
                 reward stochastic, useful for risk-sensitive planning
                 benchmarks.
+            is_dangerous_area_hit_terminal: When ``True``, a state whose
+                robot position lies geometrically inside any dangerous area
+                (within ``dangerous_area_radius`` of a centre) is treated as
+                terminal by :meth:`is_terminal`, in addition to the explicit
+                terminal-flag field. Defaults to ``False`` (opt-in; dangerous
+                areas only penalise the reward and do not end the episode).
             output_dir: Optional logging directory.
             debug: Enable debug logging.
             use_queue_logger: Use queue-based logger.
@@ -231,11 +238,20 @@ class ContinuousLaserTagPOMDP(Environment):
             action_space=SpaceType.CONTINUOUS,
             observation_space=SpaceType.CONTINUOUS,
         )
+        # The worst-case per-step reward pays the failed-tag penalty and the
+        # step cost; when dangerous areas are configured it can also incur the
+        # dangerous-area penalty, so widen the lower bound to include it.
+        effective_dangerous_areas = (
+            list(dangerous_areas) if dangerous_areas is not None else list(_DEFAULT_DANGEROUS_AREAS)
+        )
+        min_reward = -tag_penalty - step_cost
+        if effective_dangerous_areas:
+            min_reward -= dangerous_area_penalty
         super().__init__(
             discount_factor=discount_factor,
             name=name,
             space_info=space_info,
-            reward_range=(-tag_penalty - step_cost, tag_reward),
+            reward_range=(min_reward, tag_reward),
             output_dir=output_dir,
             debug=debug,
             use_queue_logger=use_queue_logger,
@@ -260,6 +276,7 @@ class ContinuousLaserTagPOMDP(Environment):
         self.dangerous_area_radius = dangerous_area_radius
         self.dangerous_area_penalty = dangerous_area_penalty
         self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
+        self.is_dangerous_area_hit_terminal = is_dangerous_area_hit_terminal
         # Packed (K, 2) float64 dangerous-area array; reused by the C++ reward kernel.
         self._dangerous_areas_arr = (
             np.ascontiguousarray(np.asarray(self.dangerous_areas, dtype=np.float64).reshape(-1, 2))
@@ -304,6 +321,7 @@ class ContinuousLaserTagPOMDP(Environment):
             "dangerous_area_radius": self.dangerous_area_radius,
             "dangerous_area_penalty": self.dangerous_area_penalty,
             "opponent_policy_code": self.opponent_policy.native_code,
+            "is_dangerous_area_hit_terminal": self.is_dangerous_area_hit_terminal,
         }
 
     # ------------------------------------------------------------------
@@ -768,7 +786,34 @@ class ContinuousLaserTagPOMDP(Environment):
         return rewards - np.where(apply_mask, deductions, 0.0)
 
     def is_terminal(self, state: np.ndarray) -> bool:
-        return bool(state[4])
+        """Check whether ``state`` is terminal.
+
+        A state is terminal when its explicit terminal-flag field is set, and,
+        when ``is_dangerous_area_hit_terminal`` is enabled, also when the robot
+        position lies geometrically inside any dangerous area.
+
+        Args:
+            state: Length-5 state ``[robot_x, robot_y, opp_x, opp_y, flag]``.
+
+        Returns:
+            ``True`` if the state is terminal, ``False`` otherwise.
+        """
+        if bool(state[4]):
+            return True
+        return self.is_dangerous_area_hit_terminal and self._robot_in_dangerous_area(state)
+
+    def _robot_in_dangerous_area(self, state: np.ndarray) -> bool:
+        if not self.dangerous_areas:
+            return False
+        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
+        robot_x = state[0]
+        robot_y = state[1]
+        for area_x, area_y in self.dangerous_areas:
+            delta_x = robot_x - area_x
+            delta_y = robot_y - area_y
+            if delta_x * delta_x + delta_y * delta_y <= radius_sq:
+                return True
+        return False
 
     def initial_state_dist(self) -> Distribution:
         if self.initial_state_value is not None:
@@ -1019,6 +1064,7 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
         dangerous_area_radius: float = 1.0,
         dangerous_area_penalty: float = 5.0,
         dangerous_area_hit_probability: float = 1.0,
+        is_dangerous_area_hit_terminal: bool = False,
         output_dir: Optional[Path] = None,
         debug: bool = False,
         use_queue_logger: bool = False,
@@ -1044,6 +1090,7 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
             dangerous_area_radius=dangerous_area_radius,
             dangerous_area_penalty=dangerous_area_penalty,
             dangerous_area_hit_probability=dangerous_area_hit_probability,
+            is_dangerous_area_hit_terminal=is_dangerous_area_hit_terminal,
             output_dir=output_dir,
             debug=debug,
             use_queue_logger=use_queue_logger,

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -177,6 +177,7 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         dangerous_areas: Optional[Set[Tuple[int, int]]] = {(5, 3), (7, 1), (2, 5)},
         dangerous_area_radius: float = 1.0,
         dangerous_area_penalty: float = 5.0,
+        is_dangerous_area_hit_terminal: bool = False,
         output_dir: Optional[Path] = None,
         debug: bool = False,
         use_queue_logger: bool = False,
@@ -201,6 +202,12 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
             dangerous_areas: List of dangerous area center positions as (row, col) tuples. Defaults to None.
             dangerous_area_radius: Radius around dangerous area centers. Defaults to 1.0.
             dangerous_area_penalty: Penalty magnitude applied randomly when in dangerous areas. Defaults to 2.0.
+            is_dangerous_area_hit_terminal: When ``True``, a state whose robot
+                cell lies within ``dangerous_area_radius`` of any dangerous-area
+                centre is treated as terminal by :meth:`is_terminal`, in
+                addition to the explicit terminal-flag field. Defaults to
+                ``False`` (opt-in; dangerous areas only penalise the reward and
+                do not end the episode).
             output_dir: Optional directory for logging output. Defaults to None.
             debug: Enable debug logging. Defaults to False.
             initial_state: Optional initial state as numpy array with shape (5,). If provided,
@@ -271,6 +278,7 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         self.dangerous_areas: List[Tuple[int, int]] = list(dangerous_areas)
         self.dangerous_area_radius = dangerous_area_radius
         self.dangerous_area_penalty = dangerous_area_penalty
+        self.is_dangerous_area_hit_terminal = is_dangerous_area_hit_terminal
         self.initial_state = initial_state
         self.transition_error_prob = transition_error_prob
         self.opponent_policy = opponent_policy
@@ -903,8 +911,34 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         return self.reward_model.compute_reward(state, action, next_state=next_state_arr)
 
     def is_terminal(self, state: np.ndarray) -> bool:
-        """Check if a state is terminal."""
-        return bool(state[4])
+        """Check if a state is terminal.
+
+        A state is terminal when its explicit terminal-flag field is set, and,
+        when ``is_dangerous_area_hit_terminal`` is enabled, also when the robot
+        cell lies within ``dangerous_area_radius`` of any dangerous-area centre.
+
+        Args:
+            state: Length-5 state ``[robot_row, robot_col, opp_row, opp_col, flag]``.
+
+        Returns:
+            ``True`` if the state is terminal, ``False`` otherwise.
+        """
+        if bool(state[4]):
+            return True
+        return self.is_dangerous_area_hit_terminal and self._robot_in_dangerous_area(state)
+
+    def _robot_in_dangerous_area(self, state: np.ndarray) -> bool:
+        if not self.dangerous_areas:
+            return False
+        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
+        robot_row = state[0]
+        robot_col = state[1]
+        for danger_row, danger_col in self.dangerous_areas:
+            delta_row = robot_row - danger_row
+            delta_col = robot_col - danger_col
+            if delta_row * delta_row + delta_col * delta_col <= radius_sq:
+                return True
+        return False
 
     def initial_state_dist(self) -> Distribution:
         """Get the initial state distribution."""
@@ -1079,6 +1113,7 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
                     reward_variant_code=self._native_reward_variant_code(),
                     penalty_decay=float(self.penalty_decay),
                     opponent_policy_code=self.opponent_policy.native_code,
+                    is_dangerous_area_hit_terminal=self.is_dangerous_area_hit_terminal,
                 )
             )
 

--- a/POMDPPlanners/environments/light_dark_pomdp/_cpp/continuous_light_dark.cpp
+++ b/POMDPPlanners/environments/light_dark_pomdp/_cpp/continuous_light_dark.cpp
@@ -608,14 +608,16 @@ static int discrete_match_candidate(
     return -1;
 }
 
-// Discrete is_terminal: goal-equality OR (in any obstacle).
-// The Python is_terminal compares state against goal_state with np.all and
-// scans obstacles with np.any-on-equality (no obstacle_hit_terminal toggle
-// — discrete env always treats obstacle as terminal in is_terminal).
+// Discrete is_terminal: goal-equality OR (is_obstacle_hit_terminal AND in any
+// obstacle). The Python is_terminal compares state against goal_state with
+// np.all and scans obstacles with np.any-on-equality; the obstacle branch is
+// gated on ``is_obstacle_hit_terminal`` so callers can opt out of treating an
+// obstacle cell as terminal while still terminating at the goal.
 bool discrete_is_terminal(
     const py::array_t<double, py::array::c_style | py::array::forcecast> &state,
     const py::array_t<double, py::array::c_style | py::array::forcecast> &goal_state_arr,
-    const py::array_t<double, py::array::c_style | py::array::forcecast> &obstacles_arr) {
+    const py::array_t<double, py::array::c_style | py::array::forcecast> &obstacles_arr,
+    bool is_obstacle_hit_terminal) {
     if (state.ndim() != 1 || static_cast<std::size_t>(state.shape(0)) != kLightDarkStateDim) {
         throw std::invalid_argument("state must have shape (2,)");
     }
@@ -623,6 +625,9 @@ bool discrete_is_terminal(
     auto gv = goal_state_arr.unchecked<1>();
     if (sv(0) == gv(0) && sv(1) == gv(1)) {
         return true;
+    }
+    if (!is_obstacle_hit_terminal) {
+        return false;
     }
     if (obstacles_arr.ndim() != 1) {
         throw std::invalid_argument("obstacles must be a flat 1-D array");
@@ -835,7 +840,8 @@ double discrete_simulate_rollout(
     const py::array_t<double, py::array::c_style | py::array::forcecast> &goal_state_arr,
     const py::array_t<double, py::array::c_style | py::array::forcecast> &obstacles_arr,
     double grid_size, double fuel_cost, double goal_reward, double obstacle_reward,
-    double obstacle_hit_probability, double transition_error_prob) {
+    double obstacle_hit_probability, double transition_error_prob,
+    bool is_obstacle_hit_terminal) {
     if (initial_state.ndim() != 1 ||
         static_cast<std::size_t>(initial_state.shape(0)) != kLightDarkStateDim) {
         throw std::invalid_argument("initial_state must have shape (2,)");
@@ -877,21 +883,25 @@ double discrete_simulate_rollout(
     int depth = start_depth;
 
     while (depth < max_depth) {
-        // Terminal: goal or any obstacle (discrete is_terminal does not
-        // honor an is_obstacle_hit_terminal flag — obstacle is always
-        // terminal in the Python is_terminal()).
+        // Terminal: goal, or (when is_obstacle_hit_terminal) any obstacle.
+        // Mirrors the Python is_terminal(): the obstacle branch is gated on
+        // ``is_obstacle_hit_terminal`` so an obstacle cell only terminates the
+        // rollout when the flag is set. The obstacle penalty below is applied
+        // independently of this terminal check.
         if (sx == goal_x && sy == goal_y) {
             break;
         }
-        bool on_obstacle = false;
-        for (std::size_t j = 0; j < n_obstacles; ++j) {
-            if (sx == obstacles_packed[j * 2] && sy == obstacles_packed[j * 2 + 1]) {
-                on_obstacle = true;
+        if (is_obstacle_hit_terminal) {
+            bool on_obstacle = false;
+            for (std::size_t j = 0; j < n_obstacles; ++j) {
+                if (sx == obstacles_packed[j * 2] && sy == obstacles_packed[j * 2 + 1]) {
+                    on_obstacle = true;
+                    break;
+                }
+            }
+            if (on_obstacle) {
                 break;
             }
-        }
-        if (on_obstacle) {
-            break;
         }
 
         const int idx_slot = depth - start_depth;
@@ -1148,7 +1158,9 @@ PYBIND11_MODULE(_native, m) {
 
     m.def("discrete_is_terminal", &discrete_is_terminal,
           py::arg("state"), py::arg("goal_state"), py::arg("obstacles"),
-          "Discrete-LD is_terminal: state-equals-goal OR state in any obstacle.");
+          py::arg("is_obstacle_hit_terminal") = true,
+          "Discrete-LD is_terminal: state-equals-goal OR (is_obstacle_hit_terminal "
+          "AND state in any obstacle).");
 
     m.def("discrete_observation_log_prob", &discrete_observation_log_prob,
           py::arg("next_state"), py::arg("observations"), py::arg("beacons"),
@@ -1186,6 +1198,7 @@ PYBIND11_MODULE(_native, m) {
           py::arg("goal_state"), py::arg("obstacles"), py::arg("grid_size"),
           py::arg("fuel_cost"), py::arg("goal_reward"), py::arg("obstacle_reward"),
           py::arg("obstacle_hit_probability"), py::arg("transition_error_prob"),
+          py::arg("is_obstacle_hit_terminal") = true,
           "Native random rollout for the discrete LightDark env. Uses the module-level "
           "C++ RNG for the obstacle-hit and transition-error draws; the per-step rollout "
           "action indices are pre-drawn on the Python side.");

--- a/POMDPPlanners/environments/light_dark_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/light_dark_pomdp/_native.pyi
@@ -92,8 +92,10 @@ def discrete_is_terminal(
     state: NDArray[np.float64],
     goal_state: NDArray[np.float64],
     obstacles: NDArray[np.float64],
+    is_obstacle_hit_terminal: bool = ...,
 ) -> bool:
-    """Discrete-LD is_terminal: state-equals-goal OR state-in-any-obstacle."""
+    """Discrete-LD is_terminal: state-equals-goal OR (``is_obstacle_hit_terminal``
+    AND state-in-any-obstacle)."""
     ...
 
 def discrete_observation_log_prob(
@@ -168,11 +170,14 @@ def discrete_simulate_rollout(
     obstacle_reward: float,
     obstacle_hit_probability: float,
     transition_error_prob: float,
+    is_obstacle_hit_terminal: bool = ...,
 ) -> float:
     """Native random rollout for the discrete LightDark env.
 
     Pre-draws action indices on the Python side; uses the module-level C++
-    RNG for the per-step obstacle-hit and transition-error draws.
+    RNG for the per-step obstacle-hit and transition-error draws. When
+    ``is_obstacle_hit_terminal`` is False an obstacle cell does not terminate
+    the rollout (the obstacle penalty is still applied).
     """
     ...
 

--- a/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
@@ -90,6 +90,11 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
         start_state: Initial robot position (x, y)
         obstacles: List of (x, y) obstacle positions to avoid
         grid_size: Dimension of the square grid world
+        is_obstacle_hit_terminal: Whether entering an obstacle cell terminates
+            the episode. When True (default) an obstacle cell is terminal,
+            preserving the historical always-terminate-on-obstacle behavior.
+            When False only the goal is terminal; the obstacle penalty is still
+            applied in the reward, so termination and penalty are independent.
 
     Example:
         >>> import numpy as np
@@ -150,11 +155,13 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
         grid_size: int = 11,
         is_stochastic_reward: bool = True,
         observation_model_type: ObservationModelType = ObservationModelType.NORMAL,
+        is_obstacle_hit_terminal: bool = True,
     ):
         self.transition_error_prob = transition_error_prob
         self.observation_error_prob = observation_error_prob
         self.is_stochastic_reward = is_stochastic_reward
         self.observation_model_type = observation_model_type
+        self.is_obstacle_hit_terminal = is_obstacle_hit_terminal
 
         super().__init__(
             discount_factor=discount_factor,
@@ -734,12 +741,15 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
     def is_terminal(self, state: np.ndarray) -> bool:
         if state.shape != (2,):
             raise ValueError("state must be a 2D vector")
-        # Native fast-path: state-equals-goal OR state-in-any-obstacle (exact
-        # float equality, matching the Python np.all/np.any-on-equality rules).
+        # Native fast-path: state-equals-goal OR (is_obstacle_hit_terminal AND
+        # state-in-any-obstacle), using exact float equality and matching the
+        # Python np.all/np.any-on-equality rules. When the flag is False only
+        # the goal is terminal; an obstacle cell stays non-terminal.
         return _native.discrete_is_terminal(
             state=np.ascontiguousarray(state, dtype=np.float64),
             goal_state=self._goal_state_f64,
             obstacles=self._obstacles_flat,
+            is_obstacle_hit_terminal=self.is_obstacle_hit_terminal,
         )
 
     def simulate_random_rollout(
@@ -823,6 +833,7 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
             obstacle_reward=float(self.obstacle_reward),
             obstacle_hit_probability=float(self.obstacle_hit_probability),
             transition_error_prob=float(self.transition_error_prob),
+            is_obstacle_hit_terminal=self.is_obstacle_hit_terminal,
         )
 
     def get_metric_names(self) -> List[str]:

--- a/POMDPPlanners/environments/pacman_pomdp/_cpp/pacman.cpp
+++ b/POMDPPlanners/environments/pacman_pomdp/_cpp/pacman.cpp
@@ -1215,6 +1215,27 @@ class PacManObservationCpp {
 //                                                   (no radius cutoff).
 // ---------------------------------------------------------------------------
 
+// Geometric hazard-zone membership: true when (new_pac_row, new_pac_col) lies
+// within ``dangerous_area_radius`` (squared-distance test) of any zone centre.
+// Mirrors the reward-kernel membership so the terminal gate agrees with the
+// penalty. ``dangerous_areas`` is a flat (D, 2) float64 buffer.
+inline bool pacman_in_dangerous_area(int new_pac_row, int new_pac_col,
+                                     const double *dangerous_areas, int n_dangerous,
+                                     double dangerous_area_radius) {
+    if (n_dangerous <= 0) {
+        return false;
+    }
+    const double radius_sq = dangerous_area_radius * dangerous_area_radius;
+    for (int d = 0; d < n_dangerous; ++d) {
+        const double dr = static_cast<double>(new_pac_row) - dangerous_areas[d * 2];
+        const double dc = static_cast<double>(new_pac_col) - dangerous_areas[d * 2 + 1];
+        if (dr * dr + dc * dc <= radius_sq) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // Contribution of the dangerous-area term for a single (next_pac_row,
 // next_pac_col). ``dangerous_areas`` is a flat (D, 2) float64 buffer.
 inline double dangerous_area_contribution(int variant_code, int new_pac_row, int new_pac_col,
@@ -1396,7 +1417,8 @@ double simulate_rollout_impl(
     double dangerous_area_radius,
     double dangerous_area_penalty,
     int reward_variant_code,
-    double penalty_decay)
+    double penalty_decay,
+    bool is_dangerous_area_hit_terminal)
 {
     const int state_dim = env.state_dim;
     std::vector<double> current(initial_state, initial_state + state_dim);
@@ -1467,6 +1489,17 @@ double simulate_rollout_impl(
         r += dangerous_area_contribution(reward_variant_code, new_pac_r, new_pac_c,
                                          dangerous_areas, n_dangerous, dangerous_area_radius,
                                          dangerous_area_penalty, penalty_decay, rng);
+
+        // Geometric hazard-terminal gate: when enabled, entering a hazard zone
+        // ends the episode. Applied after the reward for the entering step is
+        // fully accumulated so the penalty is still counted (matches the
+        // is_terminal geometric OR on the Python side). Marking the terminal
+        // field lets the while-loop exit on the next iteration.
+        if (is_dangerous_area_hit_terminal &&
+            pacman_in_dangerous_area(new_pac_r, new_pac_c, dangerous_areas, n_dangerous,
+                                     dangerous_area_radius)) {
+            next[env.idx_terminal] = 1.0;
+        }
 
         total += gamma_power * r;
         gamma_power *= discount_factor;
@@ -1559,7 +1592,8 @@ PYBIND11_MODULE(_native, m) {
            double dangerous_area_radius,
            double dangerous_area_penalty,
            int reward_variant_code,
-           double penalty_decay) -> double {
+           double penalty_decay,
+           bool is_dangerous_area_hit_terminal) -> double {
             if (state.ndim() != 1) {
                 throw std::invalid_argument("state must be 1-D");
             }
@@ -1614,7 +1648,8 @@ PYBIND11_MODULE(_native, m) {
                 dangerous_area_radius,
                 dangerous_area_penalty,
                 reward_variant_code,
-                penalty_decay);
+                penalty_decay,
+                is_dangerous_area_hit_terminal);
         },
         py::arg("state"),
         py::arg("action_indices"),
@@ -1648,6 +1683,7 @@ PYBIND11_MODULE(_native, m) {
         py::arg("dangerous_area_penalty"),
         py::arg("reward_variant_code"),
         py::arg("penalty_decay"),
+        py::arg("is_dangerous_area_hit_terminal") = false,
         "Run a random rollout from state using pre-drawn action_indices; "
         "returns the discounted cumulative reward.");
 

--- a/POMDPPlanners/environments/pacman_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/pacman_pomdp/_native.pyi
@@ -43,6 +43,7 @@ def simulate_rollout(
     dangerous_area_penalty: float,
     reward_variant_code: int,
     penalty_decay: float,
+    is_dangerous_area_hit_terminal: bool = ...,
 ) -> float:
     """Run a random rollout from state using pre-drawn action_indices.
 

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -163,6 +163,7 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         debug: bool = False,
         reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         penalty_decay: float = 1.0,
+        is_dangerous_area_hit_terminal: bool = False,
     ):
         """Initialize PacMan POMDP.
 
@@ -205,6 +206,15 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             penalty_decay: Decay length used by the
                 ``DISTANCE_DECAYED_HAZARD_PENALTY`` reward model. Ignored by the other
                 variants. Must be strictly positive. Defaults to ``1.0``.
+            is_dangerous_area_hit_terminal: When ``True``, :meth:`is_terminal`
+                additionally returns ``True`` whenever PacMan's position lies
+                geometrically inside any configured hazard zone (squared-distance
+                membership against ``dangerous_area_radius``), ending the episode
+                on zone entry. This is a pure geometric gate on position; it does
+                not widen the state, alter the reward/penalty logic, or block
+                movement. Mirrors
+                :attr:`~POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp.ContinuousLightDarkPOMDP.is_obstacle_hit_terminal`.
+                Defaults to ``False`` (opt-in).
         """
         # Calculate reward range based on parameters. The dangerous-area
         # penalty only contributes to ``min_reward`` when at least one zone
@@ -249,6 +259,7 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         )
         self.dangerous_area_radius = float(dangerous_area_radius)
         self.dangerous_area_penalty = float(dangerous_area_penalty)
+        self.is_dangerous_area_hit_terminal = bool(is_dangerous_area_hit_terminal)
         # Pre-built (D, 2) float64 array reused by the vectorised batch-reward
         # path. Kept C-contiguous so future native callers can consume it
         # without an extra copy.
@@ -510,6 +521,17 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
     def get_terminal(self, state: np.ndarray) -> bool:
         """Return whether the state is terminal."""
         return bool(state[self._idx_terminal] > 0.5)
+
+    def _pacman_in_dangerous_area(self, state: np.ndarray) -> bool:
+        # Geometric hazard-zone membership on PacMan's position, reusing the
+        # squared-distance test of the reward kernels. Disabled unless the
+        # opt-in flag is set and at least one zone is configured.
+        if not self.is_dangerous_area_hit_terminal or self._dangerous_areas_arr.shape[0] == 0:
+            return False
+        pac_pos = np.array([state[self._idx_pac_row], state[self._idx_pac_col]], dtype=np.float64)
+        deltas = self._dangerous_areas_arr - pac_pos
+        radius_sq = self.dangerous_area_radius * self.dangerous_area_radius
+        return bool(np.any(np.sum(deltas * deltas, axis=1) <= radius_sq))
 
     def _require_state_array(self, state: Any) -> np.ndarray:
         if not isinstance(state, np.ndarray) or state.shape != (self._state_dim,):
@@ -844,6 +866,7 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             dangerous_area_penalty=float(self.dangerous_area_penalty),
             reward_variant_code=_REWARD_VARIANT_CODES[self.reward_model_type],
             penalty_decay=float(self.penalty_decay),
+            is_dangerous_area_hit_terminal=self.is_dangerous_area_hit_terminal,
         )
 
     def reward(self, state: np.ndarray, action: int, next_state: Any = None) -> float:
@@ -1033,8 +1056,15 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         }
 
     def is_terminal(self, state: np.ndarray) -> bool:
-        """Check if state is terminal."""
-        return self.get_terminal(self._require_state_array(state))
+        """Check if state is terminal.
+
+        Returns ``True`` for the intrinsic terminal condition (ghost collision
+        or all pellets collected, recorded in the state's terminal field) and,
+        when ``is_dangerous_area_hit_terminal`` is enabled, also when PacMan's
+        position lies geometrically inside any configured hazard zone.
+        """
+        state_arr = self._require_state_array(state)
+        return self.get_terminal(state_arr) or self._pacman_in_dangerous_area(state_arr)
 
     def initial_state_dist(self) -> DiscreteDistribution:
         """Get initial state distribution."""

--- a/POMDPPlanners/environments/push_pomdp/_cpp/continuous_push.cpp
+++ b/POMDPPlanners/environments/push_pomdp/_cpp/continuous_push.cpp
@@ -1076,6 +1076,33 @@ static bool cont_is_terminal(const double *state) noexcept {
     return (dx * dx + dy * dy) < 0.25;  // 0.5^2
 }
 
+// Hazard-aware terminal check mirroring ContinuousPushPOMDP.is_terminal:
+// object-at-target OR (flag AND robot geometrically inside a hazard). The
+// robot position is state[0:2]; obstacle overlap uses the same circle-AABB
+// test the reward path uses, and dangerous-area membership reuses
+// point_in_dangerous_areas so a hit that charges a penalty is also terminal.
+static bool cont_is_terminal_with_hazards(
+    const double *state, const std::vector<double> &obs_flat, std::size_t n_obs,
+    double robot_radius, const std::vector<double> &dangerous_flat,
+    double dangerous_area_radius_sq, bool is_obstacle_hit_terminal,
+    bool is_dangerous_area_hit_terminal) noexcept {
+    if (cont_is_terminal(state)) {
+        return true;
+    }
+    if (is_obstacle_hit_terminal) {
+        for (std::size_t i = 0; i < n_obs; ++i) {
+            if (cont_circle_aabb_overlap(state, robot_radius, &obs_flat[i * 4])) {
+                return true;
+            }
+        }
+    }
+    if (is_dangerous_area_hit_terminal) {
+        return point_in_dangerous_areas(state[0], state[1], dangerous_flat,
+                                        dangerous_area_radius_sq);
+    }
+    return false;
+}
+
 static void cont_resolve_single_circle_wall(double *pos, const double *wall,
                                             double robot_radius) noexcept {
     const double cx = wall[0];
@@ -1256,7 +1283,8 @@ double cont_simulate_rollout(
     double dangerous_area_radius, double dangerous_area_penalty,
     const py::array_t<double> &covariance,
     double obstacle_hit_probability, double dangerous_area_hit_probability,
-    int reward_variant_code, double penalty_decay) {
+    int reward_variant_code, double penalty_decay,
+    bool is_obstacle_hit_terminal, bool is_dangerous_area_hit_terminal) {
 
     if (initial_state.ndim() != 1 ||
         static_cast<std::size_t>(initial_state.shape(0)) != kPushStateDim) {
@@ -1319,7 +1347,10 @@ double cont_simulate_rollout(
     };
 
     while (depth < max_depth) {
-        if (cont_is_terminal(state)) {
+        if (cont_is_terminal_with_hazards(
+                state, obs_flat, n_obs, robot_radius, dangerous_flat,
+                dangerous_area_radius_sq, is_obstacle_hit_terminal,
+                is_dangerous_area_hit_terminal)) {
             break;
         }
         const int idx_slot = depth - start_depth;
@@ -1783,6 +1814,8 @@ PYBIND11_MODULE(_native, m) {
           py::arg("dangerous_area_hit_probability") = 1.0,
           py::arg("reward_variant_code") = 0,
           py::arg("penalty_decay") = 1.0,
+          py::arg("is_obstacle_hit_terminal") = false,
+          py::arg("is_dangerous_area_hit_terminal") = false,
           "Native random rollout for ContinuousPushPOMDP. "
           "Returns discounted return from initial_state. "
           "action_indices must be a pre-drawn int32 array of shape (steps_left,). "

--- a/POMDPPlanners/environments/push_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/push_pomdp/_native.pyi
@@ -75,6 +75,8 @@ def cont_simulate_rollout(
     dangerous_area_hit_probability: float = 1.0,
     reward_variant_code: int = 0,
     penalty_decay: float = 1.0,
+    is_obstacle_hit_terminal: bool = False,
+    is_dangerous_area_hit_terminal: bool = False,
 ) -> float:
     """Native random rollout for ContinuousPushPOMDP.
 

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+# pylint: disable=too-many-lines  # Two env variants plus hazard geometry helpers.
 
 """Continuous Push POMDP Environment Implementation.
 
@@ -157,6 +158,19 @@ class ContinuousPushPOMDP(Environment):
         Bernoulli draw internally, so all rollouts route through the
         native kernel regardless of the configured probability.
 
+    Hazard termination:
+        ``is_obstacle_hit_terminal`` and ``is_dangerous_area_hit_terminal``
+        are opt-in flags (both default ``False`` for backward
+        compatibility). When enabled, :meth:`is_terminal` additionally
+        returns ``True`` whenever the robot position already stored in
+        the state geometrically overlaps an obstacle AABB (using
+        ``robot_radius``) or lies within ``dangerous_area_radius`` of a
+        dangerous area, respectively. The check is a pure function of the
+        robot position; it does not widen the state, alter the reward /
+        penalty logic, or move any random draw. The same geometry is
+        threaded into the native rollout terminal check so planning
+        rollouts agree with :meth:`is_terminal`.
+
     Example:
         >>> import numpy as np
         >>> np.random.seed(42)
@@ -187,6 +201,8 @@ class ContinuousPushPOMDP(Environment):
         dangerous_area_radius: float = 0.5,
         dangerous_area_penalty: float = -10.0,
         dangerous_area_hit_probability: float = 1.0,
+        is_obstacle_hit_terminal: bool = False,
+        is_dangerous_area_hit_terminal: bool = False,
         reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         penalty_decay: float = 1.0,
         robot_radius: float = 0.3,
@@ -229,6 +245,8 @@ class ContinuousPushPOMDP(Environment):
         self.dangerous_area_radius = float(dangerous_area_radius)
         self.dangerous_area_penalty = float(dangerous_area_penalty)
         self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
+        self.is_obstacle_hit_terminal = is_obstacle_hit_terminal
+        self.is_dangerous_area_hit_terminal = is_dangerous_area_hit_terminal
         self.reward_model_type = reward_model_type
         self.penalty_decay = float(penalty_decay)
         if self.dangerous_areas:
@@ -649,16 +667,31 @@ class ContinuousPushPOMDP(Environment):
                 dangerous_area_hit_probability=float(self.dangerous_area_hit_probability),
                 reward_variant_code=variant_code,
                 penalty_decay=penalty_decay,
+                is_obstacle_hit_terminal=bool(self.is_obstacle_hit_terminal),
+                is_dangerous_area_hit_terminal=bool(self.is_dangerous_area_hit_terminal),
             )
         )
 
     def is_terminal(self, state: np.ndarray) -> bool:
+        if self._is_object_at_target(state):
+            return True
+        if self.is_obstacle_hit_terminal and self._is_robot_hitting_obstacle(state):
+            return True
+        return bool(self.is_dangerous_area_hit_terminal and self._is_robot_in_hazard_zone(state))
+
+    def _is_object_at_target(self, state: np.ndarray) -> bool:
         # Inline 2-D distance squared comparison: avoids np.linalg.norm,
         # which goes through einsum + sqrt on a tiny vector and dominates
         # this hot path for POMCPOW.
         dx = state[2] - state[4]
         dy = state[3] - state[5]
         return bool((dx * dx + dy * dy) < 0.25)
+
+    def _is_robot_hitting_obstacle(self, state: np.ndarray) -> bool:
+        return self._is_circle_colliding_with_obstacle(state[0:2], self.robot_radius)
+
+    def _is_robot_in_hazard_zone(self, state: np.ndarray) -> bool:
+        return self._is_robot_in_dangerous_area(state[0:2])
 
     def initial_state_dist(self) -> Distribution:
         if self._initial_state is not None:
@@ -897,6 +930,8 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
         dangerous_area_radius: float = 0.5,
         dangerous_area_penalty: float = -10.0,
         dangerous_area_hit_probability: float = 1.0,
+        is_obstacle_hit_terminal: bool = False,
+        is_dangerous_area_hit_terminal: bool = False,
         reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         penalty_decay: float = 1.0,
         robot_radius: float = 0.3,
@@ -921,6 +956,8 @@ class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnv
             dangerous_area_radius=dangerous_area_radius,
             dangerous_area_penalty=dangerous_area_penalty,
             dangerous_area_hit_probability=dangerous_area_hit_probability,
+            is_obstacle_hit_terminal=is_obstacle_hit_terminal,
+            is_dangerous_area_hit_terminal=is_dangerous_area_hit_terminal,
             reward_model_type=reward_model_type,
             penalty_decay=penalty_decay,
             robot_radius=robot_radius,

--- a/POMDPPlanners/environments/rock_sample_pomdp/_cpp/rock_sample.cpp
+++ b/POMDPPlanners/environments/rock_sample_pomdp/_cpp/rock_sample.cpp
@@ -727,6 +727,26 @@ inline double dangerous_area_term(double next_row, double next_col,
     return 0.0;
 }
 
+// Terminal test used by the rollout: the exit sentinel ``(-1, -1)`` OR,
+// when ``is_dangerous_area_hit_terminal`` is enabled, a robot position
+// geometrically inside any dangerous area (squared-distance within
+// ``dangerous_area_radius``). Mirrors ``RockSamplePOMDP.is_terminal``: a
+// pure geometric gate independent of any penalty draw.
+inline bool is_terminal_state(const double *row, bool is_dangerous_area_hit_terminal,
+                              const double *dangers, std::size_t k,
+                              double dangerous_area_radius) {
+    if (is_terminal_row(row)) {
+        return true;
+    }
+    if (is_dangerous_area_hit_terminal && k > 0) {
+        const double radius_sq = dangerous_area_radius * dangerous_area_radius;
+        if (min_dist_to_danger_sq(row[0], row[1], dangers, k) <= radius_sq) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // Standalone reward batch kernel. Returns a (N,) float64 array where each
 // entry is the per-row reward under the configured variant.
 py::array_t<double> reward_batch(
@@ -835,7 +855,8 @@ double simulate_rollout_discrete(
     double dangerous_area_penalty,
     double dangerous_area_hit_probability,
     int reward_variant_code,
-    double penalty_decay) {
+    double penalty_decay,
+    bool is_dangerous_area_hit_terminal) {
     if (initial_state.ndim() != 1 || initial_state.shape(0) < 2) {
         throw std::invalid_argument("initial_state must be a 1-D array with length >= 2");
     }
@@ -890,7 +911,8 @@ double simulate_rollout_discrete(
     int depth = start_depth;
 
     while (depth < max_depth) {
-        if (is_terminal_row(cur.data())) {
+        if (is_terminal_state(cur.data(), is_dangerous_area_hit_terminal, dangers_data,
+                              n_dangers, dangerous_area_radius)) {
             break;
         }
 
@@ -949,12 +971,16 @@ PYBIND11_MODULE(_native, m) {
           py::arg("dangerous_area_penalty"),
           py::arg("dangerous_area_hit_probability"),
           py::arg("reward_variant_code"), py::arg("penalty_decay"),
+          py::arg("is_dangerous_area_hit_terminal") = false,
           "Native random rollout for RockSamplePOMDP with variant-aware "
           "dangerous-area reward term. Returns discounted reward sum. "
           "action_indices must be a pre-drawn int32 array of length (max_depth-start_depth). "
           "rock_positions_flat is a 1-D int32 array [row0, col0, row1, col1, ...]. "
           "dangerous_areas is a (K, 2) float64 array (may be empty). "
-          "reward_variant_code: 0=CONSTANT_HAZARD_PENALTY, 1=ZERO_MEAN_HAZARD_SHOCK, 2=DISTANCE_DECAYED_HAZARD_PENALTY.");
+          "reward_variant_code: 0=CONSTANT_HAZARD_PENALTY, 1=ZERO_MEAN_HAZARD_SHOCK, 2=DISTANCE_DECAYED_HAZARD_PENALTY. "
+          "is_dangerous_area_hit_terminal: when true, a robot position inside a "
+          "dangerous area terminates the rollout (geometric gate matching "
+          "RockSamplePOMDP.is_terminal).");
 
     m.def("reward_batch", &reward_batch,
           py::arg("states"), py::arg("action"), py::arg("next_states"),

--- a/POMDPPlanners/environments/rock_sample_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/rock_sample_pomdp/_native.pyi
@@ -41,6 +41,7 @@ def simulate_rollout_discrete(
     dangerous_area_hit_probability: float,
     reward_variant_code: int,
     penalty_decay: float,
+    is_dangerous_area_hit_terminal: bool = ...,
 ) -> float:
     """Native random rollout for RockSamplePOMDP with variant-aware reward.
 
@@ -51,6 +52,9 @@ def simulate_rollout_discrete(
     int32 array ``[row0, col0, row1, col1, …]``. ``dangerous_areas`` is a
     ``(K, 2)`` float64 array (may be empty). ``reward_variant_code``:
     ``0=CONSTANT_HAZARD_PENALTY``, ``1=ZERO_MEAN_HAZARD_SHOCK``, ``2=DISTANCE_DECAYED_HAZARD_PENALTY``.
+    When ``is_dangerous_area_hit_terminal`` is ``True``, a robot position inside
+    any dangerous area terminates the rollout (geometric gate matching
+    :meth:`RockSamplePOMDP.is_terminal`). Defaults to ``False``.
     """
     ...
 

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -30,6 +30,9 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.environments.environment_utils.dangerous_areas_kernels import (
+    membership_within_radius_batch_kernel,
+)
 from POMDPPlanners.environments.rock_sample_pomdp import _native
 from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_utils.rock_sample_reward_models import (
     BaseRockSampleRewardModel,
@@ -197,6 +200,7 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         dangerous_area_radius: float = 1.0,
         dangerous_area_penalty: float = -5.0,
         dangerous_area_hit_probability: float = 1.0,
+        is_dangerous_area_hit_terminal: bool = False,
         reward_model_type: RewardModelType = RewardModelType.CONSTANT_HAZARD_PENALTY,
         penalty_decay: float = 1.0,
         discount_factor: float = 0.95,
@@ -234,6 +238,15 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
                 ``reward(state, action)`` non-deterministic given a
                 state-action pair. Ignored by ``ZERO_MEAN_HAZARD_SHOCK``
                 and ``DISTANCE_DECAYED_HAZARD_PENALTY`` reward models.
+            is_dangerous_area_hit_terminal: When ``True``, a state whose
+                robot position lies inside any configured dangerous area
+                (squared-distance within ``dangerous_area_radius``) is
+                treated as terminal by :meth:`is_terminal`, ending the
+                episode. This is a pure geometric gate on position: it is
+                independent of the stochastic ``dangerous_area_hit_probability``
+                penalty draw and does not change the reward. Defaults to
+                ``False`` (opt-in; only the exit sentinel ``(-1, -1)`` is
+                terminal).
             reward_model_type: Which dangerous-area penalty model to use.
                 Defaults to ``RewardModelType.CONSTANT_HAZARD_PENALTY`` (legacy
                 constant-probability behaviour). ``ZERO_MEAN_HAZARD_SHOCK``
@@ -313,6 +326,7 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         self.dangerous_area_radius = dangerous_area_radius
         self.dangerous_area_penalty = dangerous_area_penalty
         self.dangerous_area_hit_probability = float(dangerous_area_hit_probability)
+        self.is_dangerous_area_hit_terminal = is_dangerous_area_hit_terminal
         self.reward_model_type = reward_model_type
         self.penalty_decay = float(penalty_decay)
 
@@ -332,15 +346,10 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
             [coord for rp in self.rock_positions for coord in rp], dtype=np.int32
         )
 
-        # Cached (K, 2) float64 dangerous-area centres for the native
-        # reward / rollout kernels. Empty (0, 2) array when no danger
-        # zones are configured.
-        if self.dangerous_areas:
-            self._dangerous_areas_arr: np.ndarray = np.ascontiguousarray(
-                np.asarray(self.dangerous_areas, dtype=np.float64)
-            )
-        else:
-            self._dangerous_areas_arr = np.empty((0, 2), dtype=np.float64)
+        # Cache dangerous-area centres / squared radius for the native reward
+        # and rollout kernels and the geometric ``is_terminal`` gate.
+        self._cache_dangerous_area_geometry()
+
         self._reward_variant_code: int = {
             RewardModelType.CONSTANT_HAZARD_PENALTY: 0,
             RewardModelType.ZERO_MEAN_HAZARD_SHOCK: 1,
@@ -368,6 +377,23 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         # / ``_get_obs_kernel`` and reset on unpickle.
         self._trans_kernel_cache: Dict[int, Any] = {}
         self._obs_kernel_cache: Dict[int, Any] = {}
+
+    def _cache_dangerous_area_geometry(self) -> None:
+        # pylint: disable=attribute-defined-outside-init
+        # Cached (K, 2) float64 centres for the native reward / rollout
+        # kernels (empty (0, 2) when no zones), plus the transposed (2, K)
+        # view and squared radius the geometric ``is_terminal`` gate feeds to
+        # the same membership kernel the reward path uses.
+        if self.dangerous_areas:
+            self._dangerous_areas_arr: np.ndarray = np.ascontiguousarray(
+                np.asarray(self.dangerous_areas, dtype=np.float64)
+            )
+        else:
+            self._dangerous_areas_arr = np.empty((0, 2), dtype=np.float64)
+        self._dangerous_areas_xy: np.ndarray = np.ascontiguousarray(self._dangerous_areas_arr.T)
+        self._dangerous_area_radius_sq: float = float(
+            self.dangerous_area_radius * self.dangerous_area_radius
+        )
 
     def _build_reward_model(self) -> BaseRockSampleRewardModel:
         common_kwargs = {
@@ -675,6 +701,7 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
             dangerous_area_hit_probability=float(self.dangerous_area_hit_probability),
             reward_variant_code=int(self._reward_variant_code),
             penalty_decay=float(self.penalty_decay),
+            is_dangerous_area_hit_terminal=bool(self.is_dangerous_area_hit_terminal),
         )
 
     def sample_next_step(
@@ -687,8 +714,33 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         return next_state, observation, reward
 
     def is_terminal(self, state: RockSampleState) -> bool:
-        """Check if state is terminal."""
-        return int(state[0]) == -1 and int(state[1]) == -1
+        """Check if a state is terminal.
+
+        A state is terminal when the robot has reached the exit sentinel
+        ``(-1, -1)`` or, when ``is_dangerous_area_hit_terminal`` is enabled,
+        when the robot's position lies inside any configured dangerous area
+        (squared-distance within ``dangerous_area_radius``). The geometric
+        gate is a pure function of position and is independent of the
+        stochastic dangerous-area penalty draw.
+
+        Args:
+            state: RockSample state array ``[robot_row, robot_col, rock_0..]``.
+
+        Returns:
+            ``True`` if the state is terminal, ``False`` otherwise.
+        """
+        if int(state[0]) == -1 and int(state[1]) == -1:
+            return True
+        if not self.is_dangerous_area_hit_terminal or not self.dangerous_areas:
+            return False
+        point = np.empty((1, 2), dtype=np.float64)
+        point[0, 0] = float(state[0])
+        point[0, 1] = float(state[1])
+        return bool(
+            membership_within_radius_batch_kernel(
+                point, self._dangerous_areas_xy, self._dangerous_area_radius_sq
+            )[0]
+        )
 
     def __getstate__(self) -> Dict[str, Any]:
         # Per-action C++ kernel caches hold pybind11 objects that aren't

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
@@ -954,6 +954,87 @@ class TestIsTerminal:
         state = np.array([5.0, 3.0, 8.0, 5.0, 1.0])
         assert env.is_terminal(state) is True
 
+    def test_default_dangerous_area_not_terminal(self, env):
+        """Test that a robot inside a dangerous area is non-terminal by default.
+
+        Purpose: Validates that the geometric hazard-terminal gate is opt-in and
+            off by default.
+
+        Given: A default ContinuousLaserTagPOMDP (is_dangerous_area_hit_terminal
+            defaults to False) and a non-terminal state whose robot position sits
+            inside the (5, 3) dangerous area.
+        When: is_terminal() is called on that state.
+        Then: Returns False because the flag is disabled.
+
+        Test type: unit
+        """
+        state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        assert env.is_dangerous_area_hit_terminal is False
+        assert env.is_terminal(state) is False
+
+    def test_dangerous_area_hit_terminal_flag_on(self):
+        """Test that the hazard-terminal flag makes hazard positions terminal.
+
+        Purpose: Validates that enabling is_dangerous_area_hit_terminal treats a
+            robot geometrically inside a dangerous area as terminal, while the
+            dangerous-area penalty and explicit tag-terminal flag still apply.
+
+        Given: A ContinuousLaserTagPOMDP with is_dangerous_area_hit_terminal=True
+            and dangerous_area_hit_probability=1.0, plus a non-terminal state whose
+            robot sits inside the (5, 3) dangerous area.
+        When: is_terminal() and reward() are evaluated on that state, and
+            is_terminal() is checked on an explicitly flagged terminal state.
+        Then: is_terminal() returns True for the hazard state, the reward on that
+            step still includes the dangerous-area penalty, and the explicit
+            terminal-flag state remains terminal.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDP(
+            discount_factor=0.95,
+            **_cont_lt_pinned_kwargs(
+                is_dangerous_area_hit_terminal=True,
+                dangerous_area_hit_probability=1.0,
+            ),
+        )
+        hazard_state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        assert env.is_terminal(hazard_state) is True
+
+        # The penalty is unchanged: entering the hazard still costs the step
+        # cost plus the dangerous-area penalty.
+        action = np.array([0.0, 0.0, 0.0])
+        reward = env.reward(hazard_state, action, next_state=hazard_state)
+        assert reward == pytest.approx(-env.step_cost - env.dangerous_area_penalty)
+
+        # Regression: explicit tag-terminal detection via state[4] still holds.
+        tag_terminal_state = np.array([1.0, 1.0, 1.0, 1.0, 1.0])
+        assert env.is_terminal(tag_terminal_state) is True
+
+    def test_dangerous_area_hit_terminal_reward_range(self):
+        """Test that the reward range lower bound includes the hazard penalty.
+
+        Purpose: Validates that reward_range accounts for the dangerous-area
+            penalty when dangerous areas are configured.
+
+        Given: A ContinuousLaserTagPOMDP with dangerous areas configured and known
+            tag_penalty, step_cost, and dangerous_area_penalty.
+        When: The reward_range attribute is read.
+        Then: reward_range[0] equals -(tag_penalty + step_cost +
+            dangerous_area_penalty) and reward_range[1] equals tag_reward.
+
+        Test type: unit
+        """
+        env = ContinuousLaserTagPOMDP(
+            discount_factor=0.95,
+            **_cont_lt_pinned_kwargs(
+                tag_penalty=10.0,
+                step_cost=1.0,
+                dangerous_area_penalty=5.0,
+                tag_reward=10.0,
+            ),
+        )
+        assert env.reward_range == (-16.0, 10.0)
+
 
 class TestInitialStateDist:
     """Tests for initial state distribution."""
@@ -2040,3 +2121,43 @@ class TestObservationLogProbabilityLowDensityB1:
         ), f"scalar single log-prob underflowed to {scalar_value} — B1 not fixed"
         assert scalar_value < -1e5
         np.testing.assert_allclose(scalar_value, batch_log_probs[0], atol=1e-6)
+
+
+class TestContinuousLaserTagHazardTerminalRollout:
+    """Tests for hazard-terminal consistency in the native rollout path."""
+
+    def test_native_rollout_from_hazard_cell_terminates(self):
+        """Test that a flag-on rollout starting in a hazard cell returns zero.
+
+        Purpose: Validates that the native rollout terminal check mirrors
+            is_terminal when is_dangerous_area_hit_terminal is enabled.
+
+        Given: A ContinuousLaserTagPOMDPDiscreteActions with
+            is_dangerous_area_hit_terminal=True and an initial state whose robot
+            already sits inside the (5, 3) dangerous area.
+        When: simulate_random_rollout is invoked from that hazard state.
+        Then: is_terminal is True for the start state and the rollout returns 0.0
+            (it terminates immediately, consistent with is_terminal).
+
+        Test type: unit
+        """
+
+        class _UniformDiscreteSampler(ActionSampler):
+            def sample(self, belief_node=None):
+                return np.random.choice(["up", "down", "right", "left", "tag"])
+
+        env = ContinuousLaserTagPOMDPDiscreteActions(
+            discount_factor=0.95,
+            **_cont_lt_pinned_kwargs(is_dangerous_area_hit_terminal=True),
+        )
+        hazard_state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        assert env.is_terminal(hazard_state) is True
+
+        _native.set_seed(1)
+        rollout_return = env.simulate_random_rollout(
+            state=hazard_state,
+            action_sampler=_UniformDiscreteSampler(),
+            max_depth=20,
+            discount_factor=0.95,
+        )
+        assert rollout_return == 0.0

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -1456,6 +1456,103 @@ class TestLaserTagPOMDP:
 
         assert env2.reward_range == (expected_min2, expected_max2)
 
+    def test_default_dangerous_area_not_terminal(self):
+        """Test that a robot inside a dangerous area is non-terminal by default.
+
+        Purpose: Validates that the geometric hazard-terminal gate is opt-in and
+            off by default.
+
+        Given: A default LaserTagPOMDP (is_dangerous_area_hit_terminal defaults to
+            False) and a non-terminal state whose robot cell is the (5, 3)
+            dangerous-area centre.
+        When: is_terminal() is called on that state.
+        Then: Returns False because the flag is disabled.
+
+        Test type: unit
+        """
+        env = LaserTagPOMDP(discount_factor=0.95, **_lt_pinned_kwargs())
+
+        hazard_state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        assert env.is_dangerous_area_hit_terminal is False
+        assert env.is_terminal(hazard_state) is False
+
+    def test_dangerous_area_hit_terminal_flag_on(self):
+        """Test that the hazard-terminal flag makes hazard cells terminal.
+
+        Purpose: Validates that enabling is_dangerous_area_hit_terminal treats a
+            robot cell inside a dangerous area as terminal, while the
+            dangerous-area penalty and explicit tag-terminal flag still apply.
+
+        Given: A LaserTagPOMDP with is_dangerous_area_hit_terminal=True, a
+            non-terminal state whose robot cell is the (5, 3) dangerous-area
+            centre, and a state moving into that cell.
+        When: is_terminal() and reward() are evaluated on those states, and
+            is_terminal() is checked on an explicitly flagged terminal state.
+        Then: is_terminal() returns True for the hazard cell, the reward for
+            moving into it still includes the dangerous-area penalty, the reward
+            range is unchanged, and the explicit terminal-flag state stays
+            terminal.
+
+        Test type: unit
+        """
+        env = LaserTagPOMDP(
+            discount_factor=0.95,
+            **_lt_pinned_kwargs(is_dangerous_area_hit_terminal=True),
+        )
+        hazard_state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        assert env.is_terminal(hazard_state) is True
+
+        # The penalty is unchanged: moving into the hazard still costs the step
+        # cost plus the dangerous-area penalty.
+        approaching_state = np.array([6.0, 3.0, 8.0, 5.0, 0.0])
+        reward = env.reward(approaching_state, 0, next_state=hazard_state)
+        assert reward == pytest.approx(-env.step_cost - env.dangerous_area_penalty)
+
+        # The discrete reward range is intentionally left unchanged.
+        assert env.reward_range == (-env.tag_penalty, env.tag_reward)
+
+        # Regression: explicit tag-terminal detection via state[4] still holds.
+        tag_terminal_state = np.array([3.0, 5.0, 3.0, 5.0, 1.0])
+        assert env.is_terminal(tag_terminal_state) is True
+
+    def test_native_rollout_from_hazard_cell_terminates(self):
+        """Test that a flag-on rollout starting in a hazard cell returns zero.
+
+        Purpose: Validates that the native discrete rollout terminal check
+            mirrors is_terminal when is_dangerous_area_hit_terminal is enabled.
+
+        Given: A LaserTagPOMDP with is_dangerous_area_hit_terminal=True and an
+            initial state whose robot cell is the (5, 3) dangerous-area centre.
+        When: simulate_random_rollout is invoked from that hazard state.
+        Then: is_terminal is True for the start state and the rollout returns 0.0
+            (it terminates immediately, consistent with is_terminal).
+
+        Test type: unit
+        """
+
+        class _UniformDiscreteSampler(ActionSampler):
+            def sample(self, belief_node=None):
+                return int(np.random.choice([0, 1, 2, 3, 4]))
+
+        env = LaserTagPOMDP(
+            discount_factor=0.95,
+            **_lt_pinned_kwargs(is_dangerous_area_hit_terminal=True),
+        )
+        hazard_state = np.array([5.0, 3.0, 8.0, 5.0, 0.0])
+        assert env.is_terminal(hazard_state) is True
+
+        # pylint: disable-next=import-outside-toplevel
+        from POMDPPlanners.environments.laser_tag_pomdp import _native
+
+        _native.set_seed(1)
+        rollout_return = env.simulate_random_rollout(
+            state=hazard_state,
+            action_sampler=_UniformDiscreteSampler(),
+            max_depth=20,
+            discount_factor=0.95,
+        )
+        assert rollout_return == 0.0
+
     def test_initial_state_distribution(self):
         """Test initial state distribution properties.
 

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_pomdp.py
@@ -2435,3 +2435,95 @@ class TestDiscreteLightDarkRewardNextStateConsistency:
             "test_setup_error: across 20 seeds, the obstacle Bernoulli never "
             "fired — strengthen the action/state to land on the obstacle."
         )
+
+
+def test_is_obstacle_hit_terminal_default_true_obstacle_is_terminal():
+    """Default DiscreteLightDarkPOMDP treats an obstacle cell as terminal.
+
+    Purpose: Validates that the ``is_obstacle_hit_terminal`` flag defaults to
+        True and preserves the historical always-terminate-on-obstacle
+        behavior.
+
+    Given: A default ``DiscreteLightDarkPOMDP`` (flag left at its True default).
+    When: ``is_terminal`` is queried on an obstacle cell.
+    Then: The flag is True and the obstacle cell is terminal.
+
+    Test type: unit
+    """
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
+
+    assert env.is_obstacle_hit_terminal is True
+    assert env.is_terminal(env.obstacles[:, 0])
+
+
+def test_is_obstacle_hit_terminal_false_obstacle_not_terminal_penalty_kept():
+    """Flag off keeps an obstacle cell non-terminal while still penalizing it.
+
+    Purpose: Validates that ``is_obstacle_hit_terminal=False`` makes an
+        obstacle cell non-terminal (only the goal terminates) yet leaves the
+        obstacle penalty intact, proving termination and penalty are
+        independent.
+
+    Given: A ``DiscreteLightDarkPOMDP`` with ``is_obstacle_hit_terminal=False``,
+        a single obstacle at (5, 5), and ``obstacle_hit_probability=1.0`` so the
+        penalty always fires.
+    When: ``is_terminal`` is queried on the obstacle cell and on the goal, and
+        ``reward`` is scored against the obstacle as the realised next_state.
+    Then: The obstacle cell is non-terminal, the goal is terminal, and the
+        reward includes the obstacle penalty.
+
+    Test type: unit
+    """
+    env = DiscreteLightDarkPOMDP(
+        discount_factor=0.95,
+        **discrete_light_dark_pinned_kwargs(
+            is_obstacle_hit_terminal=False,
+            obstacle_hit_probability=1.0,
+            obstacles=[(5, 5)],
+            goal_state=np.array([10, 5]),
+        ),
+    )
+    obstacle_state = np.array([5, 5])
+
+    assert env.is_obstacle_hit_terminal is False
+    assert not env.is_terminal(obstacle_state)
+    assert env.is_terminal(env.goal_state)
+
+    reward = env.reward(np.array([4, 5]), "right", obstacle_state)
+    baseline = -env.fuel_cost - float(np.linalg.norm(obstacle_state - env.goal_state))
+    assert reward == pytest.approx(baseline + env.obstacle_reward)
+
+
+def test_is_obstacle_hit_terminal_serialization_round_trip():
+    """The is_obstacle_hit_terminal flag survives to_dict/from_dict and config_id.
+
+    Purpose: Validates that ``is_obstacle_hit_terminal`` is auto-serialized by
+        the base ``to_dict``/``from_dict`` machinery and distinguishes the
+        deterministic ``config_id``.
+
+    Given: A ``DiscreteLightDarkPOMDP`` with ``is_obstacle_hit_terminal=False``
+        and an otherwise-identical env with the flag True.
+    When: The False env is round-tripped through ``to_dict``/``from_dict`` and
+        the two ``config_id`` values are compared.
+    Then: The serialized params expose the flag, the reconstructed env equals
+        the original, and the two envs have distinct ``config_id`` values.
+
+    Test type: unit
+    """
+    env_false = DiscreteLightDarkPOMDP(
+        discount_factor=0.95,
+        **discrete_light_dark_pinned_kwargs(is_obstacle_hit_terminal=False),
+    )
+    env_true = DiscreteLightDarkPOMDP(
+        discount_factor=0.95,
+        **discrete_light_dark_pinned_kwargs(is_obstacle_hit_terminal=True),
+    )
+
+    data = env_false.to_dict()
+    assert data["params"]["is_obstacle_hit_terminal"] is False
+
+    restored = DiscreteLightDarkPOMDP.from_dict(data)
+    assert isinstance(restored, DiscreteLightDarkPOMDP)
+    assert restored.is_obstacle_hit_terminal is False
+    assert restored == env_false
+    assert env_false.config_id != env_true.config_id

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
@@ -2931,3 +2931,213 @@ class TestPacManDangerousAreas:
         )
         expected_max = self.pomdp.step_penalty + self.pomdp.pellet_reward + self.pomdp.win_reward
         assert self.pomdp.reward_range == (expected_min, expected_max)
+
+    def _flag_on_env(self) -> PacManPOMDP:
+        return PacManPOMDP(
+            discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                maze_size=(7, 7),
+                walls=set(),
+                initial_pellets=[(0, 6)],
+                initial_pacman_pos=(0, 0),
+                num_ghosts=1,
+                initial_ghost_positions=[(6, 6)],
+                dangerous_areas={(3, 3)},
+                dangerous_area_radius=1.0,
+                dangerous_area_penalty=5.0,
+                is_dangerous_area_hit_terminal=True,
+            ),
+        )
+
+    def test_hazard_terminal_flag_defaults_false_keeps_zone_non_terminal(self):
+        """A position inside a zone is non-terminal when the flag defaults off.
+
+        Purpose: Validates that the opt-in hazard-terminal gate is disabled by
+            default, so a state whose PacMan sits geometrically inside a zone is
+            still reported as non-terminal (preserving the legacy contract).
+
+        Given: The default env (``is_dangerous_area_hit_terminal`` unset) with a
+            zone at (3, 3) radius 1.0 and PacMan placed at the zone centre.
+        When: ``is_terminal(state)`` is queried.
+        Then: It returns ``False`` because the terminal field is unset and the
+            geometric gate is disabled.
+
+        Test type: unit
+        """
+        assert self.pomdp.is_dangerous_area_hit_terminal is False
+        state = self._state_with_pac((3, 3))
+
+        assert self.pomdp.is_terminal(state) is False
+
+    def test_hazard_terminal_flag_on_makes_zone_position_terminal(self):
+        """Enabling the flag makes a zone-interior position terminal.
+
+        Purpose: Validates that ``is_dangerous_area_hit_terminal=True`` turns
+            geometric zone membership into a terminal condition without setting
+            the state's terminal field.
+
+        Given: An env with the flag enabled, a zone at (3, 3) radius 1.0, and a
+            non-terminal-field state with PacMan at the zone centre (3, 3) and
+            another at the boundary (3, 4) (distance == radius).
+        When: ``is_terminal`` is queried for each in-zone state.
+        Then: Both return ``True``.
+
+        Test type: unit
+        """
+        env = self._flag_on_env()
+        centre = env.make_state(pacman_pos=(3, 3), ghost_positions=((6, 6),), pellets=((0, 6),))
+        boundary = env.make_state(pacman_pos=(3, 4), ghost_positions=((6, 6),), pellets=((0, 6),))
+
+        assert env.get_terminal(centre) is False  # terminal field itself unset
+        assert env.is_terminal(centre) is True
+        assert env.is_terminal(boundary) is True
+
+    def test_hazard_terminal_flag_on_keeps_outside_zone_non_terminal(self):
+        """With the flag on, positions outside every zone stay non-terminal.
+
+        Purpose: Validates the symmetric negative case so the geometric gate
+            does not over-trigger away from the configured zones.
+
+        Given: An env with the flag enabled and PacMan two cells from the zone
+            centre at (3, 5) (distance 2.0 > radius 1.0).
+        When: ``is_terminal(state)`` is queried.
+        Then: It returns ``False``.
+
+        Test type: unit
+        """
+        env = self._flag_on_env()
+        outside = env.make_state(pacman_pos=(3, 5), ghost_positions=((6, 6),), pellets=((0, 6),))
+
+        assert env.is_terminal(outside) is False
+
+    def test_hazard_terminal_entry_still_incurs_danger_penalty(self):
+        """The entering step still subtracts the danger penalty when flag is on.
+
+        Purpose: Validates that the geometric terminal gate is decoupled from
+            the reward path — a step that lands PacMan inside a zone both ends
+            the episode and incurs the deterministic danger penalty.
+
+        Given: A flag-enabled env, a source state at (3, 2) and an explicit
+            next_state placing PacMan at the zone centre (3, 3).
+        When: ``reward(state, action=East, next_state=next_state)`` is called
+            and ``is_terminal(next_state)`` is queried.
+        Then: The reward equals ``step_penalty - dangerous_area_penalty`` and
+            ``is_terminal(next_state)`` is ``True``.
+
+        Test type: unit
+        """
+        env = self._flag_on_env()
+        state = env.make_state(pacman_pos=(3, 2), ghost_positions=((6, 6),), pellets=((0, 6),))
+        next_state = env.make_state(pacman_pos=(3, 3), ghost_positions=((6, 6),), pellets=((0, 6),))
+
+        reward = env.reward(state, action=1, next_state=next_state)
+
+        assert reward == env.step_penalty - env.dangerous_area_penalty
+        assert env.is_terminal(next_state) is True
+
+    def test_reward_range_unaffected_by_hazard_terminal_flag(self):
+        """``reward_range`` is identical whether or not the terminal flag is set.
+
+        Purpose: Validates that enabling the geometric terminal gate does not
+            perturb the reward bounds, which still include the danger penalty
+            purely because a zone is configured.
+
+        Given: Two envs with an identical zone, differing only in
+            ``is_dangerous_area_hit_terminal``.
+        When: ``reward_range`` is read from both.
+        Then: The ranges are equal and the lower bound includes the penalty.
+
+        Test type: unit
+        """
+        env = self._flag_on_env()
+        expected_min = env.step_penalty + env.ghost_collision_penalty - env.dangerous_area_penalty
+        expected_max = env.step_penalty + env.pellet_reward + env.win_reward
+
+        assert env.reward_range == (expected_min, expected_max)
+        assert env.reward_range == self.pomdp.reward_range
+
+    def test_hazard_terminal_rollout_zero_from_in_zone_start_matches_is_terminal(self):
+        """A rollout from an in-zone start returns 0.0 when the flag is on.
+
+        Purpose: Validates that ``simulate_random_rollout`` terminates
+            consistently with ``is_terminal`` — an in-zone start is terminal
+            under the flag, so the rollout yields no reward.
+
+        Given: A flag-enabled env and a state with PacMan at the zone centre.
+        When: ``is_terminal`` is queried and ``simulate_random_rollout`` is run.
+        Then: ``is_terminal`` is ``True`` and the rollout returns exactly 0.0.
+
+        Test type: unit
+        """
+
+        class _DummySampler:
+            def sample(self) -> int:
+                return 1  # East
+
+        env = self._flag_on_env()
+        in_zone = env.make_state(pacman_pos=(3, 3), ghost_positions=((6, 6),), pellets=((0, 6),))
+
+        assert env.is_terminal(in_zone) is True
+        result = env.simulate_random_rollout(
+            state=in_zone,
+            action_sampler=_DummySampler(),
+            max_depth=20,
+            discount_factor=0.95,
+        )
+        assert result == 0.0
+
+    def test_hazard_terminal_native_rollout_stops_on_zone_entry_mid_trajectory(self):
+        """The native rollout ends the trajectory on mid-rollout zone entry.
+
+        Purpose: Exercises the C++ rollout terminal gate directly: an
+            out-of-zone start whose first eastward step lands inside the zone
+            terminates after that single step when the flag is on, yielding a
+            strictly greater (less negative) return than the flag-off rollout
+            that keeps stepping through the zone.
+
+        Given: A flag-enabled env sharing a zone at (3, 3), an open maze, and
+            PacMan at (3, 1) (out of zone); a fixed eastward action sequence and
+            a shared C++ RNG seed.
+        When: ``_native.simulate_rollout`` is called for both flag values.
+        Then: The flag-on return equals a single entering step and is strictly
+            greater than the flag-off return.
+
+        Test type: unit
+        """
+        from POMDPPlanners.environments.pacman_pomdp import (  # pylint: disable=import-outside-toplevel
+            _native,
+        )
+
+        env = self._flag_on_env()
+        start = env.make_state(pacman_pos=(3, 1), ghost_positions=((6, 6),), pellets=((0, 6),))
+        action_indices = np.ones(3, dtype=np.int32)  # East, East, East
+        transition_kwargs = env.get_transition_cpp_ctor_kwargs()
+
+        def _run(flag: bool) -> float:
+            _native.set_seed(7)
+            return _native.simulate_rollout(
+                state=start,
+                action_indices=action_indices,
+                patrol_dir_state=env.ghost_patrol_directions,
+                ghost_collision_penalty=float(env.ghost_collision_penalty),
+                step_penalty=float(env.step_penalty),
+                win_reward=float(env.win_reward),
+                discount_factor=0.95,
+                depth=0,
+                max_depth=3,
+                dangerous_areas=env._dangerous_areas_arr,  # pylint: disable=protected-access
+                dangerous_area_radius=float(env.dangerous_area_radius),
+                dangerous_area_penalty=float(env.dangerous_area_penalty),
+                reward_variant_code=0,
+                penalty_decay=float(env.penalty_decay),
+                is_dangerous_area_hit_terminal=flag,
+                **transition_kwargs,
+            )
+
+        flag_on = _run(True)
+        flag_off = _run(False)
+
+        # One eastward step (3, 1) -> (3, 2) lands inside the zone: reward is
+        # step_penalty + (-dangerous_area_penalty) with no discount at depth 0.
+        assert flag_on == env.step_penalty - env.dangerous_area_penalty
+        assert flag_on > flag_off

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
@@ -2381,3 +2381,226 @@ class TestContinuousPushRewardNextStateConsistency:
             next_state, _, reward_returned = env.sample_next_step(state, action)
             reward_recomputed = env.reward(state, action, next_state=next_state)
             assert reward_returned == pytest.approx(reward_recomputed, abs=1e-12)
+
+
+class TestContinuousPushHazardTermination:
+    """Opt-in hazard-terminates-episode flags for the Continuous Push POMDP."""
+
+    OBSTACLE = (5.0, 5.0, 0.5)
+    DANGEROUS_CENTER = (3.0, 3.0)
+    DANGEROUS_RADIUS = 0.5
+    OBSTACLE_PENALTY = -10.0
+    DANGEROUS_PENALTY = -10.0
+
+    # Robot at obstacle / dangerous centre, object at (1, 1) far from target
+    # (9, 9): only the hazard flags can make these states terminal.
+    ROBOT_IN_OBSTACLE = np.array([5.0, 5.0, 1.0, 1.0, 9.0, 9.0])
+    ROBOT_IN_DANGER = np.array([3.0, 3.0, 1.0, 1.0, 9.0, 9.0])
+    ROBOT_SAFE = np.array([1.0, 5.0, 1.0, 1.0, 9.0, 9.0])
+
+    def _make_env(self, **overrides) -> ContinuousPushPOMDP:
+        return ContinuousPushPOMDP(
+            discount_factor=0.99,
+            **continuous_push_pinned_kwargs(
+                grid_size=10,
+                robot_radius=0.3,
+                state_transition_cov_matrix=np.eye(2) * 0.01,
+                **overrides,
+            ),
+        )
+
+    def test_hazard_flags_default_false(self):
+        """Hazard termination flags default to False (backward compatible).
+
+        Purpose: Validates the new flags are opt-in and off by default.
+
+        Given: An env constructed with obstacles and dangerous areas but no
+            explicit hazard-termination flags.
+        When: The flag attributes are read and is_terminal is called on
+            states whose robot sits inside an obstacle / dangerous area with
+            the object NOT at target.
+        Then: Both flags are False and is_terminal returns False for both
+            hazard states.
+
+        Test type: unit
+        """
+        env = self._make_env(
+            obstacles=[self.OBSTACLE],
+            dangerous_areas=[self.DANGEROUS_CENTER],
+            dangerous_area_radius=self.DANGEROUS_RADIUS,
+        )
+        assert env.is_obstacle_hit_terminal is False
+        assert env.is_dangerous_area_hit_terminal is False
+        assert not env.is_terminal(self.ROBOT_IN_OBSTACLE)
+        assert not env.is_terminal(self.ROBOT_IN_DANGER)
+
+    def test_obstacle_hit_terminates_when_flag_on(self):
+        """Robot-in-obstacle state is terminal when the obstacle flag is on.
+
+        Purpose: Validates is_obstacle_hit_terminal makes a robot-obstacle
+            collision terminal while still charging the obstacle penalty.
+
+        Given: An env with is_obstacle_hit_terminal=True and
+            obstacle_hit_probability=1.0.
+        When: is_terminal and reward are evaluated on a state whose robot
+            overlaps the obstacle (object not at target).
+        Then: is_terminal is True and entering that state charges exactly
+            obstacle_penalty relative to a non-colliding robot.
+
+        Test type: unit
+        """
+        env = self._make_env(
+            obstacles=[self.OBSTACLE],
+            obstacle_penalty=self.OBSTACLE_PENALTY,
+            obstacle_hit_probability=1.0,
+            is_obstacle_hit_terminal=True,
+        )
+        assert env.is_terminal(self.ROBOT_IN_OBSTACLE)
+        assert not env.is_terminal(self.ROBOT_SAFE)
+
+        action = np.array([0.0, 0.0])
+        reward_hit = env.reward(self.ROBOT_SAFE, action, next_state=self.ROBOT_IN_OBSTACLE)
+        reward_safe = env.reward(self.ROBOT_SAFE, action, next_state=self.ROBOT_SAFE)
+        assert reward_hit - reward_safe == pytest.approx(self.OBSTACLE_PENALTY, abs=1e-9)
+
+    def test_dangerous_area_hit_terminates_when_flag_on(self):
+        """Robot-in-dangerous-area state is terminal when the danger flag is on.
+
+        Purpose: Validates is_dangerous_area_hit_terminal makes a robot inside
+            a dangerous area terminal while still charging the penalty.
+
+        Given: An env with is_dangerous_area_hit_terminal=True and
+            dangerous_area_hit_probability=1.0.
+        When: is_terminal and reward are evaluated on a state whose robot is
+            inside a dangerous area (object not at target).
+        Then: is_terminal is True and entering that state charges exactly
+            dangerous_area_penalty relative to a robot outside any zone.
+
+        Test type: unit
+        """
+        env = self._make_env(
+            dangerous_areas=[self.DANGEROUS_CENTER],
+            dangerous_area_radius=self.DANGEROUS_RADIUS,
+            dangerous_area_penalty=self.DANGEROUS_PENALTY,
+            dangerous_area_hit_probability=1.0,
+            is_dangerous_area_hit_terminal=True,
+        )
+        assert env.is_terminal(self.ROBOT_IN_DANGER)
+        assert not env.is_terminal(self.ROBOT_SAFE)
+
+        action = np.array([0.0, 0.0])
+        reward_hit = env.reward(self.ROBOT_SAFE, action, next_state=self.ROBOT_IN_DANGER)
+        reward_safe = env.reward(self.ROBOT_SAFE, action, next_state=self.ROBOT_SAFE)
+        assert reward_hit - reward_safe == pytest.approx(self.DANGEROUS_PENALTY, abs=1e-9)
+
+    def test_object_at_target_still_terminal_with_flags_on(self):
+        """Object-at-target termination is preserved when hazard flags are on.
+
+        Purpose: Validates the existing terminal condition is not weakened by
+            the new hazard gate.
+
+        Given: An env with both hazard flags enabled.
+        When: is_terminal is called on a state whose object is at the target
+            and whose robot is nowhere near a hazard.
+        Then: is_terminal returns True.
+
+        Test type: unit
+        """
+        env = self._make_env(
+            obstacles=[self.OBSTACLE],
+            dangerous_areas=[self.DANGEROUS_CENTER],
+            dangerous_area_radius=self.DANGEROUS_RADIUS,
+            is_obstacle_hit_terminal=True,
+            is_dangerous_area_hit_terminal=True,
+        )
+        object_at_target = np.array([1.0, 1.0, 9.1, 9.1, 9.0, 9.0])
+        assert env.is_terminal(object_at_target)
+
+    def test_reward_range_includes_both_hazard_penalties(self):
+        """reward_range lower bound reflects obstacle and dangerous penalties.
+
+        Purpose: Validates the reward-range lower bound accounts for both the
+            obstacle penalty (always) and the dangerous-area penalty (when
+            zones are configured).
+
+        Given: An env configured with both obstacles and dangerous areas.
+        When: reward_range is read.
+        Then: The lower bound equals -max_distance + obstacle_penalty +
+            dangerous_area_penalty and is strictly below the bound of an
+            otherwise-identical env with no dangerous areas.
+
+        Test type: unit
+        """
+        env = self._make_env(
+            obstacles=[self.OBSTACLE],
+            obstacle_penalty=self.OBSTACLE_PENALTY,
+            dangerous_areas=[self.DANGEROUS_CENTER],
+            dangerous_area_radius=self.DANGEROUS_RADIUS,
+            dangerous_area_penalty=self.DANGEROUS_PENALTY,
+        )
+        max_distance = np.sqrt(2) * (10 - 1)
+        expected_min = -max_distance + self.OBSTACLE_PENALTY + self.DANGEROUS_PENALTY
+        assert env.reward_range[0] == pytest.approx(expected_min, abs=1e-9)
+
+        env_no_danger = self._make_env(
+            obstacles=[self.OBSTACLE],
+            obstacle_penalty=self.OBSTACLE_PENALTY,
+        )
+        assert env.reward_range[0] < env_no_danger.reward_range[0]
+
+    def test_native_rollout_terminates_on_hazard_entry(self):
+        """Native rollout stops when the start state is a hazard-terminal one.
+
+        Purpose: Validates the hazard flag is threaded into the native C++
+            rollout terminal check so rollouts agree with is_terminal.
+
+        Given: A discrete-action env with is_dangerous_area_hit_terminal=True
+            and a start state whose robot is inside a dangerous area (object
+            not at target).
+        When: simulate_random_rollout is called from that state.
+        Then: is_terminal is True and the rollout returns 0.0 (no steps),
+            while the same env with the flag off accumulates a non-zero
+            return from the same start.
+
+        Test type: unit
+        """
+        from POMDPPlanners.utils.action_samplers import (
+            DiscreteActionSampler,
+        )  # pylint: disable=import-outside-toplevel
+
+        common: Dict[str, Any] = dict(  # pylint: disable=use-dict-literal
+            grid_size=10,
+            robot_radius=0.3,
+            dangerous_areas=[self.DANGEROUS_CENTER],
+            dangerous_area_radius=self.DANGEROUS_RADIUS,
+            dangerous_area_penalty=self.DANGEROUS_PENALTY,
+            dangerous_area_hit_probability=1.0,
+            state_transition_cov_matrix=np.eye(2) * 0.05,
+        )
+        env_on = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.95,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                is_dangerous_area_hit_terminal=True, **common
+            ),
+        )
+        env_off = ContinuousPushPOMDPDiscreteActions(
+            discount_factor=0.95,
+            **continuous_push_discrete_actions_pinned_kwargs(
+                is_dangerous_area_hit_terminal=False, **common
+            ),
+        )
+        start = np.array([3.0, 3.0, 1.0, 1.0, 9.0, 9.0])
+        sampler = DiscreteActionSampler(env_on.get_actions())
+
+        assert env_on.is_terminal(start)
+        _native.set_seed(0)
+        result_on = env_on.simulate_random_rollout(
+            state=start, action_sampler=sampler, max_depth=20, discount_factor=0.95, depth=0
+        )
+        assert result_on == 0.0
+
+        _native.set_seed(0)
+        result_off = env_off.simulate_random_rollout(
+            state=start, action_sampler=sampler, max_depth=20, discount_factor=0.95, depth=0
+        )
+        assert result_off != 0.0

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
@@ -1242,6 +1242,187 @@ class TestStochasticDangerousAreaPenalty:
             )
 
 
+class TestDangerousAreaHitTerminal:
+    """Test the opt-in geometric hazard-terminal gate in ``is_terminal``."""
+
+    def test_default_flag_danger_cell_not_terminal(self):
+        """Robot on a dangerous cell is not terminal under the default flag.
+
+        Purpose: Validates that with ``is_dangerous_area_hit_terminal`` left
+        at its default (``False``), a robot standing inside a dangerous area
+        is not treated as terminal — only the exit sentinel ``(-1, -1)`` is.
+
+        Given: A RockSamplePOMDP with a dangerous area at ``(1, 1)`` and the
+            hazard-terminal flag left at its default.
+        When: ``is_terminal`` is called on a state whose robot is at ``(1, 1)``.
+        Then: ``is_terminal`` returns ``False``; the sentinel state is terminal.
+
+        Test type: unit
+        """
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(dangerous_areas=[(1, 1)], dangerous_area_radius=1.0),
+        )
+
+        in_danger = create_rock_sample_state((1, 1), (True, False, True))
+        sentinel = create_rock_sample_state((-1, -1), (True, False, True))
+
+        assert pomdp.is_terminal(in_danger) is False
+        assert pomdp.is_terminal(sentinel) is True
+
+    def test_flag_on_danger_cell_terminal_and_penalty_applied(self):
+        """Flag on makes an in-zone robot terminal while the penalty still applies.
+
+        Purpose: Validates that with ``is_dangerous_area_hit_terminal=True`` and
+        ``dangerous_area_hit_probability=1.0`` a robot inside a dangerous area
+        is terminal, that the step reward still includes the additive
+        dangerous-area penalty (termination is additive, not a reward change),
+        and that the exit sentinel remains terminal.
+
+        Given: A RockSamplePOMDP with a dangerous area at ``(1, 1)``, radius
+            ``1.0``, penalty ``-5.0``, deterministic hit probability, and the
+            hazard-terminal flag enabled.
+        When: ``is_terminal`` is queried for an in-zone robot and a step is
+            taken (sample action, no movement) from that in-zone position.
+        Then: The in-zone state and the sentinel are terminal, and the step
+            reward equals the additive dangerous-area penalty ``-5.0``.
+
+        Test type: unit
+        """
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                dangerous_areas=[(1, 1)],
+                dangerous_area_radius=1.0,
+                dangerous_area_penalty=-5.0,
+                dangerous_area_hit_probability=1.0,
+                is_dangerous_area_hit_terminal=True,
+            ),
+        )
+
+        in_danger = create_rock_sample_state((1, 1), (True, False, True))
+        sentinel = create_rock_sample_state((-1, -1), (True, False, True))
+
+        assert pomdp.is_terminal(in_danger) is True
+        assert pomdp.is_terminal(sentinel) is True
+
+        # Sample (action 0) at (1, 1) — not a rock cell — leaves the robot in
+        # the zone, so the additive penalty is the only reward contribution.
+        next_state = pomdp.sample_next_state(state=in_danger, action=0)
+        reward = pomdp._reward_from_next_state(  # pylint: disable=protected-access
+            in_danger, 0, next_state
+        )
+        assert reward == pytest.approx(-5.0)
+
+    def test_reward_range_includes_penalty_when_zones_configured(self):
+        """reward_range lower bound includes the dangerous-area penalty.
+
+        Purpose: Validates that when dangerous areas are configured the
+        environment's ``reward_range`` lower bound accounts for the additive
+        dangerous-area penalty, independent of the hazard-terminal flag.
+
+        Given: A RockSamplePOMDP with a dangerous area configured, penalty
+            ``-5.0``, and known step/rock/sensor penalties.
+        When: The ``reward_range`` attribute is read.
+        Then: ``reward_range[0]`` equals the sum of step, bad-rock, sensor, and
+            dangerous-area penalties, so the penalty is included in the range.
+
+        Test type: unit
+        """
+        pomdp = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(
+                step_penalty=-1.0,
+                bad_rock_penalty=-5.0,
+                good_rock_reward=8.0,
+                exit_reward=12.0,
+                sensor_use_penalty=-0.5,
+                dangerous_areas=[(1, 1)],
+                dangerous_area_penalty=-5.0,
+                is_dangerous_area_hit_terminal=True,
+            ),
+        )
+
+        # min = step + bad_rock + sensor + danger_term_min = -1 -5 -0.5 -5 = -11.5
+        # max = step + exit_reward + danger_term_max = -1 + 12 + 0 = 11.0
+        assert pomdp.reward_range == (-11.5, 11.0)
+
+    def test_flag_on_native_rollout_terminates_in_zone(self):
+        """Rollouts from an in-zone start terminate consistently with the flag.
+
+        Purpose: Validates that with the hazard-terminal flag enabled, both the
+        native ``simulate_rollout_discrete`` and ``simulate_random_rollout``
+        return ``0.0`` from an in-zone start (the geometric terminal gate fires
+        immediately, matching ``is_terminal``), while with the flag off the same
+        start is not terminal.
+
+        Given: RockSamplePOMDPs with a dangerous area at ``(1, 1)`` — one with
+            the hazard-terminal flag on, one off — and a robot starting in-zone.
+        When: The native rollout and ``simulate_random_rollout`` are run from
+            the in-zone start.
+        Then: With the flag on, ``is_terminal`` is ``True`` and both rollouts
+            return ``0.0``; with the flag off, ``is_terminal`` is ``False``.
+
+        Test type: integration
+        """
+        from POMDPPlanners.environments.rock_sample_pomdp import (  # pylint: disable=import-outside-toplevel
+            _native as rs_native,
+        )
+
+        common = {"dangerous_areas": [(1, 1)], "dangerous_area_radius": 1.0}
+        env_on = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(is_dangerous_area_hit_terminal=True, **common),
+        )
+        env_off = RockSamplePOMDP(
+            discount_factor=0.95,
+            **rock_sample_pinned_kwargs(**common),
+        )
+
+        in_danger = create_rock_sample_state((1, 1), (True, False, True))
+        assert env_on.is_terminal(in_danger) is True
+        assert env_off.is_terminal(in_danger) is False
+
+        max_depth = 10
+        n_actions = len(env_on.action_names)
+        np.random.seed(0)
+        action_indices = np.random.randint(0, n_actions, size=max_depth, dtype=np.int32)
+        native_return = rs_native.simulate_rollout_discrete(
+            initial_state=np.ascontiguousarray(in_danger, dtype=np.float64),
+            action_indices=action_indices,
+            rock_positions_flat=env_on._rock_positions_flat,  # pylint: disable=protected-access
+            max_depth=max_depth,
+            start_depth=0,
+            discount_factor=0.95,
+            map_rows=int(env_on.map_size[0]),
+            map_cols=int(env_on.map_size[1]),
+            n_actions=n_actions,
+            step_penalty=float(env_on.step_penalty),
+            exit_reward=float(env_on.exit_reward),
+            good_rock_reward=float(env_on.good_rock_reward),
+            bad_rock_penalty=float(env_on.bad_rock_penalty),
+            sensor_use_penalty=float(env_on.sensor_use_penalty),
+            dangerous_areas=env_on._dangerous_areas_arr,  # pylint: disable=protected-access
+            dangerous_area_radius=float(env_on.dangerous_area_radius),
+            dangerous_area_penalty=float(env_on.dangerous_area_penalty),
+            dangerous_area_hit_probability=float(env_on.dangerous_area_hit_probability),
+            reward_variant_code=int(
+                env_on._reward_variant_code
+            ),  # pylint: disable=protected-access
+            penalty_decay=float(env_on.penalty_decay),
+            is_dangerous_area_hit_terminal=True,
+        )
+        assert native_return == pytest.approx(0.0)
+
+        random_rollout_return = env_on.simulate_random_rollout(
+            state=in_danger,
+            action_sampler=_FixedActionSamplerRS(0),
+            max_depth=max_depth,
+            discount_factor=0.95,
+        )
+        assert random_rollout_return == pytest.approx(0.0)
+
+
 class TestMetricsComputation:
     """Test metrics computation."""
 

--- a/POMDPPlanners/tests/test_utils/env_pinned_kwargs.py
+++ b/POMDPPlanners/tests/test_utils/env_pinned_kwargs.py
@@ -90,6 +90,7 @@ def laser_tag_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
         "dangerous_areas": {(5, 3), (7, 1), (2, 5)},
         "dangerous_area_radius": 1.0,
         "dangerous_area_penalty": 5.0,
+        "is_dangerous_area_hit_terminal": False,
         "initial_state": None,
         "transition_error_prob": 0.0,
         "reward_model_type": LaserTagRewardModelType.CONSTANT_HAZARD_PENALTY,
@@ -134,6 +135,7 @@ def continuous_laser_tag_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
         "dangerous_area_radius": 1.0,
         "dangerous_area_penalty": 5.0,
         "dangerous_area_hit_probability": 1.0,
+        "is_dangerous_area_hit_terminal": False,
         "initial_state": None,
         "opponent_policy": OpponentPolicy.EVADE,
     }
@@ -301,6 +303,8 @@ def continuous_push_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
         "dangerous_area_radius": 0.5,
         "dangerous_area_penalty": -10.0,
         "dangerous_area_hit_probability": 1.0,
+        "is_obstacle_hit_terminal": False,
+        "is_dangerous_area_hit_terminal": False,
         "reward_model_type": PushRewardModelType.CONSTANT_HAZARD_PENALTY,
         "penalty_decay": 1.0,
         "robot_radius": 0.3,
@@ -347,6 +351,7 @@ def pacman_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
         "dangerous_areas": None,
         "dangerous_area_radius": 1.0,
         "dangerous_area_penalty": 5.0,
+        "is_dangerous_area_hit_terminal": False,
         "reward_model_type": PacManRewardModelType.CONSTANT_HAZARD_PENALTY,
         "penalty_decay": 1.0,
     }
@@ -370,6 +375,7 @@ def rock_sample_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
         "dangerous_area_radius": 1.0,
         "dangerous_area_penalty": -5.0,
         "dangerous_area_hit_probability": 1.0,
+        "is_dangerous_area_hit_terminal": False,
         "reward_model_type": RockSampleRewardModelType.CONSTANT_HAZARD_PENALTY,
         "penalty_decay": 1.0,
     }


### PR DESCRIPTION
## Summary

Adds opt-in **hazard-terminates-episode** flags to every POMDP environment that exposes obstacles and/or dangerous areas, mirroring `ContinuousLightDarkPOMDP.is_obstacle_hit_terminal`. Turning a hazard into a rare absorbing catastrophe produces the bimodal return distribution that separates risk-neutral from risk-averse policies — previously downstream users had to monkeypatch `is_terminal`.

## Semantics — geometric gate (not draw-coupled)

`is_terminal(state)` = existing-terminal **OR** (flag **AND** agent position geometrically inside the hazard zone). Penalty logic is unchanged (stays stochastic where it was); only termination is added. No state-vector widening anywhere.

This matches what the LightDark reference actually does and stays consistent across the world-sim path and the C++ rollout kernels. The simulator computes `reward(state, action)` independently of, and before, `sample_next_state`, so reward and trajectory transition are already separate draws — true per-step penalty⟺terminal coupling would require rewriting shared sim code for all envs (not opt-in). At the default `hit_probability=1.0` the geometric gate equals penalty⟺terminal anyway.

## Flags added (all default `False` — opt-in, backward compatible)

| Env | Flag(s) |
|---|---|
| `ContinuousPushPOMDP` (+ discrete-actions variant) | `is_obstacle_hit_terminal`, `is_dangerous_area_hit_terminal` |
| `ContinuousLaserTagPOMDP` (+ discrete-actions variant) | `is_dangerous_area_hit_terminal` |
| `LaserTagPOMDP` (discrete) | `is_dangerous_area_hit_terminal` |
| `PacManPOMDP` | `is_dangerous_area_hit_terminal` (terminates on entry — penalty is deterministic; sets the state's terminal field) |
| `RockSamplePOMDP` | `is_dangerous_area_hit_terminal` |
| `DiscreteLightDarkPOMDP` | `is_obstacle_hit_terminal` (**default `True`** — preserves its current hardcoded terminal-on-obstacle behavior) |

## Also

- **`ContinuousLaserTagPOMDP.reward_range` fix:** it previously omitted `dangerous_area_penalty`, so cost-bounded planners (e.g. the ICVaR planners' LCB exploration) couldn't see the hazard's magnitude. The lower bound now includes it. Discrete LaserTag `reward_range` left unchanged (pinned by a test).
- Flags threaded through each env's C++ rollout kernel with defaulted pybind args (existing call sites unaffected); `_native.pyi` stubs updated.
- `get_config()`/serialization round-trips the new flags (public `self.<flag>`).
- New unit tests per env: (a) default `False` reproduces current behavior; (b) flag on → a hazard hit yields `is_terminal(next_state) == True` and applies the penalty; (c) `reward_range` includes the hazard penalty.
- `env_pinned_kwargs.py` updated with the new pinned defaults.

## Verification

- Native extensions clean-rebuilt from source.
- Whole-tree `pyright POMDPPlanners/`: **0 new** errors/warnings (the pre-existing `*_visualizer.py` matplotlib-typing findings are untouched by this branch).
- Pylint 10.00/10 on changed source where achievable; unchanged pre-existing debt left alone.
- Full test suite green (excluding the isaac/carla/nuplan env dirs that require external simulators).

Do not change default behavior — the flags are opt-in.
