### PR TITLE
feat(core): add vectorized belief tree

### DIFF
--- a/POMDPPlanners/core/tree/vectorized_belief_tree/__init__.py
+++ b/POMDPPlanners/core/tree/vectorized_belief_tree/__init__.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+
+"""Vectorized belief tree for GPU-batched online POMDP planning.
+
+This package provides :class:`VectorizedBeliefTree`, a reusable belief-tree
+data structure stored entirely in flat PyTorch tensors. It mirrors the tensor
+tree layout used by GPU-vectorized planners (VOPP / PORPP) but contains no
+planning-algorithm logic — only the batched structural and statistical
+primitives (keyed child insertion, composite-key lookup, scatter
+aggregation, group-by-parent, depth-wise traversal) that such algorithms are
+built from.
+
+See
+:mod:`POMDPPlanners.core.tree.vectorized_belief_tree.vectorized_belief_tree`
+for the design.
+"""
+
+from POMDPPlanners.core.tree.vectorized_belief_tree.vectorized_belief_store import (
+    BeliefStore,
+)
+from POMDPPlanners.core.tree.vectorized_belief_tree.vectorized_belief_tree_fields import (
+    FieldRegistry,
+    FieldSpec,
+)
+from POMDPPlanners.core.tree.vectorized_belief_tree.vectorized_belief_tree import (
+    VectorizedBeliefTree,
+)
+
+__all__ = [
+    "VectorizedBeliefTree",
+    "BeliefStore",
+    "FieldSpec",
+    "FieldRegistry",
+]

--- a/POMDPPlanners/core/tree/vectorized_belief_tree/vectorized_belief_store.py
+++ b/POMDPPlanners/core/tree/vectorized_belief_tree/vectorized_belief_store.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT
+
+"""Protocol separating belief *content* from belief-tree *topology*.
+
+:class:`~POMDPPlanners.core.tree.vectorized_belief_tree.vectorized_belief_tree.VectorizedBeliefTree`
+stores only the topology, integer keys, and statistics of a POMDP belief
+tree. The mathematical belief attached to each belief node (a particle set,
+a categorical vector, a Gaussian, an action-observation history, a latent
+vector, ...) lives outside the tree in an object implementing
+:class:`BeliefStore`.
+
+The contract is that a belief-tree node index is the identifier the external
+store uses to look up the belief for that node::
+
+    VectorizedBeliefTree stores tree topology and statistics.
+    BeliefStore          stores or reconstructs the mathematical beliefs.
+
+The tree never calls a :class:`BeliefStore`; the protocol exists so planners
+can keep a parallel store keyed by the same integer node indices the tree
+hands out.
+"""
+
+from typing import Protocol, runtime_checkable
+
+from torch import Tensor
+
+
+@runtime_checkable
+class BeliefStore(Protocol):
+    """Interface for an external store of per-node belief representations.
+
+    Implementations map belief-tree node indices to concrete belief objects.
+    They are entirely optional: the tree is fully functional without one.
+    """
+
+    def create_root(self, belief: object) -> int:
+        """Register the root belief and return its node index (expected ``0``).
+
+        Args:
+            belief: The concrete root belief object to store.
+
+        Returns:
+            The integer node index the belief was stored under.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def create_successors(
+        self,
+        parent_belief_indices: Tensor,
+        action_keys: Tensor,
+        observation_keys: Tensor,
+    ) -> Tensor:
+        """Create and store successor beliefs for a batch of transitions.
+
+        Args:
+            parent_belief_indices: ``[batch]`` parent belief node indices.
+            action_keys: ``[batch]`` integer action keys taken.
+            observation_keys: ``[batch]`` integer observation keys received.
+
+        Returns:
+            ``[batch]`` successor belief node indices, aligned with the inputs.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis

--- a/POMDPPlanners/core/tree/vectorized_belief_tree/vectorized_belief_tree.py
+++ b/POMDPPlanners/core/tree/vectorized_belief_tree/vectorized_belief_tree.py
@@ -1,0 +1,870 @@
+# SPDX-License-Identifier: MIT
+
+"""Vectorized belief tree stored in flat PyTorch tensors.
+
+This module implements :class:`VectorizedBeliefTree`, a reusable belief-tree
+data structure for online POMDP planning. It captures the tensor tree layout
+of GPU-vectorized planners (e.g. VOPP / PORPP): rather than a graph of Python
+node objects, the whole tree is a small set of flat, preallocated tensors and
+a node is an integer index into every column.
+
+The tree alternates two node kinds::
+
+    belief node --a--> action node --o--> belief node
+
+An action node is uniquely identified by ``(parent_belief_index, action_key)``
+and a successor belief node by ``(parent_action_index, observation_key)``.
+Both keys are integers; converting continuous actions/observations into
+integer keys (binning, hashing, nearest-neighbour, progressive widening) is
+the caller's responsibility.
+
+The class stores only topology, integer keys, and statistics. The concrete
+belief attached to a belief node lives in an external
+:class:`~POMDPPlanners.core.tree.vectorized_belief_tree.vectorized_belief_store.BeliefStore`
+keyed by the integer node index. No planning-policy logic (UCB, softmax
+action selection, log-sum-exp value backups, PORPP preference updates) lives
+here — only the batched structural and statistical primitives such
+algorithms are built from.
+
+Example:
+    Basic usage on CPU or CUDA::
+
+        >>> import torch
+        >>> from POMDPPlanners.core.tree.vectorized_belief_tree import (
+        ...     VectorizedBeliefTree,
+        ... )
+        >>> tree = VectorizedBeliefTree(device=torch.device("cpu"))
+        >>> root = tree.root_index
+        >>> parents = torch.tensor([root, root, root, root])
+        >>> actions = torch.tensor([0, 1, 1, 2])
+        >>> action_nodes, created = tree.get_or_create_actions(parents, actions)
+        >>> bool(action_nodes[1] == action_nodes[2])  # duplicate pair -> one node
+        True
+        >>> tree.update_action_statistics(action_nodes, torch.tensor([1.0, 2.0, 3.0, -1.0]))
+        >>> observations = torch.tensor([4, 2, 2, 7])
+        >>> beliefs, belief_created = tree.get_or_create_beliefs(action_nodes, observations)
+        >>> tree.validate()
+"""
+
+from typing import Dict, Optional, Tuple
+
+import torch
+from torch import Tensor
+
+from POMDPPlanners.core.tree.vectorized_belief_tree.vectorized_belief_tree_fields import (
+    FieldRegistry,
+    FieldSpec,
+)
+from POMDPPlanners.core.tree.vectorized_belief_tree.vectorized_belief_tree_lookup import (
+    csr_children,
+    match_pairs,
+    scatter_or,
+    segment_reduce,
+    unique_pairs,
+)
+
+_ROOT_INDEX = 0
+
+_RESERVED_BELIEF_NAMES = frozenset({"parent_action", "parent_observation", "depth", "terminal"})
+_RESERVED_ACTION_NAMES = frozenset({"parent_belief", "key", "depth", "visit_count", "reward_sum"})
+
+
+class VectorizedBeliefTree:
+    """Flat-tensor belief tree with batched insertion, lookup, and reduction.
+
+    All persistent tree data is stored in preallocated tensors on
+    ``self.device``. Belief-node and action-node columns are stored
+    separately. Insertion, lookup, and statistic accumulation are batched and
+    free of Python per-row loops so the structure runs on a GPU without
+    per-simulation synchronization.
+
+    Attributes:
+        device: The device every persistent tensor lives on.
+        index_dtype: Integer dtype for indices and keys (default ``int64``).
+        value_dtype: Floating dtype for real-valued statistics (default
+            ``float32``).
+        growth_factor: Geometric factor used when a capacity is exceeded.
+
+    Example:
+        See the module-level docstring for a runnable example.
+    """
+
+    # pylint: disable=too-many-instance-attributes,too-many-public-methods
+    # pylint: disable=attribute-defined-outside-init
+    # The flat columns are the schema (one attribute per column) and the
+    # batched primitives are the public API; both are the design, not sprawl.
+    # Columns are allocated by ``_allocate_columns`` (called from ``__init__``
+    # and reused by ``load_state_dict``) rather than assigned inline.
+
+    def __init__(
+        self,
+        device: Optional[torch.device] = None,
+        belief_capacity: int = 1024,
+        action_capacity: int = 1024,
+        index_dtype: torch.dtype = torch.int64,
+        value_dtype: torch.dtype = torch.float32,
+        growth_factor: float = 2.0,
+    ) -> None:
+        """Initialise an empty tree containing only the root belief.
+
+        Args:
+            device: Target device; defaults to CPU.
+            belief_capacity: Initial preallocated belief-node capacity.
+            action_capacity: Initial preallocated action-node capacity.
+            index_dtype: Integer dtype for indices, keys, depths, and visits.
+            value_dtype: Floating dtype for reward sums and float fields.
+            growth_factor: Capacity multiplier on overflow (must exceed 1).
+
+        Raises:
+            ValueError: If a capacity is non-positive or ``growth_factor`` is
+                not greater than 1.
+        """
+        if belief_capacity <= 0 or action_capacity <= 0:
+            raise ValueError("capacities must be positive")
+        if growth_factor <= 1.0:
+            raise ValueError("growth_factor must be greater than 1")
+        # Normalise to a concrete, indexed device (e.g. ``cuda`` -> ``cuda:0``)
+        # so device-equality checks against materialised tensors succeed.
+        self.device = torch.empty(0, device=device).device
+        self.index_dtype = index_dtype
+        self.value_dtype = value_dtype
+        self.growth_factor = growth_factor
+        self._belief_capacity = belief_capacity
+        self._action_capacity = action_capacity
+        self._num_beliefs = 0
+        self._num_actions = 0
+        self._belief_fields = FieldRegistry(self.device, belief_capacity)
+        self._action_fields = FieldRegistry(self.device, action_capacity)
+        self._allocate_columns()
+        self._init_root()
+
+    # ------------------------------------------------------------------ #
+    # Construction / column allocation
+    # ------------------------------------------------------------------ #
+
+    def _allocate_columns(self) -> None:
+        cap_b = self._belief_capacity
+        cap_a = self._action_capacity
+        self.belief_parent_action = self._new_int_column(cap_b, -1)
+        self.belief_parent_observation = self._new_int_column(cap_b, -1)
+        self.belief_depth = self._new_int_column(cap_b, 0)
+        self.belief_terminal = torch.zeros(cap_b, dtype=torch.bool, device=self.device)
+        self.action_parent_belief = self._new_int_column(cap_a, -1)
+        self.action_key = self._new_int_column(cap_a, -1)
+        self.action_depth = self._new_int_column(cap_a, 0)
+        self.action_visit_count = self._new_int_column(cap_a, 0)
+        self.action_reward_sum = torch.zeros(cap_a, dtype=self.value_dtype, device=self.device)
+
+    def _new_int_column(self, capacity: int, fill: int) -> Tensor:
+        return torch.full((capacity,), fill, dtype=self.index_dtype, device=self.device)
+
+    def _init_root(self) -> None:
+        self._num_beliefs = 1
+        self.belief_parent_action[_ROOT_INDEX] = -1
+        self.belief_parent_observation[_ROOT_INDEX] = -1
+        self.belief_depth[_ROOT_INDEX] = 0
+        self.belief_terminal[_ROOT_INDEX] = False
+        self._belief_fields.reset_rows(0, 1)
+
+    # ------------------------------------------------------------------ #
+    # Simple accessors
+    # ------------------------------------------------------------------ #
+
+    @property
+    def root_index(self) -> int:
+        """Index of the root belief node (always ``0``)."""
+        return _ROOT_INDEX
+
+    @property
+    def num_belief_nodes(self) -> int:
+        """Number of active belief nodes."""
+        return self._num_beliefs
+
+    @property
+    def num_action_nodes(self) -> int:
+        """Number of active action nodes."""
+        return self._num_actions
+
+    @property
+    def belief_capacity(self) -> int:
+        """Current preallocated belief-node capacity."""
+        return self._belief_capacity
+
+    @property
+    def action_capacity(self) -> int:
+        """Current preallocated action-node capacity."""
+        return self._action_capacity
+
+    # ------------------------------------------------------------------ #
+    # Action-node lookup / insertion
+    # ------------------------------------------------------------------ #
+
+    def find_actions(
+        self,
+        parent_belief_indices: Tensor,
+        action_keys: Tensor,
+    ) -> Tuple[Tensor, Tensor]:
+        """Look up action nodes by ``(parent_belief, action_key)`` without mutating.
+
+        Args:
+            parent_belief_indices: ``[batch]`` parent belief indices.
+            action_keys: ``[batch]`` integer action keys.
+
+        Returns:
+            ``(action_indices, found_mask)``. Missing entries hold ``-1`` in
+            ``action_indices`` and ``False`` in ``found_mask``. Order follows
+            the input batch.
+        """
+        self._validate_pair(parent_belief_indices, action_keys, "parent_belief_indices")
+        matched = match_pairs(
+            self.action_parent_belief[: self._num_actions],
+            self.action_key[: self._num_actions],
+            parent_belief_indices,
+            action_keys,
+        )
+        return matched, matched >= 0
+
+    def get_or_create_actions(
+        self,
+        parent_belief_indices: Tensor,
+        action_keys: Tensor,
+    ) -> Tuple[Tensor, Tensor]:
+        """Return one action-node index per input row, creating missing nodes.
+
+        Duplicate ``(parent_belief, action_key)`` pairs — whether already in
+        the tree or repeated within the batch — resolve to a single node.
+
+        Args:
+            parent_belief_indices: ``[batch]`` parent belief indices.
+            action_keys: ``[batch]`` integer action keys.
+
+        Returns:
+            ``(action_indices, created_mask)`` in input order. ``created_mask``
+            is ``True`` for rows whose node did not exist before this call.
+        """
+        self._validate_pair(parent_belief_indices, action_keys, "parent_belief_indices")
+        matched = match_pairs(
+            self.action_parent_belief[: self._num_actions],
+            self.action_key[: self._num_actions],
+            parent_belief_indices,
+            action_keys,
+        )
+        result = matched.clone()
+        created_mask = matched < 0
+        new_parents = parent_belief_indices[created_mask]
+        new_keys = action_keys[created_mask]
+        unique_parents, unique_keys, inverse = unique_pairs(new_parents, new_keys)
+        new_ids = self._append_actions(unique_parents, unique_keys)
+        result[created_mask] = new_ids[inverse]
+        return result, created_mask
+
+    def _append_actions(self, parent_beliefs: Tensor, action_keys: Tensor) -> Tensor:
+        count = parent_beliefs.shape[0]
+        start = self._num_actions
+        end = start + count
+        self._ensure_action_capacity(end)
+        self.action_parent_belief[start:end] = parent_beliefs.to(self.index_dtype)
+        self.action_key[start:end] = action_keys.to(self.index_dtype)
+        self.action_depth[start:end] = self.belief_depth[parent_beliefs]
+        self.action_visit_count[start:end] = 0
+        self.action_reward_sum[start:end] = 0
+        self._action_fields.reset_rows(start, end)
+        self._num_actions = end
+        return torch.arange(start, end, dtype=self.index_dtype, device=self.device)
+
+    # ------------------------------------------------------------------ #
+    # Belief-node lookup / insertion
+    # ------------------------------------------------------------------ #
+
+    def find_beliefs(
+        self,
+        parent_action_indices: Tensor,
+        observation_keys: Tensor,
+    ) -> Tuple[Tensor, Tensor]:
+        """Look up belief nodes by ``(parent_action, observation_key)``.
+
+        Args:
+            parent_action_indices: ``[batch]`` parent action indices.
+            observation_keys: ``[batch]`` integer observation keys.
+
+        Returns:
+            ``(belief_indices, found_mask)`` with ``-1`` for missing entries,
+            in input order.
+        """
+        self._validate_pair(parent_action_indices, observation_keys, "parent_action_indices")
+        matched = match_pairs(
+            self.belief_parent_action[: self._num_beliefs],
+            self.belief_parent_observation[: self._num_beliefs],
+            parent_action_indices,
+            observation_keys,
+        )
+        return matched, matched >= 0
+
+    def get_or_create_beliefs(
+        self,
+        parent_action_indices: Tensor,
+        observation_keys: Tensor,
+        *,
+        terminal_mask: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        """Return one successor-belief index per input row, creating missing nodes.
+
+        Duplicate ``(parent_action, observation_key)`` pairs resolve to a
+        single node. A new belief's depth is its parent action's depth plus
+        one.
+
+        Terminal handling: if ``terminal_mask`` is supplied, terminal flags are
+        combined with logical OR — both when several batch rows map to the same
+        new node and when a row targets a belief that already exists (an
+        existing ``False`` flag can be promoted to ``True``, never the reverse).
+
+        Args:
+            parent_action_indices: ``[batch]`` parent action indices.
+            observation_keys: ``[batch]`` integer observation keys.
+            terminal_mask: Optional ``[batch]`` boolean terminal flags.
+
+        Returns:
+            ``(belief_indices, created_mask)`` in input order.
+        """
+        self._validate_pair(parent_action_indices, observation_keys, "parent_action_indices")
+        if terminal_mask is not None:
+            self._validate_bool(terminal_mask, parent_action_indices, "terminal_mask")
+        matched = match_pairs(
+            self.belief_parent_action[: self._num_beliefs],
+            self.belief_parent_observation[: self._num_beliefs],
+            parent_action_indices,
+            observation_keys,
+        )
+        return self._resolve_beliefs(
+            parent_action_indices, observation_keys, matched, terminal_mask
+        )
+
+    def _resolve_beliefs(
+        self,
+        parent_actions: Tensor,
+        observation_keys: Tensor,
+        matched: Tensor,
+        terminal_mask: Optional[Tensor],
+    ) -> Tuple[Tensor, Tensor]:
+        result = matched.clone()
+        created_mask = matched < 0
+        if terminal_mask is not None:
+            found_mask = ~created_mask
+            self.belief_terminal |= scatter_or(
+                matched[found_mask], terminal_mask[found_mask], self._belief_capacity
+            )
+        unique_parents, unique_obs, inverse = unique_pairs(
+            parent_actions[created_mask], observation_keys[created_mask]
+        )
+        new_ids = self._append_beliefs(unique_parents, unique_obs)
+        result[created_mask] = new_ids[inverse]
+        if terminal_mask is not None:
+            new_terminal = scatter_or(inverse, terminal_mask[created_mask], unique_parents.shape[0])
+            self.belief_terminal[new_ids] = self.belief_terminal[new_ids] | new_terminal
+        return result, created_mask
+
+    def _append_beliefs(self, parent_actions: Tensor, observation_keys: Tensor) -> Tensor:
+        count = parent_actions.shape[0]
+        start = self._num_beliefs
+        end = start + count
+        self._ensure_belief_capacity(end)
+        self.belief_parent_action[start:end] = parent_actions.to(self.index_dtype)
+        self.belief_parent_observation[start:end] = observation_keys.to(self.index_dtype)
+        self.belief_depth[start:end] = self.action_depth[parent_actions] + 1
+        self.belief_terminal[start:end] = False
+        self._belief_fields.reset_rows(start, end)
+        self._num_beliefs = end
+        return torch.arange(start, end, dtype=self.index_dtype, device=self.device)
+
+    # ------------------------------------------------------------------ #
+    # Statistic accumulation
+    # ------------------------------------------------------------------ #
+
+    def increment_action_visits(
+        self,
+        action_indices: Tensor,
+        counts: Optional[Tensor] = None,
+    ) -> None:
+        """Add visit counts to action nodes, summing duplicate indices.
+
+        Args:
+            action_indices: ``[batch]`` action node indices (may repeat).
+            counts: Optional ``[batch]`` integer increments; defaults to one.
+        """
+        self._validate_index(action_indices, "action_indices")
+        if counts is None:
+            counts = torch.ones_like(action_indices)
+        else:
+            self._validate_same_length(counts, action_indices, "counts")
+        self.action_visit_count.index_add_(0, action_indices, counts.to(self.index_dtype))
+
+    def add_action_rewards(self, action_indices: Tensor, rewards: Tensor) -> None:
+        """Add rewards to action nodes' reward sums, summing duplicate indices.
+
+        Args:
+            action_indices: ``[batch]`` action node indices (may repeat).
+            rewards: ``[batch]`` real-valued rewards.
+        """
+        self._validate_index(action_indices, "action_indices")
+        self._validate_same_length(rewards, action_indices, "rewards")
+        self.action_reward_sum.index_add_(0, action_indices, rewards.to(self.value_dtype))
+
+    def update_action_statistics(
+        self,
+        action_indices: Tensor,
+        rewards: Tensor,
+        visit_weights: Optional[Tensor] = None,
+    ) -> None:
+        """Accumulate reward sums and visit counts for action nodes in one call.
+
+        Args:
+            action_indices: ``[batch]`` action node indices (may repeat).
+            rewards: ``[batch]`` real-valued rewards.
+            visit_weights: Optional ``[batch]`` integer visit increments;
+                defaults to one per row.
+        """
+        self.add_action_rewards(action_indices, rewards)
+        self.increment_action_visits(action_indices, visit_weights)
+
+    # ------------------------------------------------------------------ #
+    # Registered fields
+    # ------------------------------------------------------------------ #
+
+    def register_belief_field(
+        self,
+        name: str,
+        shape: Tuple[int, ...] = (),
+        *,
+        dtype: Optional[torch.dtype] = None,
+        default: float = 0,
+    ) -> None:
+        """Register an extra per-belief-node field backed by its own tensor.
+
+        Args:
+            name: Field name; must not shadow a built-in belief column.
+            shape: Trailing per-node shape (``()`` for scalar).
+            dtype: Storage dtype; defaults to ``value_dtype``.
+            default: Value used to initialise new rows.
+        """
+        spec = FieldSpec(name, tuple(shape), dtype or self.value_dtype, default)
+        self._belief_fields.register(spec, _RESERVED_BELIEF_NAMES)
+
+    def register_action_field(
+        self,
+        name: str,
+        shape: Tuple[int, ...] = (),
+        *,
+        dtype: Optional[torch.dtype] = None,
+        default: float = 0,
+    ) -> None:
+        """Register an extra per-action-node field backed by its own tensor.
+
+        Args:
+            name: Field name; must not shadow a built-in action column.
+            shape: Trailing per-node shape (``()`` for scalar).
+            dtype: Storage dtype; defaults to ``value_dtype``.
+            default: Value used to initialise new rows.
+        """
+        spec = FieldSpec(name, tuple(shape), dtype or self.value_dtype, default)
+        self._action_fields.register(spec, _RESERVED_ACTION_NAMES)
+
+    def belief_field(self, name: str) -> Tensor:
+        """Return the active-rows view of a registered belief field.
+
+        The returned view spans ``[0, num_belief_nodes)`` and is valid until
+        the next structural mutation (which may reallocate the backing tensor).
+        """
+        return self._belief_fields.tensor(name)[: self._num_beliefs]
+
+    def action_field(self, name: str) -> Tensor:
+        """Return the active-rows view of a registered action field.
+
+        The returned view spans ``[0, num_action_nodes)`` and is valid until
+        the next structural mutation (which may reallocate the backing tensor).
+        """
+        return self._action_fields.tensor(name)[: self._num_actions]
+
+    # ------------------------------------------------------------------ #
+    # Traversal and indexing
+    # ------------------------------------------------------------------ #
+
+    def belief_nodes_at_depth(self, depth: int) -> Tensor:
+        """Return the indices of every active belief node at ``depth``."""
+        active = self.belief_depth[: self._num_beliefs]
+        return torch.nonzero(active == depth, as_tuple=False).flatten()
+
+    def action_nodes_at_depth(self, depth: int) -> Tensor:
+        """Return the indices of every active action node at ``depth``."""
+        active = self.action_depth[: self._num_actions]
+        return torch.nonzero(active == depth, as_tuple=False).flatten()
+
+    def parent_actions(self, belief_indices: Tensor) -> Tensor:
+        """Return the parent action index of each queried belief node.
+
+        The root belief maps to ``-1``.
+        """
+        self._validate_index(belief_indices, "belief_indices")
+        return self.belief_parent_action[belief_indices]
+
+    def parent_beliefs(self, action_indices: Tensor) -> Tensor:
+        """Return the parent belief index of each queried action node."""
+        self._validate_index(action_indices, "action_indices")
+        return self.action_parent_belief[action_indices]
+
+    def action_children(self, belief_indices: Tensor) -> Tuple[Tensor, Tensor]:
+        """Return the action children of the queried belief nodes in CSR form.
+
+        Args:
+            belief_indices: ``[M]`` parent belief node indices.
+
+        Returns:
+            ``(flat_child_indices, offsets)`` where the children of
+            ``belief_indices[m]`` are ``flat_child_indices[offsets[m]:offsets[m + 1]]``.
+        """
+        self._validate_index(belief_indices, "belief_indices")
+        return csr_children(self.action_parent_belief[: self._num_actions], belief_indices)
+
+    def belief_children(self, action_indices: Tensor) -> Tuple[Tensor, Tensor]:
+        """Return the belief children of the queried action nodes in CSR form.
+
+        Args:
+            action_indices: ``[M]`` parent action node indices.
+
+        Returns:
+            ``(flat_child_indices, offsets)`` where the children of
+            ``action_indices[m]`` are ``flat_child_indices[offsets[m]:offsets[m + 1]]``.
+        """
+        self._validate_index(action_indices, "action_indices")
+        return csr_children(self.belief_parent_action[: self._num_beliefs], action_indices)
+
+    def reduce_belief_children(
+        self,
+        parent_action_indices: Tensor,
+        child_values: Tensor,
+        *,
+        reduction: str,
+    ) -> Tensor:
+        """Reduce child values grouped by parent action node.
+
+        This is a generic segmented reduction — it does not implement any
+        algorithm-specific backup. ``parent_action_indices[k]`` is the parent
+        action node of the ``k``-th child and ``child_values[k]`` its value.
+
+        Args:
+            parent_action_indices: ``[K]`` parent action indices per child.
+            child_values: ``[K]`` per-child values.
+            reduction: One of ``"sum"``, ``"mean"``, ``"max"``, ``"min"``.
+
+        Returns:
+            ``[num_action_nodes]`` reduced value per action node. Action nodes
+            with no contributing child hold ``0``.
+        """
+        self._validate_index(parent_action_indices, "parent_action_indices")
+        self._validate_same_length(child_values, parent_action_indices, "child_values")
+        return segment_reduce(parent_action_indices, child_values, self._num_actions, reduction)
+
+    # ------------------------------------------------------------------ #
+    # Capacity management
+    # ------------------------------------------------------------------ #
+
+    def _ensure_belief_capacity(self, required: int) -> None:
+        if required <= self._belief_capacity:
+            return
+        new_capacity = self._grown_capacity(self._belief_capacity, required)
+        self.belief_parent_action = self._grow_column(self.belief_parent_action, new_capacity, -1)
+        self.belief_parent_observation = self._grow_column(
+            self.belief_parent_observation, new_capacity, -1
+        )
+        self.belief_depth = self._grow_column(self.belief_depth, new_capacity, 0)
+        self.belief_terminal = self._grow_column(self.belief_terminal, new_capacity, False)
+        self._belief_fields.grow(new_capacity)
+        self._belief_capacity = new_capacity
+
+    def _ensure_action_capacity(self, required: int) -> None:
+        if required <= self._action_capacity:
+            return
+        new_capacity = self._grown_capacity(self._action_capacity, required)
+        self.action_parent_belief = self._grow_column(self.action_parent_belief, new_capacity, -1)
+        self.action_key = self._grow_column(self.action_key, new_capacity, -1)
+        self.action_depth = self._grow_column(self.action_depth, new_capacity, 0)
+        self.action_visit_count = self._grow_column(self.action_visit_count, new_capacity, 0)
+        self.action_reward_sum = self._grow_column(self.action_reward_sum, new_capacity, 0)
+        self._action_fields.grow(new_capacity)
+        self._action_capacity = new_capacity
+
+    def _grown_capacity(self, current: int, required: int) -> int:
+        new_capacity = current
+        while new_capacity < required:
+            new_capacity = int(new_capacity * self.growth_factor) + 1
+        return new_capacity
+
+    def _grow_column(self, column: Tensor, new_capacity: int, fill: float) -> Tensor:
+        grown = torch.full(
+            (new_capacity, *column.shape[1:]),
+            fill,
+            dtype=column.dtype,
+            device=self.device,
+        )
+        grown[: column.shape[0]] = column
+        return grown
+
+    # ------------------------------------------------------------------ #
+    # Reset / clear
+    # ------------------------------------------------------------------ #
+
+    def clear(self) -> None:
+        """Remove every node except the root, preserving capacity and fields.
+
+        Registered field definitions survive; their rows reset to defaults.
+        """
+        self._num_actions = 0
+        self._init_root()
+
+    def reset_statistics(self) -> None:
+        """Reset visit counts, reward sums, and registered fields; keep topology."""
+        self.action_visit_count[: self._num_actions] = 0
+        self.action_reward_sum[: self._num_actions] = 0
+        self._belief_fields.reset_rows(0, self._num_beliefs)
+        self._action_fields.reset_rows(0, self._num_actions)
+
+    # ------------------------------------------------------------------ #
+    # Serialization / device movement
+    # ------------------------------------------------------------------ #
+
+    def to(self, device: torch.device) -> "VectorizedBeliefTree":
+        """Move every built-in and registered tensor to ``device`` in place.
+
+        Returns:
+            ``self``, for chaining.
+        """
+        self.device = torch.empty(0, device=device).device
+        for name, tensor in self._named_columns().items():
+            setattr(self, name, tensor.to(self.device))
+        self._belief_fields.to(self.device)
+        self._action_fields.to(self.device)
+        return self
+
+    def state_dict(self) -> Dict[str, object]:
+        """Serialise the active tree (topology, statistics, and fields).
+
+        Returns:
+            A picklable dict holding the active tensor rows, field
+            definitions, node counters, and reconstruction configuration.
+        """
+        return {
+            "config": self._config_dict(),
+            "num_beliefs": self._num_beliefs,
+            "num_actions": self._num_actions,
+            "columns": {
+                name: tensor[: self._active_len(name)].clone()
+                for name, tensor in self._named_columns().items()
+            },
+            "belief_fields": self._field_state(self._belief_fields, self._num_beliefs),
+            "action_fields": self._field_state(self._action_fields, self._num_actions),
+        }
+
+    def load_state_dict(self, state: Dict[str, object]) -> None:
+        """Restore the tree from a :meth:`state_dict` payload."""
+        config = _as_dict(state["config"])
+        self.index_dtype = _as_dtype(config["index_dtype"])
+        self.value_dtype = _as_dtype(config["value_dtype"])
+        self.growth_factor = _as_float(config["growth_factor"])
+        self._num_beliefs = int(_as_int(state["num_beliefs"]))
+        self._num_actions = int(_as_int(state["num_actions"]))
+        self._belief_capacity = max(self._num_beliefs, 1)
+        self._action_capacity = max(self._num_actions, 1)
+        self._allocate_columns()
+        self._restore_columns(_as_dict(state["columns"]))
+        self._belief_fields = self._restore_fields(
+            _as_dict(state["belief_fields"]), self._belief_capacity
+        )
+        self._action_fields = self._restore_fields(
+            _as_dict(state["action_fields"]), self._action_capacity
+        )
+
+    def _restore_columns(self, columns: Dict[str, object]) -> None:
+        for name, tensor in columns.items():
+            if not isinstance(tensor, Tensor):
+                raise TypeError(f"column '{name}' must be a tensor")
+            moved = tensor.to(self.device)
+            getattr(self, name)[: moved.shape[0]] = moved
+
+    def _restore_fields(self, field_state: Dict[str, object], capacity: int) -> FieldRegistry:
+        registry = FieldRegistry(self.device, capacity)
+        specs = field_state["specs"]
+        values = _as_dict(field_state["values"])
+        if not isinstance(specs, (list, tuple)):
+            raise TypeError("field specs must be a sequence")
+        for spec in specs:
+            if not isinstance(spec, FieldSpec):
+                raise TypeError("field spec must be a FieldSpec")
+            registry.register(spec, frozenset())
+            stored = values[spec.name]
+            if not isinstance(stored, Tensor):
+                raise TypeError(f"field '{spec.name}' must be a tensor")
+            registry.tensor(spec.name)[: stored.shape[0]] = stored.to(self.device)
+        return registry
+
+    # ------------------------------------------------------------------ #
+    # Validation of invariants
+    # ------------------------------------------------------------------ #
+
+    def validate(self) -> None:
+        """Assert the structural invariants of the tree.
+
+        Raises:
+            AssertionError: If any invariant is violated.
+        """
+        self._validate_root()
+        self._validate_parent_links()
+        self._validate_depths()
+        self._validate_unique_pairs()
+        self._validate_capacities()
+        self._validate_devices()
+
+    def _validate_root(self) -> None:
+        assert self._num_beliefs >= 1, "tree must contain the root belief"
+        assert bool(self.belief_parent_action[_ROOT_INDEX] == -1), "root has no parent action"
+        assert int(self.belief_depth[_ROOT_INDEX]) == 0, "root depth must be 0"
+
+    def _validate_parent_links(self) -> None:
+        if self._num_beliefs > 1:
+            parents = self.belief_parent_action[1 : self._num_beliefs]
+            assert bool((parents >= 0).all()), "non-root belief has no parent action"
+            assert bool((parents < self._num_actions).all()), "belief parent action out of range"
+        if self._num_actions > 0:
+            parents = self.action_parent_belief[: self._num_actions]
+            assert bool((parents >= 0).all()), "action node has no parent belief"
+            assert bool((parents < self._num_beliefs).all()), "action parent belief out of range"
+
+    def _validate_depths(self) -> None:
+        if self._num_actions > 0:
+            parents = self.action_parent_belief[: self._num_actions]
+            expected = self.belief_depth[parents]
+            assert bool(
+                (self.action_depth[: self._num_actions] == expected).all()
+            ), "action depth must equal parent belief depth"
+        if self._num_beliefs > 1:
+            parents = self.belief_parent_action[1 : self._num_beliefs]
+            expected = self.action_depth[parents] + 1
+            assert bool(
+                (self.belief_depth[1 : self._num_beliefs] == expected).all()
+            ), "belief depth must equal parent action depth plus one"
+
+    def _validate_unique_pairs(self) -> None:
+        self._assert_unique(
+            self.action_parent_belief[: self._num_actions],
+            self.action_key[: self._num_actions],
+            "duplicate (belief, action) pair",
+        )
+        self._assert_unique(
+            self.belief_parent_action[1 : self._num_beliefs],
+            self.belief_parent_observation[1 : self._num_beliefs],
+            "duplicate (action, observation) pair",
+        )
+
+    @staticmethod
+    def _assert_unique(first: Tensor, second: Tensor, message: str) -> None:
+        if first.shape[0] == 0:
+            return
+        pairs = torch.stack([first, second], dim=1)
+        unique_tensor = torch.unique(pairs, dim=0)
+        assert unique_tensor.shape[0] == first.shape[0], message
+
+    def _validate_capacities(self) -> None:
+        assert self._num_beliefs <= self._belief_capacity, "belief count exceeds capacity"
+        assert self._num_actions <= self._action_capacity, "action count exceeds capacity"
+
+    def _validate_devices(self) -> None:
+        for name, tensor in self._named_columns().items():
+            assert tensor.device == self.device, f"column '{name}' is on the wrong device"
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _named_columns(self) -> Dict[str, Tensor]:
+        return {
+            "belief_parent_action": self.belief_parent_action,
+            "belief_parent_observation": self.belief_parent_observation,
+            "belief_depth": self.belief_depth,
+            "belief_terminal": self.belief_terminal,
+            "action_parent_belief": self.action_parent_belief,
+            "action_key": self.action_key,
+            "action_depth": self.action_depth,
+            "action_visit_count": self.action_visit_count,
+            "action_reward_sum": self.action_reward_sum,
+        }
+
+    def _active_len(self, column_name: str) -> int:
+        return self._num_actions if column_name.startswith("action") else self._num_beliefs
+
+    def _config_dict(self) -> Dict[str, object]:
+        return {
+            "index_dtype": self.index_dtype,
+            "value_dtype": self.value_dtype,
+            "growth_factor": self.growth_factor,
+        }
+
+    @staticmethod
+    def _field_state(registry: FieldRegistry, active: int) -> Dict[str, object]:
+        return {
+            "specs": list(registry.specs()),
+            "values": {name: registry.tensor(name)[:active].clone() for name in registry.names()},
+        }
+
+    def _validate_pair(self, first: Tensor, second: Tensor, first_name: str) -> None:
+        self._validate_index(first, first_name)
+        self._validate_index(second, "keys")
+        self._validate_same_length(second, first, "keys")
+
+    def _validate_index(self, tensor: Tensor, name: str) -> None:
+        if not isinstance(tensor, Tensor):
+            # Runtime guard for callers that bypass static typing.
+            raise TypeError(f"{name} must be a torch.Tensor")  # pyright: ignore[reportUnreachable]
+        if tensor.device != self.device:
+            raise ValueError(f"{name} must be on device {self.device}, got {tensor.device}")
+        if tensor.dim() != 1:
+            raise ValueError(f"{name} must be 1-dimensional")
+        if not _is_integer_dtype(tensor.dtype):
+            raise TypeError(f"{name} must have an integer dtype")
+
+    def _validate_bool(self, tensor: Tensor, reference: Tensor, name: str) -> None:
+        if tensor.device != self.device:
+            raise ValueError(f"{name} must be on device {self.device}")
+        if tensor.dtype != torch.bool:
+            raise TypeError(f"{name} must be a boolean tensor")
+        self._validate_same_length(tensor, reference, name)
+
+    @staticmethod
+    def _validate_same_length(tensor: Tensor, reference: Tensor, name: str) -> None:
+        if tensor.shape[0] != reference.shape[0]:
+            raise ValueError(f"{name} must have the same batch size as its companion tensor")
+
+
+def _is_integer_dtype(dtype: torch.dtype) -> bool:
+    return dtype in (torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8)
+
+
+def _as_dict(value: object) -> Dict[str, object]:
+    if not isinstance(value, dict):
+        raise TypeError("expected a dict in the serialized state")
+    return value
+
+
+def _as_int(value: object) -> int:
+    if not isinstance(value, int):
+        raise TypeError("expected an int in the serialized state")
+    return value
+
+
+def _as_dtype(value: object) -> torch.dtype:
+    if not isinstance(value, torch.dtype):
+        raise TypeError("expected a torch.dtype in the serialized state")
+    return value
+
+
+def _as_float(value: object) -> float:
+    if not isinstance(value, (int, float)):
+        raise TypeError("expected a float in the serialized state")
+    return float(value)

--- a/POMDPPlanners/core/tree/vectorized_belief_tree/vectorized_belief_tree_fields.py
+++ b/POMDPPlanners/core/tree/vectorized_belief_tree/vectorized_belief_tree_fields.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MIT
+
+"""Registered-field bookkeeping for the vectorized belief tree.
+
+A *registered field* is an extra per-node column (belief-side or action-side)
+that a planning algorithm attaches to the tree without modifying the core
+storage schema. For example, a PORPP/VOPP-style planner registers a
+``preferences`` belief field of shape ``(num_actions,)`` and a ``value``
+belief field; a POMCP-style planner registers a ``q_value`` action field.
+
+Each field is described by an immutable :class:`FieldSpec` and backed by a
+preallocated tensor that a :class:`FieldRegistry` grows in lockstep with the
+node capacity of the owning tree.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Tuple, Union
+
+import torch
+from torch import Tensor
+
+DefaultValue = Union[float, int, bool]
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """Immutable description of one registered per-node field.
+
+    Attributes:
+        name: Field name, unique within its node kind and distinct from the
+            built-in column names.
+        shape: Trailing shape of the field for a single node. ``()`` denotes a
+            scalar field; ``(num_actions,)`` denotes a per-action vector, etc.
+        dtype: The tensor dtype used to store the field.
+        default: Value used to initialise newly allocated rows.
+    """
+
+    name: str
+    shape: Tuple[int, ...]
+    dtype: torch.dtype
+    default: DefaultValue
+
+
+class FieldRegistry:
+    """Owns the backing tensors for the registered fields of one node kind.
+
+    The registry preallocates one tensor per field with the tree's current
+    node capacity and keeps every field tensor on the tree's device. Growing
+    the registry reallocates each field tensor geometrically while preserving
+    existing rows.
+    """
+
+    def __init__(self, device: torch.device, capacity: int) -> None:
+        self._device = device
+        self._capacity = capacity
+        self._specs: Dict[str, FieldSpec] = {}
+        self._tensors: Dict[str, Tensor] = {}
+
+    @property
+    def device(self) -> torch.device:
+        """Device shared by every field tensor in the registry."""
+        return self._device
+
+    def names(self) -> Tuple[str, ...]:
+        """Return the registered field names in insertion order."""
+        return tuple(self._specs)
+
+    def specs(self) -> Tuple[FieldSpec, ...]:
+        """Return the registered :class:`FieldSpec` objects in insertion order."""
+        return tuple(self._specs.values())
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._specs
+
+    def register(self, spec: FieldSpec, reserved_names: frozenset) -> None:
+        """Register a new field, allocating its backing tensor.
+
+        Args:
+            spec: The field description.
+            reserved_names: Built-in column names the field may not shadow.
+
+        Raises:
+            ValueError: If the name collides with a reserved name or an
+                already-registered field.
+        """
+        if spec.name in reserved_names:
+            raise ValueError(f"field name '{spec.name}' collides with a built-in column")
+        if spec.name in self._specs:
+            raise ValueError(f"field '{spec.name}' is already registered")
+        self._specs[spec.name] = spec
+        self._tensors[spec.name] = self._allocate(spec, self._capacity)
+
+    def tensor(self, name: str) -> Tensor:
+        """Return the full backing tensor for a registered field.
+
+        Raises:
+            KeyError: If no field with ``name`` is registered.
+        """
+        if name not in self._tensors:
+            raise KeyError(f"no registered field named '{name}'")
+        return self._tensors[name]
+
+    def grow(self, new_capacity: int) -> None:
+        """Reallocate every field tensor to ``new_capacity`` rows, preserving data."""
+        for name, spec in self._specs.items():
+            old = self._tensors[name]
+            grown = self._allocate(spec, new_capacity)
+            grown[: old.shape[0]] = old
+            self._tensors[name] = grown
+        self._capacity = new_capacity
+
+    def reset_rows(self, start: int, end: int) -> None:
+        """Reset rows ``[start, end)`` of every field tensor to its default."""
+        for spec in self._specs.values():
+            self._tensors[spec.name][start:end] = spec.default
+
+    def to(self, device: torch.device) -> None:
+        """Move every field tensor to ``device`` in place."""
+        self._device = device
+        for name, tensor in self._tensors.items():
+            self._tensors[name] = tensor.to(device)
+
+    def _allocate(self, spec: FieldSpec, capacity: int) -> Tensor:
+        return torch.full(
+            (capacity, *spec.shape),
+            spec.default,
+            dtype=spec.dtype,
+            device=self._device,
+        )

--- a/POMDPPlanners/core/tree/vectorized_belief_tree/vectorized_belief_tree_lookup.py
+++ b/POMDPPlanners/core/tree/vectorized_belief_tree/vectorized_belief_tree_lookup.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: MIT
+
+"""Vectorized composite-key lookup and segmented-grouping helpers.
+
+These are pure tensor functions used by
+:class:`~POMDPPlanners.core.tree.vectorized_belief_tree.vectorized_belief_tree.VectorizedBeliefTree`.
+None of them mutate persistent tree state; each operates on the flat column
+tensors passed in and returns index or value tensors. Every function is
+batched — there are no Python loops over individual rows.
+
+The two structural keys of a belief tree are composite integer pairs:
+
+* ``(parent_belief_index, action_key)`` identifying an action node;
+* ``(parent_action_index, observation_key)`` identifying a belief node.
+
+Matching them is done with :func:`match_pairs`, which packs a pair-match into
+a single :func:`torch.unique` call rather than an unsafe integer packing that
+could overflow ``int64`` when either component is large.
+
+Complexity notes use ``E`` for the number of existing rows, ``Q`` for the
+query batch size, ``A`` for the number of active nodes, and ``M`` for the
+number of queried parents.
+"""
+
+from typing import Tuple
+
+import torch
+from torch import Tensor
+
+
+def match_pairs(
+    existing_first: Tensor,
+    existing_second: Tensor,
+    query_first: Tensor,
+    query_second: Tensor,
+) -> Tensor:
+    """Match each query pair against the existing pairs.
+
+    Args:
+        existing_first: ``[E]`` first component of the existing pairs.
+        existing_second: ``[E]`` second component of the existing pairs.
+        query_first: ``[Q]`` first component of the query pairs.
+        query_second: ``[Q]`` second component of the query pairs.
+
+    Returns:
+        ``[Q]`` tensor whose ``i``-th entry is the index into the existing
+        pairs that matches query ``i``, or ``-1`` if no existing pair matches.
+        Order follows the query batch.
+
+    In belief-tree terms each pair is a composite node key: for action-node
+    lookup the components are ``(parent_belief_index, action_key)``; for
+    belief-node lookup they are ``(parent_action_index, observation_key)``. The
+    ``existing_*`` tensors are the corresponding column tensors of the nodes
+    already in the tree and the ``query_*`` tensors are the keys being searched;
+    a returned index is the matching child node, ``-1`` meaning that edge does
+    not exist yet.
+
+    Complexity:
+        ``O((E + Q) log (E + Q))`` from a single lexicographic ``torch.unique``.
+
+    Example:
+        Three existing action nodes keyed by ``(parent_belief, action_key)``,
+        looked up by three query pairs (matching on the pair, not either
+        component alone)::
+
+            >>> import torch
+            >>> existing_first = torch.tensor([0, 0, 1])   # parent belief index
+            >>> existing_second = torch.tensor([2, 4, 2])  # action key
+            >>> query_first = torch.tensor([0, 1, 0])
+            >>> query_second = torch.tensor([4, 2, 9])
+            >>> match_pairs(existing_first, existing_second, query_first, query_second)
+            tensor([ 1,  2, -1])
+
+        Query ``(0, 4)`` matches existing row ``1``, ``(1, 2)`` matches row
+        ``2``, and ``(0, 9)`` has no match so it returns ``-1``.
+    """
+    device = query_first.device
+    num_existing = existing_first.shape[0]
+    num_query = query_first.shape[0]
+    if num_query == 0:
+        return torch.empty(0, dtype=torch.int64, device=device)
+    all_first = torch.cat([existing_first, query_first])
+    all_second = torch.cat([existing_second, query_second])
+    pairs = torch.stack([all_first, all_second], dim=1)
+    unique_pairs_tensor, inverse = torch.unique(pairs, dim=0, return_inverse=True)
+    num_groups = unique_pairs_tensor.shape[0]
+    group_to_existing = torch.full((num_groups,), -1, dtype=torch.int64, device=device)
+    if num_existing > 0:
+        existing_groups = inverse[:num_existing]
+        group_to_existing[existing_groups] = torch.arange(
+            num_existing, dtype=torch.int64, device=device
+        )
+    query_groups = inverse[num_existing:]
+    return group_to_existing[query_groups]
+
+
+def unique_pairs(first: Tensor, second: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+    """Deduplicate a batch of integer pairs.
+
+    Args:
+        first: ``[Q]`` first component of the pairs.
+        second: ``[Q]`` second component of the pairs.
+
+    Returns:
+        A tuple ``(unique_first, unique_second, inverse)`` where the unique
+        arrays hold each distinct pair once and ``inverse`` maps every input
+        row to its unique-pair index (``inverse`` has length ``Q``).
+
+    Complexity:
+        ``O(Q log Q)``.
+    """
+    if first.shape[0] == 0:
+        empty = torch.empty(0, dtype=first.dtype, device=first.device)
+        return empty, empty.clone(), empty.clone()
+    pairs = torch.stack([first, second], dim=1)
+    unique_tensor, inverse = torch.unique(pairs, dim=0, return_inverse=True)
+    return unique_tensor[:, 0].contiguous(), unique_tensor[:, 1].contiguous(), inverse
+
+
+def csr_children(parent_column: Tensor, query_parents: Tensor) -> Tuple[Tensor, Tensor]:
+    """Group node indices by parent into a CSR (segmented) representation.
+
+    Args:
+        parent_column: ``[A]`` parent id of every active node of one kind.
+            Position ``a`` holds the parent id of node ``a``.
+        query_parents: ``[M]`` parent ids whose children are requested.
+
+    Returns:
+        A tuple ``(flat_children, offsets)`` where ``offsets`` has length
+        ``M + 1`` and the children of ``query_parents[m]`` are
+        ``flat_children[offsets[m]:offsets[m + 1]]``.
+
+    Complexity:
+        ``O(A log A + M log A)``.
+    """
+    device = parent_column.device
+    num_query = query_parents.shape[0]
+    order = torch.argsort(parent_column)
+    sorted_parents = parent_column[order]
+    low = torch.searchsorted(sorted_parents, query_parents, side="left")
+    high = torch.searchsorted(sorted_parents, query_parents, side="right")
+    counts = high - low
+    offsets = torch.zeros(num_query + 1, dtype=torch.int64, device=device)
+    torch.cumsum(counts, dim=0, out=offsets[1:])
+    total = int(offsets[-1].item())
+    if total == 0:
+        return torch.empty(0, dtype=torch.int64, device=device), offsets
+    segment = torch.repeat_interleave(torch.arange(num_query, device=device), counts)
+    within = torch.arange(total, device=device) - offsets[segment]
+    source = low[segment] + within
+    return order[source], offsets
+
+
+def scatter_or(indices: Tensor, values: Tensor, size: int) -> Tensor:
+    """Reduce boolean ``values`` by logical OR, grouped by ``indices``.
+
+    Args:
+        indices: ``[N]`` target index of every value (may contain duplicates).
+        values: ``[N]`` boolean values to OR into their target positions.
+        size: Length of the output tensor.
+
+    Returns:
+        ``[size]`` boolean tensor; position ``p`` is ``True`` iff any value
+        routed to ``p`` is ``True``. Untargeted positions are ``False``.
+    """
+    contrib = torch.zeros(size, dtype=torch.uint8, device=values.device)
+    contrib.scatter_reduce_(0, indices, values.to(torch.uint8), reduce="amax", include_self=True)
+    return contrib.to(torch.bool)
+
+
+def segment_reduce(
+    segment_ids: Tensor,
+    values: Tensor,
+    num_segments: int,
+    reduction: str,
+) -> Tensor:
+    """Reduce ``values`` grouped by ``segment_ids`` into a dense tensor.
+
+    Args:
+        segment_ids: ``[N]`` segment index of every value.
+        values: ``[N]`` values to reduce.
+        num_segments: Length of the output tensor.
+        reduction: One of ``"sum"``, ``"mean"``, ``"max"``, ``"min"``.
+
+    Returns:
+        ``[num_segments]`` reduced values. Empty segments are ``0`` for every
+        reduction (documented default so the result is always well defined).
+
+    Raises:
+        ValueError: If ``reduction`` is not a supported name.
+    """
+    out = torch.zeros(num_segments, dtype=values.dtype, device=values.device)
+    if reduction == "sum":
+        return out.index_add_(0, segment_ids, values)
+    if reduction == "mean":
+        return _segment_mean(segment_ids, values, num_segments, out)
+    if reduction in ("max", "min"):
+        reduce_op = "amax" if reduction == "max" else "amin"
+        out.scatter_reduce_(0, segment_ids, values, reduce=reduce_op, include_self=False)
+        return out
+    raise ValueError(f"unsupported reduction '{reduction}'")
+
+
+def _segment_mean(
+    segment_ids: Tensor,
+    values: Tensor,
+    num_segments: int,
+    out: Tensor,
+) -> Tensor:
+    totals = out.index_add_(0, segment_ids, values)
+    counts = torch.zeros(num_segments, dtype=values.dtype, device=values.device)
+    counts.index_add_(0, segment_ids, torch.ones_like(values))
+    safe_counts = torch.where(counts > 0, counts, torch.ones_like(counts))
+    return totals / safe_counts

--- a/POMDPPlanners/tests/test_core/test_vectorized_belief_tree/__init__.py
+++ b/POMDPPlanners/tests/test_core/test_vectorized_belief_tree/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for :mod:`POMDPPlanners.core.tree.vectorized_belief_tree`."""

--- a/POMDPPlanners/tests/test_core/test_vectorized_belief_tree/test_vectorized_belief_tree.py
+++ b/POMDPPlanners/tests/test_core/test_vectorized_belief_tree/test_vectorized_belief_tree.py
@@ -1,0 +1,726 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for :class:`VectorizedBeliefTree`.
+
+The tree stores a POMDP belief tree as flat tensors: a node is an integer
+index into every column, belief and action nodes alternate, and every
+structural or statistical operation is batched. These tests validate that
+contract on CPU (always) and CUDA (when available).
+"""
+
+# pylint: disable=too-many-lines
+
+import pytest
+import torch
+
+from POMDPPlanners.core.tree.vectorized_belief_tree import (
+    VectorizedBeliefTree,
+)
+
+CPU = torch.device("cpu")
+
+
+def _tensor(values, device=CPU, dtype=torch.int64):
+    return torch.tensor(values, device=device, dtype=dtype)
+
+
+@pytest.fixture(name="tree")
+def _tree_fixture():
+    """Return a fresh CPU tree for each test."""
+    return VectorizedBeliefTree(device=CPU)
+
+
+class TestInitialization:
+    """Root creation and initial counters."""
+
+    def test_root_is_created_at_index_zero(self, tree):
+        """A new tree contains exactly the root belief at index 0.
+
+        Purpose: Validates that construction creates the root correctly.
+
+        Given: A freshly constructed tree
+        When: Its counters and root columns are inspected
+        Then: The root index is 0, there is one belief and no actions, and the
+            root has no parent and zero depth
+
+        Test type: unit
+        """
+        assert tree.root_index == 0
+        assert tree.num_belief_nodes == 1
+        assert tree.num_action_nodes == 0
+        assert int(tree.belief_parent_action[0]) == -1
+        assert int(tree.belief_parent_observation[0]) == -1
+        assert int(tree.belief_depth[0]) == 0
+        assert not bool(tree.belief_terminal[0])
+
+    def test_invalid_capacity_raises(self):
+        """Non-positive capacities are rejected at construction.
+
+        Purpose: Validates capacity argument checking.
+
+        Given: A zero belief capacity
+        When: A tree is constructed
+        Then: A ValueError is raised
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError):
+            VectorizedBeliefTree(device=CPU, belief_capacity=0)
+
+    def test_invalid_growth_factor_raises(self):
+        """A growth factor of 1 or less is rejected.
+
+        Purpose: Validates growth-factor argument checking.
+
+        Given: A growth factor of 1.0
+        When: A tree is constructed
+        Then: A ValueError is raised
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError):
+            VectorizedBeliefTree(device=CPU, growth_factor=1.0)
+
+
+class TestActionInsertion:
+    """Action-node lookup and creation semantics."""
+
+    def test_duplicate_pairs_map_to_single_action(self, tree):
+        """Repeated (belief, action) pairs in one batch create one node each.
+
+        Purpose: Validates in-batch deduplication of action creation.
+
+        Given: A batch where pair (0, 2) appears twice alongside distinct pairs
+        When: get_or_create_actions is called
+        Then: The duplicate rows return the same index and only unique pairs
+            create nodes
+
+        Test type: unit
+        """
+        parents = _tensor([0, 0, 0, 0])
+        actions = _tensor([2, 2, 4, 1])
+
+        indices, created = tree.get_or_create_actions(parents, actions)
+
+        assert int(indices[0]) == int(indices[1])
+        assert tree.num_action_nodes == 3
+        assert created.tolist() == [True, True, True, True]
+
+    def test_existing_action_lookup_creates_nothing(self, tree):
+        """Re-inserting an existing pair returns it without creating a node.
+
+        Purpose: Validates against-tree deduplication.
+
+        Given: A tree already holding pair (0, 2)
+        When: get_or_create_actions is called again with (0, 2)
+        Then: The same index is returned, created is False, and the count is
+            unchanged
+
+        Test type: unit
+        """
+        first, _ = tree.get_or_create_actions(_tensor([0]), _tensor([2]))
+
+        second, created = tree.get_or_create_actions(_tensor([0]), _tensor([2]))
+
+        assert int(first[0]) == int(second[0])
+        assert created.tolist() == [False]
+        assert tree.num_action_nodes == 1
+
+    def test_find_actions_reports_hits_and_misses(self, tree):
+        """find_actions returns existing indices and -1 for absent pairs.
+
+        Purpose: Validates non-mutating action lookup.
+
+        Given: A tree holding pair (0, 2)
+        When: find_actions queries (0, 2) and (0, 9)
+        Then: The present pair resolves to its index and the absent pair to -1
+            without creating nodes
+
+        Test type: unit
+        """
+        created_index, _ = tree.get_or_create_actions(_tensor([0]), _tensor([2]))
+
+        indices, found = tree.find_actions(_tensor([0, 0]), _tensor([2, 9]))
+
+        assert int(indices[0]) == int(created_index[0])
+        assert int(indices[1]) == -1
+        assert found.tolist() == [True, False]
+        assert tree.num_action_nodes == 1
+
+    def test_mixed_existing_and_new_batch(self, tree):
+        """A batch mixing existing, repeated-new, and distinct-new pairs resolves.
+
+        Purpose: Validates the combined dedup + lookup + create path.
+
+        Given: A tree holding pair (0, 1), and a batch with (0, 1), (0, 5)
+            twice, and (0, 7)
+        When: get_or_create_actions is called
+        Then: The existing pair keeps its index, repeats share an index, and
+            created flags reflect only newly created rows
+
+        Test type: unit
+        """
+        existing, _ = tree.get_or_create_actions(_tensor([0]), _tensor([1]))
+
+        parents = _tensor([0, 0, 0, 0])
+        actions = _tensor([1, 5, 5, 7])
+        indices, created = tree.get_or_create_actions(parents, actions)
+
+        assert int(indices[0]) == int(existing[0])
+        assert int(indices[1]) == int(indices[2])
+        assert created.tolist() == [False, True, True, True]
+        assert tree.num_action_nodes == 3
+
+
+class TestBeliefInsertion:
+    """Successor-belief lookup and creation semantics."""
+
+    def _make_actions(self, tree):
+        indices, _ = tree.get_or_create_actions(_tensor([0, 0, 0]), _tensor([0, 1, 2]))
+        return indices
+
+    def test_duplicate_action_observation_pairs_collapse(self, tree):
+        """Repeated (action, observation) pairs create a single belief.
+
+        Purpose: Validates successor-belief uniqueness.
+
+        Given: One action node and a batch where observation 2 repeats under it
+        When: get_or_create_beliefs is called
+        Then: Both rows return the same belief index and only unique pairs add
+            nodes
+
+        Test type: unit
+        """
+        actions = self._make_actions(tree)
+        parent_actions = _tensor([int(actions[0]), int(actions[0]), int(actions[1])])
+        observations = _tensor([2, 2, 7])
+
+        beliefs, created = tree.get_or_create_beliefs(parent_actions, observations)
+
+        assert int(beliefs[0]) == int(beliefs[1])
+        assert tree.num_belief_nodes == 1 + 2
+        assert created.tolist() == [True, True, True]
+
+    def test_new_belief_depth_is_parent_action_depth_plus_one(self, tree):
+        """A created belief's depth is one greater than its parent action.
+
+        Purpose: Validates depth propagation on belief creation.
+
+        Given: A root-level action node at depth 0
+        When: A successor belief is created under it
+        Then: The successor belief has depth 1
+
+        Test type: unit
+        """
+        actions = self._make_actions(tree)
+
+        beliefs, _ = tree.get_or_create_beliefs(_tensor([int(actions[0])]), _tensor([5]))
+
+        assert int(tree.belief_depth[int(beliefs[0])]) == 1
+
+    def test_terminal_flag_applies_and_ors_on_repeat(self, tree):
+        """Terminal flags are set on creation and OR-combined thereafter.
+
+        Purpose: Validates the documented logical-OR terminal semantics.
+
+        Given: A belief created as non-terminal
+        When: The same belief is re-inserted with terminal True
+        Then: The existing belief is promoted to terminal
+
+        Test type: unit
+        """
+        actions = self._make_actions(tree)
+        beliefs, _ = tree.get_or_create_beliefs(
+            _tensor([int(actions[0])]),
+            _tensor([5]),
+            terminal_mask=torch.tensor([False], device=CPU),
+        )
+        assert not bool(tree.belief_terminal[int(beliefs[0])])
+
+        tree.get_or_create_beliefs(
+            _tensor([int(actions[0])]),
+            _tensor([5]),
+            terminal_mask=torch.tensor([True], device=CPU),
+        )
+
+        assert bool(tree.belief_terminal[int(beliefs[0])])
+
+    def test_find_beliefs_reports_hits_and_misses(self, tree):
+        """find_beliefs resolves present pairs and marks absent ones -1.
+
+        Purpose: Validates non-mutating belief lookup.
+
+        Given: A belief created under action a for observation 5
+        When: find_beliefs queries (a, 5) and (a, 6)
+        Then: The present pair resolves and the absent pair returns -1
+
+        Test type: unit
+        """
+        actions = self._make_actions(tree)
+        created, _ = tree.get_or_create_beliefs(_tensor([int(actions[0])]), _tensor([5]))
+
+        parent = int(actions[0])
+        indices, found = tree.find_beliefs(_tensor([parent, parent]), _tensor([5, 6]))
+
+        assert int(indices[0]) == int(created[0])
+        assert int(indices[1]) == -1
+        assert found.tolist() == [True, False]
+
+
+class TestStatistics:
+    """Scatter-based accumulation of action statistics."""
+
+    def test_duplicate_indices_accumulate_visits_and_rewards(self, tree):
+        """Duplicate action indices sum visits and rewards.
+
+        Purpose: Validates scatter accumulation over repeated indices.
+
+        Given: Three action nodes and an update batch referencing node 1 twice
+        When: update_action_statistics is applied
+        Then: Node 1's visits and reward sum reflect both contributions
+
+        Test type: unit
+        """
+        actions, _ = tree.get_or_create_actions(_tensor([0, 0, 0]), _tensor([0, 1, 2]))
+        update_indices = _tensor([int(actions[1]), int(actions[1]), int(actions[0])])
+        rewards = torch.tensor([2.0, 3.0, 1.0], device=CPU)
+
+        tree.update_action_statistics(update_indices, rewards)
+
+        node_one = int(actions[1])
+        assert int(tree.action_visit_count[node_one]) == 2
+        assert float(tree.action_reward_sum[node_one]) == pytest.approx(5.0)
+        assert int(tree.action_visit_count[int(actions[0])]) == 1
+
+    def test_increment_visits_defaults_to_one(self, tree):
+        """increment_action_visits adds one per row when counts is omitted.
+
+        Purpose: Validates the default visit increment.
+
+        Given: A single action node
+        When: increment_action_visits is called without counts twice
+        Then: The visit count is 2
+
+        Test type: unit
+        """
+        actions, _ = tree.get_or_create_actions(_tensor([0]), _tensor([0]))
+
+        tree.increment_action_visits(actions)
+        tree.increment_action_visits(actions)
+
+        assert int(tree.action_visit_count[int(actions[0])]) == 2
+
+
+class TestTraversal:
+    """Depth queries, parent links, and CSR child queries."""
+
+    def _two_levels(self, tree):
+        actions, _ = tree.get_or_create_actions(_tensor([0, 0]), _tensor([0, 1]))
+        beliefs, _ = tree.get_or_create_beliefs(
+            _tensor([int(actions[0]), int(actions[0]), int(actions[1])]),
+            _tensor([5, 6, 7]),
+        )
+        return actions, beliefs
+
+    def test_depth_queries_return_expected_nodes(self, tree):
+        """Nodes-at-depth returns the correct belief and action indices.
+
+        Purpose: Validates depth-indexed traversal.
+
+        Given: A two-level tree
+        When: Belief and action nodes are queried by depth
+        Then: The root is the only depth-0 belief and successors are depth 1
+
+        Test type: unit
+        """
+        self._two_levels(tree)
+
+        root_level = tree.belief_nodes_at_depth(0)
+        next_level = tree.belief_nodes_at_depth(1)
+        action_level = tree.action_nodes_at_depth(0)
+
+        assert root_level.tolist() == [0]
+        assert next_level.shape[0] == 3
+        assert action_level.shape[0] == 2
+
+    def test_parent_links_round_trip(self, tree):
+        """Parent accessors return the linking action/belief indices.
+
+        Purpose: Validates parent-link accessors.
+
+        Given: A two-level tree
+        When: parent_actions and parent_beliefs are queried
+        Then: A successor belief's parent action's parent belief is the root
+
+        Test type: unit
+        """
+        _, beliefs = self._two_levels(tree)
+
+        parent_action = tree.parent_actions(_tensor([int(beliefs[0])]))
+        grandparent_belief = tree.parent_beliefs(parent_action)
+
+        assert int(grandparent_belief[0]) == tree.root_index
+
+    def test_action_children_csr_layout(self, tree):
+        """action_children returns children of each belief in CSR form.
+
+        Purpose: Validates CSR child grouping for beliefs.
+
+        Given: A root with two action children
+        When: action_children queries the root
+        Then: The offsets delimit exactly the two action nodes
+
+        Test type: unit
+        """
+        actions, _ = self._two_levels(tree)
+
+        flat, offsets = tree.action_children(_tensor([tree.root_index]))
+
+        assert offsets.tolist() == [0, 2]
+        assert sorted(flat.tolist()) == sorted(actions.tolist())
+
+    def test_belief_children_csr_layout(self, tree):
+        """belief_children returns successor beliefs of each action in CSR form.
+
+        Purpose: Validates CSR child grouping for actions.
+
+        Given: An action node with two successor beliefs
+        When: belief_children queries that action
+        Then: The offsets delimit exactly its two belief children
+
+        Test type: unit
+        """
+        actions, beliefs = self._two_levels(tree)
+
+        flat, offsets = tree.belief_children(_tensor([int(actions[0])]))
+
+        assert offsets.tolist() == [0, 2]
+        assert sorted(flat.tolist()) == sorted([int(beliefs[0]), int(beliefs[1])])
+
+    def test_reduce_belief_children_sums_per_parent(self, tree):
+        """reduce_belief_children reduces child values grouped by parent action.
+
+        Purpose: Validates the generic segmented reduction over children.
+
+        Given: Two successor beliefs under one action with values 2 and 3
+        When: reduce_belief_children sums them
+        Then: The parent action's entry equals 5 and unrelated actions are 0
+
+        Test type: unit
+        """
+        actions, beliefs = self._two_levels(tree)
+        parent_of_children = _tensor([int(actions[0]), int(actions[0])])
+        values = torch.tensor([2.0, 3.0], device=CPU)
+
+        reduced = tree.reduce_belief_children(parent_of_children, values, reduction="sum")
+
+        assert float(reduced[int(actions[0])]) == pytest.approx(5.0)
+        assert float(reduced[int(actions[1])]) == pytest.approx(0.0)
+        assert beliefs.shape[0] == 3
+
+
+class TestRegisteredFields:
+    """Registration, defaults, growth, reset, and access of extra fields."""
+
+    def test_register_and_write_belief_field(self, tree):
+        """A registered belief field initialises to its default and is writable.
+
+        Purpose: Validates field registration, defaults, and access.
+
+        Given: A belief field 'value' registered with default 0
+        When: The active view is read and then written
+        Then: The default is observed and the write persists
+
+        Test type: unit
+        """
+        tree.register_belief_field("value", default=0.0)
+
+        view = tree.belief_field("value")
+        assert view.tolist() == [0.0]
+        view[0] = 7.5
+        assert float(tree.belief_field("value")[0]) == pytest.approx(7.5)
+
+    def test_vector_valued_field_shape(self, tree):
+        """A field with a trailing shape allocates a per-node vector.
+
+        Purpose: Validates non-scalar registered fields.
+
+        Given: A belief field 'preferences' of shape (3,)
+        When: Its active view is inspected
+        Then: The view has one row of width 3
+
+        Test type: unit
+        """
+        tree.register_belief_field("preferences", shape=(3,), default=0.0)
+
+        view = tree.belief_field("preferences")
+
+        assert tuple(view.shape) == (1, 3)
+
+    def test_duplicate_field_name_raises(self, tree):
+        """Registering a duplicate or reserved field name raises.
+
+        Purpose: Validates field-name collision checks.
+
+        Given: A tree with 'value' already registered
+        When: 'value' is registered again and 'depth' (reserved) is registered
+        Then: Both raise ValueError
+
+        Test type: unit
+        """
+        tree.register_belief_field("value")
+
+        with pytest.raises(ValueError):
+            tree.register_belief_field("value")
+        with pytest.raises(ValueError):
+            tree.register_belief_field("depth")
+
+    def test_registered_field_grows_with_capacity(self):
+        """A registered field is preserved and extended across capacity growth.
+
+        Purpose: Validates that field tensors grow in lockstep with nodes.
+
+        Given: A tiny-capacity tree with a registered action field
+        When: Enough action nodes are inserted to force growth
+        Then: Every active node has the field default and no error occurs
+
+        Test type: unit
+        """
+        tree = VectorizedBeliefTree(device=CPU, action_capacity=2)
+        tree.register_action_field("q_value", default=0.0)
+
+        parents = _tensor([0, 0, 0, 0, 0])
+        actions = _tensor([0, 1, 2, 3, 4])
+        tree.get_or_create_actions(parents, actions)
+
+        assert tree.action_capacity >= 5
+        assert tree.action_field("q_value").tolist() == [0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+class TestCapacityAndReset:
+    """Geometric growth, clear, and statistic reset."""
+
+    def test_capacity_growth_preserves_nodes(self):
+        """Forcing multiple expansions preserves existing nodes.
+
+        Purpose: Validates geometric capacity growth correctness.
+
+        Given: A tree with belief and action capacity 1
+        When: Several actions and beliefs are inserted, forcing growth
+        Then: Counts are correct, capacities grew, and validate passes
+
+        Test type: unit
+        """
+        tree = VectorizedBeliefTree(device=CPU, belief_capacity=1, action_capacity=1)
+
+        actions, _ = tree.get_or_create_actions(_tensor([0, 0, 0]), _tensor([0, 1, 2]))
+        tree.get_or_create_beliefs(
+            _tensor([int(actions[0]), int(actions[1]), int(actions[2])]),
+            _tensor([1, 2, 3]),
+        )
+
+        assert tree.num_action_nodes == 3
+        assert tree.num_belief_nodes == 4
+        assert tree.action_capacity >= 3
+        assert tree.belief_capacity >= 4
+        tree.validate()
+
+    def test_clear_keeps_only_root(self, tree):
+        """clear removes all nodes except the root and keeps capacity.
+
+        Purpose: Validates the clear operation.
+
+        Given: A populated tree
+        When: clear is called
+        Then: Only the root remains and validate passes
+
+        Test type: unit
+        """
+        actions, _ = tree.get_or_create_actions(_tensor([0, 0]), _tensor([0, 1]))
+        tree.get_or_create_beliefs(_tensor([int(actions[0])]), _tensor([5]))
+
+        tree.clear()
+
+        assert tree.num_belief_nodes == 1
+        assert tree.num_action_nodes == 0
+        tree.validate()
+
+    def test_reset_statistics_preserves_topology(self, tree):
+        """reset_statistics zeroes stats but keeps nodes and links.
+
+        Purpose: Validates statistic reset without topology loss.
+
+        Given: A tree with accumulated visit counts and rewards
+        When: reset_statistics is called
+        Then: Stats are zero, node counts are unchanged, and validate passes
+
+        Test type: unit
+        """
+        actions, _ = tree.get_or_create_actions(_tensor([0, 0]), _tensor([0, 1]))
+        tree.update_action_statistics(actions, torch.tensor([1.0, 2.0], device=CPU))
+
+        tree.reset_statistics()
+
+        assert int(tree.action_visit_count[: tree.num_action_nodes].sum()) == 0
+        assert float(tree.action_reward_sum[: tree.num_action_nodes].sum()) == pytest.approx(0.0)
+        assert tree.num_action_nodes == 2
+        tree.validate()
+
+
+class TestSerialization:
+    """State-dict round trips and validation."""
+
+    def test_state_dict_round_trip_restores_tree(self, tree):
+        """A tree survives a state_dict / load_state_dict round trip.
+
+        Purpose: Validates serialization of topology, stats, and fields.
+
+        Given: A populated tree with a registered action field
+        When: Its state is saved and loaded into a new tree
+        Then: Counts, statistics, and field values match and validate passes
+
+        Test type: unit
+        """
+        tree.register_action_field("q_value", default=0.0)
+        actions, _ = tree.get_or_create_actions(_tensor([0, 0]), _tensor([0, 1]))
+        tree.update_action_statistics(actions, torch.tensor([1.0, 2.0], device=CPU))
+        tree.action_field("q_value")[0] = 9.0
+        state = tree.state_dict()
+
+        restored = VectorizedBeliefTree(device=CPU)
+        restored.load_state_dict(state)
+
+        assert restored.num_belief_nodes == tree.num_belief_nodes
+        assert restored.num_action_nodes == tree.num_action_nodes
+        assert float(restored.action_field("q_value")[0]) == pytest.approx(9.0)
+        assert restored.action_reward_sum[: restored.num_action_nodes].tolist() == [1.0, 2.0]
+        restored.validate()
+
+    def test_validate_detects_valid_tree(self, tree):
+        """validate passes on a well-formed multi-level tree.
+
+        Purpose: Validates the invariant checker on a correct tree.
+
+        Given: A two-level tree built through the public API
+        When: validate is called
+        Then: No assertion is raised
+
+        Test type: unit
+        """
+        actions, _ = tree.get_or_create_actions(_tensor([0, 0]), _tensor([0, 1]))
+        tree.get_or_create_beliefs(_tensor([int(actions[0])]), _tensor([5]))
+
+        tree.validate()
+
+
+class TestInvalidInputs:
+    """Input validation for device, dtype, and shape."""
+
+    def test_non_integer_keys_rejected(self, tree):
+        """Float action keys are rejected.
+
+        Purpose: Validates integer-dtype enforcement on keys.
+
+        Given: A float action-key tensor
+        When: get_or_create_actions is called
+        Then: A TypeError is raised
+
+        Test type: unit
+        """
+        with pytest.raises(TypeError):
+            tree.get_or_create_actions(_tensor([0]), torch.tensor([1.0], device=CPU))
+
+    def test_mismatched_batch_sizes_rejected(self, tree):
+        """Parent and key tensors of different lengths are rejected.
+
+        Purpose: Validates batch-size matching.
+
+        Given: A parent batch of length 2 and a key batch of length 1
+        When: get_or_create_actions is called
+        Then: A ValueError is raised
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError):
+            tree.get_or_create_actions(_tensor([0, 0]), _tensor([1]))
+
+    def test_wrong_dimensionality_rejected(self, tree):
+        """A 2-D index tensor is rejected.
+
+        Purpose: Validates the one-dimensional input requirement.
+
+        Given: A 2-D parent tensor
+        When: get_or_create_actions is called
+        Then: A ValueError is raised
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError):
+            tree.get_or_create_actions(_tensor([[0]]), _tensor([[1]]))
+
+    def test_wrong_device_rejected(self, tree):
+        """A CUDA tensor is rejected by a CPU tree.
+
+        Purpose: Validates device consistency without silent movement.
+
+        Given: A CPU tree and a CUDA parent tensor
+        When: get_or_create_actions is called
+        Then: A ValueError is raised
+
+        Test type: unit
+        """
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        with pytest.raises(ValueError):
+            tree.get_or_create_actions(
+                torch.tensor([0], device="cuda"), torch.tensor([1], device="cuda")
+            )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestCuda:
+    """The tree operates end-to-end on CUDA."""
+
+    def test_build_and_validate_on_cuda(self):
+        """A tree builds, accumulates stats, and validates on CUDA.
+
+        Purpose: Validates that all persistent tensors stay on the CUDA device.
+
+        Given: A tree constructed on cuda
+        When: Actions and beliefs are inserted and statistics accumulated
+        Then: All columns are on cuda and validate passes
+
+        Test type: integration
+        """
+        device = torch.device("cuda")
+        tree = VectorizedBeliefTree(device=device)
+        actions, _ = tree.get_or_create_actions(
+            torch.tensor([0, 0, 0], device=device), torch.tensor([0, 1, 1], device=device)
+        )
+        tree.update_action_statistics(actions, torch.tensor([1.0, 2.0, 3.0], device=device))
+        tree.get_or_create_beliefs(actions, torch.tensor([4, 5, 5], device=device))
+
+        assert tree.action_reward_sum.device.type == "cuda"
+        assert int(tree.action_visit_count[int(actions[1])]) == 2
+        tree.validate()
+
+    def test_move_between_devices(self):
+        """to() moves every built-in and registered tensor.
+
+        Purpose: Validates device movement of a populated tree.
+
+        Given: A populated CPU tree with a registered field
+        When: to('cuda') then to('cpu') is called
+        Then: Columns and fields end on CPU and validate passes
+
+        Test type: integration
+        """
+        tree = VectorizedBeliefTree(device=CPU)
+        tree.register_action_field("q_value", default=0.0)
+        tree.get_or_create_actions(_tensor([0, 0]), _tensor([0, 1]))
+
+        tree.to(torch.device("cuda")).to(CPU)
+
+        assert tree.action_parent_belief.device.type == "cpu"
+        assert tree.action_field("q_value").device.type == "cpu"
+        tree.validate()

--- a/POMDPPlanners/tests/test_core/test_vectorized_belief_tree/test_vectorized_belief_tree_lookup.py
+++ b/POMDPPlanners/tests/test_core/test_vectorized_belief_tree/test_vectorized_belief_tree_lookup.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the pure vectorized lookup and grouping helpers.
+
+These cover the batched primitives underpinning the belief tree —
+composite-pair matching, pair deduplication, CSR child grouping, boolean
+scatter-OR, and segmented reductions — in isolation from the tree class.
+"""
+
+import torch
+
+from POMDPPlanners.core.tree.vectorized_belief_tree.vectorized_belief_tree_lookup import (
+    csr_children,
+    match_pairs,
+    scatter_or,
+    segment_reduce,
+    unique_pairs,
+)
+
+
+def test_match_pairs_finds_existing_and_marks_missing():
+    """Composite-pair matching returns existing indices and -1 for misses.
+
+    Purpose: Validates that match_pairs resolves query pairs against existing
+        pairs while preserving batch order.
+
+    Given: Two existing (first, second) pairs and a query batch mixing a hit,
+        a miss, and a repeated hit
+    When: match_pairs is called
+    Then: Matching queries return the existing index and misses return -1, in
+        input order
+
+    Test type: unit
+    """
+    existing_first = torch.tensor([0, 3])
+    existing_second = torch.tensor([2, 1])
+    query_first = torch.tensor([0, 5, 3, 0])
+    query_second = torch.tensor([2, 9, 1, 2])
+
+    matched = match_pairs(existing_first, existing_second, query_first, query_second)
+
+    assert matched.tolist() == [0, -1, 1, 0]
+
+
+def test_match_pairs_with_no_existing_returns_all_missing():
+    """match_pairs against an empty existing set returns all -1.
+
+    Purpose: Validates the empty-tree lookup path.
+
+    Given: No existing pairs and a non-empty query batch
+    When: match_pairs is called
+    Then: Every query resolves to -1
+
+    Test type: unit
+    """
+    empty = torch.empty(0, dtype=torch.int64)
+    query_first = torch.tensor([1, 2])
+    query_second = torch.tensor([3, 4])
+
+    matched = match_pairs(empty, empty.clone(), query_first, query_second)
+
+    assert matched.tolist() == [-1, -1]
+
+
+def test_unique_pairs_collapses_duplicates_with_inverse():
+    """unique_pairs deduplicates and returns a reconstructing inverse.
+
+    Purpose: Validates deduplication of a pair batch and the inverse mapping.
+
+    Given: A batch of pairs with two identical entries
+    When: unique_pairs is called
+    Then: Distinct pairs appear once and the inverse reproduces the input
+
+    Test type: unit
+    """
+    first = torch.tensor([0, 0, 1, 0])
+    second = torch.tensor([2, 2, 5, 9])
+
+    unique_first, unique_second, inverse = unique_pairs(first, second)
+
+    reconstructed_first = unique_first[inverse]
+    reconstructed_second = unique_second[inverse]
+    assert unique_first.shape[0] == 3
+    assert reconstructed_first.tolist() == first.tolist()
+    assert reconstructed_second.tolist() == second.tolist()
+
+
+def test_csr_children_groups_by_parent():
+    """csr_children returns a CSR grouping of nodes by parent.
+
+    Purpose: Validates segmented child grouping with offsets.
+
+    Given: A parent column assigning four nodes to parents 0, 1, 0, 2
+    When: csr_children queries parents [0, 1, 2, 3]
+    Then: Offsets delimit each parent's children and an absent parent is empty
+
+    Test type: unit
+    """
+    parent_column = torch.tensor([0, 1, 0, 2])
+    query_parents = torch.tensor([0, 1, 2, 3])
+
+    flat, offsets = csr_children(parent_column, query_parents)
+
+    children_of_zero = sorted(flat[offsets[0] : offsets[1]].tolist())
+    children_of_three = flat[offsets[3] : offsets[4]].tolist()
+    assert children_of_zero == [0, 2]
+    assert flat[offsets[1] : offsets[2]].tolist() == [1]
+    assert children_of_three == []
+
+
+def test_scatter_or_reduces_booleans_by_index():
+    """scatter_or ORs boolean values into their target positions.
+
+    Purpose: Validates duplicate-safe boolean scatter used for terminal flags.
+
+    Given: Values routed to indices where one target sees both True and False
+    When: scatter_or reduces them into a size-4 tensor
+    Then: A target is True iff any routed value is True; others are False
+
+    Test type: unit
+    """
+    indices = torch.tensor([0, 0, 2])
+    values = torch.tensor([False, True, False])
+
+    result = scatter_or(indices, values, size=4)
+
+    assert result.tolist() == [True, False, False, False]
+
+
+def test_segment_reduce_supports_sum_mean_max_min():
+    """segment_reduce computes each supported reduction with empty defaults.
+
+    Purpose: Validates the generic segmented reduction helper.
+
+    Given: Values grouped into segments with one empty segment
+    When: segment_reduce is applied with each supported reduction
+    Then: Non-empty segments reduce correctly and empty segments are 0
+
+    Test type: unit
+    """
+    segment_ids = torch.tensor([0, 0, 2])
+    values = torch.tensor([1.0, 3.0, 5.0])
+
+    total = segment_reduce(segment_ids, values, 4, "sum")
+    mean = segment_reduce(segment_ids, values, 4, "mean")
+    maximum = segment_reduce(segment_ids, values, 4, "max")
+    minimum = segment_reduce(segment_ids, values, 4, "min")
+
+    assert total.tolist() == [4.0, 0.0, 5.0, 0.0]
+    assert mean.tolist() == [2.0, 0.0, 5.0, 0.0]
+    assert maximum.tolist() == [3.0, 0.0, 5.0, 0.0]
+    assert minimum.tolist() == [1.0, 0.0, 5.0, 0.0]
+
+
+def test_segment_reduce_rejects_unknown_reduction():
+    """segment_reduce raises on an unsupported reduction name.
+
+    Purpose: Validates input validation of the reduction argument.
+
+    Given: A valid segment/value batch
+    When: segment_reduce is called with an unknown reduction name
+    Then: A ValueError is raised
+
+    Test type: unit
+    """
+    segment_ids = torch.tensor([0, 1])
+    values = torch.tensor([1.0, 2.0])
+
+    try:
+        segment_reduce(segment_ids, values, 2, "median")
+        raised = False
+    except ValueError:
+        raised = True
+
+    assert raised


### PR DESCRIPTION
## Summary

Adds a struct-of-arrays (vectorized) belief tree for POMDP planning under `POMDPPlanners/core/tree/vectorized_belief_tree/`:

- `vectorized_belief_tree.py` — the tree itself (SoA layout, growth, (de)serialization, invariant validation)
- `vectorized_belief_tree_fields.py` — field registry / `FieldSpec` backing arrays
- `vectorized_belief_store.py` — belief column store
- `vectorized_belief_tree_lookup.py` — lookup helper
- Full unit tests under `POMDPPlanners/tests/test_core/test_vectorized_belief_tree/`

The package is self-contained — it only imports within its own subpackage (plus `torch`/`numpy`), so it adds no coupling to the rest of the tree.

## Checks

- `pyright POMDPPlanners/` (torch installed) — **0 errors, 0 warnings**
- `pylint` on source + tests — **10.00/10**
- `pytest` — **40 passed**

> Note: the local pre-commit/pre-push **pyright** hook runs in an isolated env without `torch`, which degrades `torch.Tensor` to `Unknown` and spuriously flags two `isinstance(x, Tensor)` narrowings in the (de)serialization helpers. CI runs pyright inside the Docker image with torch installed (`.github/workflows/tests.yml`), where these files are clean.