### PR TITLE
feat(vectorized): VOPP planner and vectorized generative models

### DIFF
--- a/POMDPPlanners/core/environment/vectorized_generative_model.py
+++ b/POMDPPlanners/core/environment/vectorized_generative_model.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: MIT
+
+"""Protocol for a fully vectorized POMDP generative model ``G(S, A)``.
+
+A :class:`VectorizedGenerativeModel` is the batched, on-device counterpart of
+the scalar generative interface on
+:class:`~POMDPPlanners.core.environment.environment.Environment`. It is the
+external model a GPU-vectorized planner such as VOPP drives during its
+forward search: given a tensor of states and a tensor of per-row actions it
+produces tensors of next states, observations, and rewards in a single
+vectorized call, with no Python per-row loop and no host/device sync.
+
+This protocol is deliberately narrow and *opt-in*. The base ``Environment``
+ABC is untouched: an environment need not provide a vectorized model, and
+every existing (scalar / small-batch) planner keeps working unchanged. Only
+the handful of environments a vectorized planner is actually run on implement
+this protocol, in a small module beside the environment. The environment
+remains the single source of truth for configuration (spaces, reward
+semantics, terminal rules); only the tight numeric kernels are re-expressed in
+torch, and a parity test pins the two together.
+
+Conventions
+-----------
+* Every argument and return value is a :class:`torch.Tensor` on
+  :attr:`~VectorizedGenerativeModel.device`.
+* ``N`` is the batch (number of parallel particles / episodes); ``ds`` and
+  ``do`` are the state and observation dimensions.
+* Actions are integer indices into a fixed, finite action set (the VOPP
+  representative-action assumption), so an actions tensor has shape ``[N]``
+  and integer dtype.
+* Observation and action *keys* are the integer tree keys consumed by
+  :class:`~POMDPPlanners.core.tree.vectorized_belief_tree.vectorized_belief_tree.VectorizedBeliefTree`;
+  turning continuous observations into integer keys (binning / hashing) is the
+  model's responsibility.
+"""
+
+from typing import Protocol, runtime_checkable
+
+import torch
+from torch import Tensor
+
+
+@runtime_checkable
+class VectorizedGenerativeModel(Protocol):
+    """Batched generative model consumed by a vectorized online POMDP planner.
+
+    Implementations expose the transition, observation, reward, terminal, and
+    observation-likelihood kernels a planner needs, all as vectorized torch
+    operations over a batch dimension. See the module docstring for the shape
+    and dtype conventions shared by every method.
+    """
+
+    @property
+    def device(self) -> torch.device:
+        """Device every tensor argument and return value must live on."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        """Sample one next state per row under the transition model.
+
+        Args:
+            states: ``[N, ds]`` current states.
+            actions: ``[N]`` integer action indices.
+
+        Returns:
+            ``[N, ds]`` sampled next states.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        """Sample one observation per row under the observation model.
+
+        Args:
+            next_states: ``[N, ds]`` post-transition states.
+            actions: ``[N]`` integer action indices.
+
+        Returns:
+            ``[N, do]`` sampled observations.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        """Return one immediate reward per row.
+
+        Args:
+            states: ``[N, ds]`` current states.
+            actions: ``[N]`` integer action indices.
+            next_states: ``[N, ds]`` realised next states from
+                :meth:`sample_next_states`.
+
+        Returns:
+            ``[N]`` immediate rewards.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        """Return a boolean terminal flag per row.
+
+        Args:
+            states: ``[N, ds]`` states to test.
+
+        Returns:
+            ``[N]`` boolean tensor, ``True`` where the state is terminal.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        """Return the observation log-likelihood per row (for belief updates).
+
+        Args:
+            next_states: ``[N, ds]`` post-transition states.
+            actions: ``[N]`` integer action indices.
+            observations: ``[N, do]`` observations to score.
+
+        Returns:
+            ``[N]`` log-likelihoods ``log Z(o | s', a)``.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        """Map action indices to the integer keys used by the belief tree.
+
+        Args:
+            actions: ``[N]`` integer action indices.
+
+        Returns:
+            ``[N]`` integer action keys.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        """Map observations to the integer keys used by the belief tree.
+
+        Args:
+            observations: ``[N, do]`` observations.
+
+        Returns:
+            ``[N]`` integer observation keys.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis

--- a/POMDPPlanners/environments/carla_pomdp/carla_generative_models/carla_kinematic_vectorized_model.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_generative_models/carla_kinematic_vectorized_model.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for the kinematic CARLA model.
+
+This module provides :class:`CarlaKinematicVectorizedModel`, a fully batched,
+GPU-friendly implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+for :class:`~POMDPPlanners.environments.carla_pomdp.carla_generative_models.carla_kinematic_model_pomdp.KinematicCarlaModelPOMDP`.
+
+It re-expresses the scalar model's kinematic-bicycle transition, obstacle-aware
+driving-quality reward, predicted-collision terminal check, and factored
+perception (GNSS Gaussian noise plus per-slot agent detection with range and
+occlusion gating and additive pose noise) as torch tensor kernels, so a
+vectorized planner (VOPP) can run tens of thousands of parallel simulations on
+the GPU without a host/device sync. Every constant (control presets, kinematic
+coefficients, reward weights, perception parameters) is read from a live
+:class:`KinematicCarlaModelPOMDP` instance, so the environment stays the single
+source of truth for configuration; only the numeric kernels are duplicated in
+torch. The accompanying parity test pins these kernels to the scalar model.
+
+State layout is ``[ego(7)] + K*[present, rel_x, rel_y, rel_yaw, rel_speed]`` with
+``K = max_tracked_agents`` (default ``ds = 7 + 5*5 = 32``); the observation drops
+the ego block down to the GNSS position and keeps the agent slots
+(``do = 2 + K*5 = 27``). Actions are integer indices into the discrete
+``(throttle, steer, brake)`` control presets.
+"""
+
+import math
+from typing import Optional
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.carla_pomdp.carla_generative_models.carla_kinematic_model_pomdp import (
+    KinematicCarlaModelPOMDP,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.agent_models import (
+    FactoredAgentObservationModel,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.gnss_models import (
+    GnssObservationModel,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_pomdp import (
+    AGENT_SLOT_WIDTH,
+    EGO_STATE_WIDTH,
+    REWARD_FAST_PENALTY,
+    REWARD_LAT_WEIGHT,
+    REWARD_OUT_PENALTY,
+    REWARD_SPEED_WEIGHT,
+    REWARD_STEER_WEIGHT,
+    REWARD_STEP_COST,
+)
+
+# Log-prob floor for impossible / near-zero events, mirroring ``_LOG_EPS`` in
+# ``carla_perception.observation_models.agent_models``.
+_LOG_EPS = -50.0
+
+
+def _first_n_primes(count: int) -> np.ndarray:
+    """Return the first ``count`` primes as an int64 array (spatial-hash weights)."""
+    primes = []
+    candidate = 2
+    while len(primes) < count:
+        if all(candidate % p for p in primes):
+            primes.append(candidate)
+        candidate += 1
+    return np.array(primes, dtype=np.int64)
+
+
+class CarlaKinematicVectorizedModel:
+    """Fully vectorized torch generative model for the kinematic CARLA model.
+
+    The model batches the transition, observation, reward, terminal, and
+    observation-likelihood kernels over a leading particle dimension and keeps
+    every tensor on a single device. Actions are integer indices into the fixed
+    ``(throttle, steer, brake)`` control-preset table read from the scalar model.
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for state / observation / reward tensors.
+        num_actions: Number of discrete control presets.
+        state_dim: Width of the state vectors (``7 + K*5``).
+        observation_dim: Width of the observation vectors (``2 + K*5``).
+
+    Example:
+        >>> import torch
+        >>> from POMDPPlanners.environments.carla_pomdp.carla_generative_models.carla_kinematic_model_pomdp import (
+        ...     KinematicCarlaModelPOMDP,
+        ... )
+        >>> from POMDPPlanners.environments.carla_pomdp.carla_generative_models.carla_kinematic_vectorized_model import (
+        ...     CarlaKinematicVectorizedModel,
+        ... )
+        >>> torch.manual_seed(0)  # doctest: +ELLIPSIS
+        <torch._C.Generator object at ...>
+        >>> env = KinematicCarlaModelPOMDP(discount_factor=0.95, dt=0.05)
+        >>> model = CarlaKinematicVectorizedModel(env, device=torch.device("cpu"))
+        >>> states = torch.zeros(3, model.state_dim)
+        >>> actions = torch.zeros(3, dtype=torch.int64)  # cruise straight
+        >>> next_states = model.sample_next_states(states, actions)
+        >>> rewards = model.rewards(states, actions, next_states)
+        >>> tuple(next_states.shape), tuple(rewards.shape)
+        ((3, 32), (3,))
+    """
+
+    def __init__(
+        self,
+        env: KinematicCarlaModelPOMDP,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+        observation_resolution: float = 0.5,
+    ) -> None:
+        """Build the model from a live kinematic CARLA model instance.
+
+        Args:
+            env: The scalar model whose parameters and presets are mirrored.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for real-valued tensors.
+            observation_resolution: Grid spacing used to quantize continuous
+                observations into integer tree keys.
+
+        Raises:
+            ValueError: If ``observation_resolution`` is not positive.
+            NotImplementedError: If ``env`` does not use the factored agent and
+                gaussian GNSS observation models.
+        """
+        if observation_resolution <= 0.0:
+            raise ValueError("observation_resolution must be positive")
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self._obs_resolution = float(observation_resolution)
+        self._num_agents = int(env.max_tracked_agents)
+        self.state_dim = EGO_STATE_WIDTH + self._num_agents * AGENT_SLOT_WIDTH
+        self.observation_dim = 2 + self._num_agents * AGENT_SLOT_WIDTH
+        self._action_table = self._to_tensor(np.asarray(env.action_presets, dtype=np.float64))
+        self.num_actions = int(self._action_table.shape[0])
+        self._read_dynamics_params(env)
+        self._read_perception_params(env)
+        self._obs_hash = torch.as_tensor(
+            _first_n_primes(self.observation_dim), dtype=torch.int64, device=self.device
+        )
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    def _read_dynamics_params(self, env: KinematicCarlaModelPOMDP) -> None:
+        self._dt = float(env.dt)
+        self._wheelbase = float(env.wheelbase)
+        self._max_steer_angle = float(env.max_steer_angle)
+        self._accel = float(env.accel)
+        self._brake_decel = float(env.brake_decel)
+        self._drag = float(env.drag)
+        self._collision_gap = float(env.collision_gap)
+        self._collision_halfwidth = float(env.collision_halfwidth)
+        self._safe_distance = float(env.safe_distance)
+        self._stop_gap = float(env.stop_gap)
+        self._desired_speed = float(env.desired_speed)
+        self._out_lane_thresh = float(env.out_lane_thresh)
+        self._collision_penalty = float(env.collision_penalty)
+
+    def _read_perception_params(self, env: KinematicCarlaModelPOMDP) -> None:
+        models = env.observation_models or {}
+        agents = models.get("agents")
+        gnss = models.get("gnss")
+        if not isinstance(agents, FactoredAgentObservationModel):
+            raise NotImplementedError(
+                "vectorized model requires the factored agent observation model"
+            )
+        if not isinstance(gnss, GnssObservationModel):
+            raise NotImplementedError(
+                "vectorized model requires the gaussian gnss observation model"
+            )
+        perception_range = agents.perception_range
+        self._perception_range = math.inf if perception_range is None else float(perception_range)
+        self._occlusion_radius = float(agents.occlusion_radius)
+        self._pose_std = float(agents.pose_std)
+        self._detect_prob = float(agents.detect_prob)
+        self._gnss_std = float(gnss.gnss_std)
+
+    def _to_tensor(self, array: np.ndarray) -> Tensor:
+        return torch.as_tensor(np.asarray(array), dtype=self.dtype, device=self.device)
+
+    def _agent_rows(self, states: Tensor) -> Tensor:
+        return states[:, EGO_STATE_WIDTH:].reshape(
+            states.shape[0], self._num_agents, AGENT_SLOT_WIDTH
+        )
+
+    # ------------------------------------------------------------------ #
+    # Transition
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        control = self._action_table[actions]
+        ego_next = self._propagate_ego(states[:, :EGO_STATE_WIDTH], control)
+        agents_next = self._advance_agents(self._agent_rows(states), ego_next[:, 3], ego_next[:, 4])
+        return torch.cat([ego_next, agents_next.reshape(states.shape[0], -1)], dim=1)
+
+    def _propagate_ego(self, ego: Tensor, control: Tensor) -> Tensor:
+        throttle, steer, brake = control[:, 0], control[:, 1], control[:, 2]
+        yaw = torch.deg2rad(ego[:, 2])
+        speed = torch.hypot(ego[:, 3], ego[:, 4])
+        accel = throttle * self._accel - brake * self._brake_decel - self._drag * speed
+        speed_next = torch.clamp_min(speed + accel * self._dt, 0.0)
+        yaw_rate = (speed_next / self._wheelbase) * torch.tan(steer * self._max_steer_angle)
+        yaw_next = yaw + yaw_rate * self._dt
+        vx_next = speed_next * torch.cos(yaw_next)
+        vy_next = speed_next * torch.sin(yaw_next)
+        heading_err_next = ego[:, 6] + yaw_rate * self._dt
+        lateral_next = ego[:, 5] + speed_next * torch.sin(heading_err_next) * self._dt
+        return torch.stack(
+            [
+                ego[:, 0] + vx_next * self._dt,
+                ego[:, 1] + vy_next * self._dt,
+                torch.rad2deg(yaw_next),
+                vx_next,
+                vy_next,
+                lateral_next,
+                heading_err_next,
+            ],
+            dim=1,
+        )
+
+    def _advance_agents(self, rows: Tensor, vx_next: Tensor, vy_next: Tensor) -> Tensor:
+        ego_speed = torch.hypot(vx_next, vy_next)
+        present = rows[..., 0] == 1.0
+        closing = (rows[..., 4] - ego_speed[:, None]) * self._dt
+        rel_x_next = rows[..., 1] + torch.where(present, closing, torch.zeros_like(closing))
+        agents = rows.clone()
+        agents[..., 1] = rel_x_next
+        return agents
+
+    # ------------------------------------------------------------------ #
+    # Terminal / reward
+    # ------------------------------------------------------------------ #
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        rows = self._agent_rows(states)
+        present = rows[..., 0] == 1.0
+        rel_x, rel_y = rows[..., 1], rows[..., 2]
+        hit = present & (rel_x >= 0.0) & (rel_x < self._collision_gap)
+        hit = hit & (rel_y.abs() < self._collision_halfwidth)
+        return hit.any(dim=1)
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        del states  # Reward scores the realised next state only.
+        steer = self._action_table[actions, 1]
+        ego_yaw = torch.deg2rad(next_states[:, 2])
+        lane_yaw = ego_yaw - next_states[:, 6]
+        lspeed = next_states[:, 3] * torch.cos(lane_yaw) + next_states[:, 4] * torch.sin(lane_yaw)
+        desired = self._obstacle_aware_desired_speed(next_states)
+        r_fast = torch.where(lspeed > desired, -1.0, 0.0)
+        r_out = torch.where(next_states[:, 5].abs() > self._out_lane_thresh, -1.0, 0.0)
+        r_coll = torch.where(self.terminal_mask(next_states), -1.0, 0.0)
+        return (
+            self._collision_penalty * r_coll
+            + REWARD_SPEED_WEIGHT * lspeed
+            + REWARD_FAST_PENALTY * r_fast
+            + REWARD_OUT_PENALTY * r_out
+            - REWARD_STEER_WEIGHT * steer**2
+            - REWARD_LAT_WEIGHT * steer.abs() * lspeed**2
+            - REWARD_STEP_COST
+        )
+
+    def _obstacle_aware_desired_speed(self, next_states: Tensor) -> Tensor:
+        full = torch.full(
+            (next_states.shape[0],), self._desired_speed, dtype=self.dtype, device=self.device
+        )
+        if self._stop_gap == 0.0:
+            return full
+        rows = self._agent_rows(next_states)
+        rel_x, rel_y = rows[..., 1], rows[..., 2]
+        lead = (rows[..., 0] == 1.0) & (rel_x > 0.0) & (rel_y.abs() < self._collision_halfwidth)
+        gaps = torch.where(lead, rel_x, torch.full_like(rel_x, math.inf))
+        gap = gaps.min(dim=1).values
+        ramp = self._desired_speed * (gap - self._stop_gap) / (self._safe_distance - self._stop_gap)
+        ramped = torch.where(gap <= self._stop_gap, torch.zeros_like(gap), ramp)
+        return torch.where(gap >= self._safe_distance, full, ramped)
+
+    # ------------------------------------------------------------------ #
+    # Observation
+    # ------------------------------------------------------------------ #
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions  # Perception does not depend on the action.
+        gnss = (
+            next_states[:, :2]
+            + torch.randn(next_states.shape[0], 2, dtype=self.dtype, device=self.device)
+            * self._gnss_std
+        )
+        rows = self._agent_rows(next_states)
+        visible = self._visible_mask(rows)
+        noise = (
+            torch.randn(
+                rows.shape[0],
+                self._num_agents,
+                AGENT_SLOT_WIDTH - 1,
+                dtype=self.dtype,
+                device=self.device,
+            )
+            * self._pose_std
+        )
+        perceived = torch.zeros_like(rows)
+        perceived[..., 0] = visible.to(self.dtype)
+        perceived[..., 1:] = torch.where(
+            visible[..., None], rows[..., 1:] + noise, torch.zeros_like(noise)
+        )
+        return torch.cat([gnss, perceived.reshape(rows.shape[0], -1)], dim=1)
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions  # Perception does not depend on the action.
+        gnss_diff = observations[:, :2] - next_states[:, :2]
+        gnss_lp = -0.5 * (gnss_diff / self._gnss_std).pow(2).sum(dim=1) - 2.0 * math.log(
+            self._gnss_std
+        )
+        return gnss_lp + self._agent_log_probs(next_states, observations)
+
+    def _agent_log_probs(self, next_states: Tensor, observations: Tensor) -> Tensor:
+        rows = self._agent_rows(next_states)
+        obs_rows = observations[:, 2:].reshape(rows.shape[0], self._num_agents, AGENT_SLOT_WIDTH)
+        vis_present = (rows[..., 0] == 1.0) & self._visible_mask(rows)
+        obs_present = obs_rows[..., 0] == 1.0
+        pose_diff = obs_rows[..., 1:] - rows[..., 1:]
+        gauss = (
+            math.log(self._detect_prob)
+            - 0.5 * (pose_diff / self._pose_std).pow(2).sum(dim=-1)
+            - (AGENT_SLOT_WIDTH - 1) * math.log(self._pose_std)
+        )
+        miss = math.log(max(1.0 - self._detect_prob, math.exp(_LOG_EPS)))
+        detected = torch.where(obs_present, gauss, torch.full_like(gauss, miss))
+        gated = torch.where(obs_present, torch.full_like(gauss, _LOG_EPS), torch.zeros_like(gauss))
+        slot_lp = torch.where(vis_present, detected, gated)
+        return slot_lp.sum(dim=1)
+
+    def _visible_mask(self, rows: Tensor) -> Tensor:
+        present = rows[..., 0] == 1.0
+        distance = torch.hypot(rows[..., 1], rows[..., 2])
+        in_range = distance <= self._perception_range
+        return present & in_range & ~self._occluded_mask(rows, present)
+
+    def _occluded_mask(self, rows: Tensor, present: Tensor) -> Tensor:
+        target_x, target_y = rows[..., 1:2], rows[..., 2:3]  # [N, K, 1]
+        blocker_x, blocker_y = rows[..., 1].unsqueeze(1), rows[..., 2].unsqueeze(1)  # [N, 1, K]
+        seg_len_sq = target_x * target_x + target_y * target_y  # [N, K, 1]
+        dot = blocker_x * target_x + blocker_y * target_y  # [N, K, K]
+        param = dot / torch.where(seg_len_sq > 0.0, seg_len_sq, torch.ones_like(seg_len_sq))
+        perp_x = param * target_x - blocker_x
+        perp_y = param * target_y - blocker_y
+        perp = torch.hypot(perp_x, perp_y)
+        not_self = ~torch.eye(self._num_agents, dtype=torch.bool, device=self.device)
+        occ = (
+            present.unsqueeze(1)
+            & not_self.unsqueeze(0)
+            & (seg_len_sq > 0.0)
+            & (param > 0.0)
+            & (param < 1.0)
+            & (perp < self._occlusion_radius)
+        )
+        return occ.any(dim=2)
+
+    # ------------------------------------------------------------------ #
+    # Tree keys
+    # ------------------------------------------------------------------ #
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        quantized = torch.floor(observations / self._obs_resolution).to(torch.int64)
+        return (quantized * self._obs_hash).sum(dim=1)

--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_vectorized_model.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_vectorized_model.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for CartPole POMDP.
+
+This module provides :class:`CartPoleVectorizedModel`, a fully batched,
+GPU-friendly implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+for :class:`~POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp.CartPolePOMDP`.
+
+It re-expresses the environment's classical cart-pole physics (the same
+``temp`` / ``thetaacc`` / ``xacc`` update the native C++ kernel integrates),
+its zero-mean Gaussian transition and observation noise, its per-step
+"+1 while alive" reward, and its out-of-bounds terminal rule as torch tensor
+kernels so a vectorized planner (VOPP) can run tens of thousands of parallel
+simulations on the GPU without a host/device sync. Every constant (masses,
+lengths, force magnitude, integration step, thresholds, covariances) is read
+from a live environment instance, so the environment stays the single source
+of truth for configuration; only the numeric kernels are duplicated in torch.
+The accompanying parity test pins these kernels to the environment's native
+(C++) implementations.
+
+Only the default ``"euler"`` kinematics integrator is supported. The
+semi-implicit Euler variant is a different (velocity-first) update and is
+checked at construction; any mismatch raises :class:`NotImplementedError`.
+"""
+
+import math
+from typing import Tuple
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp import CartPolePOMDP
+
+# Spatial-hash primes for turning a quantized 4-D observation into an int key.
+_HASH_PRIMES = (73856093, 19349663, 83492791, 50331653)
+
+
+class CartPoleVectorizedModel:
+    """Fully vectorized torch generative model for the CartPole POMDP.
+
+    The model batches the transition, observation, reward, terminal, and
+    observation-likelihood kernels over a leading particle dimension and keeps
+    every tensor on a single device. The 4-D state is
+    ``[x, x_dot, theta, theta_dot]``; actions are the two discrete pushes
+    (``0`` = push left, ``1`` = push right) used directly as their own tree
+    keys; observations are the noisy 4-D state measurements of the environment.
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for state / observation / reward tensors.
+        num_actions: Number of discrete actions (always two for CartPole).
+
+    Example:
+        >>> import numpy as np
+        >>> import torch
+        >>> from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp import (
+        ...     CartPolePOMDP,
+        ... )
+        >>> from POMDPPlanners.environments.cartpole_pomdp.cartpole_vectorized_model import (
+        ...     CartPoleVectorizedModel,
+        ... )
+        >>> torch.manual_seed(0)  # doctest: +ELLIPSIS
+        <torch._C.Generator object at ...>
+        >>> env = CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+        >>> model = CartPoleVectorizedModel(env, device=torch.device("cpu"))
+        >>> states = torch.zeros(3, 4)
+        >>> actions = torch.tensor([1, 0, 1])  # push right, left, right
+        >>> next_states = model.sample_next_states(states, actions)
+        >>> observations = model.sample_observations(next_states, actions)
+        >>> rewards = model.rewards(states, actions, next_states)
+        >>> tuple(next_states.shape), tuple(observations.shape), tuple(rewards.shape)
+        ((3, 4), (3, 4), (3,))
+    """
+
+    def __init__(
+        self,
+        env: CartPolePOMDP,
+        *,
+        device: torch.device | None = None,
+        dtype: torch.dtype = torch.float32,
+        observation_resolution: float = 0.05,
+    ) -> None:
+        """Build the model from a live environment instance.
+
+        Args:
+            env: The environment whose physics, covariances, and thresholds are
+                mirrored.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for real-valued tensors.
+            observation_resolution: Grid spacing used to quantize continuous
+                observations into integer tree keys.
+
+        Raises:
+            NotImplementedError: If ``env`` uses a kinematics integrator other
+                than the supported plain ``"euler"`` update.
+            ValueError: If ``observation_resolution`` is not positive.
+        """
+        self._require_supported_config(env)
+        if observation_resolution <= 0.0:
+            raise ValueError("observation_resolution must be positive")
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self._obs_resolution = float(observation_resolution)
+        self.num_actions = 2
+        self._build_physics(env)
+        self._build_noise_kernels(env)
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _require_supported_config(env: CartPolePOMDP) -> None:
+        if env.kinematics_integrator != "euler":
+            raise NotImplementedError(
+                "vectorized model supports only the 'euler' kinematics integrator, "
+                f"got {env.kinematics_integrator!r}"
+            )
+
+    def _build_physics(self, env: CartPolePOMDP) -> None:
+        self._force_mag = float(env.force_mag)
+        self._total_mass = float(env.total_mass)
+        self._polemass_length = float(env.polemass_length)
+        self._gravity = float(env.gravity)
+        self._length = float(env.length)
+        self._masspole = float(env.masspole)
+        self._tau = float(env.tau)
+        self._x_threshold = float(env.x_threshold)
+        self._theta_threshold = float(env.theta_threshold_radians)
+
+    def _build_noise_kernels(self, env: CartPolePOMDP) -> None:
+        trans_cov = self._to_tensor(np.asarray(env.state_transition_cov, dtype=np.float64))
+        obs_cov = self._to_tensor(np.asarray(env.noise_cov, dtype=np.float64))
+        self._trans_chol_t = torch.linalg.cholesky(trans_cov).mT.contiguous()
+        self._obs_chol_t = torch.linalg.cholesky(obs_cov).mT.contiguous()
+        self._obs_inv, self._obs_lognorm = self._inverse_and_lognorm(obs_cov)
+
+    def _to_tensor(self, array: np.ndarray) -> Tensor:
+        return torch.as_tensor(np.asarray(array), dtype=self.dtype, device=self.device)
+
+    def _inverse_and_lognorm(self, cov: Tensor) -> Tuple[Tensor, float]:
+        inverse = torch.linalg.inv(cov).contiguous()
+        logdet = float(torch.linalg.slogdet(cov)[1])
+        lognorm = -0.5 * (cov.shape[0] * math.log(2.0 * math.pi) + logdet)
+        return inverse, lognorm
+
+    # ------------------------------------------------------------------ #
+    # Generative kernels
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        mean = self._transition_mean(states, actions)
+        noise = torch.randn(states.shape[0], 4, dtype=self.dtype, device=self.device)
+        return mean + noise @ self._trans_chol_t
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions  # Observation noise does not depend on the action.
+        noise = torch.randn(next_states.shape[0], 4, dtype=self.dtype, device=self.device)
+        return next_states + noise @ self._obs_chol_t
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        del actions, next_states  # Reward is +1 while the current state is alive.
+        alive = ~self.terminal_mask(states)
+        return alive.to(self.dtype)
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        x = states[:, 0]
+        theta = states[:, 2]
+        return (
+            (x < -self._x_threshold)
+            | (x > self._x_threshold)
+            | (theta < -self._theta_threshold)
+            | (theta > self._theta_threshold)
+        )
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions  # Observation likelihood does not depend on the action.
+        diff = observations - next_states
+        maha = torch.einsum("ni,ij,nj->n", diff, self._obs_inv, diff)
+        return self._obs_lognorm - 0.5 * maha
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        quantized = torch.floor(observations / self._obs_resolution).to(torch.int64)
+        primes = torch.tensor(_HASH_PRIMES, dtype=torch.int64, device=self.device)
+        return (quantized * primes).sum(dim=1)
+
+    # ------------------------------------------------------------------ #
+    # Internal physics helpers
+    # ------------------------------------------------------------------ #
+
+    def _transition_mean(self, states: Tensor, actions: Tensor) -> Tensor:
+        x, x_dot, theta, theta_dot = states.unbind(dim=1)
+        force = (actions.to(self.dtype) * 2.0 - 1.0) * self._force_mag
+        costheta = torch.cos(theta)
+        sintheta = torch.sin(theta)
+        temp = (force + self._polemass_length * theta_dot * theta_dot * sintheta) / self._total_mass
+        thetaacc = (self._gravity * sintheta - costheta * temp) / (
+            self._length * (4.0 / 3.0 - self._masspole * costheta * costheta / self._total_mass)
+        )
+        xacc = temp - self._polemass_length * thetaacc * costheta / self._total_mass
+        next_x = x + self._tau * x_dot
+        next_x_dot = x_dot + self._tau * xacc
+        next_theta = theta + self._tau * theta_dot
+        next_theta_dot = theta_dot + self._tau * thetaacc
+        return torch.stack([next_x, next_x_dot, next_theta, next_theta_dot], dim=1)

--- a/POMDPPlanners/environments/isaac_lab_pomdp/__init__.py
+++ b/POMDPPlanners/environments/isaac_lab_pomdp/__init__.py
@@ -8,8 +8,25 @@ as a ground-truth world for the POMDPPlanners episode loop.
 Classes:
     IsaacLabPOMDP: Forward-only adapter exposing an IsaacLab task as a world.
     IsaacLabPOMDPVisualizer: RGB-frame-to-``.mp4`` video writer for episodes.
+    IsaacLabModelPOMDP: Planner-side generative model POMCPOW searches inside.
+    GaussianObservationModel: Additive-Normal observation model (obs = state + noise).
+    TransitionModel: Interface for a state-transition model.
+    GaussianRandomWalkTransition: Action-ignoring Gaussian random-walk transition.
+    LinearGaussianTransition: Fit-from-data linear-Gaussian action-conditioned transition.
+    RewardModel: Interface for a reward model.
+    LinearRewardModel: Fit-from-data linear reward model POMCPOW optimizes.
 """
 
+from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_model_pomdp import (
+    GaussianObservationModel,
+    GaussianRandomWalkTransition,
+    IsaacLabModelPOMDP,
+    IsaacLabSimulatorTransition,
+    LinearGaussianTransition,
+    LinearRewardModel,
+    RewardModel,
+    TransitionModel,
+)
 from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_pomdp import IsaacLabPOMDP
 from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_visualizer import (
     IsaacLabPOMDPVisualizer,
@@ -18,4 +35,12 @@ from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_visualizer import (
 __all__ = [
     "IsaacLabPOMDP",
     "IsaacLabPOMDPVisualizer",
+    "IsaacLabModelPOMDP",
+    "GaussianObservationModel",
+    "TransitionModel",
+    "GaussianRandomWalkTransition",
+    "LinearGaussianTransition",
+    "IsaacLabSimulatorTransition",
+    "RewardModel",
+    "LinearRewardModel",
 ]

--- a/POMDPPlanners/environments/isaac_lab_pomdp/isaac_lab_model_pomdp.py
+++ b/POMDPPlanners/environments/isaac_lab_pomdp/isaac_lab_model_pomdp.py
@@ -1,0 +1,735 @@
+# SPDX-License-Identifier: MIT
+
+"""Planner-side generative model for the IsaacLab POMDP.
+
+:class:`~POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_pomdp.IsaacLabPOMDP`
+is a forward-only *world*: it steps a live IsaacLab task and emits the real
+observation, but it cannot resample from an arbitrary state or score observation
+densities. A belief filter and a planner such as POMCPOW therefore need a
+separate *generative model* to search inside — this module provides it.
+
+Design (see the project discussion that motivated it): rather than hand-splitting
+each of IsaacLab's ~200 tasks into privileged-state vs sensor-observation terms,
+the model keeps **state and observation in the same space** and treats the
+observation as the state seen through additive Gaussian sensor noise —
+``observation = state + N(0, Sigma)``. This makes the observation model generic
+(one model for every task), trivially samplable from any state, and guarantees
+the state explains the observation by construction. Truly unmeasurable *constant*
+parameters (friction, added mass, actuator gains) are handled as domain
+randomization on the world side, not as observation channels.
+
+The Normal-noise mechanism reuses
+:class:`~POMDPPlanners.utils.multivariate_normal.CovarianceParameterizedMultivariateNormal`
+— the same fixed-covariance-varying-mean multivariate normal the continuous
+light-dark POMDP uses for its ``NORMAL_NOISE`` observation model and its state
+transition — so the Cholesky factorization is computed once and reused.
+
+Transition model — a swappable seam. IsaacLab's true contact dynamics are not
+analytic, so the transition is injected via the :class:`TransitionModel`
+interface. Two concretes ship here:
+
+* :class:`GaussianRandomWalkTransition` — the trivial, action-ignoring default
+  (``next = state + N(0, Sigma)``); planning is cosmetic under it.
+* :class:`LinearGaussianTransition` — a first-order **learned** dynamics model
+  ``next = A @ state + B @ action + b + N(0, Sigma)`` whose parameters are fit
+  from ``(state, action, next_state)`` rollouts via ridge least squares. It is
+  action-conditioned, so POMCPOW's lookahead sees that actions move the state.
+
+A learned, history-conditioned world model (RSSM/Dreamer) can be dropped in as a
+third :class:`TransitionModel` without touching the observation model or the
+planner.
+
+Reward model — the objective POMCPOW optimizes. The forward-only world cannot be
+queried for the reward of a hypothetical in-tree transition, so the reward is also
+injected, via :class:`RewardModel`. :class:`LinearRewardModel` is fit from the same
+warm-up rollouts as the transition; without it the model's reward is a flat zero
+and the planner has no objective, so the task is never solved.
+
+Classes:
+    TransitionModel: Interface for a state-transition model (sample + log-density).
+    GaussianRandomWalkTransition: Action-ignoring Gaussian random-walk transition.
+    LinearGaussianTransition: Fit-from-data linear-Gaussian action-conditioned transition.
+    IsaacLabSimulatorTransition: Steps the IsaacLab simulator as the true transition.
+    RewardModel: Interface for a reward model over the state/observation space.
+    LinearRewardModel: Fit-from-data linear reward model POMCPOW optimizes.
+    GaussianObservationModel: Additive-Normal observation model (obs = state + noise).
+    IsaacLabModelPOMDP: Discrete-action generative model POMCPOW searches inside.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Hashable
+from typing import Any, Callable, Dict, List, Optional, Union
+
+import numpy as np
+
+from POMDPPlanners.core.distributions import Distribution
+from POMDPPlanners.core.environment import (
+    DiscreteActionsEnvironment,
+    SpaceInfo,
+    SpaceType,
+)
+
+# Reuse the world module's launch seam so both share the single per-process
+# ``SimulationApp`` (IsaacLab permits exactly one) and so tests can monkeypatch
+# ``_build_isaac_env`` here to inject a fake batched env.
+from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_pomdp import (
+    _build_isaac_env,
+    _to_numpy,
+)
+from POMDPPlanners.utils.multivariate_normal import (
+    CovarianceParameterizedMultivariateNormal,
+)
+
+NoiseStd = Union[float, np.ndarray]
+
+# A ``state_writer`` writes a ``(batch, dim)`` block of flat state vectors back
+# into the live IsaacLab env (the inverse of the world's state extractor).
+StateWriter = Callable[[Any, np.ndarray], None]
+StateReader = Callable[[Any], np.ndarray]
+
+
+def _diagonal_covariance(dim: int, std: NoiseStd) -> np.ndarray:
+    """Build a diagonal covariance from a scalar or per-channel standard deviation.
+
+    Args:
+        dim: Dimensionality of the state/observation vector.
+        std: A scalar standard deviation (isotropic noise) or a length-``dim``
+            array of per-channel standard deviations.
+
+    Returns:
+        A ``(dim, dim)`` diagonal covariance matrix.
+
+    Raises:
+        ValueError: If any standard deviation is non-positive or ``std`` has the
+            wrong length.
+    """
+    std_vector = np.broadcast_to(np.asarray(std, dtype=float), (dim,)).astype(float)
+    if np.any(std_vector <= 0.0):
+        raise ValueError("noise standard deviations must be strictly positive")
+    return np.diag(std_vector**2)
+
+
+class TransitionModel(ABC):
+    """Interface for a state-transition model over the shared state/observation space.
+
+    A concrete transition supplies a generative next-state sampler and the matching
+    log-density, both conditioned on ``(state, action)``. Implementations here are
+    analytic Gaussians; a learned world model can implement the same two methods.
+
+    Note:
+        This is an abstract base class and cannot be instantiated directly.
+    """
+
+    @abstractmethod
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        """Sample ``n_samples`` next states for ``(state, action)``.
+
+        Args:
+            state: The current state, a length-``dim`` vector.
+            action: The action applied at ``state``.
+            n_samples: Number of next states to draw.
+
+        Returns:
+            A single ``(dim,)`` next state when ``n_samples == 1``, else a
+            ``(n_samples, dim)`` array.
+        """
+
+    @abstractmethod
+    def log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+        """Log-density of each of ``next_states`` under the transition for ``(state, action)``.
+
+        Args:
+            state: The current state, a length-``dim`` vector.
+            action: The action applied at ``state``.
+            next_states: A single ``(dim,)`` next state or a ``(n, dim)`` batch.
+
+        Returns:
+            A ``(n,)`` array of log-densities.
+        """
+
+
+class GaussianRandomWalkTransition(TransitionModel):
+    """Action-ignoring Gaussian random walk: ``next_state = state + N(0, Sigma)``.
+
+    The trivial placeholder transition. Because it ignores the action, a planner's
+    lookahead cannot distinguish actions under it — use it only for wiring/tests
+    or when a learned transition is not yet available.
+
+    Example:
+        Draw a next state near the current one::
+
+            transition = GaussianRandomWalkTransition(dim=4, process_noise_std=0.05)
+            nxt = transition.sample_next_state([0.0, 1.0, 2.0, 3.0], action=None)
+    """
+
+    def __init__(self, dim: int, process_noise_std: NoiseStd = 0.05) -> None:
+        """Initialize the random-walk transition.
+
+        Args:
+            dim: Dimensionality of the state vector.
+            process_noise_std: Scalar or per-channel std of the process noise.
+        """
+        self.dim = int(dim)
+        self._normal = CovarianceParameterizedMultivariateNormal(
+            _diagonal_covariance(self.dim, process_noise_std)
+        )
+
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        del action  # random walk ignores the action
+        mean = np.asarray(state, dtype=float).reshape(-1)
+        samples = self._normal.sample(mean, n_samples=n_samples)
+        return samples[0] if n_samples == 1 else samples
+
+    def log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+        del action
+        mean = np.asarray(state, dtype=float).reshape(-1)
+        return self._normal.log_pdf(np.asarray(next_states, dtype=float), mean)
+
+
+class LinearGaussianTransition(TransitionModel):
+    """Learned linear-Gaussian transition ``next = A @ state + B @ action + b + N(0, Sigma)``.
+
+    A first-order, action-conditioned dynamics model whose parameters are fit from
+    ``(state, action, next_state)`` rollouts (see :meth:`fit`). Analytic, so both
+    sampling and log-density reuse the pre-factorized normal. It is deliberately a
+    system-identification baseline — a linear approximation of the true nonlinear
+    contact dynamics — but, unlike the random walk, it makes actions move the
+    predicted state so POMCPOW's planning is meaningful.
+
+    Attributes:
+        dim: State dimensionality.
+        action_dim: Action dimensionality.
+
+    Example:
+        Fit from rollouts, then sample::
+
+            transition = LinearGaussianTransition.fit(states, actions, next_states)
+            nxt = transition.sample_next_state(states[0], actions[0])
+    """
+
+    def __init__(
+        self,
+        weight_state: np.ndarray,
+        weight_action: np.ndarray,
+        bias: np.ndarray,
+        covariance: np.ndarray,
+    ) -> None:
+        """Initialize the linear-Gaussian transition from explicit parameters.
+
+        Args:
+            weight_state: State matrix ``A`` of shape ``(dim, dim)``.
+            weight_action: Action matrix ``B`` of shape ``(dim, action_dim)``.
+            bias: Offset vector ``b`` of shape ``(dim,)``.
+            covariance: Residual covariance of shape ``(dim, dim)``.
+        """
+        self._weight_state = np.asarray(weight_state, dtype=float)
+        self._weight_action = np.asarray(weight_action, dtype=float)
+        self._bias = np.asarray(bias, dtype=float).reshape(-1)
+        self.dim = self._weight_state.shape[0]
+        self.action_dim = self._weight_action.shape[1]
+        self._normal = CovarianceParameterizedMultivariateNormal(
+            np.asarray(covariance, dtype=float)
+        )
+
+    def _mean(self, state: Any, action: Any) -> np.ndarray:
+        state_vector = np.asarray(state, dtype=float).reshape(-1)
+        action_vector = np.asarray(action, dtype=float).reshape(-1)
+        return self._weight_state @ state_vector + self._weight_action @ action_vector + self._bias
+
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        mean = self._mean(state, action)
+        samples = self._normal.sample(mean, n_samples=n_samples)
+        return samples[0] if n_samples == 1 else samples
+
+    def log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+        mean = self._mean(state, action)
+        return self._normal.log_pdf(np.asarray(next_states, dtype=float), mean)
+
+    @classmethod
+    def fit(
+        cls,
+        states: np.ndarray,
+        actions: np.ndarray,
+        next_states: np.ndarray,
+        regularization: float = 1e-4,
+        min_variance: float = 1e-6,
+    ) -> "LinearGaussianTransition":
+        """Fit ``A``, ``B``, ``b`` and a diagonal residual covariance via ridge least squares.
+
+        Args:
+            states: Array of shape ``(N, dim)`` of source states.
+            actions: Array of shape ``(N, action_dim)`` of applied actions.
+            next_states: Array of shape ``(N, dim)`` of resulting states.
+            regularization: Ridge penalty added to the normal-equations diagonal.
+            min_variance: Floor on each residual variance to keep the covariance
+                positive definite.
+
+        Returns:
+            A fitted :class:`LinearGaussianTransition`.
+
+        Raises:
+            ValueError: If fewer than two transitions are supplied or shapes disagree.
+        """
+        states_2d = np.atleast_2d(np.asarray(states, dtype=float))
+        actions_2d = np.atleast_2d(np.asarray(actions, dtype=float))
+        next_2d = np.atleast_2d(np.asarray(next_states, dtype=float))
+        if states_2d.shape[0] < 2:
+            raise ValueError("fitting a linear transition needs at least two transitions")
+        if not states_2d.shape[0] == actions_2d.shape[0] == next_2d.shape[0]:
+            raise ValueError("states, actions, and next_states must have equal length")
+
+        dim = states_2d.shape[1]
+        action_dim = actions_2d.shape[1]
+        ones = np.ones((states_2d.shape[0], 1))
+        design = np.hstack([states_2d, actions_2d, ones])  # (N, dim + action_dim + 1)
+
+        gram = design.T @ design + regularization * np.eye(design.shape[1])
+        weights = np.linalg.solve(gram, design.T @ next_2d)  # (dim + action_dim + 1, dim)
+
+        weight_state = weights[:dim].T
+        weight_action = weights[dim : dim + action_dim].T
+        bias = weights[-1]
+        residuals = next_2d - design @ weights
+        variances = np.maximum(np.var(residuals, axis=0), min_variance)
+        return cls(weight_state, weight_action, bias, np.diag(variances))
+
+
+class IsaacLabSimulatorTransition(TransitionModel):
+    """State-transition model that steps the IsaacLab simulator itself.
+
+    ``next_state = f_sim(state, action) + N(0, Sigma)``: the flat state vector is
+    written back into the physics engine, the sim is advanced one step under
+    ``action``, and the resulting state is read out as the transition **mean**. A
+    small diagonal process noise is added so the transition is a proper, samplable
+    density — the bare physics step is a deterministic point mass with no density
+    for the belief filter to weight against.
+
+    Unlike :class:`LinearGaussianTransition`, this is the *true* nonlinear
+    dynamics rather than a linear fit, so POMCPOW plans against exact contact
+    physics. The cost is one GPU sim step per query.
+
+    Constraints:
+        * **One SimulationApp per process.** This transition builds its own
+          batched IsaacLab env through the same launch singleton the world uses,
+          so it cannot coexist with an IsaacLab *world* in the same process — pair
+          it with a non-IsaacLab world (real robot or a cheaper simulator).
+        * **State writer is task-specific.** Writing a flat state back into the
+          sim is the inverse of the world's state extractor and depends on the
+          asset/frame conventions, so it is injected via ``state_writer`` rather
+          than guessed.
+
+    Attributes:
+        dim: Dimensionality of the shared state/observation vector.
+        num_envs: Number of parallel sim envs the batched model env is built with.
+
+    Example:
+        Wrap a task, supplying the inverse of the world's state extractor::
+
+            def write_state(env, states):  # states: (batch, dim)
+                env.unwrapped.write_root_state_to_sim(to_torch(states))
+
+            transition = IsaacLabSimulatorTransition(
+                task_id="Isaac-Reach-Franka-v0", dim=18, state_writer=write_state,
+                device="cpu", process_noise_std=0.01,
+            )
+            nxt = transition.sample_next_state(state, action)
+    """
+
+    def __init__(
+        self,
+        task_id: str,
+        dim: int,
+        state_writer: StateWriter,
+        num_envs: int = 1,
+        device: str = "cuda",
+        env_cfg_kwargs: Optional[Dict[str, Any]] = None,
+        headless: bool = True,
+        process_noise_std: NoiseStd = 0.01,
+        state_reader: Optional[StateReader] = None,
+        state_asset: str = "robot",
+        action_space_type: SpaceType = SpaceType.CONTINUOUS,
+    ) -> None:
+        """Initialize the simulator-backed transition.
+
+        Args:
+            task_id: Registered IsaacLab task id (e.g. ``"Isaac-Reach-Franka-v0"``).
+            dim: Dimensionality of the flat state/observation vector.
+            state_writer: Callback ``(env, states) -> None`` writing a ``(batch, dim)``
+                block of flat states into the live env — the inverse of the world's
+                state extractor.
+            num_envs: Parallel sim envs the model env is built with. Defaults to 1.
+            device: Torch device the simulator runs on. Defaults to ``"cuda"``.
+            env_cfg_kwargs: Extra keyword args for ``parse_env_cfg``. Defaults to none.
+            headless: Launch the simulator without a GUI. Defaults to True.
+            process_noise_std: Scalar or per-channel std of the additive process
+                noise around the physics step. Defaults to 0.01.
+            state_reader: Optional ``env -> (num_envs, dim)`` reader of the resulting
+                states. Defaults to concatenating root pose/velocity and joint state.
+            state_asset: Scene key for the ground-truth articulation. Defaults to
+                ``"robot"``.
+            action_space_type: Action space category. Defaults to CONTINUOUS.
+        """
+        self.task_id = task_id
+        self.dim = int(dim)
+        self.num_envs = int(num_envs)
+        self.device = device
+        self.env_cfg_kwargs: Dict[str, Any] = dict(env_cfg_kwargs) if env_cfg_kwargs else {}
+        self.headless = headless
+        self.state_asset = state_asset
+        self.action_space_type = action_space_type
+        self._state_writer = state_writer
+        self._state_reader = state_reader
+        self._env: Optional[Any] = None
+        self._normal = CovarianceParameterizedMultivariateNormal(
+            _diagonal_covariance(self.dim, process_noise_std)
+        )
+
+    def _get_env(self) -> Any:
+        if self._env is None:
+            self._env = _build_isaac_env(
+                self.task_id, self.num_envs, self.device, self.env_cfg_kwargs, self.headless
+            )
+        return self._env
+
+    def _to_isaac_action(self, action: Any, batch: int) -> Any:
+        import torch  # pylint: disable=import-outside-toplevel
+
+        if self.action_space_type == SpaceType.DISCRETE:
+            return torch.as_tensor([[int(action)]] * batch, device=self.device)
+        row = np.asarray(action, dtype=np.float32).reshape(-1)
+        return torch.as_tensor(np.tile(row, (batch, 1)), device=self.device)
+
+    def _read_states(self, env: Any) -> np.ndarray:
+        if self._state_reader is not None:
+            return np.atleast_2d(np.asarray(self._state_reader(env), dtype=float))
+        return self._default_read_states(env)
+
+    def _default_read_states(self, env: Any) -> np.ndarray:
+        """Read the ground-truth state of every env as a ``(num_envs, dim)`` block."""
+        data = env.unwrapped.scene[self.state_asset].data
+        components = (
+            "root_pos_w",
+            "root_quat_w",
+            "root_lin_vel_w",
+            "root_ang_vel_w",
+            "joint_pos",
+            "joint_vel",
+        )
+        parts = [
+            _to_numpy(getattr(data, attr)).reshape(self.num_envs, -1)
+            for attr in components
+            if getattr(data, attr, None) is not None
+        ]
+        if not parts:
+            raise RuntimeError(
+                f"No ground-truth state fields found on scene asset "
+                f"'{self.state_asset}'; pass a custom state_reader."
+            )
+        return np.concatenate(parts, axis=1)
+
+    def _sim_step_mean(self, state: Any, action: Any) -> np.ndarray:
+        """Write ``state`` into the sim, step once under ``action``, read the result."""
+        env = self._get_env()
+        self._state_writer(env, np.asarray(state, dtype=float).reshape(1, -1))
+        env.step(self._to_isaac_action(action, batch=1))
+        return self._read_states(env)[0]
+
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        mean = self._sim_step_mean(state, action)
+        samples = self._normal.sample(mean, n_samples=n_samples)
+        return samples[0] if n_samples == 1 else samples
+
+    def log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+        mean = self._sim_step_mean(state, action)
+        return self._normal.log_pdf(np.asarray(next_states, dtype=float), mean)
+
+
+class RewardModel(ABC):
+    """Interface for a reward model over the shared state/observation space.
+
+    A concrete reward model scores a ``(state, action, next_state)`` transition.
+    The planner-side model needs one because the forward-only world cannot be
+    queried for the reward of a hypothetical in-tree transition.
+
+    Note:
+        This is an abstract base class and cannot be instantiated directly.
+    """
+
+    @abstractmethod
+    def reward(self, state: Any, action: Any, next_state: Any) -> float:
+        """Return the scalar reward for a ``(state, action, next_state)`` transition."""
+
+
+class LinearRewardModel(RewardModel):
+    """Learned linear reward ``r = w_s . state + w_a . action + w_n . next_state + b``.
+
+    Fit from ``(state, action, next_state, reward)`` rollouts via ridge least
+    squares (see :meth:`fit`). It is a first-order approximation of the task's true
+    (often nonlinear) reward, but it gives POMCPOW a real objective to optimize —
+    without it the planner has no signal and produces undirected behavior.
+
+    Example:
+        Fit from rollouts, then score a transition::
+
+            reward_model = LinearRewardModel.fit(states, actions, next_states, rewards)
+            value = reward_model.reward(states[0], actions[0], next_states[0])
+    """
+
+    def __init__(
+        self,
+        weight_state: np.ndarray,
+        weight_action: np.ndarray,
+        weight_next_state: np.ndarray,
+        bias: float,
+    ) -> None:
+        """Initialize the linear reward model from explicit parameters.
+
+        Args:
+            weight_state: Coefficients on the state, shape ``(dim,)``.
+            weight_action: Coefficients on the action, shape ``(action_dim,)``.
+            weight_next_state: Coefficients on the next state, shape ``(dim,)``.
+            bias: Scalar offset.
+        """
+        self._weight_state = np.asarray(weight_state, dtype=float).reshape(-1)
+        self._weight_action = np.asarray(weight_action, dtype=float).reshape(-1)
+        self._weight_next_state = np.asarray(weight_next_state, dtype=float).reshape(-1)
+        self._bias = float(bias)
+
+    def reward(self, state: Any, action: Any, next_state: Any) -> float:
+        state_vector = np.asarray(state, dtype=float).reshape(-1)
+        action_vector = np.asarray(action, dtype=float).reshape(-1)
+        next_vector = np.asarray(next_state, dtype=float).reshape(-1)
+        return float(
+            self._weight_state @ state_vector
+            + self._weight_action @ action_vector
+            + self._weight_next_state @ next_vector
+            + self._bias
+        )
+
+    @classmethod
+    def fit(
+        cls,
+        states: np.ndarray,
+        actions: np.ndarray,
+        next_states: np.ndarray,
+        rewards: np.ndarray,
+        regularization: float = 1e-4,
+    ) -> "LinearRewardModel":
+        """Fit the reward coefficients via ridge least squares.
+
+        Args:
+            states: Array of shape ``(N, dim)`` of source states.
+            actions: Array of shape ``(N, action_dim)`` of applied actions.
+            next_states: Array of shape ``(N, dim)`` of resulting states.
+            rewards: Array of shape ``(N,)`` of observed rewards.
+            regularization: Ridge penalty added to the normal-equations diagonal.
+
+        Returns:
+            A fitted :class:`LinearRewardModel`.
+
+        Raises:
+            ValueError: If fewer than two transitions are supplied or shapes disagree.
+        """
+        states_2d = np.atleast_2d(np.asarray(states, dtype=float))
+        actions_2d = np.atleast_2d(np.asarray(actions, dtype=float))
+        next_2d = np.atleast_2d(np.asarray(next_states, dtype=float))
+        rewards_1d = np.asarray(rewards, dtype=float).reshape(-1)
+        if states_2d.shape[0] < 2:
+            raise ValueError("fitting a linear reward needs at least two transitions")
+        if not states_2d.shape[0] == actions_2d.shape[0] == next_2d.shape[0] == rewards_1d.shape[0]:
+            raise ValueError("states, actions, next_states, and rewards must have equal length")
+
+        dim = states_2d.shape[1]
+        action_dim = actions_2d.shape[1]
+        ones = np.ones((states_2d.shape[0], 1))
+        design = np.hstack([states_2d, actions_2d, next_2d, ones])
+        gram = design.T @ design + regularization * np.eye(design.shape[1])
+        weights = np.linalg.solve(gram, design.T @ rewards_1d)
+        return cls(
+            weight_state=weights[:dim],
+            weight_action=weights[dim : dim + action_dim],
+            weight_next_state=weights[dim + action_dim : 2 * dim + action_dim],
+            bias=float(weights[-1]),
+        )
+
+
+class GaussianObservationModel:
+    """Additive-Normal observation model: ``observation = state + N(0, Sigma)``.
+
+    A fixed-covariance multivariate normal whose mean is the state, mirroring the
+    continuous light-dark ``NORMAL_NOISE`` model. The covariance is diagonal and
+    parameterized per channel, so proprioceptive channels can carry tight noise
+    and exteroceptive ones looser noise without any per-task code.
+
+    Attributes:
+        dim: Dimensionality of the observation/state vector.
+
+    Example:
+        Sample and score an observation for a 4-D state::
+
+            model = GaussianObservationModel(observation_dim=4, noise_std=0.1)
+            obs = model.sample([0.0, 1.0, 2.0, 3.0])
+            log_p = model.log_probability([0.0, 1.0, 2.0, 3.0], obs)
+    """
+
+    def __init__(self, observation_dim: int, noise_std: NoiseStd = 0.1) -> None:
+        """Initialize the additive-Normal observation model.
+
+        Args:
+            observation_dim: Dimensionality of the observation/state vector.
+            noise_std: Scalar (isotropic) or per-channel standard deviation of the
+                additive Gaussian sensor noise. Defaults to 0.1.
+        """
+        self.dim = int(observation_dim)
+        covariance = _diagonal_covariance(self.dim, noise_std)
+        self._normal = CovarianceParameterizedMultivariateNormal(covariance)
+
+    def sample(self, state: Any, n_samples: int = 1) -> np.ndarray:
+        """Draw ``observation = state + noise`` for the given state.
+
+        Args:
+            state: The (next) state to observe, a length-``dim`` vector.
+            n_samples: Number of observations to draw. Defaults to 1.
+
+        Returns:
+            A single ``(dim,)`` observation when ``n_samples == 1``, else a
+            ``(n_samples, dim)`` array.
+        """
+        mean = np.asarray(state, dtype=float).reshape(-1)
+        samples = self._normal.sample(mean, n_samples=n_samples)
+        return samples[0] if n_samples == 1 else samples
+
+    def log_probability(self, state: Any, observations: Any) -> np.ndarray:
+        """Gaussian log-density of ``observations`` centered on ``state``.
+
+        Args:
+            state: The (next) state, a length-``dim`` vector (the Gaussian mean).
+            observations: A single ``(dim,)`` observation or a ``(n, dim)`` batch.
+
+        Returns:
+            A ``(n,)`` array of log-densities, one per observation.
+        """
+        mean = np.asarray(state, dtype=float).reshape(-1)
+        return self._normal.log_pdf(np.asarray(observations, dtype=float), mean)
+
+
+class IsaacLabModelPOMDP(DiscreteActionsEnvironment):
+    """Discrete-action generative model POMCPOW searches inside for IsaacLab.
+
+    State and observation share one space; the observation is the state seen
+    through :class:`GaussianObservationModel`, and the transition is any
+    :class:`TransitionModel` (defaulting to :class:`GaussianRandomWalkTransition`).
+    Actions are a finite set of continuous control vectors applied verbatim to the
+    world.
+
+    Attributes:
+        observation_dim: Dimensionality of the shared state/observation vector.
+        action_presets: The finite set of action vectors the planner chooses among.
+
+    Example:
+        Build a model over a 4-D observation with three 2-D action presets::
+
+            import numpy as np
+            presets = [np.zeros(2), np.ones(2), -np.ones(2)]
+            model = IsaacLabModelPOMDP(observation_dim=4, action_presets=presets,
+                                       discount_factor=0.99)
+            actions = model.get_actions()
+    """
+
+    def __init__(
+        self,
+        observation_dim: int,
+        action_presets: List[np.ndarray],
+        discount_factor: float,
+        observation_noise_std: NoiseStd = 0.1,
+        process_noise_std: NoiseStd = 0.05,
+        transition: Optional[TransitionModel] = None,
+        reward_model: Optional[RewardModel] = None,
+        name: Optional[str] = None,
+    ) -> None:
+        """Initialize the planner-side generative model.
+
+        Args:
+            observation_dim: Dimensionality of the shared state/observation vector.
+            action_presets: Finite list of continuous action vectors to plan over.
+            discount_factor: POMDP discount factor (shared with the world).
+            observation_noise_std: Scalar or per-channel std of the observation noise.
+            process_noise_std: Scalar or per-channel std of the default random-walk
+                transition. Ignored when an explicit ``transition`` is given.
+            transition: The state-transition model to plan with. Defaults to a
+                :class:`GaussianRandomWalkTransition` built from ``process_noise_std``.
+            reward_model: The reward model POMCPOW optimizes. Defaults to ``None``,
+                which yields a flat zero reward (undirected planning) — supply a
+                fitted :class:`LinearRewardModel` to make the planner solve the task.
+            name: Model name (also used to label planner output).
+        """
+        super().__init__(
+            discount_factor=discount_factor,
+            name=name if name is not None else type(self).__name__,
+            space_info=SpaceInfo(
+                action_space=SpaceType.DISCRETE,
+                observation_space=SpaceType.CONTINUOUS,
+            ),
+        )
+        self.observation_dim = int(observation_dim)
+        self.action_presets = [np.asarray(a, dtype=float).reshape(-1) for a in action_presets]
+        self._observation_model = GaussianObservationModel(
+            self.observation_dim, observation_noise_std
+        )
+        self._transition = (
+            transition
+            if transition is not None
+            else GaussianRandomWalkTransition(self.observation_dim, process_noise_std)
+        )
+        self._reward_model = reward_model
+
+    def get_actions(self) -> List[np.ndarray]:
+        """Return the finite set of action vectors the planner chooses among."""
+        return [preset.copy() for preset in self.action_presets]
+
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        return self._transition.sample_next_state(state, action, n_samples=n_samples)
+
+    def transition_log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+        return self._transition.log_probability(state, action, next_states)
+
+    def sample_observation(self, next_state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        del action
+        return self._observation_model.sample(next_state, n_samples=n_samples)
+
+    def observation_log_probability(
+        self, next_state: Any, action: Any, observations: Any
+    ) -> np.ndarray:
+        del action
+        return self._observation_model.log_probability(next_state, observations)
+
+    def reward(self, state: Any, action: Any, next_state: Any = None) -> float:
+        if self._reward_model is None:
+            return 0.0  # no reward model → undirected planning (see __init__ docstring)
+        resulting = state if next_state is None else next_state
+        return self._reward_model.reward(state, action, resulting)
+
+    def is_terminal(self, state: Any) -> bool:
+        del state
+        return False
+
+    def initial_state_dist(self) -> Distribution:
+        raise NotImplementedError(
+            "IsaacLabModelPOMDP has no initial-state prior; seed the belief from "
+            "the world's initial observation."
+        )
+
+    def initial_observation_dist(self) -> Distribution:
+        raise NotImplementedError(
+            "IsaacLabModelPOMDP has no initial-observation prior; seed the belief "
+            "from the world's initial observation."
+        )
+
+    def is_equal_observation(self, observation1: Any, observation2: Any) -> bool:
+        return np.array_equal(np.asarray(observation1), np.asarray(observation2))
+
+    def hash_observation(self, observation: Any) -> Hashable:
+        return np.asarray(observation).tobytes()
+
+    def hash_action(self, action: Any) -> Hashable:
+        return np.asarray(action).tobytes()

--- a/POMDPPlanners/environments/isaac_lab_pomdp/isaac_lab_vectorized_model.py
+++ b/POMDPPlanners/environments/isaac_lab_pomdp/isaac_lab_vectorized_model.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for the Isaac Lab planner model.
+
+This module provides :class:`IsaacLabVectorizedModel`, a fully batched,
+GPU-friendly implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+built from the *fitted* planner-side model of
+:mod:`POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_model_pomdp`.
+
+The Isaac Lab world is a physics simulator, so the model VOPP searches is not
+the simulator itself but the linear-Gaussian surrogate fit from a warm-up of
+random transitions: a :class:`LinearGaussianTransition`, a
+:class:`GaussianObservationModel`, and a :class:`LinearRewardModel`. Because
+those three are already linear / Gaussian, they re-express exactly as batched
+torch kernels:
+
+* transition ``s' = A s + B a + b + N(0, Sigma_tr)``,
+* observation ``o = s' + N(0, Sigma_obs)`` (state and observation share one
+  space, so ``ds == do``),
+* reward ``r = w_s . s + w_a . a + w_n . s' + b_r``, and
+* a terminal test that is always ``False`` (the Isaac velocity tasks never
+  terminate the model).
+
+Actions are integer indices into a fixed preset table of continuous action
+vectors (the VOPP representative-action assumption); the ground-truth Isaac
+action for index ``i`` is ``action_presets[i]``. An accompanying parity test
+pins every kernel to the fitted numpy models.
+"""
+
+import math
+from typing import Optional
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_model_pomdp import (
+    GaussianObservationModel,
+    LinearGaussianTransition,
+    LinearRewardModel,
+)
+
+
+class IsaacLabVectorizedModel:
+    """Fully vectorized torch generative model for the Isaac Lab surrogate model.
+
+    The model batches the linear-Gaussian transition, additive-Gaussian
+    observation, linear reward, always-false terminal, and observation
+    log-likelihood kernels over a leading particle dimension, keeping every
+    tensor on one device. Actions are integer indices into a fixed preset table
+    of continuous Isaac actions.
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for state / observation / reward tensors.
+        num_actions: Number of preset actions (rows of the action table).
+
+    Example:
+        >>> import numpy as np
+        >>> import torch
+        >>> from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_model_pomdp import (
+        ...     GaussianObservationModel,
+        ...     LinearGaussianTransition,
+        ...     LinearRewardModel,
+        ... )
+        >>> transition = LinearGaussianTransition(
+        ...     np.eye(3), np.zeros((3, 2)), np.zeros(3), 0.01 * np.eye(3)
+        ... )
+        >>> observation = GaussianObservationModel(3, noise_std=0.1)
+        >>> reward = LinearRewardModel(np.zeros(3), np.zeros(2), np.ones(3), 0.0)
+        >>> presets = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        >>> model = IsaacLabVectorizedModel(
+        ...     transition, observation, reward, presets, device=torch.device("cpu")
+        ... )
+        >>> states = torch.zeros(4, 3)
+        >>> actions = torch.tensor([0, 1, 2, 1])
+        >>> next_states = model.sample_next_states(states, actions)
+        >>> tuple(next_states.shape), model.num_actions
+        ((4, 3), 3)
+    """
+
+    def __init__(
+        self,
+        transition: LinearGaussianTransition,
+        observation_model: GaussianObservationModel,
+        reward_model: LinearRewardModel,
+        action_presets: np.ndarray,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+        observation_resolution: float = 0.5,
+    ) -> None:
+        """Build the vectorized model from the fitted planner-side models.
+
+        Args:
+            transition: Fitted linear-Gaussian transition surrogate.
+            observation_model: Fitted additive-Gaussian observation model.
+            reward_model: Fitted linear reward model.
+            action_presets: ``[num_actions, action_dim]`` table of continuous
+                Isaac action vectors; action index ``i`` selects row ``i``.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for real-valued tensors.
+            observation_resolution: Grid spacing used to quantize observations
+                into integer tree keys.
+
+        Raises:
+            ValueError: If the model dimensions are inconsistent or
+                ``observation_resolution`` is not positive.
+        """
+        self._validate_dimensions(transition, observation_model, action_presets)
+        if observation_resolution <= 0.0:
+            raise ValueError("observation_resolution must be positive")
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self._obs_resolution = float(observation_resolution)
+        self._action_table = self._to_tensor(np.asarray(action_presets, dtype=np.float64))
+        self.num_actions = int(self._action_table.shape[0])
+        self._build_transition(transition)
+        self._build_observation(observation_model)
+        self._build_reward(reward_model)
+        self._hash_primes = self._build_hash_primes(transition.dim)
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _validate_dimensions(
+        transition: LinearGaussianTransition,
+        observation_model: GaussianObservationModel,
+        action_presets: np.ndarray,
+    ) -> None:
+        if observation_model.dim != transition.dim:
+            raise ValueError("observation dim must equal state dim (obs == state space)")
+        presets = np.asarray(action_presets)
+        if presets.ndim != 2 or presets.shape[0] == 0:
+            raise ValueError("action_presets must be a non-empty [num_actions, action_dim] array")
+        if presets.shape[1] != transition.action_dim:
+            raise ValueError("action_presets action_dim must match the transition action_dim")
+
+    def _build_transition(self, transition: LinearGaussianTransition) -> None:
+        self._weight_state = self._to_tensor(
+            transition._weight_state
+        )  # pylint: disable=protected-access
+        self._weight_action = self._to_tensor(
+            transition._weight_action
+        )  # pylint: disable=protected-access
+        self._bias = self._to_tensor(transition._bias)  # pylint: disable=protected-access
+        covariance = self._to_tensor(
+            transition._normal.covariance
+        )  # pylint: disable=protected-access
+        self._trans_chol_t = torch.linalg.cholesky(covariance).mT.contiguous()
+
+    def _build_observation(self, observation_model: GaussianObservationModel) -> None:
+        covariance = self._to_tensor(
+            observation_model._normal.covariance
+        )  # pylint: disable=protected-access
+        self._obs_chol_t = torch.linalg.cholesky(covariance).mT.contiguous()
+        self._obs_inv = torch.linalg.inv(covariance).contiguous()
+        logdet = torch.linalg.slogdet(covariance)[1]
+        dim = observation_model.dim
+        self._obs_lognorm = float(-0.5 * dim * math.log(2.0 * math.pi) - 0.5 * logdet.item())
+
+    def _build_reward(self, reward_model: LinearRewardModel) -> None:
+        self._reward_state = self._to_tensor(
+            reward_model._weight_state
+        )  # pylint: disable=protected-access
+        self._reward_action = self._to_tensor(
+            reward_model._weight_action
+        )  # pylint: disable=protected-access
+        self._reward_next = self._to_tensor(
+            reward_model._weight_next_state
+        )  # pylint: disable=protected-access
+        self._reward_bias = float(reward_model._bias)  # pylint: disable=protected-access
+
+    def _build_hash_primes(self, dim: int) -> Tensor:
+        primes = self._first_primes(dim)
+        return torch.as_tensor(primes, dtype=torch.int64, device=self.device)
+
+    @staticmethod
+    def _first_primes(count: int) -> np.ndarray:
+        primes = []
+        candidate = 73856093
+        while len(primes) < count:
+            if all(candidate % p != 0 for p in range(2, int(candidate**0.5) + 1)):
+                primes.append(candidate)
+            candidate += 2
+        return np.asarray(primes, dtype=np.int64)
+
+    def _to_tensor(self, array: np.ndarray) -> Tensor:
+        return torch.as_tensor(np.asarray(array), dtype=self.dtype, device=self.device)
+
+    @property
+    def action_vectors(self) -> Tensor:
+        """The ``[num_actions, action_dim]`` table of continuous action vectors."""
+        return self._action_table
+
+    # ------------------------------------------------------------------ #
+    # Generative kernels
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        mean = self._transition_mean(states, actions)
+        noise = torch.randn(states.shape[0], states.shape[1], dtype=self.dtype, device=self.device)
+        return mean + noise @ self._trans_chol_t
+
+    def _transition_mean(self, states: Tensor, actions: Tensor) -> Tensor:
+        action_vectors = self._action_table[actions]
+        return states @ self._weight_state.mT + action_vectors @ self._weight_action.mT + self._bias
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions  # observation noise is additive and action-independent.
+        noise = torch.randn(
+            next_states.shape[0], next_states.shape[1], dtype=self.dtype, device=self.device
+        )
+        return next_states + noise @ self._obs_chol_t
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        action_vectors = self._action_table[actions]
+        return (
+            states @ self._reward_state
+            + action_vectors @ self._reward_action
+            + next_states @ self._reward_next
+            + self._reward_bias
+        )
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        return torch.zeros(states.shape[0], dtype=torch.bool, device=self.device)
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions  # additive-Gaussian likelihood does not depend on the action.
+        diff = observations - next_states
+        maha = torch.einsum("ni,ij,nj->n", diff, self._obs_inv, diff)
+        return self._obs_lognorm - 0.5 * maha
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        quantized = torch.floor(observations / self._obs_resolution).to(torch.int64)
+        return (quantized * self._hash_primes).sum(dim=1)

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_vectorized_model.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_vectorized_model.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for the discrete LaserTag POMDP.
+
+This module provides :class:`LaserTagVectorizedModel`, a fully batched,
+GPU-friendly implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+for :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp.LaserTagPOMDP`.
+
+It re-expresses the environment's EVADE opponent-motion kernel, its
+8-direction laser observation kernel, and its ``CONSTANT_HAZARD_PENALTY``
+reward kernel as torch tensor operations so a vectorized planner (VOPP) can
+run tens of thousands of parallel simulations on the GPU without a
+host/device sync. Every constant (grid geometry, walls, dangerous areas,
+measurement noise, costs, action directions) is read from a live environment
+instance, so the environment stays the single source of truth for
+configuration; only the numeric kernels are duplicated in torch. The
+accompanying parity test pins these kernels to the environment's native
+scalar kernels.
+
+Only the single most standard LaserTag configuration is supported: the
+``CONSTANT_HAZARD_PENALTY`` reward model, the ``EVADE`` opponent policy,
+deterministic robot motion (``transition_error_prob == 0.0``), and
+``is_dangerous_area_hit_terminal=False``. Any other configuration is checked
+at construction and raises :class:`NotImplementedError`.
+"""
+
+from typing import Optional
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import (
+    LaserTagPOMDP,
+    RewardModelType,
+)
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils import (
+    OpponentPolicy,
+)
+
+# 5 discrete actions: North, South, East, West, Tag (matches LaserTagPOMDP).
+_ACTION_DIRECTIONS = np.array([[-1, 0], [1, 0], [0, 1], [0, -1], [0, 0]], dtype=np.float64)
+# 8 laser directions: N, NE, E, SE, S, SW, W, NW (matches LaserTagPOMDP).
+_LASER_DIRECTIONS = np.array(
+    [[-1, 0], [-1, 1], [0, 1], [1, 1], [1, 0], [1, -1], [0, -1], [-1, -1]],
+    dtype=np.float64,
+)
+# Opponent candidate cells in categorical order: stay, north, south, east, west.
+_OPPONENT_OFFSETS = np.array([[0, 0], [-1, 0], [1, 0], [0, 1], [0, -1]], dtype=np.float64)
+# Distinct primes for hashing quantized 8-D observations into integer keys.
+_HASH_PRIMES = np.array(
+    [73856093, 19349663, 83492791, 39916801, 51539607, 15485863, 32452843, 49979687],
+    dtype=np.int64,
+)
+_TAG_ACTION = 4
+
+
+class LaserTagVectorizedModel:
+    """Fully vectorized torch generative model for the discrete LaserTag POMDP.
+
+    The model batches the transition, observation, reward, terminal, and
+    observation-likelihood kernels over a leading particle dimension and keeps
+    every tensor on a single device. States are ``[robot_row, robot_col,
+    opp_row, opp_col, terminal]`` rows; actions are the integer indices
+    ``0..4`` of the environment's discrete action set; observations are the
+    8-direction laser ranges (with an all ``-1`` sentinel for terminal states).
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for state / observation / reward tensors.
+        num_actions: Number of discrete actions (always ``5``).
+
+    Example:
+        >>> import torch
+        >>> from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import (
+        ...     LaserTagPOMDP,
+        ... )
+        >>> from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_vectorized_model import (
+        ...     LaserTagVectorizedModel,
+        ... )
+        >>> torch.manual_seed(0)  # doctest: +ELLIPSIS
+        <torch._C.Generator object at ...>
+        >>> env = LaserTagPOMDP(discount_factor=0.95)
+        >>> model = LaserTagVectorizedModel(env, device=torch.device("cpu"))
+        >>> states = torch.tensor([[0.0, 0.0, 6.0, 5.0, 0.0], [2.0, 3.0, 2.0, 3.0, 0.0]])
+        >>> actions = torch.tensor([2, 4])  # move east, tag
+        >>> next_states = model.sample_next_states(states, actions)
+        >>> observations = model.sample_observations(next_states, actions)
+        >>> rewards = model.rewards(states, actions, next_states)
+        >>> tuple(next_states.shape), tuple(observations.shape), tuple(rewards.shape)
+        ((2, 5), (2, 8), (2,))
+    """
+
+    def __init__(
+        self,
+        env: LaserTagPOMDP,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+        observation_resolution: float = 0.1,
+    ) -> None:
+        """Build the model from a live environment instance.
+
+        Args:
+            env: The environment whose parameters and model types are mirrored.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for real-valued tensors.
+            observation_resolution: Grid spacing used to quantize continuous
+                laser observations into integer tree keys.
+
+        Raises:
+            NotImplementedError: If ``env`` uses a reward model, opponent
+                policy, transition-error, or hazard-terminal configuration
+                the torch kernels do not model.
+            ValueError: If ``observation_resolution`` is not positive.
+        """
+        self._require_supported_config(env)
+        if observation_resolution <= 0.0:
+            raise ValueError("observation_resolution must be positive")
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self._obs_resolution = float(observation_resolution)
+        self.num_actions = int(len(env.get_actions()))
+        self._build_geometry(env)
+        self._build_noise_and_reward(env)
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _require_supported_config(env: LaserTagPOMDP) -> None:
+        if env.reward_model_type is not RewardModelType.CONSTANT_HAZARD_PENALTY:
+            raise NotImplementedError(
+                "vectorized model supports only the CONSTANT_HAZARD_PENALTY reward model"
+            )
+        if env.opponent_policy is not OpponentPolicy.EVADE:
+            raise NotImplementedError("vectorized model supports only the EVADE opponent policy")
+        if float(env.transition_error_prob) != 0.0:
+            raise NotImplementedError(
+                "vectorized model supports only deterministic robot motion "
+                "(transition_error_prob == 0.0)"
+            )
+        if env.is_dangerous_area_hit_terminal:
+            raise NotImplementedError(
+                "vectorized model requires is_dangerous_area_hit_terminal=False "
+                "(the draw-coupled hazard-terminal absorbing slot is not modeled)"
+            )
+
+    def _build_geometry(self, env: LaserTagPOMDP) -> None:
+        self._rows, self._cols = int(env.floor_shape[0]), int(env.floor_shape[1])
+        self._max_ray = max(self._rows, self._cols)
+        wall_grid = np.zeros((self._rows, self._cols), dtype=bool)
+        for wall_row, wall_col in env.walls:
+            if 0 <= wall_row < self._rows and 0 <= wall_col < self._cols:
+                wall_grid[wall_row, wall_col] = True
+        self._wall_grid = torch.as_tensor(wall_grid, device=self.device)
+        self._action_dirs = self._to_tensor(_ACTION_DIRECTIONS)
+        self._laser_dirs = self._to_tensor(_LASER_DIRECTIONS)
+        self._opp_offsets = self._to_tensor(_OPPONENT_OFFSETS)
+        self._hash_primes = torch.as_tensor(_HASH_PRIMES, device=self.device)
+
+    def _build_noise_and_reward(self, env: LaserTagPOMDP) -> None:
+        self._sigma = float(env.measurement_noise)
+        self._variance = self._sigma * self._sigma
+        self._log_norm_1d = -0.5 * float(np.log(2.0 * np.pi * self._variance))
+        self._tag_reward = float(env.tag_reward)
+        self._tag_penalty = float(env.tag_penalty)
+        self._step_cost = float(env.step_cost)
+        self._area_penalty = float(env.dangerous_area_penalty)
+        self._danger_radius_sq = float(env.dangerous_area_radius) ** 2
+        if env.dangerous_areas:
+            centers = np.asarray(env.dangerous_areas, dtype=np.float64).reshape(-1, 2)
+        else:
+            centers = np.empty((0, 2), dtype=np.float64)
+        self._danger_centers = self._to_tensor(centers)
+
+    def _to_tensor(self, array: np.ndarray) -> Tensor:
+        return torch.as_tensor(np.asarray(array), dtype=self.dtype, device=self.device)
+
+    # ------------------------------------------------------------------ #
+    # Generative kernels
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        robot, opp = states[:, 0:2], states[:, 2:4]
+        robot_next = self._robot_next(robot, actions)
+        probs = self._opponent_move_probs(robot, opp)
+        choice = torch.multinomial(probs, 1).squeeze(1)
+        opp_next = opp + self._opp_offsets[choice]
+        tag_success = (actions == _TAG_ACTION) & self._same_cell(robot, opp)
+        opp_next = torch.where(tag_success[:, None], opp, opp_next)
+        terminal = tag_success.to(self.dtype)[:, None]
+        return torch.cat([robot_next, opp_next, terminal], dim=1)
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions  # observations do not depend on the action in LaserTag.
+        true_dist = self._laser_distances(next_states[:, 0:2], next_states[:, 2:4])
+        noise = torch.randn(true_dist.shape, dtype=self.dtype, device=self.device)
+        observations = torch.clamp(true_dist + noise * self._sigma, min=0.0)
+        sentinel = torch.full_like(observations, -1.0)
+        terminal = next_states[:, 4] > 0.5
+        return torch.where(terminal[:, None], sentinel, observations)
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        robot, opp = states[:, 0:2], states[:, 2:4]
+        tag_base = torch.where(
+            self._same_cell(robot, opp),
+            torch.tensor(self._tag_reward, dtype=self.dtype, device=self.device),
+            torch.tensor(-self._tag_penalty, dtype=self.dtype, device=self.device),
+        )
+        base = torch.where(
+            actions == _TAG_ACTION, tag_base, -self._step_cost * torch.ones_like(tag_base)
+        )
+        realised = next_states[:, 0:2]
+        penalised = self._is_wall_cell(realised) | self._in_danger(realised)
+        base = base - penalised.to(self.dtype) * self._area_penalty
+        state_terminal = states[:, 4] > 0.5
+        return torch.where(state_terminal, torch.zeros_like(base), base)
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        return states[:, 4] > 0.5
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions  # likelihood does not depend on the action in LaserTag.
+        true_dist = self._laser_distances(next_states[:, 0:2], next_states[:, 2:4])
+        diff = observations - true_dist
+        gaussian = 8.0 * self._log_norm_1d - 0.5 * (diff * diff).sum(dim=1) / self._variance
+        neg_inf = torch.full_like(gaussian, float("-inf"))
+        non_terminal = torch.where((observations < 0.0).any(dim=1), neg_inf, gaussian)
+        is_sentinel = (observations == -1.0).all(dim=1)
+        terminal_logp = torch.where(is_sentinel, torch.zeros_like(gaussian), neg_inf)
+        return torch.where(next_states[:, 4] > 0.5, terminal_logp, non_terminal)
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        quantized = torch.floor(observations / self._obs_resolution).to(torch.int64)
+        return (quantized * self._hash_primes).sum(dim=1)
+
+    # ------------------------------------------------------------------ #
+    # Internal transition / geometry helpers
+    # ------------------------------------------------------------------ #
+
+    def _robot_next(self, robot: Tensor, actions: Tensor) -> Tensor:
+        candidate = robot + self._action_dirs[actions]
+        valid = self._cell_valid(candidate)
+        return torch.where(valid[:, None], candidate, robot)
+
+    def _opponent_move_probs(self, robot: Tensor, opp: Tensor) -> Tensor:
+        robot_r, robot_c = robot[:, 0], robot[:, 1]
+        opp_r, opp_c = opp[:, 0], opp[:, 1]
+        north = self._flee_prob(robot_r > opp_r, robot_r == opp_r)
+        south = self._flee_prob(robot_r < opp_r, robot_r == opp_r)
+        east = self._flee_prob(robot_c < opp_c, robot_c == opp_c)
+        west = self._flee_prob(robot_c > opp_c, robot_c == opp_c)
+        north = north * self._cell_valid(opp + self._opp_offsets[1]).to(self.dtype)
+        south = south * self._cell_valid(opp + self._opp_offsets[2]).to(self.dtype)
+        east = east * self._cell_valid(opp + self._opp_offsets[3]).to(self.dtype)
+        west = west * self._cell_valid(opp + self._opp_offsets[4]).to(self.dtype)
+        stay = 1.0 - (north + south + east + west)
+        return torch.stack([stay, north, south, east, west], dim=1)
+
+    def _flee_prob(self, away: Tensor, aligned: Tensor) -> Tensor:
+        # EVADE puts 0.4 on the away cell, or a symmetric 0.2 split when aligned.
+        return torch.where(
+            away,
+            torch.full_like(away, 0.4, dtype=self.dtype),
+            torch.where(
+                aligned,
+                torch.full_like(aligned, 0.2, dtype=self.dtype),
+                torch.zeros(away.shape, dtype=self.dtype, device=self.device),
+            ),
+        )
+
+    def _laser_distances(self, robot: Tensor, opp: Tensor) -> Tensor:
+        batch = robot.shape[0]
+        pos = robot[:, None, :].expand(batch, 8, 2).clone()
+        opp_cell = opp[:, None, :]
+        count = torch.zeros(batch, 8, dtype=self.dtype, device=self.device)
+        active = torch.ones(batch, 8, dtype=torch.bool, device=self.device)
+        for _ in range(self._max_ray):
+            pos = pos + self._laser_dirs
+            in_bounds = self._in_bounds(pos)
+            is_wall = self._wall_at(pos) & in_bounds
+            is_opp = (pos == opp_cell).all(dim=2)
+            free = active & in_bounds & ~is_wall & ~is_opp
+            count = count + free.to(self.dtype)
+            active = active & ~(~in_bounds | is_wall | is_opp)
+        return count
+
+    def _cell_valid(self, cells: Tensor) -> Tensor:
+        in_bounds = self._in_bounds(cells)
+        return in_bounds & ~(self._wall_at(cells) & in_bounds)
+
+    def _is_wall_cell(self, cells: Tensor) -> Tensor:
+        return self._in_bounds(cells) & self._wall_at(cells)
+
+    def _in_bounds(self, cells: Tensor) -> Tensor:
+        rows = cells[..., 0]
+        cols = cells[..., 1]
+        return (rows >= 0) & (rows < self._rows) & (cols >= 0) & (cols < self._cols)
+
+    def _wall_at(self, cells: Tensor) -> Tensor:
+        rows = cells[..., 0].round().long().clamp(0, self._rows - 1)
+        cols = cells[..., 1].round().long().clamp(0, self._cols - 1)
+        return self._wall_grid[rows, cols]
+
+    def _in_danger(self, points: Tensor) -> Tensor:
+        if self._danger_centers.shape[0] == 0:
+            return torch.zeros(points.shape[0], dtype=torch.bool, device=self.device)
+        diff = points[:, None, :] - self._danger_centers[None, :, :]
+        min_sq = (diff * diff).sum(dim=2).min(dim=1).values
+        return min_sq <= self._danger_radius_sq
+
+    @staticmethod
+    def _same_cell(first: Tensor, second: Tensor) -> Tensor:
+        return (first == second).all(dim=1)

--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_vectorized_model.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_vectorized_model.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for Continuous Light-Dark.
+
+This module provides :class:`ContinuousLightDarkVectorizedModel`, a fully
+batched, GPU-friendly implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+for :class:`~POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp.ContinuousLightDarkPOMDP`.
+
+It re-expresses the environment's ``NORMAL_NOISE`` observation model and
+``CONSTANT_HAZARD_PENALTY`` reward model as torch tensor kernels so a
+vectorized planner (VOPP) can run tens of thousands of parallel simulations
+on the GPU without a host/device sync. Every constant (covariances, beacons,
+obstacles, goal, radii, costs) is read from a live environment instance, so
+the environment stays the single source of truth for configuration; only the
+numeric kernels are duplicated in torch. The accompanying parity test pins
+these kernels to the environment's native (C++/numba) implementations.
+
+Only one environment configuration is supported: the ``CONSTANT_HAZARD_PENALTY``
+reward model, the ``NORMAL_NOISE`` observation model, and
+``is_obstacle_hit_terminal=False``. The default draw-coupled hazard-terminal
+path appends a dynamic absorbing state slot to the transition and is not
+modeled here; all three conditions are checked at construction and any
+mismatch raises :class:`NotImplementedError`.
+"""
+
+import math
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ContinuousLightDarkPOMDP,
+    ContinuousLightDarkRewardModel,
+    ObservationModelType,
+)
+
+_DEFAULT_ACTION_VECTORS = np.array(
+    [[0.0, 1.0], [0.0, -1.0], [1.0, 0.0], [-1.0, 0.0]], dtype=np.float64
+)
+# Spatial-hash primes for turning quantized 2-D observations into integer keys.
+_HASH_PRIME_X = 73856093
+_HASH_PRIME_Y = 19349663
+
+
+class ContinuousLightDarkVectorizedModel:
+    """Fully vectorized torch generative model for the Continuous Light-Dark POMDP.
+
+    The model batches the transition, observation, reward, terminal, and
+    observation-likelihood kernels over a leading particle dimension and keeps
+    every tensor on a single device. Actions are integer indices into a fixed
+    action table (defaulting to the four unit-direction moves); observations
+    are the noisy 2-D positions of the ``NORMAL_NOISE`` model.
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for state / observation / reward tensors.
+        num_actions: Number of rows in the action table.
+
+    Example:
+        >>> import torch
+        >>> from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+        ...     ContinuousLightDarkPOMDP,
+        ... )
+        >>> from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_vectorized_model import (
+        ...     ContinuousLightDarkVectorizedModel,
+        ... )
+        >>> torch.manual_seed(0)  # doctest: +ELLIPSIS
+        <torch._C.Generator object at ...>
+        >>> env = ContinuousLightDarkPOMDP(discount_factor=0.95, is_obstacle_hit_terminal=False)
+        >>> model = ContinuousLightDarkVectorizedModel(env, device=torch.device("cpu"))
+        >>> states = torch.tensor([[0.0, 5.0], [1.0, 5.0], [2.0, 5.0]])
+        >>> actions = torch.tensor([2, 2, 2])  # move right
+        >>> next_states = model.sample_next_states(states, actions)
+        >>> observations = model.sample_observations(next_states, actions)
+        >>> rewards = model.rewards(states, actions, next_states)
+        >>> tuple(next_states.shape), tuple(observations.shape), tuple(rewards.shape)
+        ((3, 2), (3, 2), (3,))
+    """
+
+    def __init__(
+        self,
+        env: ContinuousLightDarkPOMDP,
+        action_vectors: Optional[np.ndarray] = None,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+        observation_resolution: float = 0.1,
+    ) -> None:
+        """Build the model from a live environment instance.
+
+        Args:
+            env: The environment whose parameters and model types are mirrored.
+            action_vectors: Optional ``[num_actions, 2]`` array of continuous
+                action vectors. Defaults to the four unit-direction moves.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for real-valued tensors.
+            observation_resolution: Grid spacing used to quantize continuous
+                observations into integer tree keys.
+
+        Raises:
+            NotImplementedError: If ``env`` uses a reward or observation model
+                other than the supported ``CONSTANT_HAZARD_PENALTY`` /
+                ``NORMAL_NOISE`` pair.
+            ValueError: If ``observation_resolution`` is not positive.
+        """
+        self._require_supported_models(env)
+        if observation_resolution <= 0.0:
+            raise ValueError("observation_resolution must be positive")
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self._obs_resolution = float(observation_resolution)
+        vectors = _DEFAULT_ACTION_VECTORS if action_vectors is None else np.asarray(action_vectors)
+        self._action_table = self._to_tensor(vectors)
+        self.num_actions = int(self._action_table.shape[0])
+        self._build_noise_kernels(env)
+        self._build_reward_geometry(env)
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _require_supported_models(env: ContinuousLightDarkPOMDP) -> None:
+        # Exact-type check on purpose: the zero-mean-hazard model subclasses
+        # ContinuousLightDarkRewardModel, so isinstance would wrongly accept it.
+        reward_model_type = type(env.reward_model)  # pylint: disable=unidiomatic-typecheck
+        if reward_model_type is not ContinuousLightDarkRewardModel:
+            raise NotImplementedError(
+                "vectorized model supports only the CONSTANT_HAZARD_PENALTY reward model"
+            )
+        if env.observation_model_type is not ObservationModelType.NORMAL_NOISE:
+            raise NotImplementedError(
+                "vectorized model supports only the NORMAL_NOISE observation model"
+            )
+        if env.is_obstacle_hit_terminal:
+            raise NotImplementedError(
+                "vectorized model requires is_obstacle_hit_terminal=False "
+                "(the draw-coupled hazard-terminal absorbing slot is not modeled)"
+            )
+
+    def _build_noise_kernels(self, env: ContinuousLightDarkPOMDP) -> None:
+        trans_cov = self._to_tensor(env.state_transition_cov_matrix)
+        obs_cov_far = self._to_tensor(env.observation_cov_matrix)
+        obs_cov_near = obs_cov_far * 0.5
+        self._trans_chol_t = torch.linalg.cholesky(trans_cov).mT.contiguous()
+        self._obs_chol_t = torch.stack(
+            [torch.linalg.cholesky(obs_cov_near).mT, torch.linalg.cholesky(obs_cov_far).mT]
+        )
+        self._trans_inv, self._trans_lognorm = self._inverse_and_lognorm(trans_cov)
+        obs_inv_near, obs_lognorm_near = self._inverse_and_lognorm(obs_cov_near)
+        obs_inv_far, obs_lognorm_far = self._inverse_and_lognorm(obs_cov_far)
+        self._obs_inv = torch.stack([obs_inv_near, obs_inv_far])
+        self._obs_lognorm = torch.stack([obs_lognorm_near, obs_lognorm_far])
+        self._beacons = self._to_tensor(np.asarray(env.beacons, dtype=np.float64).T)
+        self._beacon_radius_sq = float(env.beacon_radius) ** 2
+
+    def _build_reward_geometry(self, env: ContinuousLightDarkPOMDP) -> None:
+        self._goal = self._to_tensor(np.asarray(env.goal_state, dtype=np.float64))
+        self._obstacles = self._to_tensor(np.asarray(env.obstacles, dtype=np.float64).T)
+        self._goal_radius = float(env.goal_state_radius)
+        self._obstacle_radius = float(env.obstacle_radius)
+        self._grid_size = float(env.grid_size)
+        self._fuel_cost = float(env.fuel_cost)
+        self._goal_reward = float(env.goal_reward)
+        self._obstacle_reward = float(env.obstacle_reward)
+        self._hit_probability = float(env.obstacle_hit_probability)
+
+    def _to_tensor(self, array: np.ndarray) -> Tensor:
+        return torch.as_tensor(np.asarray(array), dtype=self.dtype, device=self.device)
+
+    def _inverse_and_lognorm(self, cov: Tensor) -> Tuple[Tensor, Tensor]:
+        inverse = torch.linalg.inv(cov).contiguous()
+        logdet = torch.linalg.slogdet(cov)[1]
+        lognorm = -math.log(2.0 * math.pi) - 0.5 * logdet
+        return inverse, lognorm
+
+    @property
+    def action_vectors(self) -> Tensor:
+        """The ``[num_actions, 2]`` table of continuous action displacements.
+
+        Row ``i`` is the ``(dx, dy)`` displacement applied by action index
+        ``i`` (used, for example, to draw action arrows in a visualization).
+        """
+        return self._action_table
+
+    # ------------------------------------------------------------------ #
+    # Generative kernels
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        mean = states + self._action_table[actions]
+        noise = torch.randn(states.shape[0], 2, dtype=self.dtype, device=self.device)
+        return mean + noise @ self._trans_chol_t
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions  # NORMAL_NOISE observations do not depend on the action.
+        cov_index = self._near_beacon_index(next_states)
+        chol_t = self._obs_chol_t[cov_index]
+        noise = torch.randn(next_states.shape[0], 2, dtype=self.dtype, device=self.device)
+        return next_states + torch.einsum("nj,nji->ni", noise, chol_t)
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        del states, actions  # Reward scores the realised next state only.
+        dist_to_goal = torch.linalg.vector_norm(next_states - self._goal, dim=1)
+        reward = -self._fuel_cost - dist_to_goal
+        is_goal = dist_to_goal <= self._goal_radius
+        in_obstacle = self._in_obstacle_range(next_states) & ~is_goal
+        out_of_grid = self._out_of_grid(next_states) & ~is_goal & ~in_obstacle
+        reward = reward + self._goal_reward * is_goal.to(self.dtype)
+        reward = reward + self._obstacle_reward * out_of_grid.to(self.dtype)
+        reward = reward + self._sample_hazard(in_obstacle)
+        return reward
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        dist_to_goal = torch.linalg.vector_norm(states[:, :2] - self._goal, dim=1)
+        return dist_to_goal <= self._goal_radius
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions  # NORMAL_NOISE likelihood does not depend on the action.
+        cov_index = self._near_beacon_index(next_states)
+        inverse = self._obs_inv[cov_index]
+        diff = observations - next_states
+        maha = torch.einsum("ni,nij,nj->n", diff, inverse, diff)
+        return self._obs_lognorm[cov_index] - 0.5 * maha
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        quantized = torch.floor(observations / self._obs_resolution).to(torch.int64)
+        return quantized[:, 0] * _HASH_PRIME_X + quantized[:, 1] * _HASH_PRIME_Y
+
+    # ------------------------------------------------------------------ #
+    # Internal reward / geometry helpers
+    # ------------------------------------------------------------------ #
+
+    def _near_beacon_index(self, points: Tensor) -> Tensor:
+        # 0 -> near a beacon (use the near covariance), 1 -> far from all.
+        diff = points[:, None, :] - self._beacons[None, :, :]
+        min_sq = (diff * diff).sum(dim=-1).min(dim=1).values
+        return (min_sq >= self._beacon_radius_sq).to(torch.long)
+
+    def _in_obstacle_range(self, points: Tensor) -> Tensor:
+        if self._obstacles.shape[0] == 0:
+            return torch.zeros(points.shape[0], dtype=torch.bool, device=self.device)
+        diff = points[:, None, :] - self._obstacles[None, :, :]
+        min_sq = (diff * diff).sum(dim=-1).min(dim=1).values
+        return min_sq <= self._obstacle_radius * self._obstacle_radius
+
+    def _out_of_grid(self, points: Tensor) -> Tensor:
+        below = (points < 0.0).any(dim=1)
+        above = (points > self._grid_size).any(dim=1)
+        return below | above
+
+    def _sample_hazard(self, in_obstacle: Tensor) -> Tensor:
+        draws = torch.rand(in_obstacle.shape[0], dtype=self.dtype, device=self.device)
+        hit = in_obstacle & (draws < self._hit_probability)
+        return self._obstacle_reward * hit.to(self.dtype)

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_vectorized_model.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_vectorized_model.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for the Mountain Car POMDP.
+
+This module provides :class:`MountainCarVectorizedModel`, a fully batched,
+GPU-friendly implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+for :class:`~POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp.MountainCarPOMDP`.
+
+It re-expresses the environment's physics transition (the ``cos(3*position)``
+hill, gravity, force, and the velocity / position clamping with the
+min-position corner rule), its Gaussian observation model, and its sparse
+step reward as torch tensor kernels so a vectorized planner (VOPP) can run
+tens of thousands of parallel simulations on the GPU without a host/device
+sync. Every constant (power, gravity, speed / position bounds, goal, the
+discrete action set, and the transition / observation covariances) is read
+from a live environment instance, so the environment stays the single source
+of truth for configuration; only the numeric kernels are duplicated in torch.
+The accompanying parity test pins these kernels to the environment's native
+(C++) implementations.
+
+The Mountain Car action set is already discrete (``[-1, 0, 1]``); the model
+uses it directly, so action index ``i`` maps to force multiplier
+``env.get_actions()[i]``. The model requires the standard scalar action set;
+a non-scalar action set raises :class:`NotImplementedError`.
+"""
+
+import math
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp import (
+    MountainCarPOMDP,
+)
+
+# Spatial-hash primes for turning quantized 2-D observations into integer keys.
+_HASH_PRIME_X = 73856093
+_HASH_PRIME_Y = 19349663
+
+
+class MountainCarVectorizedModel:
+    """Fully vectorized torch generative model for the Mountain Car POMDP.
+
+    The model batches the transition, observation, reward, terminal, and
+    observation-likelihood kernels over a leading particle dimension and keeps
+    every tensor on a single device. Actions are integer indices into the
+    environment's discrete action set (``[-1, 0, 1]`` by default); observations
+    are the noisy 2-D ``[position, velocity]`` measurements of the Gaussian
+    observation model.
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for state / observation / reward tensors.
+        num_actions: Number of actions in the discrete action set.
+
+    Example:
+        >>> import torch
+        >>> from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp import (
+        ...     MountainCarPOMDP,
+        ... )
+        >>> from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_vectorized_model import (
+        ...     MountainCarVectorizedModel,
+        ... )
+        >>> torch.manual_seed(0)  # doctest: +ELLIPSIS
+        <torch._C.Generator object at ...>
+        >>> env = MountainCarPOMDP(discount_factor=0.99)
+        >>> model = MountainCarVectorizedModel(env, device=torch.device("cpu"))
+        >>> states = torch.tensor([[-0.5, 0.0], [-0.4, 0.01], [-0.6, -0.01]])
+        >>> actions = torch.tensor([2, 0, 1])  # forward, reverse, neutral
+        >>> next_states = model.sample_next_states(states, actions)
+        >>> observations = model.sample_observations(next_states, actions)
+        >>> rewards = model.rewards(states, actions, next_states)
+        >>> tuple(next_states.shape), tuple(observations.shape), tuple(rewards.shape)
+        ((3, 2), (3, 2), (3,))
+    """
+
+    def __init__(
+        self,
+        env: MountainCarPOMDP,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+        observation_resolution: float = 0.01,
+    ) -> None:
+        """Build the model from a live environment instance.
+
+        Args:
+            env: The environment whose parameters and action set are mirrored.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for real-valued tensors.
+            observation_resolution: Grid spacing used to quantize continuous
+                observations into integer tree keys.
+
+        Raises:
+            NotImplementedError: If ``env`` exposes a non-scalar action set that
+                the scalar force-multiplier kernel cannot model.
+            ValueError: If ``observation_resolution`` is not positive.
+        """
+        self._require_supported_action_set(env)
+        if observation_resolution <= 0.0:
+            raise ValueError("observation_resolution must be positive")
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self._obs_resolution = float(observation_resolution)
+        self._build_physics(env)
+        self._build_noise_kernels(env)
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _require_supported_action_set(env: MountainCarPOMDP) -> None:
+        actions = env.get_actions()
+        if not actions or not all(np.isscalar(action) for action in actions):
+            raise NotImplementedError(
+                "vectorized model supports only a non-empty scalar discrete "
+                "action set (force multipliers such as [-1, 0, 1])"
+            )
+
+    def _build_physics(self, env: MountainCarPOMDP) -> None:
+        self.num_actions = len(env.get_actions())
+        self._action_forces = self._to_tensor(
+            np.asarray(env.get_actions(), dtype=np.float64) * env.power
+        )
+        self._gravity = float(env.gravity)
+        self._max_speed = float(env.max_speed)
+        self._min_position = float(env.min_position)
+        self._max_position = float(env.max_position)
+        self._goal_position = float(env.goal_position)
+
+    def _build_noise_kernels(self, env: MountainCarPOMDP) -> None:
+        trans_cov = self._to_tensor(np.asarray(env.state_transition_cov, dtype=np.float64))
+        obs_cov = self._to_tensor(np.asarray(env.cov_matrix, dtype=np.float64))
+        self._trans_chol_t = torch.linalg.cholesky(trans_cov).mT.contiguous()
+        self._obs_chol_t = torch.linalg.cholesky(obs_cov).mT.contiguous()
+        self._obs_inv, self._obs_lognorm = self._inverse_and_lognorm(obs_cov)
+
+    def _to_tensor(self, array: np.ndarray) -> Tensor:
+        return torch.as_tensor(np.asarray(array), dtype=self.dtype, device=self.device)
+
+    def _inverse_and_lognorm(self, cov: Tensor) -> Tuple[Tensor, Tensor]:
+        inverse = torch.linalg.inv(cov).contiguous()
+        logdet = torch.linalg.slogdet(cov)[1]
+        lognorm = -math.log(2.0 * math.pi) - 0.5 * logdet
+        return inverse, lognorm
+
+    # ------------------------------------------------------------------ #
+    # Generative kernels
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        mean = self._deterministic_next(states, actions)
+        noise = torch.randn(states.shape[0], 2, dtype=self.dtype, device=self.device)
+        return self._apply_bounds(mean + noise @ self._trans_chol_t)
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions  # Observations do not depend on the action.
+        noise = torch.randn(next_states.shape[0], 2, dtype=self.dtype, device=self.device)
+        return next_states + noise @ self._obs_chol_t
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        del actions, next_states  # Reward scores the current state's position only.
+        reached_goal = states[:, 0] >= self._goal_position
+        return torch.where(
+            reached_goal,
+            torch.zeros((), dtype=self.dtype, device=self.device),
+            -torch.ones((), dtype=self.dtype, device=self.device),
+        )
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        return states[:, 0] >= self._goal_position
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions  # Observation likelihood does not depend on the action.
+        diff = observations - next_states
+        maha = torch.einsum("ni,ij,nj->n", diff, self._obs_inv, diff)
+        return self._obs_lognorm - 0.5 * maha
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        quantized = torch.floor(observations / self._obs_resolution).to(torch.int64)
+        return quantized[:, 0] * _HASH_PRIME_X + quantized[:, 1] * _HASH_PRIME_Y
+
+    # ------------------------------------------------------------------ #
+    # Internal physics helpers
+    # ------------------------------------------------------------------ #
+
+    def _deterministic_next(self, states: Tensor, actions: Tensor) -> Tensor:
+        position = states[:, 0]
+        velocity = states[:, 1] + self._action_forces[actions]
+        velocity = velocity - self._gravity * torch.cos(3.0 * position)
+        velocity = torch.clamp(velocity, -self._max_speed, self._max_speed)
+        next_position = torch.clamp(position + velocity, self._min_position, self._max_position)
+        return self._resolve_min_position_corner(next_position, velocity)
+
+    def _apply_bounds(self, sample: Tensor) -> Tensor:
+        velocity = torch.clamp(sample[:, 1], -self._max_speed, self._max_speed)
+        position = torch.clamp(sample[:, 0], self._min_position, self._max_position)
+        return self._resolve_min_position_corner(position, velocity)
+
+    def _resolve_min_position_corner(self, position: Tensor, velocity: Tensor) -> Tensor:
+        at_floor = (position == self._min_position) & (velocity < 0.0)
+        velocity = torch.where(at_floor, torch.zeros_like(velocity), velocity)
+        return torch.stack((position, velocity), dim=1)

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_vectorized_model.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_vectorized_model.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for the PacMan POMDP.
+
+This module provides :class:`PacManVectorizedModel`, a fully batched,
+GPU-friendly implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+for :class:`~POMDPPlanners.environments.pacman_pomdp.pacman_pomdp.PacManPOMDP`.
+
+It re-expresses the environment's native C++ transition, observation, and
+reward kernels as torch tensor operations so a vectorized planner (VOPP) can
+run tens of thousands of parallel simulations on the GPU without a host/device
+sync. Every constant (maze neighbor table, pellet positions, ghost
+aggressiveness, observation-noise parameters, reward scalars, hazard geometry)
+is read from a live environment instance, so the environment stays the single
+source of truth for configuration; only the numeric kernels are duplicated in
+torch. The accompanying parity test pins these kernels to the environment's
+native implementations.
+
+Only the standard PacMan configuration is supported: ``independent`` ghost
+coordination, all-``aggressive`` ghost strategies, the
+``CONSTANT_HAZARD_PENALTY`` reward model, and
+``is_dangerous_area_hit_terminal=False``. The patrol/ambush strategies and the
+coordinated/mixed modes carry hidden or non-per-particle state (a ghost patrol
+direction lives on the environment, not the particle), and the draw-coupled
+hazard-terminal path couples an absorbing slot to the reward draw; none is
+modeled here. All four conditions are checked at construction and any mismatch
+raises :class:`NotImplementedError`.
+"""
+
+import math
+from typing import TYPE_CHECKING, Optional, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor
+
+if TYPE_CHECKING:
+    from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import PacManPOMDP
+
+# log(1e-300); the native ``batch_log_likelihood`` floors impossible-event
+# log-likelihoods to this value, so the torch kernel matches it exactly.
+_LOG_PROB_FLOOR = -690.7755278982137
+# Odd multiplier for the rolling polynomial hash that turns a discrete
+# observation (small non-negative integer coordinates) into one int64 key.
+_OBS_HASH_MULTIPLIER = 2654435761
+
+
+class PacManVectorizedModel:
+    """Fully vectorized torch generative model for the PacMan POMDP.
+
+    The model batches the transition, observation, reward, terminal, and
+    observation-likelihood kernels over a leading particle dimension and keeps
+    every tensor on a single device. Actions are the five discrete moves
+    (north, east, south, west, stay) indexed ``0..4``; observations are the
+    per-ghost noisy integer grid positions of the native observation model.
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for state / observation / reward tensors.
+        num_actions: Number of discrete actions (always 5 for PacMan).
+
+    Example:
+        >>> import torch
+        >>> from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import (
+        ...     create_simple_maze_pacman,
+        ... )
+        >>> from POMDPPlanners.environments.pacman_pomdp.pacman_vectorized_model import (
+        ...     PacManVectorizedModel,
+        ... )
+        >>> torch.manual_seed(0)  # doctest: +ELLIPSIS
+        <torch._C.Generator object at ...>
+        >>> env = create_simple_maze_pacman()
+        >>> model = PacManVectorizedModel(env, device=torch.device("cpu"))
+        >>> state = torch.as_tensor(env.initial_state_dist().sample()[0]).unsqueeze(0)
+        >>> actions = torch.tensor([1])  # east
+        >>> next_states = model.sample_next_states(state, actions)
+        >>> observations = model.sample_observations(next_states, actions)
+        >>> rewards = model.rewards(state, actions, next_states)
+        >>> tuple(next_states.shape[1:]), tuple(observations.shape), tuple(rewards.shape)
+        ((10,), (1, 2), (1,))
+    """
+
+    def __init__(
+        self,
+        env: "PacManPOMDP",
+        *,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float64,
+    ) -> None:
+        """Build the model from a live environment instance.
+
+        Args:
+            env: The environment whose parameters and kernels are mirrored.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for real-valued tensors.
+
+        Raises:
+            NotImplementedError: If ``env`` uses ghost coordination other than
+                ``independent``, any non-``aggressive`` ghost strategy, a reward
+                model other than ``CONSTANT_HAZARD_PENALTY``, or the draw-coupled
+                ``is_dangerous_area_hit_terminal`` path.
+        """
+        self._require_supported_config(env)
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self.num_actions = 5
+        self._build_layout(env)
+        self._build_maze_tables()
+        self._build_scalars(env)
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _require_supported_config(env: "PacManPOMDP") -> None:
+        from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import (  # pylint: disable=import-outside-toplevel
+            RewardModelType,
+        )
+
+        if env.ghost_coordination != "independent":
+            raise NotImplementedError(
+                "vectorized model supports only 'independent' ghost coordination"
+            )
+        if any(strategy != "aggressive" for strategy in env.ghost_strategies):
+            raise NotImplementedError(
+                "vectorized model supports only the 'aggressive' ghost strategy"
+            )
+        if env.reward_model_type is not RewardModelType.CONSTANT_HAZARD_PENALTY:
+            raise NotImplementedError(
+                "vectorized model supports only the CONSTANT_HAZARD_PENALTY reward model"
+            )
+        if env.is_dangerous_area_hit_terminal:
+            raise NotImplementedError(
+                "vectorized model requires is_dangerous_area_hit_terminal=False "
+                "(the draw-coupled hazard-terminal absorbing slot is not modeled)"
+            )
+
+    def _build_layout(self, env: "PacManPOMDP") -> None:
+        trans = env.get_transition_cpp_ctor_kwargs()
+        self._num_ghosts = int(trans["num_ghosts"])
+        self._idx_pac_row = int(trans["idx_pac_row"])
+        self._idx_pac_col = int(trans["idx_pac_col"])
+        self._idx_ghosts_start = int(trans["idx_ghosts_start"])
+        self._idx_ghosts_end = self._idx_ghosts_start + 2 * self._num_ghosts
+        self._idx_pellets_start = int(trans["idx_pellets_start"])
+        self._idx_pellets_end = int(trans["idx_pellets_end"])
+        self._idx_score = int(trans["idx_score"])
+        self._idx_terminal = int(trans["idx_terminal"])
+        self._num_pellets = self._idx_pellets_end - self._idx_pellets_start
+        self._trans_kwargs = trans
+
+    def _build_maze_tables(self) -> None:
+        trans = self._trans_kwargs
+        self._maze_rows = int(trans["maze_rows"])
+        self._maze_cols = int(trans["maze_cols"])
+        self._neighbor_table = torch.as_tensor(
+            np.asarray(trans["neighbor_table"], dtype=np.int64), device=self.device
+        )
+        self._neighbor_validity = torch.as_tensor(
+            np.asarray(trans["neighbor_validity"], dtype=np.bool_), device=self.device
+        )
+        pellets = np.asarray(trans["pellet_positions"], dtype=np.int64).reshape(-1, 2)
+        self._pellet_positions = torch.as_tensor(pellets, device=self.device)
+
+    def _build_scalars(self, env: "PacManPOMDP") -> None:
+        obs = env.get_observation_cpp_ctor_kwargs()
+        self._ghost_aggressiveness = float(self._trans_kwargs["ghost_aggressiveness"])
+        self._pellet_reward = float(self._trans_kwargs["pellet_reward"])
+        self._obs_noise_factor = float(obs["observation_noise_factor"])
+        self._max_obs_noise = float(obs["max_observation_noise"])
+        self._step_penalty = float(env.step_penalty)
+        self._collision_penalty = float(env.ghost_collision_penalty)
+        self._win_reward = float(env.win_reward)
+        self._danger_penalty = float(env.dangerous_area_penalty)
+        self._danger_radius_sq = float(env.dangerous_area_radius) ** 2
+        danger = np.asarray(self._trans_kwargs["dangerous_areas"], dtype=np.float64).reshape(-1, 2)
+        self._dangerous_areas = torch.as_tensor(danger, dtype=self.dtype, device=self.device)
+
+    # ------------------------------------------------------------------ #
+    # Generative kernels
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        out = states.clone()
+        active = states[:, self._idx_terminal] <= 0.5
+        old_pac = states[:, self._idx_pac_row : self._idx_pac_col + 1].round().long()
+        new_pac = self._move_pacman(old_pac, actions)
+        old_ghosts = states[:, self._idx_ghosts_start : self._idx_ghosts_end].round().long()
+        new_ghosts = self._move_ghosts(old_ghosts, old_pac)
+        collided = self._transition_collision(old_pac, new_pac, old_ghosts, new_ghosts)
+        new_pellets, collected = self._collect_pellets(states, new_pac, collided)
+        new_score = states[:, self._idx_score] + collected.to(self.dtype) * self._pellet_reward
+        won = (~collided) & (~self._any_pellet_active(new_pellets))
+        new_terminal = (collided | won).to(self.dtype)
+        self._write_active(out, active, new_pac, new_ghosts, new_pellets, new_score, new_terminal)
+        return out
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions  # Observations do not depend on the action.
+        num_rows = next_states.shape[0]
+        pac = next_states[:, self._idx_pac_row : self._idx_pac_col + 1]
+        ghosts = next_states[:, self._idx_ghosts_start : self._idx_ghosts_end].view(
+            num_rows, self._num_ghosts, 2
+        )
+        std = self._observation_std(ghosts, pac)
+        noise = torch.randn(num_rows, self._num_ghosts, 2, dtype=self.dtype, device=self.device)
+        obs = torch.round(ghosts + noise * std.unsqueeze(-1))
+        obs[..., 0] = torch.clamp(obs[..., 0], 0, self._maze_rows - 1)
+        obs[..., 1] = torch.clamp(obs[..., 1], 0, self._maze_cols - 1)
+        terminal = next_states[:, self._idx_terminal] > 0.5
+        obs[terminal] = -1.0
+        return obs.reshape(num_rows, 2 * self._num_ghosts)
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        del actions  # Reward is action-independent given (state, next_state).
+        num_rows = states.shape[0]
+        reward = torch.full((num_rows,), self._step_penalty, dtype=self.dtype, device=self.device)
+        reward = reward + self._reward_collision(next_states) * self._collision_penalty
+        got_pellet = next_states[:, self._idx_score] > states[:, self._idx_score]
+        reward = reward + got_pellet.to(self.dtype) * self._pellet_reward
+        won = (next_states[:, self._idx_terminal] > 0.5) & (
+            ~self._any_pellet_active(
+                next_states[:, self._idx_pellets_start : self._idx_pellets_end]
+            )
+        )
+        reward = reward + won.to(self.dtype) * self._win_reward
+        reward = reward - self._danger_contribution(next_states) * self._danger_penalty
+        active = states[:, self._idx_terminal] <= 0.5
+        return torch.where(active, reward, torch.zeros_like(reward))
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        return states[:, self._idx_terminal] > 0.5
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions  # Observation likelihood is action-independent.
+        num_rows = next_states.shape[0]
+        state_terminal = next_states[:, self._idx_terminal] > 0.5
+        obs = observations.view(num_rows, self._num_ghosts, 2)
+        obs_terminal_ghost = (obs < -0.5).all(dim=-1)
+        obs_all_terminal = obs_terminal_ghost.all(dim=1)
+        per_ghost = self._per_ghost_log_prob(next_states, obs)
+        per_ghost = torch.where(obs_terminal_ghost, self._neg_inf(obs_terminal_ghost), per_ghost)
+        total = per_ghost.sum(dim=1)
+        neg_inf = torch.full_like(total, float("-inf"))
+        zeros = torch.zeros_like(total)
+        terminal_branch = torch.where(obs_all_terminal, zeros, neg_inf)
+        non_terminal_branch = torch.where(obs_all_terminal, neg_inf, total)
+        result = torch.where(state_terminal, terminal_branch, non_terminal_branch)
+        return torch.clamp(result, min=_LOG_PROB_FLOOR)
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        coords = observations.round().to(torch.int64) + 1  # shift -1 sentinel to 0
+        key = torch.zeros(observations.shape[0], dtype=torch.int64, device=observations.device)
+        for column in range(coords.shape[1]):
+            key = key * _OBS_HASH_MULTIPLIER + coords[:, column]
+        return key
+
+    # ------------------------------------------------------------------ #
+    # Transition internals
+    # ------------------------------------------------------------------ #
+
+    def _move_pacman(self, pac: Tensor, actions: Tensor) -> Tensor:
+        return self._neighbor_table[pac[:, 0], pac[:, 1], actions.to(torch.int64)]
+
+    def _move_ghosts(self, ghosts: Tensor, pac: Tensor) -> Tensor:
+        num_rows = ghosts.shape[0]
+        moved = torch.empty(num_rows, 2 * self._num_ghosts, dtype=self.dtype, device=self.device)
+        for ghost in range(self._num_ghosts):
+            gpos = ghosts[:, 2 * ghost : 2 * ghost + 2]
+            neighbors = self._neighbor_table[gpos[:, 0], gpos[:, 1]]  # [N, 5, 2]
+            validity = self._neighbor_validity[gpos[:, 0], gpos[:, 1]]  # [N, 5]
+            dist = (neighbors - pac.unsqueeze(1)).abs().sum(dim=-1).to(self.dtype)
+            scores = -dist / self._ghost_aggressiveness
+            scores = torch.where(validity, scores, torch.full_like(scores, float("-inf")))
+            probs = torch.softmax(scores, dim=1)
+            choice = torch.multinomial(probs, num_samples=1).squeeze(1)
+            picked = neighbors[torch.arange(num_rows, device=self.device), choice]
+            moved[:, 2 * ghost : 2 * ghost + 2] = picked.to(self.dtype)
+        return moved
+
+    def _transition_collision(
+        self, old_pac: Tensor, new_pac: Tensor, old_ghosts: Tensor, new_ghosts: Tensor
+    ) -> Tensor:
+        num_rows = new_pac.shape[0]
+        new_pac_f = new_pac.to(self.dtype)
+        collided = torch.zeros(num_rows, dtype=torch.bool, device=self.device)
+        old_pac_f = old_pac.to(self.dtype)
+        for ghost in range(self._num_ghosts):
+            new_g = new_ghosts[:, 2 * ghost : 2 * ghost + 2]
+            old_g = old_ghosts[:, 2 * ghost : 2 * ghost + 2].to(self.dtype)
+            same_cell = (new_g == new_pac_f).all(dim=1)
+            swap = (old_g == new_pac_f).all(dim=1) & (new_g == old_pac_f).all(dim=1)
+            collided = collided | same_cell | swap
+        return collided
+
+    def _collect_pellets(
+        self, states: Tensor, new_pac: Tensor, collided: Tensor
+    ) -> Tuple[Tensor, Tensor]:
+        block = states[:, self._idx_pellets_start : self._idx_pellets_end]
+        if self._num_pellets == 0:
+            return block, torch.zeros(states.shape[0], dtype=torch.bool, device=self.device)
+        new_pac_f = new_pac.to(self.dtype)
+        pellets = self._pellet_positions.to(self.dtype)
+        match = (pellets.unsqueeze(0) == new_pac_f.unsqueeze(1)).all(dim=-1)  # [N, P]
+        can_collect = match & (block > 0.5) & (~collided).unsqueeze(1)
+        new_block = torch.where(can_collect, torch.zeros_like(block), block)
+        return new_block, can_collect.any(dim=1)
+
+    def _any_pellet_active(self, block: Tensor) -> Tensor:
+        if self._num_pellets == 0:
+            return torch.zeros(block.shape[0], dtype=torch.bool, device=self.device)
+        return (block > 0.5).any(dim=1)
+
+    def _write_active(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        out: Tensor,
+        active: Tensor,
+        new_pac: Tensor,
+        new_ghosts: Tensor,
+        new_pellets: Tensor,
+        new_score: Tensor,
+        new_terminal: Tensor,
+    ) -> None:
+        active_col = active.unsqueeze(1)
+        pac_block = out[:, self._idx_pac_row : self._idx_pac_col + 1]
+        out[:, self._idx_pac_row : self._idx_pac_col + 1] = torch.where(
+            active_col, new_pac.to(self.dtype), pac_block
+        )
+        ghost_block = out[:, self._idx_ghosts_start : self._idx_ghosts_end]
+        out[:, self._idx_ghosts_start : self._idx_ghosts_end] = torch.where(
+            active_col, new_ghosts, ghost_block
+        )
+        pellet_block = out[:, self._idx_pellets_start : self._idx_pellets_end]
+        out[:, self._idx_pellets_start : self._idx_pellets_end] = torch.where(
+            active_col, new_pellets, pellet_block
+        )
+        out[:, self._idx_score] = torch.where(active, new_score, out[:, self._idx_score])
+        out[:, self._idx_terminal] = torch.where(active, new_terminal, out[:, self._idx_terminal])
+
+    # ------------------------------------------------------------------ #
+    # Observation / reward internals
+    # ------------------------------------------------------------------ #
+
+    def _observation_std(self, ghosts: Tensor, pac: Tensor) -> Tensor:
+        dist = (ghosts - pac.unsqueeze(1)).abs().sum(dim=-1).to(self.dtype)
+        std = dist * self._obs_noise_factor
+        std = torch.clamp(std, max=self._max_obs_noise)
+        return torch.clamp(std, min=1e-6)
+
+    def _reward_collision(self, next_states: Tensor) -> Tensor:
+        num_rows = next_states.shape[0]
+        pac = next_states[:, self._idx_pac_row : self._idx_pac_col + 1]
+        ghosts = next_states[:, self._idx_ghosts_start : self._idx_ghosts_end].view(
+            num_rows, self._num_ghosts, 2
+        )
+        same_cell = (ghosts == pac.unsqueeze(1)).all(dim=-1)
+        return same_cell.any(dim=1).to(self.dtype)
+
+    def _danger_contribution(self, next_states: Tensor) -> Tensor:
+        num_rows = next_states.shape[0]
+        if self._dangerous_areas.shape[0] == 0:
+            return torch.zeros(num_rows, dtype=self.dtype, device=self.device)
+        pac = next_states[:, self._idx_pac_row : self._idx_pac_col + 1]
+        diff = pac.unsqueeze(1) - self._dangerous_areas.unsqueeze(0)
+        min_sq = (diff * diff).sum(dim=-1).min(dim=1).values
+        return (min_sq <= self._danger_radius_sq).to(self.dtype)
+
+    def _per_ghost_log_prob(self, next_states: Tensor, obs: Tensor) -> Tensor:
+        num_rows = next_states.shape[0]
+        pac = next_states[:, self._idx_pac_row : self._idx_pac_col + 1]
+        ghosts = next_states[:, self._idx_ghosts_start : self._idx_ghosts_end].view(
+            num_rows, self._num_ghosts, 2
+        )
+        std = self._observation_std(ghosts, pac)
+        log_row = self._bin_log_prob(obs[..., 0], ghosts[..., 0], std, self._maze_rows - 1)
+        log_col = self._bin_log_prob(obs[..., 1], ghosts[..., 1], std, self._maze_cols - 1)
+        return log_row + log_col
+
+    def _bin_log_prob(self, obs: Tensor, mean: Tensor, std: Tensor, max_coord: int) -> Tensor:
+        coord = obs.to(torch.int64)
+        coord_f = coord.to(self.dtype)
+        inv = 1.0 / (std * math.sqrt(2.0))
+
+        def cdf(value: Tensor) -> Tensor:
+            return 0.5 * (1.0 + torch.erf((value - mean) * inv))
+
+        interior = cdf(coord_f + 0.5) - cdf(coord_f - 0.5)
+        low = cdf(torch.full_like(coord_f, 0.5))
+        high = 1.0 - cdf(torch.full_like(coord_f, max_coord - 0.5))
+        mass = torch.where(coord == 0, low, torch.where(coord == max_coord, high, interior))
+        log_prob = torch.log(mass)
+        in_range = (coord >= 0) & (coord <= max_coord) & (mass > 0.0)
+        return torch.where(in_range, log_prob, self._neg_inf(log_prob))
+
+    def _neg_inf(self, template: Tensor) -> Tensor:
+        return torch.full(template.shape, float("-inf"), dtype=self.dtype, device=self.device)

--- a/POMDPPlanners/environments/push_pomdp/push_vectorized_model.py
+++ b/POMDPPlanners/environments/push_pomdp/push_vectorized_model.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for the (discrete) Push POMDP.
+
+This module provides :class:`PushVectorizedModel`, a fully batched,
+GPU-friendly implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+for :class:`~POMDPPlanners.environments.push_pomdp.push_pomdp.PushPOMDP`.
+
+It re-expresses the environment's closed-form deterministic push transition
+(robot move with obstacle blocking, friction-scaled object push, grid
+clipping) and its ``CONSTANT_HAZARD_PENALTY`` reward / Gaussian
+object-position observation model as torch tensor kernels, so a vectorized
+planner (VOPP) can run tens of thousands of parallel simulations on the GPU
+without a host/device sync. Every constant (grid size, push threshold,
+friction, obstacle / dangerous-area geometry, penalties, observation noise,
+action-error probability) is read from a live environment instance, so the
+environment stays the single source of truth for configuration; only the
+numeric kernels are duplicated in torch. The accompanying parity test pins
+these kernels to the environment's native (C++/numpy) implementations.
+
+The discrete Push POMDP is a natural fit for VOPP: its four moves
+(``up``/``down``/``right``/``left``) form the fixed, finite representative
+action set indexed ``0..3`` directly, with no preset-table synthesis. Only
+the standard ``CONSTANT_HAZARD_PENALTY`` reward model is supported; the
+zero-mean-shock and distance-decayed reward variants are not modeled and are
+rejected at construction with :class:`NotImplementedError`.
+"""
+
+import math
+from typing import Optional
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.push_pomdp.push_pomdp import PushPOMDP
+from POMDPPlanners.environments.push_pomdp.push_pomdp_utils.push_reward_models import (
+    RewardModelType,
+)
+
+# Action index -> (dx, dy) offset, matching PushPOMDP.actions ordering
+# ("up", "down", "right", "left").
+_ACTION_VECTORS = np.array([[0.0, 1.0], [0.0, -1.0], [1.0, 0.0], [-1.0, 0.0]], dtype=np.float64)
+# Spatial-hash primes for turning quantized 2-D object observations into keys.
+_HASH_PRIME_X = 73856093
+_HASH_PRIME_Y = 19349663
+
+
+class PushVectorizedModel:
+    """Fully vectorized torch generative model for the discrete Push POMDP.
+
+    The model batches the transition, observation, reward, terminal, and
+    observation-likelihood kernels over a leading particle dimension and keeps
+    every tensor on a single device. State and observation are the 6-D vector
+    ``[robot_x, robot_y, object_x, object_y, target_x, target_y]``; only the
+    object-position slice carries observation noise. Actions are the four
+    integer move indices (``0`` up, ``1`` down, ``2`` right, ``3`` left);
+    observation keys hash the quantized object position.
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for state / observation / reward tensors.
+        num_actions: Number of moves in the action set (always 4).
+
+    Example:
+        >>> import torch
+        >>> from POMDPPlanners.environments.push_pomdp.push_pomdp import PushPOMDP
+        >>> from POMDPPlanners.environments.push_pomdp.push_vectorized_model import (
+        ...     PushVectorizedModel,
+        ... )
+        >>> torch.manual_seed(0)  # doctest: +ELLIPSIS
+        <torch._C.Generator object at ...>
+        >>> env = PushPOMDP(discount_factor=0.99)
+        >>> model = PushVectorizedModel(env, device=torch.device("cpu"))
+        >>> states = torch.tensor([[1.0, 1.0, 1.5, 1.0, 9.0, 9.0]])
+        >>> actions = torch.tensor([2])  # move right
+        >>> next_states = model.sample_next_states(states, actions)
+        >>> observations = model.sample_observations(next_states, actions)
+        >>> rewards = model.rewards(states, actions, next_states)
+        >>> tuple(next_states.shape), tuple(observations.shape), tuple(rewards.shape)
+        ((1, 6), (1, 6), (1,))
+    """
+
+    def __init__(
+        self,
+        env: PushPOMDP,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+        observation_resolution: float = 0.1,
+    ) -> None:
+        """Build the model from a live environment instance.
+
+        Args:
+            env: The environment whose parameters and reward model are mirrored.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for real-valued tensors.
+            observation_resolution: Grid spacing used to quantize continuous
+                object observations into integer tree keys.
+
+        Raises:
+            NotImplementedError: If ``env`` uses a reward model other than the
+                supported ``CONSTANT_HAZARD_PENALTY`` variant.
+            ValueError: If ``observation_resolution`` is not positive.
+        """
+        self._require_supported_models(env)
+        if observation_resolution <= 0.0:
+            raise ValueError("observation_resolution must be positive")
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self._obs_resolution = float(observation_resolution)
+        self._action_table = self._to_tensor(_ACTION_VECTORS)
+        self.num_actions = int(self._action_table.shape[0])
+        self._build_transition_geometry(env)
+        self._build_reward_geometry(env)
+        self._build_observation_kernel(env)
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _require_supported_models(env: PushPOMDP) -> None:
+        if env.reward_model_type is not RewardModelType.CONSTANT_HAZARD_PENALTY:
+            raise NotImplementedError(
+                "vectorized model supports only the CONSTANT_HAZARD_PENALTY reward model"
+            )
+
+    def _build_transition_geometry(self, env: PushPOMDP) -> None:
+        self._grid_max = float(env.grid_size - 1)
+        self._push_threshold_sq = float(env.push_threshold) ** 2
+        self._push_scale = 1.0 - float(env.friction_coefficient)
+        self._transition_error_prob = float(env.transition_error_prob)
+        self._obstacles = self._centres_tensor(env.obstacles)
+        self._obstacle_radius_sq = float(env.obstacle_radius) ** 2
+
+    def _build_reward_geometry(self, env: PushPOMDP) -> None:
+        self._obstacle_penalty = float(env.obstacle_penalty)
+        self._obstacle_hit_prob = float(env.obstacle_hit_probability)
+        self._dangerous_areas = self._centres_tensor(env.dangerous_areas)
+        self._danger_radius_sq = float(env.dangerous_area_radius) ** 2
+        self._danger_penalty = float(env.dangerous_area_penalty)
+        self._danger_hit_prob = float(env.dangerous_area_hit_probability)
+
+    def _build_observation_kernel(self, env: PushPOMDP) -> None:
+        self._obs_noise = float(env.observation_noise)
+        self._obs_variance = self._obs_noise * self._obs_noise
+        self._obs_log_norm = -math.log(2.0 * math.pi * self._obs_variance)
+
+    def _centres_tensor(self, centres: object) -> Tensor:
+        array = np.asarray(centres, dtype=np.float64).reshape(-1, 2)
+        return self._to_tensor(array)
+
+    def _to_tensor(self, array: np.ndarray) -> Tensor:
+        return torch.as_tensor(np.asarray(array), dtype=self.dtype, device=self.device)
+
+    # ------------------------------------------------------------------ #
+    # Generative kernels
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        # The env clips only after the push distance is measured, so the robot
+        # and object positions are resolved unclamped and clamped together last.
+        offsets = self._action_table[self._resolve_actions(actions)]
+        robot = self._resolve_robot(states[:, 0:2], offsets)
+        obj = self._resolve_object(robot, states[:, 2:4], offsets)
+        clipped = torch.clamp(torch.cat([robot, obj], dim=1), 0.0, self._grid_max)
+        return torch.cat([clipped, states[:, 4:6]], dim=1)
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions  # Observation noise is action-independent for this env.
+        noise = torch.randn(next_states.shape[0], 2, dtype=self.dtype, device=self.device)
+        obj_obs = torch.clamp(next_states[:, 2:4] + noise * self._obs_noise, 0.0, self._grid_max)
+        observations = next_states.clone()
+        observations[:, 2:4] = obj_obs
+        return observations
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        del states, actions  # Reward scores the realised next state only.
+        delta = next_states[:, 2:4] - next_states[:, 4:6]
+        dist = torch.linalg.vector_norm(delta, dim=1)
+        reward = -dist + 100.0 * (dist < 0.5).to(self.dtype)
+        robot = next_states[:, 0:2]
+        reward = reward + self._obstacle_contribution(robot)
+        reward = reward + self._dangerous_area_contribution(robot)
+        return reward
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        delta = states[:, 2:4] - states[:, 4:6]
+        return (delta * delta).sum(dim=1) < 0.25
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions  # Object-position Gaussian likelihood ignores the action.
+        diff = observations[:, 2:4] - next_states[:, 2:4]
+        sq = (diff * diff).sum(dim=1)
+        return self._obs_log_norm - 0.5 * sq / self._obs_variance
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        quantized = torch.floor(observations[:, 2:4] / self._obs_resolution).to(torch.int64)
+        return quantized[:, 0] * _HASH_PRIME_X + quantized[:, 1] * _HASH_PRIME_Y
+
+    # ------------------------------------------------------------------ #
+    # Internal transition helpers
+    # ------------------------------------------------------------------ #
+
+    def _resolve_actions(self, actions: Tensor) -> Tensor:
+        indices = actions.to(torch.int64)
+        if self._transition_error_prob <= 0.0:
+            return indices
+        draws = torch.rand(indices.shape[0], dtype=self.dtype, device=self.device)
+        errored = draws < self._transition_error_prob
+        offset = torch.randint(1, self.num_actions, indices.shape, device=self.device)
+        return torch.where(errored, (indices + offset) % self.num_actions, indices)
+
+    def _resolve_robot(self, robot: Tensor, offsets: Tensor) -> Tensor:
+        # Unclamped: obstacle blocking keeps the old position, else moves.
+        intended = robot + offsets
+        blocked = self._in_obstacle(intended).unsqueeze(1)
+        return torch.where(blocked, robot, intended)
+
+    def _resolve_object(self, robot: Tensor, obj: Tensor, offsets: Tensor) -> Tensor:
+        # ``robot`` is the unclamped new robot position (matches the env's push
+        # distance check); the object is clamped by the caller afterwards.
+        diff = robot - obj
+        pushed_mask = ((diff * diff).sum(dim=1) < self._push_threshold_sq).unsqueeze(1)
+        intended = obj + offsets * self._push_scale
+        blocked = self._in_obstacle(intended).unsqueeze(1)
+        moved = torch.where(blocked, obj, intended)
+        return torch.where(pushed_mask, moved, obj)
+
+    def _in_obstacle(self, points: Tensor) -> Tensor:
+        return self._within_radius(points, self._obstacles, self._obstacle_radius_sq)
+
+    # ------------------------------------------------------------------ #
+    # Internal reward helpers
+    # ------------------------------------------------------------------ #
+
+    def _obstacle_contribution(self, robot: Tensor) -> Tensor:
+        collide = self._in_obstacle(robot)
+        applied = self._apply_hit_probability(collide, self._obstacle_hit_prob)
+        return self._obstacle_penalty * applied.to(self.dtype)
+
+    def _dangerous_area_contribution(self, robot: Tensor) -> Tensor:
+        in_zone = self._within_radius(robot, self._dangerous_areas, self._danger_radius_sq)
+        applied = self._apply_hit_probability(in_zone, self._danger_hit_prob)
+        return self._danger_penalty * applied.to(self.dtype)
+
+    def _apply_hit_probability(self, hit: Tensor, probability: float) -> Tensor:
+        if probability >= 1.0:
+            return hit
+        draws = torch.rand(hit.shape[0], dtype=self.dtype, device=self.device)
+        return hit & (draws < probability)
+
+    def _within_radius(self, points: Tensor, centres: Tensor, radius_sq: float) -> Tensor:
+        if centres.shape[0] == 0:
+            return torch.zeros(points.shape[0], dtype=torch.bool, device=self.device)
+        diff = points[:, None, :] - centres[None, :, :]
+        min_sq = (diff * diff).sum(dim=-1).min(dim=1).values
+        return min_sq <= radius_sq

--- a/POMDPPlanners/environments/rock_sample_pomdp/rocksample_vectorized_model.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rocksample_vectorized_model.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for RockSample.
+
+This module provides :class:`RockSampleVectorizedModel`, a fully batched,
+GPU-friendly implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+for :class:`~POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp.RockSamplePOMDP`.
+
+It re-expresses the environment's deterministic grid transition, its noisy
+long-range Bernoulli sensor observation, and its ``CONSTANT_HAZARD_PENALTY``
+reward as torch tensor kernels so a vectorized planner (VOPP) can run tens of
+thousands of parallel simulations on the GPU without a host/device sync. Every
+constant (grid size, rock positions, sensor efficiency, costs, dangerous-area
+geometry) is read from a live environment instance, so the environment stays
+the single source of truth for configuration; only the numeric kernels are
+duplicated in torch. The accompanying parity test pins these kernels to the
+environment's native (C++) implementations.
+
+State layout per particle mirrors the environment:
+``[robot_row, robot_col, rock_0_quality, ..., rock_{R-1}_quality]`` with the
+terminal sentinel ``[-1, -1, ...]``. Observations are the categorical sensor
+codes ``0=none``, ``1=good``, ``2=bad`` carried in a width-1 tensor.
+
+Only one environment configuration is supported: the
+``CONSTANT_HAZARD_PENALTY`` reward model with
+``is_dangerous_area_hit_terminal=False``. The zero-mean and distance-decayed
+hazard variants and the draw-coupled hazard-terminal state slot are not
+modeled here; each is checked at construction and any mismatch raises
+:class:`NotImplementedError`.
+"""
+
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import (
+    RewardModelType,
+    RockSamplePOMDP,
+)
+
+# Observation codes must match the native kernel / vectorized updater.
+_OBS_NONE = 0
+_OBS_GOOD = 1
+_OBS_BAD = 2
+
+# Defensive flooring constants mirroring the native kernel so impossible
+# events score the same finite log-likelihood in both implementations.
+_PROB_FLOOR = 1e-300
+_LOG_PROB_FLOOR = -690.7755278982137  # == log(_PROB_FLOOR)
+
+# Number of non-check actions (sample, north, east, south, west).
+_NUM_MOVE_ACTIONS = 5
+
+
+class RockSampleVectorizedModel:
+    """Fully vectorized torch generative model for the RockSample POMDP.
+
+    The model batches the transition, observation, reward, terminal, and
+    observation-likelihood kernels over a leading particle dimension and keeps
+    every tensor on a single device. Actions are the environment's discrete
+    action ids used directly as integer indices (``0=sample``, ``1..4`` moves,
+    ``5..4+R`` check-rock), so ``num_actions == 5 + R``; observations are the
+    categorical sensor codes ``0/1/2``.
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for state / observation / reward tensors.
+        num_actions: Number of discrete actions (``5 + num_rocks``).
+
+    Example:
+        >>> import torch
+        >>> from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import (
+        ...     RockSamplePOMDP,
+        ... )
+        >>> from POMDPPlanners.environments.rock_sample_pomdp.rocksample_vectorized_model import (
+        ...     RockSampleVectorizedModel,
+        ... )
+        >>> torch.manual_seed(0)  # doctest: +ELLIPSIS
+        <torch._C.Generator object at ...>
+        >>> env = RockSamplePOMDP(map_size=(5, 5), rock_positions=[(0, 0), (2, 2), (3, 3)])
+        >>> model = RockSampleVectorizedModel(env, device=torch.device("cpu"))
+        >>> states = torch.tensor([[0.0, 0.0, 1.0, 0.0, 1.0], [2.0, 2.0, 1.0, 1.0, 0.0]])
+        >>> actions = torch.tensor([2, 5])  # move east, check rock 0
+        >>> next_states = model.sample_next_states(states, actions)
+        >>> observations = model.sample_observations(next_states, actions)
+        >>> rewards = model.rewards(states, actions, next_states)
+        >>> tuple(next_states.shape), tuple(observations.shape), tuple(rewards.shape)
+        ((2, 5), (2, 1), (2,))
+    """
+
+    def __init__(
+        self,
+        env: RockSamplePOMDP,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+    ) -> None:
+        """Build the model from a live environment instance.
+
+        Args:
+            env: The environment whose parameters and models are mirrored.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for real-valued tensors.
+
+        Raises:
+            NotImplementedError: If ``env`` uses a reward model other than
+                ``CONSTANT_HAZARD_PENALTY`` or enables the draw-coupled
+                hazard-terminal state slot.
+        """
+        self._require_supported_config(env)
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self._num_rocks = len(env.rock_positions)
+        self.num_actions = _NUM_MOVE_ACTIONS + self._num_rocks
+        self._build_geometry(env)
+        self._build_reward(env)
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _require_supported_config(env: RockSamplePOMDP) -> None:
+        if env.reward_model_type is not RewardModelType.CONSTANT_HAZARD_PENALTY:
+            raise NotImplementedError(
+                "vectorized model supports only the CONSTANT_HAZARD_PENALTY reward model"
+            )
+        if env.is_dangerous_area_hit_terminal:
+            raise NotImplementedError(
+                "vectorized model requires is_dangerous_area_hit_terminal=False "
+                "(the draw-coupled hazard-terminal absorbing slot is not modeled)"
+            )
+
+    def _build_geometry(self, env: RockSamplePOMDP) -> None:
+        self._map_rows = int(env.map_size[0])
+        self._map_cols = int(env.map_size[1])
+        rocks = np.asarray(env.rock_positions, dtype=np.float64).reshape(-1, 2)
+        self._rock_rows = self._to_tensor(rocks[:, 0])
+        self._rock_cols = self._to_tensor(rocks[:, 1])
+        self._sensor_efficiency = float(env.sensor_efficiency)
+        self._inv_sigma = 1.0 / self._sensor_efficiency
+
+    def _build_reward(self, env: RockSamplePOMDP) -> None:
+        self._step_penalty = float(env.step_penalty)
+        self._exit_reward = float(env.exit_reward)
+        self._good_rock_reward = float(env.good_rock_reward)
+        self._bad_rock_penalty = float(env.bad_rock_penalty)
+        self._sensor_use_penalty = float(env.sensor_use_penalty)
+        dangers = np.asarray(env.dangerous_areas, dtype=np.float64).reshape(-1, 2)
+        self._danger_centres = self._to_tensor(dangers)
+        self._num_dangers = int(dangers.shape[0])
+        self._danger_radius_sq = float(env.dangerous_area_radius) ** 2
+        self._danger_penalty = float(env.dangerous_area_penalty)
+        self._danger_hit_prob = float(env.dangerous_area_hit_probability)
+
+    def _to_tensor(self, array: np.ndarray) -> Tensor:
+        return torch.as_tensor(np.asarray(array), dtype=self.dtype, device=self.device)
+
+    # ------------------------------------------------------------------ #
+    # Generative kernels
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        row, col = states[:, 0], states[:, 1]
+        new_row = torch.where(actions == 1, torch.clamp(row - 1.0, min=0.0), row)
+        new_row = torch.where(
+            actions == 3, torch.clamp(row + 1.0, max=float(self._map_rows - 1)), new_row
+        )
+        east_col = col + 1.0
+        new_col = torch.where(actions == 4, torch.clamp(col - 1.0, min=0.0), col)
+        new_col = torch.where(actions == 2, east_col, new_col)
+        nxt = states.clone()
+        nxt[:, 0], nxt[:, 1] = new_row, new_col
+        self._apply_sample_flip(nxt, states, actions)
+        exit_mask = (actions == 2) & (east_col >= float(self._map_cols))
+        neg = torch.full_like(row, -1.0)
+        nxt[:, 0] = torch.where(exit_mask, neg, nxt[:, 0])
+        nxt[:, 1] = torch.where(exit_mask, neg, nxt[:, 1])
+        terminal_in = self._terminal_rows(states)
+        return torch.where(terminal_in.unsqueeze(1), states, nxt)
+
+    def _apply_sample_flip(self, nxt: Tensor, states: Tensor, actions: Tensor) -> None:
+        row, col = states[:, 0], states[:, 1]
+        sample_mask = actions == 0
+        for k in range(self._num_rocks):
+            hit = sample_mask & (row == self._rock_rows[k]) & (col == self._rock_cols[k])
+            nxt[:, 2 + k] = torch.where(hit, torch.zeros_like(nxt[:, 2 + k]), nxt[:, 2 + k])
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        is_check = actions >= _NUM_MOVE_ACTIONS
+        efficiency, rock_good = self._sensor_efficiency_and_quality(next_states, actions)
+        correct = torch.where(rock_good, float(_OBS_GOOD), float(_OBS_BAD))
+        flipped = torch.where(rock_good, float(_OBS_BAD), float(_OBS_GOOD))
+        draws = torch.rand(next_states.shape[0], dtype=self.dtype, device=self.device)
+        check_obs = torch.where(draws < efficiency, correct, flipped)
+        obs = torch.where(is_check, check_obs, torch.full_like(check_obs, float(_OBS_NONE)))
+        return obs.unsqueeze(1)
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        reward, is_exit = self._base_reward(states, actions)
+        return reward + self._danger_reward(next_states, is_exit)
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        return self._terminal_rows(states)
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        obs = observations[:, 0]
+        is_check = actions >= _NUM_MOVE_ACTIONS
+        efficiency, rock_good = self._sensor_efficiency_and_quality(next_states, actions)
+        prob_good = torch.where(rock_good, efficiency, 1.0 - efficiency)
+        prob_bad = torch.where(rock_good, 1.0 - efficiency, efficiency)
+        prob = torch.where(obs == _OBS_GOOD, prob_good, prob_bad)
+        logp = torch.clamp(torch.log(torch.clamp(prob, min=_PROB_FLOOR)), min=_LOG_PROB_FLOOR)
+        terminal = self._terminal_rows(next_states)
+        floor = torch.full_like(logp, _LOG_PROB_FLOOR)
+        check_result = torch.where((obs == _OBS_NONE) | terminal, floor, logp)
+        noncheck_result = torch.where(obs == _OBS_NONE, torch.zeros_like(logp), floor)
+        return torch.where(is_check, check_result, noncheck_result)
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        return observations[:, 0].to(torch.int64)
+
+    # ------------------------------------------------------------------ #
+    # Internal reward / sensor helpers
+    # ------------------------------------------------------------------ #
+
+    def _terminal_rows(self, states: Tensor) -> Tensor:
+        return (states[:, 0] < 0.0) & (states[:, 1] < 0.0)
+
+    def _sensor_efficiency_and_quality(
+        self, next_states: Tensor, actions: Tensor
+    ) -> Tuple[Tensor, Tensor]:
+        rock_idx = torch.clamp(actions - _NUM_MOVE_ACTIONS, min=0)
+        if self._num_rocks == 0:
+            zeros = torch.zeros(next_states.shape[0], dtype=self.dtype, device=self.device)
+            return zeros, zeros > 0.5
+        rock_r = self._rock_rows[rock_idx]
+        rock_c = self._rock_cols[rock_idx]
+        dist = torch.sqrt((next_states[:, 0] - rock_r) ** 2 + (next_states[:, 1] - rock_c) ** 2)
+        efficiency = torch.exp(-dist * self._inv_sigma)
+        quality = next_states.gather(1, (rock_idx + 2).unsqueeze(1)).squeeze(1)
+        return efficiency, quality > 0.5
+
+    def _base_reward(self, states: Tensor, actions: Tensor) -> Tuple[Tensor, Tensor]:
+        col = states[:, 1]
+        reward = torch.full(
+            (states.shape[0],), self._step_penalty, dtype=self.dtype, device=self.device
+        )
+        reward = reward + self._sample_reward(states, actions)
+        reward = reward + (actions >= _NUM_MOVE_ACTIONS).to(self.dtype) * self._sensor_use_penalty
+        is_exit = (actions == 2) & (col == float(self._map_cols - 1))
+        reward = reward + is_exit.to(self.dtype) * self._exit_reward
+        return reward, is_exit
+
+    def _sample_reward(self, states: Tensor, actions: Tensor) -> Tensor:
+        row, col = states[:, 0], states[:, 1]
+        sample_mask = actions == 0
+        reward = torch.zeros(states.shape[0], dtype=self.dtype, device=self.device)
+        matched = torch.zeros(states.shape[0], dtype=torch.bool, device=self.device)
+        for k in range(self._num_rocks):
+            at_rock = (
+                sample_mask & ~matched & (row == self._rock_rows[k]) & (col == self._rock_cols[k])
+            )
+            good = states[:, 2 + k] > 0.5
+            delta = good.to(self.dtype) * self._good_rock_reward
+            delta = delta + (~good).to(self.dtype) * self._bad_rock_penalty
+            reward = reward + at_rock.to(self.dtype) * delta
+            matched = matched | at_rock
+        return reward
+
+    def _danger_reward(self, next_states: Tensor, is_exit: Tensor) -> Tensor:
+        if self._num_dangers == 0:
+            return torch.zeros(next_states.shape[0], dtype=self.dtype, device=self.device)
+        diff = next_states[:, None, :2] - self._danger_centres[None, :, :]
+        min_sq = (diff * diff).sum(dim=-1).min(dim=1).values
+        in_zone = (min_sq <= self._danger_radius_sq) & ~is_exit
+        draws = torch.rand(next_states.shape[0], dtype=self.dtype, device=self.device)
+        hit = in_zone & (draws < self._danger_hit_prob)
+        return hit.to(self.dtype) * self._danger_penalty

--- a/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_vectorized_model.py
+++ b/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_vectorized_model.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for Safety Ant Velocity.
+
+This module provides :class:`SafetyAntVelocityVectorizedModel`, a fully
+batched, GPU-friendly implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+for :class:`~POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_pomdp.SafeAntVelocityPOMDP`.
+
+It re-expresses the environment's damped-force transition (a deterministic
+integration step driven by a uniformly-sampled force direction), its
+identity-mean diagonal-Gaussian observation model, and its speed-based reward
+and terminal rules as torch tensor kernels so a vectorized planner (VOPP) can
+run tens of thousands of parallel simulations on the GPU without a host/device
+sync. Every constant (time step, mass, damping, max force, force scales, noise
+standard deviations, safety threshold, penalty, movement scale) is read from a
+live environment instance, so the environment stays the single source of truth
+for configuration; only the numeric kernels are duplicated in torch. The
+accompanying parity test pins these kernels to the environment's native
+(C++) implementations.
+
+The Safety Ant Velocity action space is already discrete -- four force levels
+indexed ``0..3`` -- so actions pass straight through as integer indices into
+the environment's ``DEFAULT_FORCE_SCALES`` table; no preset representative
+action table is synthesized. The only supported configuration is one whose
+discrete action set is exactly ``range(len(force_scales))`` (so that action
+index ``i`` selects ``force_scales[i]``); any other action set raises
+:class:`NotImplementedError`.
+"""
+
+import math
+from typing import Optional
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_pomdp import (
+    DEFAULT_FORCE_SCALES,
+    SafeAntVelocityPOMDP,
+)
+
+# Spatial-hash primes for turning quantized 4-D observations into integer keys.
+_HASH_PRIMES = (73856093, 19349663, 83492791, 39916801)
+
+
+class SafetyAntVelocityVectorizedModel:
+    """Fully vectorized torch generative model for the Safety Ant Velocity POMDP.
+
+    The model batches the transition, observation, reward, terminal, and
+    observation-likelihood kernels over a leading particle dimension and keeps
+    every tensor on a single device. States and observations are the 4-D vector
+    ``[position_x, position_y, velocity_x, velocity_y]``. Actions are integer
+    indices ``0..num_actions-1`` into the environment's force-scale table.
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for state / observation / reward tensors.
+        num_actions: Number of discrete force levels (rows in the force table).
+
+    Example:
+        >>> import torch
+        >>> from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_pomdp import (
+        ...     SafeAntVelocityPOMDP,
+        ... )
+        >>> from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_vectorized_model import (
+        ...     SafetyAntVelocityVectorizedModel,
+        ... )
+        >>> torch.manual_seed(0)  # doctest: +ELLIPSIS
+        <torch._C.Generator object at ...>
+        >>> env = SafeAntVelocityPOMDP(discount_factor=0.99)
+        >>> model = SafetyAntVelocityVectorizedModel(env, device=torch.device("cpu"))
+        >>> states = torch.tensor([[0.0, 0.0, 0.5, 0.0], [1.0, 0.0, 0.0, 0.3]])
+        >>> actions = torch.tensor([2, 2])
+        >>> next_states = model.sample_next_states(states, actions)
+        >>> observations = model.sample_observations(next_states, actions)
+        >>> rewards = model.rewards(states, actions, next_states)
+        >>> tuple(next_states.shape), tuple(observations.shape), tuple(rewards.shape)
+        ((2, 4), (2, 4), (2,))
+    """
+
+    def __init__(
+        self,
+        env: SafeAntVelocityPOMDP,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+        observation_resolution: float = 0.1,
+    ) -> None:
+        """Build the model from a live environment instance.
+
+        Args:
+            env: The environment whose physics, noise, and reward parameters are
+                mirrored.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for real-valued tensors.
+            observation_resolution: Grid spacing used to quantize continuous
+                observations into integer tree keys.
+
+        Raises:
+            NotImplementedError: If ``env``'s discrete action set is not exactly
+                ``range(len(force_scales))`` (the index-into-force-table
+                assumption the transition kernel makes).
+            ValueError: If ``observation_resolution`` or the environment mass is
+                not positive.
+        """
+        self._require_supported_action_set(env)
+        if observation_resolution <= 0.0:
+            raise ValueError("observation_resolution must be positive")
+        if env.mass <= 0.0:
+            raise ValueError("environment mass must be positive")
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self._obs_resolution = float(observation_resolution)
+        self._hash_primes = torch.tensor(_HASH_PRIMES, dtype=torch.int64, device=self.device)
+        self._build_physics(env)
+        self._build_noise_kernels(env)
+        self._build_reward_geometry(env)
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _require_supported_action_set(env: SafeAntVelocityPOMDP) -> None:
+        expected = list(range(len(DEFAULT_FORCE_SCALES)))
+        if list(env.get_actions()) != expected:
+            raise NotImplementedError(
+                "vectorized model supports only the default force-level action "
+                "set range(len(force_scales)); action index i must select "
+                "force_scales[i]"
+            )
+
+    def _build_physics(self, env: SafeAntVelocityPOMDP) -> None:
+        force_scales = self._to_tensor(np.asarray(DEFAULT_FORCE_SCALES, dtype=np.float64))
+        self.num_actions = int(force_scales.shape[0])
+        self._dt = float(env.dt)
+        self._mass = float(env.mass)
+        self._damping = float(env.damping)
+        # Per-action force magnitude: force_scales[action] * max_force.
+        self._force_magnitudes = force_scales * float(env.max_force)
+
+    def _build_noise_kernels(self, env: SafeAntVelocityPOMDP) -> None:
+        std = np.array(
+            [env.position_noise, env.position_noise, env.velocity_noise, env.velocity_noise],
+            dtype=np.float64,
+        )
+        self._obs_std = self._to_tensor(std)
+        self._obs_inv_var = self._to_tensor(1.0 / (std * std))
+        self._obs_lognorm = float(
+            -0.5 * std.shape[0] * math.log(2.0 * math.pi) - np.sum(np.log(std))
+        )
+
+    def _build_reward_geometry(self, env: SafeAntVelocityPOMDP) -> None:
+        self._safe_threshold = float(env.safe_velocity_threshold)
+        self._terminal_threshold = float(env.safe_velocity_threshold) * 1.5
+        self._violation_penalty = float(env.safety_violation_penalty)
+        self._movement_scale = float(env.movement_reward_scale)
+
+    def _to_tensor(self, array: np.ndarray) -> Tensor:
+        return torch.as_tensor(np.asarray(array), dtype=self.dtype, device=self.device)
+
+    # ------------------------------------------------------------------ #
+    # Generative kernels
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        force_magnitude = self._force_magnitudes[actions]
+        theta = torch.rand(states.shape[0], dtype=self.dtype, device=self.device)
+        theta = theta * (2.0 * math.pi) - math.pi
+        force_x = force_magnitude * torch.cos(theta)
+        force_y = force_magnitude * torch.sin(theta)
+        return self._integrate_step(states, force_x, force_y)
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions  # Observation noise does not depend on the action.
+        noise = torch.randn(next_states.shape, dtype=self.dtype, device=self.device)
+        return next_states + noise * self._obs_std
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        del states, actions  # Reward scores the realised next-state speed only.
+        speed = torch.linalg.vector_norm(next_states[:, 2:4], dim=1)
+        reward = speed * self._movement_scale
+        unsafe = speed > self._safe_threshold
+        return reward + self._violation_penalty * unsafe.to(self.dtype)
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        speed = torch.linalg.vector_norm(states[:, 2:4], dim=1)
+        return speed > self._terminal_threshold
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions  # Diagonal-Gaussian likelihood does not depend on the action.
+        diff = observations - next_states
+        maha = (diff * diff * self._obs_inv_var).sum(dim=1)
+        return self._obs_lognorm - 0.5 * maha
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        quantized = torch.floor(observations / self._obs_resolution).to(torch.int64)
+        return (quantized * self._hash_primes).sum(dim=1)
+
+    # ------------------------------------------------------------------ #
+    # Internal physics helper
+    # ------------------------------------------------------------------ #
+
+    def _integrate_step(self, states: Tensor, force_x: Tensor, force_y: Tensor) -> Tensor:
+        velocity = states[:, 2:4]
+        accel_x = (force_x - self._damping * velocity[:, 0]) / self._mass
+        accel_y = (force_y - self._damping * velocity[:, 1]) / self._mass
+        next_vx = velocity[:, 0] + accel_x * self._dt
+        next_vy = velocity[:, 1] + accel_y * self._dt
+        next_px = states[:, 0] + next_vx * self._dt
+        next_py = states[:, 1] + next_vy * self._dt
+        return torch.stack([next_px, next_py, next_vx, next_vy], dim=1)

--- a/POMDPPlanners/environments/sanity_pomdp_vectorized_model.py
+++ b/POMDPPlanners/environments/sanity_pomdp_vectorized_model.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for the Sanity POMDP.
+
+This module provides :class:`SanityVectorizedModel`, a fully batched
+implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+for :class:`~POMDPPlanners.environments.sanity_pomdp.SanityPOMDP`.
+
+The Sanity POMDP is deterministic and perfectly observable: two states
+(``0`` good, ``1`` bad), two actions (``0`` -> good, ``1`` -> bad), the
+observation equals the state, the reward is ``1.0`` in the good state and
+``0.0`` otherwise, and no state is terminal. Every one of these numeric
+constants is read from a live environment instance in ``__init__`` (a
+next-state table, a reward table, and a terminal table), so the environment
+stays the single source of truth; only the lookups are re-expressed as
+batched torch gathers. The accompanying parity test pins these kernels to
+the environment's native scalar kernels.
+
+Only the standard two-action ``[0, 1]`` configuration is supported; any other
+action set raises :class:`NotImplementedError` at construction, because the
+transition and reward tables assume that ``action == next_state`` structure.
+"""
+
+from typing import List, Optional
+
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.sanity_pomdp import SanityPOMDP
+
+_SUPPORTED_ACTIONS: List[int] = [0, 1]
+_SUPPORTED_STATES: List[int] = [0, 1]
+
+
+class SanityVectorizedModel:
+    """Fully vectorized torch generative model for the Sanity POMDP.
+
+    The model batches the transition, observation, reward, terminal, and
+    observation-likelihood kernels over a leading particle dimension ``N`` and
+    keeps every tensor on a single device. States and observations are the
+    scalar state index carried in a ``[N, 1]`` tensor; actions are integer
+    indices into the environment's two-action set.
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for state / observation / reward tensors.
+        num_actions: Number of actions in the environment's action set.
+
+    Example:
+        >>> import torch
+        >>> from POMDPPlanners.environments.sanity_pomdp import SanityPOMDP
+        >>> from POMDPPlanners.environments.sanity_pomdp_vectorized_model import (
+        ...     SanityVectorizedModel,
+        ... )
+        >>> env = SanityPOMDP(discount_factor=0.95)
+        >>> model = SanityVectorizedModel(env, device=torch.device("cpu"))
+        >>> states = torch.tensor([[0.0], [1.0], [0.0]])
+        >>> actions = torch.tensor([0, 1, 1])
+        >>> next_states = model.sample_next_states(states, actions)
+        >>> observations = model.sample_observations(next_states, actions)
+        >>> rewards = model.rewards(states, actions, next_states)
+        >>> tuple(next_states.shape), tuple(observations.shape), tuple(rewards.shape)
+        ((3, 1), (3, 1), (3,))
+        >>> rewards.tolist()
+        [1.0, 0.0, 0.0]
+    """
+
+    def __init__(
+        self,
+        env: SanityPOMDP,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+    ) -> None:
+        """Build the model from a live environment instance.
+
+        Args:
+            env: The environment whose transition, reward, and terminal
+                kernels are mirrored into lookup tables.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for real-valued tensors.
+
+        Raises:
+            NotImplementedError: If ``env`` exposes an action set other than
+                the standard ``[0, 1]`` two-action set.
+        """
+        self._require_supported_actions(env)
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self.num_actions = len(env.get_actions())
+        self._build_tables(env)
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _require_supported_actions(env: SanityPOMDP) -> None:
+        if list(env.get_actions()) != _SUPPORTED_ACTIONS:
+            raise NotImplementedError(
+                "vectorized model supports only the standard two-action "
+                f"{_SUPPORTED_ACTIONS} Sanity POMDP action set"
+            )
+
+    def _build_tables(self, env: SanityPOMDP) -> None:
+        # The transition is state-independent, so a dummy state suffices.
+        next_states = [int(env.sample_next_state(0, action)) for action in _SUPPORTED_ACTIONS]
+        rewards = [float(env.reward(0, action)) for action in _SUPPORTED_ACTIONS]
+        terminals = [bool(env.is_terminal(state)) for state in _SUPPORTED_STATES]
+        self._next_state_table = torch.tensor(next_states, dtype=self.dtype, device=self.device)
+        self._reward_table = torch.tensor(rewards, dtype=self.dtype, device=self.device)
+        self._terminal_table = torch.tensor(terminals, dtype=torch.bool, device=self.device)
+
+    # ------------------------------------------------------------------ #
+    # Generative kernels
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        del states  # Transition depends only on the action in the Sanity POMDP.
+        return self._next_state_table[actions].unsqueeze(-1)
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions  # Perfect observability: the observation equals the state.
+        return next_states.clone()
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        del states, next_states  # Reward is a function of the action alone.
+        return self._reward_table[actions]
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        return self._terminal_table[states[:, 0].to(torch.int64)]
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions  # Perfect observability does not depend on the action.
+        match = observations[:, 0] == next_states[:, 0]
+        return torch.where(
+            match,
+            torch.zeros(match.shape[0], dtype=self.dtype, device=self.device),
+            torch.full((match.shape[0],), -torch.inf, dtype=self.dtype, device=self.device),
+        )
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        return observations[:, 0].to(torch.int64)

--- a/POMDPPlanners/environments/tiger_pomdp_vectorized_model.py
+++ b/POMDPPlanners/environments/tiger_pomdp_vectorized_model.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for the Tiger POMDP.
+
+This module provides :class:`TigerVectorizedModel`, a fully batched,
+GPU-friendly implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+for :class:`~POMDPPlanners.environments.tiger_pomdp.TigerPOMDP`.
+
+The Tiger problem is fully discrete: two states (``tiger_left``,
+``tiger_right``), three actions (``listen``, ``open_left``, ``open_right``),
+and three observations (``hear_left``, ``hear_right``, ``hear_nothing``). The
+model re-expresses the environment's transition, observation, and reward
+kernels as small torch lookup tables so a vectorized planner (VOPP) can run
+tens of thousands of parallel simulations on the GPU without a host/device
+sync.
+
+Every table is populated by querying a live environment instance in
+``__init__`` (``transition_log_probability``, ``observation_log_probability``,
+``reward``), so the environment stays the single source of truth for the
+transition/observation/reward semantics; only the batched lookups are
+re-expressed in torch. The accompanying parity test pins these kernels to the
+environment's native scalar implementations.
+
+States and observations are represented as integer-coded ``[N, 1]`` tensors
+whose single column holds the index into ``STATES`` / ``OBSERVATIONS``.
+Actions are integer indices into the fixed three-element action set. Only the
+standard Tiger label sets are supported; a reconfigured subclass with
+different labels raises :class:`NotImplementedError`.
+"""
+
+from typing import Optional
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.tiger_pomdp import (
+    ACTIONS,
+    OBSERVATIONS,
+    STATES,
+    TigerPOMDP,
+)
+
+
+class TigerVectorizedModel:
+    """Fully vectorized torch generative model for the Tiger POMDP.
+
+    The model batches the transition, observation, reward, terminal, and
+    observation-likelihood kernels over a leading particle dimension ``N`` and
+    keeps every tensor on a single device. States and observations are
+    integer-coded ``[N, 1]`` tensors; actions are integer indices into the
+    fixed three-element action set (``listen``, ``open_left``, ``open_right``).
+    All kernels reduce to gathers into small probability / reward tables read
+    from the environment at construction.
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for reward and log-probability tensors.
+        num_actions: Number of actions in the fixed action set (three).
+        num_states: Number of discrete states (two).
+        num_observations: Number of discrete observations (three).
+
+    Example:
+        >>> import torch
+        >>> from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+        >>> from POMDPPlanners.environments.tiger_pomdp_vectorized_model import (
+        ...     TigerVectorizedModel,
+        ... )
+        >>> torch.manual_seed(0)  # doctest: +ELLIPSIS
+        <torch._C.Generator object at ...>
+        >>> env = TigerPOMDP(discount_factor=0.95)
+        >>> model = TigerVectorizedModel(env, device=torch.device("cpu"))
+        >>> states = torch.tensor([[0], [1], [0]])
+        >>> actions = torch.tensor([0, 1, 2])  # listen, open_left, open_right
+        >>> next_states = model.sample_next_states(states, actions)
+        >>> observations = model.sample_observations(next_states, actions)
+        >>> rewards = model.rewards(states, actions, next_states)
+        >>> tuple(next_states.shape), tuple(observations.shape), tuple(rewards.shape)
+        ((3, 1), (3, 1), (3,))
+    """
+
+    def __init__(
+        self,
+        env: TigerPOMDP,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+    ) -> None:
+        """Build the model from a live environment instance.
+
+        Args:
+            env: The environment whose transition, observation, and reward
+                kernels are mirrored into torch lookup tables.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for reward and log-probability tensors.
+
+        Raises:
+            NotImplementedError: If ``env`` uses non-standard state, action, or
+                observation label sets that this model does not represent.
+        """
+        self._require_supported_labels(env)
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self.num_states = len(STATES)
+        self.num_actions = len(ACTIONS)
+        self.num_observations = len(OBSERVATIONS)
+        self._transition_probs = self._build_transition_probs(env)
+        self._observation_log_probs, self._observation_probs = self._build_observation_tables(env)
+        self._reward_table = self._build_reward_table(env)
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _require_supported_labels(env: TigerPOMDP) -> None:
+        if (
+            list(env.states) != STATES
+            or list(env.actions) != ACTIONS
+            or list(env.observations) != OBSERVATIONS
+        ):
+            raise NotImplementedError(
+                "vectorized model supports only the standard Tiger label sets "
+                "(states/actions/observations)"
+            )
+
+    def _build_transition_probs(self, env: TigerPOMDP) -> Tensor:
+        table = np.zeros((self.num_actions, self.num_states, self.num_states))
+        for a_idx, action in enumerate(ACTIONS):
+            for s_idx, state in enumerate(STATES):
+                table[a_idx, s_idx] = np.exp(env.transition_log_probability(state, action, STATES))
+        return self._to_float_tensor(table)
+
+    def _build_observation_tables(self, env: TigerPOMDP) -> tuple[Tensor, Tensor]:
+        log_table = np.zeros((self.num_actions, self.num_states, self.num_observations))
+        for a_idx, action in enumerate(ACTIONS):
+            for ns_idx, next_state in enumerate(STATES):
+                log_table[a_idx, ns_idx] = env.observation_log_probability(
+                    next_state, action, OBSERVATIONS
+                )
+        return self._to_float_tensor(log_table), self._to_float_tensor(np.exp(log_table))
+
+    def _build_reward_table(self, env: TigerPOMDP) -> Tensor:
+        table = np.zeros((self.num_actions, self.num_states))
+        for a_idx, action in enumerate(ACTIONS):
+            for s_idx, state in enumerate(STATES):
+                table[a_idx, s_idx] = env.reward(state, action)
+        return self._to_float_tensor(table)
+
+    def _to_float_tensor(self, array: np.ndarray) -> Tensor:
+        return torch.as_tensor(array, dtype=self.dtype, device=self.device)
+
+    # ------------------------------------------------------------------ #
+    # Generative kernels
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        probs = self._transition_probs[actions.to(torch.int64), self._indices(states)]
+        return torch.multinomial(probs, num_samples=1)
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        probs = self._observation_probs[actions.to(torch.int64), self._indices(next_states)]
+        return torch.multinomial(probs, num_samples=1)
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        del next_states  # Tiger rewards depend only on the current state/action.
+        return self._reward_table[actions.to(torch.int64), self._indices(states)]
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        # TigerPOMDP.is_terminal is always False (doors reset via the transition).
+        return torch.zeros(states.shape[0], dtype=torch.bool, device=self.device)
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        return self._observation_log_probs[
+            actions.to(torch.int64), self._indices(next_states), self._indices(observations)
+        ]
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        return self._indices(observations)
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _indices(coded: Tensor) -> Tensor:
+        return coded.reshape(coded.shape[0], -1)[:, 0].to(torch.int64)

--- a/POMDPPlanners/planners/vectorized_planners/__init__.py
+++ b/POMDPPlanners/planners/vectorized_planners/__init__.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+
+"""GPU-vectorized online POMDP planners.
+
+This package hosts planners whose whole search is expressed as batched tensor
+operations over the flat-tensor belief tree in
+:mod:`POMDPPlanners.core.tree.vectorized_belief_tree`. Unlike the Monte Carlo
+Tree Search planners in :mod:`POMDPPlanners.planners.mcts_planners`, these run
+tens of thousands of parallel simulations per planning step with no Python
+per-simulation loop and no host/device synchronization.
+
+Currently provided:
+
+* :class:`~POMDPPlanners.planners.vectorized_planners.vopp.VOPPPlanner` --
+  the Vectorized Online POMDP Planner (VOPP / PORPP).
+"""
+
+from POMDPPlanners.planners.vectorized_planners.vopp import VOPPPlanner
+
+__all__ = ["VOPPPlanner"]

--- a/POMDPPlanners/planners/vectorized_planners/vopp.py
+++ b/POMDPPlanners/planners/vectorized_planners/vopp.py
@@ -1,0 +1,391 @@
+# SPDX-License-Identifier: MIT
+
+"""Vectorized Online POMDP Planner (VOPP / PORPP).
+
+This module implements :class:`VOPPPlanner`, a fully GPU-vectorized online
+POMDP solver following Hoerger, Sudrajat and Kurniawati, *Vectorized Online
+POMDP Planning* (arXiv:2510.27191). VOPP is the vectorized realization of
+Partially Observable Reference Policy Programming (PORPP): rather than
+interleaving numerical optimization with expectation estimation, it solves the
+value function analytically (a log-sum-exp over action *preferences*) and
+leaves only expectations to Monte Carlo.
+
+The planner drives three collaborating pieces, none of which contains any
+planning-policy logic itself:
+
+* a :class:`~POMDPPlanners.core.tree.vectorized_belief_tree.vectorized_belief_tree.VectorizedBeliefTree`
+  holding the tree topology, per-action visit/reward statistics, and two
+  registered belief fields -- ``preferences`` (the ``|A|``-vector ``Psi`` of
+  eq. 4) and ``value`` (the scalar belief value ``V``);
+* a :class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+  supplying the batched transition / observation / reward / terminal / key
+  kernels; and
+* a root belief represented as a tensor of state particles.
+
+Each planning iteration runs two fully vectorized passes over the tree:
+
+#. **Forward search** (Algorithm 2): from the root belief, sample ``n_p``
+   states, and repeatedly -- for every live episode in parallel -- sample an
+   action from ``softmax(eta * Psi)``, push it through the generative model,
+   accumulate the immediate reward on the action node, drop terminated
+   episodes, and append the successor belief nodes. This descends one tree
+   level per step until ``max_depth`` is exceeded, where a value heuristic
+   scores the leaf states.
+#. **Preference backup** (Algorithm 3): from the deepest level up to the root,
+   compute per-action ``Q = mean_reward + gamma * weighted_future_value`` and
+   apply the PORPP preference update (eq. 5)
+   ``Psi <- Psi - L_eta[Psi] + Q`` on every belief, recomputing each belief's
+   value ``V = L_eta[Psi]`` as it goes.
+
+After the configured budget of iterations the planner returns the root action
+with the highest preference.
+
+VOPP assumes a fixed, finite *representative* action set indexed
+``0 .. num_actions - 1``; the model's ``action_keys`` must return exactly that
+integer index so it can address a column of the dense ``preferences`` field.
+
+Example:
+    Planning one step in Continuous Light-Dark::
+
+        >>> import torch
+        >>> from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+        ...     ContinuousLightDarkPOMDP,
+        ... )
+        >>> from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_vectorized_model import (
+        ...     ContinuousLightDarkVectorizedModel,
+        ... )
+        >>> from POMDPPlanners.planners.vectorized_planners import VOPPPlanner
+        >>> _ = torch.manual_seed(0)
+        >>> env = ContinuousLightDarkPOMDP(discount_factor=0.95, is_obstacle_hit_terminal=False)
+        >>> model = ContinuousLightDarkVectorizedModel(env, device=torch.device("cpu"))
+        >>> planner = VOPPPlanner(
+        ...     model,
+        ...     num_actions=model.num_actions,
+        ...     num_particles=256,
+        ...     max_depth=5,
+        ...     num_planning_iterations=8,
+        ...     discount_factor=0.95,
+        ... )
+        >>> root_particles = torch.tensor([[2.0, 2.0]]).repeat(256, 1)
+        >>> action = planner.plan(root_particles)
+        >>> 0 <= action < model.num_actions
+        True
+"""
+
+from typing import Callable, List, Optional, Tuple
+
+import torch
+from torch import Tensor
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.core.policy import PolicyInfoVariable
+from POMDPPlanners.core.tree.vectorized_belief_tree import VectorizedBeliefTree
+from POMDPPlanners.utils.tree_statistics import compute_vectorized_tree_metrics
+
+ValueHeuristic = Callable[[Tensor], Tensor]
+
+_PREFERENCES_FIELD = "preferences"
+_VALUE_FIELD = "value"
+
+
+def _zero_value_heuristic(states: Tensor) -> Tensor:
+    """Default leaf heuristic: zero future value for every leaf state."""
+    return torch.zeros(states.shape[0], dtype=states.dtype, device=states.device)
+
+
+class VOPPPlanner:
+    """Fully vectorized online POMDP planner (VOPP / PORPP).
+
+    The planner owns a :class:`VectorizedBeliefTree` and repeatedly expands and
+    backs it up entirely with batched tensor operations. A single call to
+    :meth:`plan` samples particles from the supplied root belief, runs the
+    configured number of forward-search / preference-backup iterations, and
+    returns the greedy root action.
+
+    Attributes:
+        device: Device every tensor lives on (taken from the model).
+        num_actions: Size of the fixed representative action set.
+
+    Example:
+        See the module-level docstring for a runnable example.
+    """
+
+    def __init__(
+        self,
+        model: VectorizedGenerativeModel,
+        num_actions: int,
+        *,
+        temperature: float = 2.0,
+        num_particles: int = 1000,
+        max_depth: int = 10,
+        discount_factor: float = 0.95,
+        num_planning_iterations: int = 100,
+        value_heuristic: Optional[ValueHeuristic] = None,
+        belief_capacity: int = 1024,
+        action_capacity: int = 1024,
+        value_dtype: torch.dtype = torch.float32,
+    ) -> None:
+        """Initialise the planner and its belief tree.
+
+        Args:
+            model: Batched generative model driving the forward search.
+            num_actions: Number of representative actions; the ``preferences``
+                field has this many columns and actions index them directly.
+            temperature: PORPP temperature ``eta`` (must be positive).
+            num_particles: Episodes sampled in parallel per iteration (``n_p``).
+            max_depth: Maximum search depth; leaves sit one level below it.
+            discount_factor: POMDP discount ``gamma`` in ``(0, 1]``.
+            num_planning_iterations: Forward-search / backup passes per
+                :meth:`plan` call (the planning budget).
+            value_heuristic: Optional leaf value estimator mapping
+                ``[n, ds]`` states to ``[n]`` values; defaults to zeros.
+            belief_capacity: Initial preallocated belief-node capacity.
+            action_capacity: Initial preallocated action-node capacity.
+            value_dtype: Floating dtype for preferences, values, and rewards.
+
+        Raises:
+            ValueError: If ``num_actions`` or ``temperature`` is non-positive,
+                or ``max_depth`` / ``num_particles`` / ``num_planning_iterations``
+                is not positive.
+        """
+        self._validate_hyperparameters(
+            num_actions, temperature, num_particles, max_depth, num_planning_iterations
+        )
+        self._model = model
+        self.num_actions = num_actions
+        self.device = model.device
+        self._temperature = float(temperature)
+        self._num_particles = num_particles
+        self._max_depth = max_depth
+        self._discount_factor = float(discount_factor)
+        self._num_iterations = num_planning_iterations
+        self._value_heuristic = value_heuristic or _zero_value_heuristic
+        self._value_dtype = value_dtype
+        self._tree = VectorizedBeliefTree(
+            device=self.device,
+            belief_capacity=belief_capacity,
+            action_capacity=action_capacity,
+            value_dtype=value_dtype,
+        )
+        self._tree.register_belief_field(
+            _PREFERENCES_FIELD, (num_actions,), dtype=value_dtype, default=0.0
+        )
+        self._tree.register_belief_field(_VALUE_FIELD, dtype=value_dtype, default=0.0)
+
+    @staticmethod
+    def _validate_hyperparameters(
+        num_actions: int,
+        temperature: float,
+        num_particles: int,
+        max_depth: int,
+        num_planning_iterations: int,
+    ) -> None:
+        if num_actions <= 0:
+            raise ValueError("num_actions must be positive")
+        if temperature <= 0.0:
+            raise ValueError("temperature must be positive")
+        if num_particles <= 0:
+            raise ValueError("num_particles must be positive")
+        if max_depth <= 0:
+            raise ValueError("max_depth must be positive")
+        if num_planning_iterations <= 0:
+            raise ValueError("num_planning_iterations must be positive")
+
+    @property
+    def tree(self) -> VectorizedBeliefTree:
+        """The belief tree built by the most recent :meth:`plan` call."""
+        return self._tree
+
+    def tree_metrics(self) -> List[PolicyInfoVariable]:
+        """Root-tree analysis metrics for the most recent :meth:`plan` call.
+
+        Returns the same :class:`~POMDPPlanners.utils.tree_statistics.TreeMetrics`
+        set the MCTS planners report (root action visit min / max / entropy,
+        number of root actions, root visit count, max depth, leaf flag), making
+        VOPP directly comparable to them.
+
+        Returns:
+            A list of :class:`~POMDPPlanners.core.policy.PolicyInfoVariable`
+            describing the current tree.
+        """
+        return compute_vectorized_tree_metrics(self._tree)
+
+    def plan(self, root_particles: Tensor) -> int:
+        """Plan from a particle-set root belief and return the greedy action.
+
+        The tree is cleared, then ``num_planning_iterations`` forward-search /
+        preference-backup passes refine the root action preferences. The action
+        with the highest root preference is returned.
+
+        Args:
+            root_particles: ``[num_root_particles, ds]`` states representing the
+                current belief; iterations resample ``num_particles`` of them
+                with replacement.
+
+        Returns:
+            The index of the greedy root action in ``[0, num_actions)``.
+
+        Raises:
+            ValueError: If ``root_particles`` is not a 2-D tensor on the
+                planner's device.
+        """
+        self._validate_root_particles(root_particles)
+        self._tree.clear()
+        root = self._tree.root_index
+        for _ in range(self._num_iterations):
+            states = self._sample_root_states(root_particles)
+            beliefs = torch.full(
+                (states.shape[0],), root, dtype=self._tree.index_dtype, device=self.device
+            )
+            leaf_beliefs, leaf_values = self._forward_search(states, beliefs)
+            self._backup(leaf_beliefs, leaf_values)
+        root_preferences = self._tree.belief_field(_PREFERENCES_FIELD)[root]
+        return int(torch.argmax(root_preferences).item())
+
+    def _validate_root_particles(self, root_particles: Tensor) -> None:
+        if root_particles.dim() != 2:
+            raise ValueError("root_particles must be a 2-D [num_particles, ds] tensor")
+        if root_particles.device != self.device:
+            raise ValueError(f"root_particles must be on device {self.device}")
+
+    def _sample_root_states(self, root_particles: Tensor) -> Tensor:
+        indices = torch.randint(
+            0, root_particles.shape[0], (self._num_particles,), device=self.device
+        )
+        return root_particles[indices]
+
+    # ------------------------------------------------------------------ #
+    # Forward search (Algorithm 2)
+    # ------------------------------------------------------------------ #
+
+    def _forward_search(self, states: Tensor, beliefs: Tensor) -> Tuple[Tensor, Tensor]:
+        """Expand the tree one level per step, returning ``(leaf_beliefs, H)``."""
+        depth = 0
+        while depth <= self._max_depth:
+            actions = self._sample_actions(beliefs)
+            action_nodes, _ = self._tree.get_or_create_actions(
+                beliefs, self._model.action_keys(actions)
+            )
+            next_states = self._model.sample_next_states(states, actions)
+            rewards = self._model.rewards(states, actions, next_states)
+            self._tree.update_action_statistics(action_nodes, rewards.to(self._value_dtype))
+            survivors = ~self._model.terminal_mask(next_states)
+            if not bool(survivors.any()):
+                return self._empty_leaves()
+            states, beliefs = self._expand_survivors(action_nodes, next_states, actions, survivors)
+            depth += 1
+        return beliefs, self._value_heuristic(states).to(self._value_dtype)
+
+    def _sample_actions(self, beliefs: Tensor) -> Tensor:
+        preferences = self._tree.belief_field(_PREFERENCES_FIELD)[beliefs]
+        probabilities = torch.softmax(self._temperature * preferences, dim=1)
+        return torch.multinomial(probabilities, 1).squeeze(1)
+
+    def _expand_survivors(
+        self,
+        action_nodes: Tensor,
+        next_states: Tensor,
+        actions: Tensor,
+        survivors: Tensor,
+    ) -> Tuple[Tensor, Tensor]:
+        surviving_states = next_states[survivors]
+        surviving_actions = actions[survivors]
+        observations = self._model.sample_observations(surviving_states, surviving_actions)
+        observation_keys = self._model.observation_keys(observations)
+        child_beliefs, _ = self._tree.get_or_create_beliefs(
+            action_nodes[survivors], observation_keys
+        )
+        return surviving_states, child_beliefs
+
+    def _empty_leaves(self) -> Tuple[Tensor, Tensor]:
+        empty_index = torch.empty(0, dtype=self._tree.index_dtype, device=self.device)
+        empty_value = torch.empty(0, dtype=self._value_dtype, device=self.device)
+        return empty_index, empty_value
+
+    # ------------------------------------------------------------------ #
+    # Preference backup (Algorithm 3)
+    # ------------------------------------------------------------------ #
+
+    def _backup(self, leaf_beliefs: Tensor, leaf_values: Tensor) -> None:
+        """Propagate leaf values to the root via the PORPP preference update."""
+        num_beliefs = self._tree.num_belief_nodes
+        belief_visits = self._init_leaf_values(leaf_beliefs, leaf_values, num_beliefs)
+        stats = self._action_statistics()
+        for depth in range(self._max_depth, -1, -1):
+            self._backup_depth(depth, belief_visits, stats)
+
+    def _init_leaf_values(
+        self, leaf_beliefs: Tensor, leaf_values: Tensor, num_beliefs: int
+    ) -> Tensor:
+        belief_visits = torch.zeros(num_beliefs, dtype=self._value_dtype, device=self.device)
+        if leaf_beliefs.numel() == 0:
+            return belief_visits
+        value = self._tree.belief_field(_VALUE_FIELD)
+        belief_visits.index_add_(0, leaf_beliefs, torch.ones_like(leaf_values))
+        heuristic_sum = torch.zeros(num_beliefs, dtype=self._value_dtype, device=self.device)
+        heuristic_sum.index_add_(0, leaf_beliefs, leaf_values)
+        leaves = belief_visits > 0
+        value[leaves] = heuristic_sum[leaves] / belief_visits[leaves]
+        return belief_visits
+
+    def _action_statistics(self) -> dict:
+        num_actions = self._tree.num_action_nodes
+        visits = self._tree.action_visit_count[:num_actions].to(self._value_dtype)
+        return {
+            "parent_belief": self._tree.action_parent_belief[:num_actions],
+            "key": self._tree.action_key[:num_actions],
+            "depth": self._tree.action_depth[:num_actions],
+            "visits": visits,
+            "mean_reward": self._tree.action_reward_sum[:num_actions] / visits.clamp_min(1.0),
+            "count": num_actions,
+        }
+
+    def _backup_depth(self, depth: int, belief_visits: Tensor, stats: dict) -> None:
+        beliefs_at_depth = self._tree.belief_nodes_at_depth(depth)
+        if beliefs_at_depth.numel() == 0:
+            return
+        actions_at_depth = torch.nonzero(stats["depth"] == depth, as_tuple=False).flatten()
+        q_values = self._action_q_values(depth, belief_visits, stats)
+        self._accumulate_belief_visits(belief_visits, actions_at_depth, stats)
+        self._apply_preference_update(beliefs_at_depth, actions_at_depth, q_values, stats)
+
+    def _action_q_values(self, depth: int, belief_visits: Tensor, stats: dict) -> Tensor:
+        child_beliefs = self._tree.belief_nodes_at_depth(depth + 1)
+        future = torch.zeros(stats["count"], dtype=self._value_dtype, device=self.device)
+        if child_beliefs.numel() > 0:
+            value = self._tree.belief_field(_VALUE_FIELD)
+            weighted = belief_visits[child_beliefs] * value[child_beliefs]
+            parents = self._tree.belief_parent_action[child_beliefs]
+            future.index_add_(0, parents, weighted)
+        weighted_future = future / stats["visits"].clamp_min(1.0)
+        return stats["mean_reward"] + self._discount_factor * weighted_future
+
+    def _accumulate_belief_visits(
+        self, belief_visits: Tensor, actions_at_depth: Tensor, stats: dict
+    ) -> None:
+        totals = torch.zeros_like(belief_visits)
+        totals.index_add_(
+            0, stats["parent_belief"][actions_at_depth], stats["visits"][actions_at_depth]
+        )
+        belief_visits[:] = torch.where(totals > 0, totals, belief_visits)
+
+    def _apply_preference_update(
+        self,
+        beliefs_at_depth: Tensor,
+        actions_at_depth: Tensor,
+        q_values: Tensor,
+        stats: dict,
+    ) -> None:
+        preferences = self._tree.belief_field(_PREFERENCES_FIELD)
+        value = self._tree.belief_field(_VALUE_FIELD)
+        current_value = self._log_sum_exp(preferences[beliefs_at_depth])
+        preferences[beliefs_at_depth] = preferences[beliefs_at_depth] - current_value.unsqueeze(1)
+        preferences[
+            stats["parent_belief"][actions_at_depth], stats["key"][actions_at_depth]
+        ] += q_values[actions_at_depth]
+        value[beliefs_at_depth] = self._log_sum_exp(preferences[beliefs_at_depth])
+
+    def _log_sum_exp(self, preferences: Tensor) -> Tensor:
+        return torch.logsumexp(self._temperature * preferences, dim=1) / self._temperature

--- a/POMDPPlanners/planners/vectorized_planners/vopp_episode_runner.py
+++ b/POMDPPlanners/planners/vectorized_planners/vopp_episode_runner.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: MIT
+
+"""Closed-loop episode driver for the vectorized planner (VOPP / PORPP).
+
+:class:`VOPPPlanner` only answers a single question -- ``plan(root_particles)``
+returns one greedy action index -- so on its own it cannot run a POMDP
+*episode*: there is no ground-truth world stepping forward, no belief filter
+threading information between steps, and no record of the trajectory. This
+module adds exactly that thin layer.
+
+:class:`VOPPEpisodeRunner` drives a full closed loop entirely on-device:
+
+#. plan an action from the current particle belief with the wrapped
+   :class:`VOPPPlanner` (timed with a CUDA sync so the wall clock is real);
+#. step a ground-truth world state forward and draw an observation;
+#. run a sequential-importance-resampling (SIR) particle filter -- propagate
+   the belief particles through the model transition, weight them by the
+   model observation likelihood, and resample -- to obtain the next belief.
+
+The world is, by default, the same :class:`VectorizedGenerativeModel` the
+planner searches (a faithful "model-is-world" rollout, justified for
+Continuous Light-Dark by its native-parity test). A caller with a *different*
+ground-truth simulator -- a real CARLA or Isaac world -- injects it through the
+optional ``world_transition`` / ``world_observation`` hooks while the belief
+filter keeps using the vectorized model.
+
+Every quantity the definition-of-done analysis needs is recorded per step:
+the true state, the belief particle cloud, the chosen action, the immediate
+reward, the planning wall-clock time, and the planner's tree metrics.
+"""
+
+import time
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional
+
+import torch
+from torch import Tensor
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.planners.vectorized_planners.vopp import VOPPPlanner
+
+WorldTransition = Callable[[Tensor, Tensor], Tensor]
+WorldObservation = Callable[[Tensor, Tensor], Tensor]
+
+
+@dataclass
+class VOPPEpisodeResult:
+    """Recorded trajectory and per-step statistics of one VOPP episode.
+
+    Attributes:
+        states: ``[ds]`` true states, one per visited step plus the final state.
+        beliefs: Belief particle clouds ``[num_particles, ds]``, one per step.
+        action_indices: Greedy action index chosen at each step.
+        rewards: Immediate reward collected at each step.
+        plan_times: Wall-clock seconds spent inside each :meth:`plan` call.
+        root_visit_counts: Planner root visit count (forward-search particle
+            simulations) backing each step's action.
+        reached_goal: Whether the world reached a terminal (goal) state.
+        num_steps: Number of executed actions.
+    """
+
+    states: List[Tensor] = field(default_factory=list)
+    beliefs: List[Tensor] = field(default_factory=list)
+    action_indices: List[int] = field(default_factory=list)
+    rewards: List[float] = field(default_factory=list)
+    plan_times: List[float] = field(default_factory=list)
+    root_visit_counts: List[int] = field(default_factory=list)
+    reached_goal: bool = False
+    num_steps: int = 0
+
+    @property
+    def total_plan_time(self) -> float:
+        """Total wall-clock seconds spent planning across the episode."""
+        return float(sum(self.plan_times))
+
+    @property
+    def total_root_visits(self) -> int:
+        """Total forward-search particle simulations across the episode."""
+        return int(sum(self.root_visit_counts))
+
+
+class VOPPEpisodeRunner:
+    """Runs closed-loop POMDP episodes with a :class:`VOPPPlanner`.
+
+    The runner owns the interaction loop but no planning policy of its own: the
+    planner decides actions, the vectorized model supplies the dynamics and the
+    belief filter, and an optional pair of world hooks overrides the
+    ground-truth transition / observation when a real simulator is the world.
+
+    Attributes:
+        num_belief_particles: Size of the particle belief carried between steps.
+        max_steps: Maximum number of actions per episode.
+
+    Example:
+        >>> import torch
+        >>> from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+        ...     ContinuousLightDarkPOMDP,
+        ... )
+        >>> from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_vectorized_model import (
+        ...     ContinuousLightDarkVectorizedModel,
+        ... )
+        >>> from POMDPPlanners.planners.vectorized_planners import VOPPPlanner
+        >>> from POMDPPlanners.planners.vectorized_planners.vopp_episode_runner import (
+        ...     VOPPEpisodeRunner,
+        ... )
+        >>> _ = torch.manual_seed(0)
+        >>> env = ContinuousLightDarkPOMDP(discount_factor=0.95, is_obstacle_hit_terminal=False)
+        >>> model = ContinuousLightDarkVectorizedModel(env, device=torch.device("cpu"))
+        >>> planner = VOPPPlanner(
+        ...     model, num_actions=model.num_actions, num_particles=128,
+        ...     max_depth=6, num_planning_iterations=8,
+        ... )
+        >>> runner = VOPPEpisodeRunner(planner, model, num_belief_particles=256, max_steps=20)
+        >>> initial = torch.tensor([[0.0, 5.0]])
+        >>> result = runner.run_episode(initial)
+        >>> result.num_steps >= 1
+        True
+    """
+
+    def __init__(
+        self,
+        planner: VOPPPlanner,
+        model: VectorizedGenerativeModel,
+        *,
+        num_belief_particles: int = 1000,
+        max_steps: int = 50,
+        world_transition: Optional[WorldTransition] = None,
+        world_observation: Optional[WorldObservation] = None,
+    ) -> None:
+        """Initialise the runner.
+
+        Args:
+            planner: The vectorized planner queried once per step.
+            model: Vectorized generative model providing the belief filter and
+                the default ground-truth dynamics.
+            num_belief_particles: Number of particles in the carried belief.
+            max_steps: Maximum actions taken before the episode is cut off.
+            world_transition: Optional ``(state, action) -> next_state`` hook
+                overriding the ground-truth transition (e.g. a real simulator).
+            world_observation: Optional ``(next_state, action) -> observation``
+                hook overriding the ground-truth observation model.
+
+        Raises:
+            ValueError: If ``num_belief_particles`` or ``max_steps`` is not
+                positive.
+        """
+        if num_belief_particles <= 0:
+            raise ValueError("num_belief_particles must be positive")
+        if max_steps <= 0:
+            raise ValueError("max_steps must be positive")
+        self._planner = planner
+        self._model = model
+        self.num_belief_particles = num_belief_particles
+        self.max_steps = max_steps
+        self.device = model.device
+        self._world_transition = world_transition or model.sample_next_states
+        self._world_observation = world_observation or model.sample_observations
+
+    def run_episode(
+        self, initial_state: Tensor, initial_particles: Optional[Tensor] = None
+    ) -> VOPPEpisodeResult:
+        """Run one closed-loop episode and return its recorded trajectory.
+
+        Args:
+            initial_state: ``[1, ds]`` (or ``[ds]``) ground-truth start state.
+            initial_particles: Optional ``[num_particles, ds]`` initial belief;
+                defaults to the start state replicated across the particle set.
+
+        Returns:
+            A :class:`VOPPEpisodeResult` holding the states, beliefs, actions,
+            rewards, planning times, and root visit counts of the episode.
+
+        Raises:
+            ValueError: If ``initial_state`` does not describe a single state.
+        """
+        state = self._validate_initial_state(initial_state)
+        particles = self._initial_particles(state, initial_particles)
+        result = VOPPEpisodeResult()
+        for _ in range(self.max_steps):
+            action_index, plan_time = self._timed_plan(particles)
+            next_state, reward, observation = self._step_world(state, action_index)
+            self._record_step(result, state, particles, action_index, reward, plan_time)
+            state = next_state
+            if bool(self._model.terminal_mask(state).any()):
+                result.reached_goal = True
+                break
+            particles = self._filter_belief(particles, action_index, observation)
+        result.states.append(state.squeeze(0))
+        result.num_steps = len(result.action_indices)
+        return result
+
+    def _validate_initial_state(self, initial_state: Tensor) -> Tensor:
+        state = initial_state.reshape(1, -1) if initial_state.dim() == 1 else initial_state
+        if state.dim() != 2 or state.shape[0] != 1:
+            raise ValueError("initial_state must describe a single [1, ds] state")
+        return state.to(self.device)
+
+    def _initial_particles(self, state: Tensor, initial_particles: Optional[Tensor]) -> Tensor:
+        if initial_particles is not None:
+            return initial_particles.to(self.device)
+        return state.repeat(self.num_belief_particles, 1)
+
+    def _timed_plan(self, particles: Tensor) -> tuple[int, float]:
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+        start = time.perf_counter()
+        action_index = self._planner.plan(particles)
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+        return action_index, time.perf_counter() - start
+
+    def _step_world(self, state: Tensor, action_index: int) -> tuple[Tensor, float, Tensor]:
+        action = torch.tensor([action_index], dtype=torch.int64, device=self.device)
+        next_state = self._world_transition(state, action)
+        reward = float(self._model.rewards(state, action, next_state).item())
+        observation = self._world_observation(next_state, action)
+        return next_state, reward, observation
+
+    def _record_step(
+        self,
+        result: VOPPEpisodeResult,
+        state: Tensor,
+        particles: Tensor,
+        action_index: int,
+        reward: float,
+        plan_time: float,
+    ) -> None:
+        result.states.append(state.squeeze(0))
+        result.beliefs.append(particles.clone())
+        result.action_indices.append(action_index)
+        result.rewards.append(reward)
+        result.plan_times.append(plan_time)
+        result.root_visit_counts.append(self._root_visit_count())
+
+    def _root_visit_count(self) -> int:
+        for variable in self._planner.tree_metrics():
+            if variable.name == "root_visit_count":
+                return int(variable.value)
+        return 0
+
+    def _filter_belief(self, particles: Tensor, action_index: int, observation: Tensor) -> Tensor:
+        """Propagate, weight, and resample the belief (a SIR particle filter)."""
+        actions = torch.full(
+            (particles.shape[0],), action_index, dtype=torch.int64, device=self.device
+        )
+        propagated = self._model.sample_next_states(particles, actions)
+        observations = observation.expand(particles.shape[0], -1)
+        log_weights = self._model.observation_log_probs(propagated, actions, observations)
+        weights = self._normalize_weights(log_weights)
+        resampled = torch.multinomial(weights, particles.shape[0], replacement=True)
+        return propagated[resampled]
+
+    def _normalize_weights(self, log_weights: Tensor) -> Tensor:
+        """Softmax the log-weights, falling back to uniform on total degeneracy.
+
+        If every particle assigns zero likelihood to the observation (all
+        log-weights ``-inf``), the softmax would be all-NaN and resampling would
+        fail; in that case the belief carries no information and we resample
+        uniformly instead.
+        """
+        if not bool(torch.isfinite(log_weights).any()):
+            return torch.full_like(log_weights, 1.0 / log_weights.shape[0])
+        return torch.softmax(log_weights, dim=0)

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_generative_models/test_carla_kinematic_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_generative_models/test_carla_kinematic_vectorized_model.py
@@ -1,0 +1,474 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests: torch vectorized model vs. the scalar kinematic CARLA model.
+
+These tests pin :class:`CarlaKinematicVectorizedModel` to the scalar
+:class:`KinematicCarlaModelPOMDP` so the two implementations cannot drift. The
+deterministic kernels (transition, reward, terminal, observation log-density)
+are compared exactly in float64 over random batches spanning several supported
+configurations (flat vs. obstacle-aware desired speed, custom perception); the
+stochastic observation sampler is compared by empirical moments against the
+scalar sampler. Geometric edge cases (occlusion, out-of-range agents) get
+dedicated crafted-state checks.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_generative_models.carla_kinematic_model_pomdp import (
+    KinematicCarlaModelPOMDP,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_generative_models.carla_kinematic_vectorized_model import (
+    CarlaKinematicVectorizedModel,
+)
+from POMDPPlanners.environments.carla_pomdp.carla_perception.observation_models.gnss_models import (
+    GnssObservationModel,
+)
+
+_CUSTOM_PRESETS = [
+    (0.6, 0.0, 0.0),
+    (0.2, -0.4, 0.0),
+    (0.4, 0.3, 0.0),
+    (0.0, 0.1, 0.9),
+    (0.8, -0.2, 0.0),
+]
+
+# Each case is scalar-model kwargs; all are supported configurations.
+_SUPPORTED_CASES = [
+    {"discount_factor": 0.95, "dt": 0.05},
+    {
+        "discount_factor": 0.9,
+        "dt": 0.05,
+        "desired_speed": 5.0,
+        "collision_gap": 5.0,
+        "safe_distance": 15.0,
+        "stop_gap": 7.0,
+    },
+    {
+        "discount_factor": 0.95,
+        "dt": 0.1,
+        "action_presets": _CUSTOM_PRESETS,
+        "wheelbase": 3.2,
+        "max_steer_angle": 0.5,
+        "accel": 2.5,
+        "brake_decel": 6.0,
+        "drag": 0.1,
+        "pose_std": 0.8,
+        "gnss_std": 1e-4,
+        "detect_prob": 0.85,
+        "perception_range": 30.0,
+        "occlusion_radius": 2.0,
+        "collision_halfwidth": 1.5,
+    },
+]
+_CASE_IDS = ["flat-speed", "obstacle-aware", "custom-perception"]
+
+
+@dataclass
+class _Case:
+    env: KinematicCarlaModelPOMDP
+    model: CarlaKinematicVectorizedModel
+
+
+@pytest.fixture(params=_SUPPORTED_CASES, ids=_CASE_IDS, name="case")
+def case_fixture(request: pytest.FixtureRequest) -> _Case:
+    env = KinematicCarlaModelPOMDP(**request.param)
+    model = CarlaKinematicVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    return _Case(env=env, model=model)
+
+
+def _tensor(array: np.ndarray) -> torch.Tensor:
+    return torch.as_tensor(array, dtype=torch.float64)
+
+
+def _random_states(rng: np.random.Generator, env: KinematicCarlaModelPOMDP, n: int) -> np.ndarray:
+    """Build random states with a mix of present/absent, near/far agent slots."""
+    width = 7 + env.max_tracked_agents * 5
+    states = np.zeros((n, width))
+    states[:, 0:2] = rng.uniform(-20.0, 20.0, size=(n, 2))
+    states[:, 2] = rng.uniform(-180.0, 180.0, size=n)
+    states[:, 3:5] = rng.uniform(-5.0, 10.0, size=(n, 2))
+    states[:, 5] = rng.uniform(-3.0, 3.0, size=n)
+    states[:, 6] = rng.uniform(-0.5, 0.5, size=n)
+    rows = states[:, 7:].reshape(n, env.max_tracked_agents, 5)
+    rows[..., 0] = (rng.uniform(size=(n, env.max_tracked_agents)) < 0.6).astype(float)
+    rows[..., 1] = rng.uniform(-60.0, 60.0, size=(n, env.max_tracked_agents))
+    rows[..., 2] = rng.uniform(-8.0, 8.0, size=(n, env.max_tracked_agents))
+    rows[..., 3] = rng.uniform(-np.pi, np.pi, size=(n, env.max_tracked_agents))
+    rows[..., 4] = rng.uniform(0.0, 10.0, size=(n, env.max_tracked_agents))
+    return states
+
+
+def _random_actions(rng: np.random.Generator, env: KinematicCarlaModelPOMDP, n: int) -> np.ndarray:
+    return rng.integers(0, len(env.action_presets), size=n)
+
+
+def _flat_observations(
+    rng: np.random.Generator, env: KinematicCarlaModelPOMDP, next_states: np.ndarray
+) -> np.ndarray:
+    """Random flat 27-vectors exercising present/absent observed agent slots."""
+    n = next_states.shape[0]
+    obs = np.zeros((n, 2 + env.max_tracked_agents * 5))
+    obs[:, 0:2] = next_states[:, 0:2] + rng.normal(0.0, 1e-4, size=(n, 2))
+    obs_rows = obs[:, 2:].reshape(n, env.max_tracked_agents, 5)
+    true_rows = next_states[:, 7:].reshape(n, env.max_tracked_agents, 5)
+    obs_rows[..., 0] = (rng.uniform(size=(n, env.max_tracked_agents)) < 0.6).astype(float)
+    obs_rows[..., 1:] = true_rows[..., 1:] + rng.normal(
+        0.0, 1.0, size=(n, env.max_tracked_agents, 4)
+    )
+    return obs
+
+
+def _obs_dict(flat: np.ndarray) -> Dict[str, np.ndarray]:
+    return {"gnss": flat[:2].copy(), "agents": flat[2:].copy()}
+
+
+def test_model_conforms_to_protocol_across_configs(case: _Case) -> None:
+    """Every supported config yields a conforming VectorizedGenerativeModel.
+
+    Purpose: Validates structural protocol conformance and reported dimensions
+
+    Given: A model built from each supported scalar-model configuration
+    When: It is checked against the runtime-checkable protocol
+    Then: isinstance reports conformance and the dimensions match the schema
+
+    Test type: unit
+    """
+    assert isinstance(case.model, VectorizedGenerativeModel)
+    assert case.model.num_actions == len(case.env.action_presets)
+    assert case.model.state_dim == 7 + case.env.max_tracked_agents * 5
+    assert case.model.observation_dim == 2 + case.env.max_tracked_agents * 5
+
+
+def test_transition_matches_native_exactly(case: _Case) -> None:
+    """Sampled next states equal the scalar kinematic propagation per row.
+
+    Purpose: Validates the batched kinematic-bicycle transition kernel
+
+    Given: Random states with per-row random action indices
+    When: The vectorized transition is compared to sample_next_state per row
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(1)
+    states = _random_states(rng, case.env, 256)
+    actions = _random_actions(rng, case.env, 256)
+    expected = np.stack(
+        [case.env.sample_next_state(states[i], int(actions[i])) for i in range(states.shape[0])]
+    )
+    actual = case.model.sample_next_states(
+        _tensor(states), torch.as_tensor(actions, dtype=torch.int64)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_reward_matches_native_exactly(case: _Case) -> None:
+    """Rewards equal the scalar driving-quality reward per row.
+
+    Purpose: Validates the reward kernel including obstacle-aware desired speed
+
+    Given: Random states/actions and their vectorized next states
+    When: The vectorized reward is compared to env.reward per row
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(2)
+    states = _random_states(rng, case.env, 256)
+    actions = _random_actions(rng, case.env, 256)
+    action_t = torch.as_tensor(actions, dtype=torch.int64)
+    next_states = case.model.sample_next_states(_tensor(states), action_t)
+    expected = np.array(
+        [
+            case.env.reward(states[i], int(actions[i]), next_states[i].numpy())
+            for i in range(states.shape[0])
+        ]
+    )
+    actual = case.model.rewards(_tensor(states), action_t, next_states).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_terminal_matches_native_exactly(case: _Case) -> None:
+    """Terminal flags equal the scalar predicted-collision check per row.
+
+    Purpose: Validates the batched terminal mask
+
+    Given: Random states with present/absent near/far agent slots
+    When: The vectorized terminal mask is compared to env.is_terminal per row
+    Then: Every entry agrees
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(3)
+    states = _random_states(rng, case.env, 512)
+    expected = np.array([case.env.is_terminal(states[i]) for i in range(states.shape[0])])
+    actual = case.model.terminal_mask(_tensor(states)).numpy()
+    assert np.array_equal(expected, actual)
+
+
+def test_observation_log_probs_match_native_exactly(case: _Case) -> None:
+    """Observation log-densities equal the scalar per-channel density per row.
+
+    Purpose: Validates the GNSS + factored-agent observation likelihood kernel
+
+    Given: Random next states and random observations spanning all slot branches
+    When: The vectorized log-density is compared to env.observation_log_probability
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(4)
+    next_states = _random_states(rng, case.env, 256)
+    observations = _flat_observations(rng, case.env, next_states)
+    expected = np.array(
+        [
+            case.env.observation_log_probability(next_states[i], 0, _obs_dict(observations[i]))[0]
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actual = case.model.observation_log_probs(
+        _tensor(next_states), torch.zeros(256, dtype=torch.int64), _tensor(observations)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def _occlusion_state() -> np.ndarray:
+    """Two present agents where the blocker occludes the farther target."""
+    state = np.zeros(32)
+    state[7:12] = [1.0, 20.0, 0.0, 0.0, 0.0]  # slot 0: target ahead
+    state[12:17] = [1.0, 10.0, 0.5, 0.0, 0.0]  # slot 1: blocker on the sight line
+    return state
+
+
+def test_occlusion_log_prob_matches_native() -> None:
+    """An occluded agent is scored as invisible, matching the scalar density.
+
+    Purpose: Validates the O(K^2) sight-line occlusion gate in the density
+
+    Given: A crafted state whose slot-1 blocker occludes the slot-0 target,
+        with an observation reporting the (unobservable) occluded target present
+    When: The vectorized log-density is compared to env.observation_log_probability
+    Then: The two agree to 1e-9 (the occluded-but-observed slot floors to _LOG_EPS)
+
+    Test type: unit
+    """
+    env = KinematicCarlaModelPOMDP(discount_factor=0.95, dt=0.05)
+    model = CarlaKinematicVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    state = _occlusion_state()
+    obs = np.zeros(27)
+    obs[0:2] = state[0:2]
+    obs[2:7] = [1.0, 20.0, 0.0, 0.0, 0.0]  # report the occluded target as present
+    obs[7:12] = [1.0, 10.0, 0.5, 0.0, 0.0]  # blocker correctly observed present
+    expected = env.observation_log_probability(state, 0, {"gnss": obs[:2], "agents": obs[2:]})[0]
+    actual = float(
+        model.observation_log_probs(
+            _tensor(state[None]), torch.zeros(1, dtype=torch.int64), _tensor(obs[None])
+        )[0]
+    )
+    assert abs(expected - actual) < 1e-9
+    # Correctly reporting the occluded target as absent (a forced miss) must score
+    # far higher, confirming the occlusion gate floored the present report.
+    obs_absent = obs.copy()
+    obs_absent[2:7] = 0.0
+    log_prob_absent = float(
+        model.observation_log_probs(
+            _tensor(state[None]), torch.zeros(1, dtype=torch.int64), _tensor(obs_absent[None])
+        )[0]
+    )
+    assert actual < log_prob_absent - 40.0
+
+
+def test_none_perception_range_parity() -> None:
+    """A far agent stays visible when the range gate is disabled (range=None).
+
+    Purpose: Validates that perception_range=None disables the range gate
+
+    Given: A state with a present agent well beyond the default 50 m range
+    When: The vectorized density is compared to the scalar density
+    Then: The two agree to 1e-9 and the far agent contributes a Gaussian term
+
+    Test type: unit
+    """
+    env = KinematicCarlaModelPOMDP(discount_factor=0.95, dt=0.05, perception_range=None)
+    model = CarlaKinematicVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    state = np.zeros(32)
+    state[7:12] = [1.0, 200.0, 0.0, 0.0, 3.0]  # present agent far beyond 50 m
+    obs = np.zeros(27)
+    obs[2:7] = [1.0, 200.5, 0.1, 0.0, 3.0]  # detected with small pose noise
+    expected = env.observation_log_probability(state, 0, {"gnss": obs[:2], "agents": obs[2:]})[0]
+    actual = float(
+        model.observation_log_probs(
+            _tensor(state[None]), torch.zeros(1, dtype=torch.int64), _tensor(obs[None])
+        )[0]
+    )
+    assert abs(expected - actual) < 1e-9
+
+
+def _sample_agent_slot0(
+    sampler: Callable[[np.ndarray], Dict[str, np.ndarray]],
+    next_state: np.ndarray,
+    n: int,
+    extract: Callable[[Dict[str, np.ndarray]], np.ndarray],
+) -> np.ndarray:
+    return np.stack([extract(sampler(next_state)) for _ in range(n)])
+
+
+def test_gnss_sampling_matches_native_moments(case: _Case) -> None:
+    """Sampled GNSS noise matches the scalar Gaussian in mean and covariance.
+
+    Purpose: Validates the GNSS observation sampler's noise statistics
+
+    Given: A fixed next state sampled many times by both implementations
+    When: Empirical GNSS mean and covariance (normalised by gnss_std) are compared
+    Then: The normalised mean is near zero and the covariance near the identity
+
+    Test type: unit
+    """
+    torch.manual_seed(5)
+    next_state = np.zeros(32)
+    twin = case.model.sample_observations(
+        _tensor(np.tile(next_state, (60000, 1))), torch.zeros(60000, dtype=torch.int64)
+    ).numpy()
+    gnss_model = case.env.observation_models["gnss"] if case.env.observation_models else None
+    assert isinstance(gnss_model, GnssObservationModel)
+    normalised = (twin[:, 0:2] - next_state[0:2]) / gnss_model.gnss_std
+    assert np.max(np.abs(normalised.mean(axis=0))) < 0.03
+    assert np.max(np.abs(np.cov(normalised.T) - np.eye(2))) < 0.05
+
+
+def test_agent_pose_sampling_matches_native_moments(case: _Case) -> None:
+    """Sampled detected-agent pose noise matches the scalar sampler's moments.
+
+    Purpose: Validates the per-slot additive pose-noise sampler for a visible agent
+
+    Given: A next state with one visible present agent, sampled many times by both
+    When: Empirical per-column mean and covariance of the slot are compared
+    Then: Means agree within 0.02 and covariances within a Monte Carlo tolerance
+
+    Test type: unit
+    """
+    np.random.seed(6)
+    torch.manual_seed(6)
+    next_state = np.zeros(32)
+    next_state[7:12] = [1.0, 10.0, 0.0, 0.3, 4.0]  # in range, unoccluded, visible
+    twin = case.model.sample_observations(
+        _tensor(np.tile(next_state, (40000, 1))), torch.zeros(40000, dtype=torch.int64)
+    ).numpy()[:, 3:7]
+    native = _sample_agent_slot0(
+        lambda s: case.env.sample_observation(s, 0),
+        next_state,
+        40000,
+        lambda obs: np.asarray(obs["agents"], dtype=float)[1:5],
+    )
+    assert np.max(np.abs(twin.mean(axis=0) - native.mean(axis=0))) < 0.02
+    assert np.max(np.abs(np.cov(twin.T) - np.cov(native.T))) < 0.02
+
+
+def test_method_shapes_and_dtypes(case: _Case) -> None:
+    """All generative methods return the documented shapes and dtypes.
+
+    Purpose: Validates the tensor contract of every public method
+
+    Given: A small batch of states, actions, next states, and observations
+    When: Each generative / key method is invoked
+    Then: Shapes match [N, .] / [N] and integer keys are int64
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(8)
+    states = _tensor(_random_states(rng, case.env, 16))
+    actions = torch.zeros(16, dtype=torch.int64)
+    next_states = case.model.sample_next_states(states, actions)
+    observations = case.model.sample_observations(next_states, actions)
+    assert next_states.shape == (16, case.model.state_dim)
+    assert observations.shape == (16, case.model.observation_dim)
+    assert case.model.rewards(states, actions, next_states).shape == (16,)
+    assert case.model.terminal_mask(states).dtype == torch.bool
+    assert case.model.action_keys(actions).dtype == torch.int64
+    assert case.model.observation_keys(observations).dtype == torch.int64
+
+
+def test_keys_are_deterministic_and_discriminating(case: _Case) -> None:
+    """Action and observation keys are stable and separate distinct inputs.
+
+    Purpose: Validates the integer tree-key mappings
+
+    Given: Repeated actions and observations, some identical and some distinct
+    When: The key methods are called twice
+    Then: Identical inputs map to identical keys and distinct inputs differ
+
+    Test type: unit
+    """
+    actions = torch.tensor([0, 1, 2, 3])
+    assert torch.equal(case.model.action_keys(actions), actions.to(torch.int64))
+    base = torch.zeros(3, case.model.observation_dim, dtype=torch.float64)
+    base[1, 0] = 5.0
+    base[2, 4] = 9.0
+    keys_first = case.model.observation_keys(base)
+    keys_second = case.model.observation_keys(base)
+    assert torch.equal(keys_first, keys_second)
+    assert keys_first[0] != keys_first[1]
+    assert keys_first[0] != keys_first[2]
+
+
+def test_nonpositive_observation_resolution_raises() -> None:
+    """A non-positive observation resolution is rejected at construction.
+
+    Purpose: Validates the guard on the observation-resolution knob
+
+    Given: A valid scalar model and a non-positive observation_resolution
+    When: A vectorized model is constructed
+    Then: ValueError is raised
+
+    Test type: unit
+    """
+    env = KinematicCarlaModelPOMDP(discount_factor=0.95, dt=0.05)
+    with pytest.raises(ValueError):
+        CarlaKinematicVectorizedModel(env, observation_resolution=0.0)
+
+
+def test_unsupported_observation_models_raise() -> None:
+    """Constructing without the factored/gaussian perception pair is rejected.
+
+    Purpose: Validates the scope guard on the required observation models
+
+    Given: A scalar model whose observation-model map has been cleared
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = KinematicCarlaModelPOMDP(discount_factor=0.95, dt=0.05)
+    env.observation_models = {}
+    with pytest.raises(NotImplementedError):
+        CarlaKinematicVectorizedModel(env)
+
+
+def test_transition_batch_helper_matches_vectorized() -> None:
+    """The scalar batch transition agrees with the vectorized kernel.
+
+    Purpose: Cross-checks sample_next_state_batch against the vectorized model
+
+    Given: Random states and a single shared action index
+    When: The scalar batch transition and the vectorized transition are compared
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: integration
+    """
+    rng = np.random.default_rng(9)
+    env = KinematicCarlaModelPOMDP(discount_factor=0.95, dt=0.05)
+    model = CarlaKinematicVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    states = _random_states(rng, env, 128)
+    expected = env.sample_next_state_batch(states, 2)
+    actual = model.sample_next_states(
+        _tensor(states), torch.full((128,), 2, dtype=torch.int64)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp_vectorized_model.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests: torch vectorized model vs. the native CartPole POMDP env.
+
+These tests pin :class:`CartPoleVectorizedModel` to the environment's native
+(C++) kernels so the two implementations cannot drift. The parity checks run
+over a sweep of supported configurations (varying the transition and
+observation covariances) so a wiring bug that default parameters would hide is
+caught. Observation log-densities, rewards, and terminal flags are compared
+exactly; the stochastic transition / observation kernels are compared by
+empirical moments over a large batch.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.environments.cartpole_pomdp.cartpole_pomdp import CartPolePOMDP
+from POMDPPlanners.environments.cartpole_pomdp.cartpole_vectorized_model import (
+    CartPoleVectorizedModel,
+)
+
+# Each case is (noise_cov, state_transition_cov | None). All are supported
+# configurations (default "euler" integrator); the covariances vary widely.
+_SUPPORTED_CASES = [
+    (np.diag([0.1, 0.1, 0.1, 0.1]), None),
+    (np.diag([0.02, 0.2, 0.05, 0.3]), np.diag([1e-3, 5e-4, 2e-4, 8e-4])),
+    (
+        np.array(
+            [
+                [0.10, 0.01, 0.00, 0.00],
+                [0.01, 0.08, 0.00, 0.00],
+                [0.00, 0.00, 0.05, 0.01],
+                [0.00, 0.00, 0.01, 0.04],
+            ]
+        ),
+        None,
+    ),
+]
+_CASE_IDS = ["default", "anisotropic", "correlated-obs"]
+
+
+@dataclass
+class _Case:
+    env: CartPolePOMDP
+    model: CartPoleVectorizedModel
+
+
+@pytest.fixture(params=_SUPPORTED_CASES, ids=_CASE_IDS, name="case")
+def case_fixture(request: pytest.FixtureRequest) -> _Case:
+    noise_cov, state_transition_cov = request.param
+    env = CartPolePOMDP(
+        discount_factor=0.99,
+        noise_cov=noise_cov,
+        state_transition_cov=state_transition_cov,
+    )
+    model = CartPoleVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    return _Case(env=env, model=model)
+
+
+def _tensor(array: np.ndarray) -> torch.Tensor:
+    return torch.as_tensor(array, dtype=torch.float64)
+
+
+def _random_nonterminal_states(env: CartPolePOMDP, count: int, seed: int) -> np.ndarray:
+    """Sample states comfortably inside the alive region (deterministic reward)."""
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(-env.x_threshold + 0.2, env.x_threshold - 0.2, size=count)
+    x_dot = rng.uniform(-1.0, 1.0, size=count)
+    theta = rng.uniform(
+        -env.theta_threshold_radians + 0.02, env.theta_threshold_radians - 0.02, size=count
+    )
+    theta_dot = rng.uniform(-1.0, 1.0, size=count)
+    return np.stack([x, x_dot, theta, theta_dot], axis=1)
+
+
+def test_model_satisfies_protocol_for_every_supported_config(case: _Case) -> None:
+    """Every supported config yields a conforming VectorizedGenerativeModel.
+
+    Purpose: Validates structural protocol conformance across configs
+
+    Given: A model built from each supported environment configuration
+    When: It is checked against the runtime-checkable protocol
+    Then: isinstance reports conformance and the action count is two
+
+    Test type: unit
+    """
+    assert isinstance(case.model, VectorizedGenerativeModel)
+    assert case.model.num_actions == 2
+
+
+def test_observation_log_probs_match_native_exactly(case: _Case) -> None:
+    """Observation log-likelihoods match the native kernel to float64 precision.
+
+    Purpose: Validates the observation likelihood kernel across configs
+
+    Given: (next_state, observation) pairs drawn around random next states
+    When: The model's observation_log_probs is compared to the env per pair
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    next_states = _random_nonterminal_states(case.env, 256, seed=3)
+    rng = np.random.default_rng(11)
+    observations = next_states + rng.normal(scale=0.2, size=(256, 4))
+    expected = np.array(
+        [
+            case.env.observation_log_probability(next_states[i], 0, observations[i].reshape(1, 4))[
+                0
+            ]
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actual = case.model.observation_log_probs(
+        _tensor(next_states), torch.zeros(256, dtype=torch.int64), _tensor(observations)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+@pytest.mark.parametrize("action", [0, 1])
+def test_reward_matches_native(case: _Case, action: int) -> None:
+    """Rewards match the native +1-while-alive kernel exactly across configs.
+
+    Purpose: Validates the deterministic reward path over alive/terminal states
+
+    Given: A mix of clearly-alive and clearly-terminal states per config
+    When: The model reward is compared to env.reward_batch on those states
+    Then: Every entry agrees exactly
+
+    Test type: unit
+    """
+    alive = _random_nonterminal_states(case.env, 200, seed=5)
+    terminal = np.array(
+        [
+            [case.env.x_threshold + 1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, case.env.theta_threshold_radians + 0.1, 0.0],
+        ]
+    )
+    states = np.vstack([alive, terminal])
+    expected = case.env.reward_batch(states, action, next_states=states)
+    actual = case.model.rewards(
+        _tensor(states), torch.full((states.shape[0],), action, dtype=torch.int64), _tensor(states)
+    ).numpy()
+    assert np.array_equal(expected, actual)
+
+
+def test_terminal_mask_matches_native(case: _Case) -> None:
+    """Terminal flags match the native per-state terminal check across configs.
+
+    Purpose: Validates the batched terminal mask against env.is_terminal
+
+    Given: States on both sides of the x and theta thresholds
+    When: The model terminal mask is compared to env.is_terminal per row
+    Then: Every entry agrees
+
+    Test type: unit
+    """
+    x_thr = case.env.x_threshold
+    theta_thr = case.env.theta_threshold_radians
+    states = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+            [x_thr + 0.1, 0.0, 0.0, 0.0],
+            [-x_thr - 0.1, 0.0, 0.0, 0.0],
+            [0.0, 0.0, theta_thr + 0.01, 0.0],
+            [0.0, 0.0, -theta_thr - 0.01, 0.0],
+            [x_thr - 0.1, 5.0, theta_thr - 0.01, -5.0],
+        ]
+    )
+    expected = np.array([case.env.is_terminal(s) for s in states])
+    actual = case.model.terminal_mask(_tensor(states)).numpy()
+    assert np.array_equal(expected, actual)
+
+
+@pytest.mark.parametrize("action", [0, 1])
+def test_transition_sampling_matches_native_moments(case: _Case, action: int) -> None:
+    """Sampled next-state moments match the native transition kernel per config.
+
+    Purpose: Validates the batched cart-pole physics + transition noise
+
+    Given: A fixed non-trivial state and action sampled many times by both
+    When: Empirical mean and covariance are compared
+    Then: Mean gap < 1e-3 and covariance gap < 1e-3
+
+    Test type: unit
+    """
+    torch.manual_seed(1)
+    state = np.array([0.3, 0.5, 0.08, -0.4])
+    native = case.env.sample_next_state_batch(np.tile(state, (60000, 1)), action)
+    twin = case.model.sample_next_states(
+        _tensor(np.tile(state, (60000, 1))),
+        torch.full((60000,), action, dtype=torch.int64),
+    ).numpy()
+    assert np.max(np.abs(native.mean(0) - twin.mean(0))) < 1e-3
+    assert np.max(np.abs(np.cov(native.T) - np.cov(twin.T))) < 1e-3
+
+
+def test_observation_sampling_matches_noise_covariance(case: _Case) -> None:
+    """Observation sampling reproduces the env's observation covariance.
+
+    Purpose: Validates the observation noise kernel across configs
+
+    Given: A fixed next state sampled many times by the model
+    When: The empirical mean and covariance of the observations are computed
+    Then: The mean matches the next state and the covariance matches noise_cov
+
+    Test type: unit
+    """
+    torch.manual_seed(2)
+    next_state = np.array([0.2, -0.3, 0.05, 0.4])
+    twin = case.model.sample_observations(
+        _tensor(np.tile(next_state, (60000, 1))), torch.zeros(60000, dtype=torch.int64)
+    ).numpy()
+    assert np.max(np.abs(twin.mean(0) - next_state)) < 0.02
+    assert np.max(np.abs(np.cov(twin.T) - case.env.noise_cov)) < 0.02
+
+
+def test_action_keys_are_passthrough_indices(case: _Case) -> None:
+    """Action keys are the integer action indices themselves.
+
+    Purpose: Validates the discrete-action passthrough key mapping
+
+    Given: A tensor of the two discrete action indices
+    When: action_keys is called
+    Then: The int64 keys equal the input indices
+
+    Test type: unit
+    """
+    actions = torch.tensor([0, 1, 1, 0], dtype=torch.int64)
+    keys = case.model.action_keys(actions)
+    assert keys.dtype == torch.int64
+    assert torch.equal(keys, actions)
+
+
+def test_observation_keys_are_deterministic_and_discriminating(case: _Case) -> None:
+    """Observation keys are stable per input and separate distinct cells.
+
+    Purpose: Validates the continuous-observation to integer-key hashing
+
+    Given: Observations, some identical and some in different grid cells
+    When: observation_keys is called twice
+    Then: Identical inputs map to identical keys and distinct cells differ
+
+    Test type: unit
+    """
+    observations = torch.tensor(
+        [
+            [0.01, 0.01, 0.01, 0.01],
+            [0.01, 0.01, 0.01, 0.01],
+            [1.2, -0.7, 0.3, 2.4],
+            [-1.0, -1.0, -1.0, -1.0],
+        ],
+        dtype=torch.float64,
+    )
+    keys_first = case.model.observation_keys(observations)
+    keys_second = case.model.observation_keys(observations)
+    assert torch.equal(keys_first, keys_second)
+    assert keys_first[0] == keys_first[1]
+    assert keys_first[0] != keys_first[2]
+    assert keys_first[2] != keys_first[3]
+
+
+def test_unsupported_integrator_raises() -> None:
+    """Constructing on a non-euler integrator is rejected.
+
+    Purpose: Validates the scope guard on the kinematics integrator
+
+    Given: An env switched to the semi-implicit euler integrator
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    env.kinematics_integrator = "semi-implicit euler"
+    with pytest.raises(NotImplementedError):
+        CartPoleVectorizedModel(env)
+
+
+def test_non_positive_observation_resolution_raises() -> None:
+    """A non-positive observation resolution is rejected.
+
+    Purpose: Validates the observation_resolution input guard
+
+    Given: A default env and a zero observation resolution
+    When: A vectorized model is constructed with that resolution
+    Then: ValueError is raised
+
+    Test type: unit
+    """
+    env = CartPolePOMDP(discount_factor=0.99, noise_cov=np.diag([0.1, 0.1, 0.1, 0.1]))
+    with pytest.raises(ValueError):
+        CartPoleVectorizedModel(env, observation_resolution=0.0)

--- a/POMDPPlanners/tests/test_environments/test_isaac_lab_pomdp/test_isaac_lab_model_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_isaac_lab_pomdp/test_isaac_lab_model_pomdp.py
@@ -1,0 +1,586 @@
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the IsaacLab planner-side generative model.
+
+These tests exercise :class:`GaussianObservationModel` and
+:class:`IsaacLabModelPOMDP` as pure-numpy components — they never launch Isaac
+Sim, so they run in the plain project venv and in CI. The additive-Normal
+observation model is checked for numerical agreement against a closed-form
+diagonal-Gaussian reference; the generative model is checked for its full
+abstract-method surface plus a POMCPOW + particle-belief integration round-trip.
+"""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief import WeightedParticleBelief
+from POMDPPlanners.environments.isaac_lab_pomdp import (
+    GaussianObservationModel,
+    GaussianRandomWalkTransition,
+    IsaacLabModelPOMDP,
+    IsaacLabSimulatorTransition,
+    LinearGaussianTransition,
+    LinearRewardModel,
+)
+from POMDPPlanners.environments.isaac_lab_pomdp import isaac_lab_model_pomdp
+from POMDPPlanners.planners.mcts_planners.pomcpow import POMCPOW
+from POMDPPlanners.utils.action_samplers import DiscreteActionSampler
+
+
+def _reference_diagonal_gaussian_logpdf(
+    values: np.ndarray, mean: np.ndarray, std: np.ndarray
+) -> np.ndarray:
+    """Closed-form log-density of a diagonal Gaussian, independent of the model impl."""
+    rows = np.atleast_2d(np.asarray(values, dtype=float))
+    variance = np.asarray(std, dtype=float) ** 2
+    quadratic = np.sum((rows - mean) ** 2 / variance, axis=1)
+    normalizer = np.sum(np.log(2.0 * np.pi * variance))
+    return -0.5 * (quadratic + normalizer)
+
+
+def _build_model(observation_dim: int = 5, action_dim: int = 3) -> IsaacLabModelPOMDP:
+    """Construct a small model with a zero action plus random preset vectors."""
+    rng = np.random.default_rng(0)
+    presets = [np.zeros(action_dim)] + [rng.standard_normal(action_dim) for _ in range(4)]
+    return IsaacLabModelPOMDP(
+        observation_dim=observation_dim,
+        action_presets=presets,
+        discount_factor=0.99,
+        observation_noise_std=0.1,
+        process_noise_std=0.05,
+    )
+
+
+def test_observation_log_probability_matches_scipy_single_and_batch():
+    """Additive-Normal log-density agrees with scipy for one and many observations.
+
+    Purpose: Validates the observation model is a correct isotropic-per-channel Gaussian.
+
+    Given: A GaussianObservationModel with per-channel std and a fixed state.
+    When: log_probability is evaluated on one observation and on a batch.
+    Then: Values equal scipy.multivariate_normal.logpdf with the same diagonal covariance.
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(1)
+    dim = 5
+    std = np.array([0.1, 0.2, 0.05, 0.3, 0.15])
+    model = GaussianObservationModel(dim, std)
+    state = rng.standard_normal(dim)
+
+    obs = rng.standard_normal(dim)
+    single = model.log_probability(state, obs)
+    assert single.shape == (1,)
+    assert np.allclose(single[0], _reference_diagonal_gaussian_logpdf(obs, state, std)[0])
+
+    batch = rng.standard_normal((4, dim))
+    assert np.allclose(
+        model.log_probability(state, batch),
+        _reference_diagonal_gaussian_logpdf(batch, state, std),
+    )
+
+
+def test_observation_sampling_shapes_and_mean_centered_on_state():
+    """Sampled observations have the right shape and are centered on the state.
+
+    Purpose: Validates the observation model draws obs = state + zero-mean noise.
+
+    Given: A GaussianObservationModel and a fixed state.
+    When: A single sample and a large batch are drawn.
+    Then: Single sample is (dim,), batch is (n, dim), and the empirical mean ~ state.
+
+    Test type: unit
+    """
+    dim = 5
+    model = GaussianObservationModel(dim, 0.1)
+    state = np.arange(dim, dtype=float)
+    assert model.sample(state).shape == (dim,)
+    samples = model.sample(state, n_samples=20000)
+    assert samples.shape == (20000, dim)
+    assert np.allclose(samples.mean(axis=0), state, atol=0.02)
+
+
+def test_observation_model_rejects_nonpositive_std():
+    """A non-positive noise std is rejected at construction.
+
+    Purpose: Validates covariance construction guards against degenerate noise.
+
+    Given: An observation dimension and a zero (or negative) standard deviation.
+    When: GaussianObservationModel is constructed.
+    Then: A ValueError is raised.
+
+    Test type: unit
+    """
+    with pytest.raises(ValueError):
+        GaussianObservationModel(3, 0.0)
+    with pytest.raises(ValueError):
+        GaussianObservationModel(3, np.array([0.1, -0.2, 0.3]))
+
+
+def test_model_transition_is_gaussian_random_walk_centered_on_state():
+    """The placeholder transition samples a Gaussian random walk about the state.
+
+    Purpose: Validates sample_next_state / transition_log_probability shapes and centering.
+
+    Given: An IsaacLabModelPOMDP and a fixed state.
+    When: Next states are sampled (single and batch) and scored.
+    Then: Shapes are correct and the empirical next-state mean ~ the input state.
+
+    Test type: unit
+    """
+    model = _build_model()
+    state = np.arange(model.observation_dim, dtype=float)
+    action = model.get_actions()[1]
+    assert model.sample_next_state(state, action).shape == (model.observation_dim,)
+    batch = model.sample_next_state(state, action, n_samples=5000)
+    assert batch.shape == (5000, model.observation_dim)
+    assert np.allclose(batch.mean(axis=0), state, atol=0.02)
+    log_probs = model.transition_log_probability(state, action, batch[:4])
+    assert log_probs.shape == (4,)
+
+
+def test_model_observation_surface_shapes():
+    """The model's observation methods return the belief-filter-expected shapes.
+
+    Purpose: Validates sample_observation and the scalar/per-state density helpers.
+
+    Given: An IsaacLabModelPOMDP, a state, and an observation.
+    When: The observation and its densities (single, batch, per-state) are computed.
+    Then: All shapes/types match what the particle belief and POMCPOW expect.
+
+    Test type: unit
+    """
+    model = _build_model()
+    state = np.arange(model.observation_dim, dtype=float)
+    action = model.get_actions()[1]
+    obs = model.sample_observation(state, action)
+    assert obs.shape == (model.observation_dim,)
+    assert model.observation_log_probability(state, action, [obs, obs]).shape == (2,)
+    assert isinstance(model.observation_log_probability_single(state, action, obs), float)
+    per_state = model.observation_log_probability_per_state([state, state, state], action, obs)
+    assert per_state.shape == (3,)
+    assert len(model.sample_next_state_batch([state, state], action)) == 2
+
+
+def test_linear_reward_recovers_known_reward_and_drives_the_model():
+    """A fitted linear reward recovers the true reward and is used by the model.
+
+    Purpose: Validates LinearRewardModel.fit and its wiring into IsaacLabModelPOMDP.reward.
+
+    Given: Transitions labeled by a known reward = w_s.state + w_a.action + w_n.next + b.
+    When: LinearRewardModel.fit is applied and injected into a model.
+    Then: The model's reward reproduces the true reward for held-out transitions.
+
+    Test type: integration
+    """
+    rng = np.random.default_rng(6)
+    dim, action_dim, n = 4, 2, 300
+    w_s = rng.standard_normal(dim)
+    w_a = rng.standard_normal(action_dim)
+    w_n = rng.standard_normal(dim)
+    bias = 0.7
+    states = rng.standard_normal((n, dim))
+    actions = rng.standard_normal((n, action_dim))
+    next_states = rng.standard_normal((n, dim))
+    rewards = states @ w_s + actions @ w_a + next_states @ w_n + bias
+
+    reward_model = LinearRewardModel.fit(states, actions, next_states, rewards, regularization=0.0)
+    model = IsaacLabModelPOMDP(
+        observation_dim=dim,
+        action_presets=[np.zeros(action_dim), np.ones(action_dim)],
+        discount_factor=0.99,
+        reward_model=reward_model,
+    )
+    test_s, test_a, test_n = states[0], actions[0], next_states[0]
+    expected = float(test_s @ w_s + test_a @ w_a + test_n @ w_n + bias)
+    assert np.isclose(model.reward(test_s, test_a, test_n), expected, atol=1e-6)
+
+
+def test_model_reward_is_flat_zero_without_a_reward_model():
+    """Without a reward model the model reward stays a flat zero (undirected planning).
+
+    Purpose: Validates the documented default when no reward model is supplied.
+
+    Given: An IsaacLabModelPOMDP built without a reward_model.
+    When: reward is evaluated on an arbitrary transition.
+    Then: It returns 0.0.
+
+    Test type: unit
+    """
+    model = _build_model()
+    state = np.ones(model.observation_dim)
+    assert model.reward(state, model.get_actions()[1], state) == 0.0
+
+
+def test_model_static_semantics():
+    """Reward, terminality, actions, hashing, and equality behave as specified.
+
+    Purpose: Validates the remaining concrete Environment surface.
+
+    Given: An IsaacLabModelPOMDP with five action presets.
+    When: reward, is_terminal, get_actions, hash_action, and is_equal_observation are called.
+    Then: Reward is the flat placeholder 0.0, states are never terminal, and the
+        five presets are returned with hashable actions and array-equality on observations.
+
+    Test type: unit
+    """
+    model = _build_model()
+    state = np.zeros(model.observation_dim)
+    action = model.get_actions()[2]
+    assert model.reward(state, action, state) == 0.0
+    assert model.is_terminal(state) is False
+    assert len(model.get_actions()) == 5
+    assert isinstance(model.hash_action(action), bytes)
+    assert model.is_equal_observation(state, state.copy())
+    assert not model.is_equal_observation(state, state + 1.0)
+
+
+def test_model_has_no_initial_priors():
+    """The model exposes no initial-state/observation prior (belief seeded externally).
+
+    Purpose: Validates the documented contract that the belief is seeded from the world.
+
+    Given: An IsaacLabModelPOMDP.
+    When: initial_state_dist / initial_observation_dist are called.
+    Then: Both raise NotImplementedError.
+
+    Test type: unit
+    """
+    model = _build_model()
+    with pytest.raises(NotImplementedError):
+        model.initial_state_dist()
+    with pytest.raises(NotImplementedError):
+        model.initial_observation_dist()
+
+
+def test_random_walk_transition_is_action_ignoring_and_centered():
+    """The random-walk transition centers on the state and ignores the action.
+
+    Purpose: Validates GaussianRandomWalkTransition sampling and action-invariance.
+
+    Given: A GaussianRandomWalkTransition and a fixed state.
+    When: Next states are sampled under two different actions.
+    Then: Both empirical means equal the state (the action has no effect).
+
+    Test type: unit
+    """
+    transition = GaussianRandomWalkTransition(dim=4, process_noise_std=0.05)
+    state = np.array([1.0, -2.0, 3.0, 0.5])
+    mean_a = transition.sample_next_state(state, action=np.zeros(3), n_samples=8000).mean(axis=0)
+    mean_b = transition.sample_next_state(state, action=np.ones(3), n_samples=8000).mean(axis=0)
+    assert np.allclose(mean_a, state, atol=0.02)
+    assert np.allclose(mean_b, state, atol=0.02)
+
+
+def test_linear_transition_recovers_known_dynamics_from_rollouts():
+    """Fitting recovers the true A, B, b of a noise-free linear system.
+
+    Purpose: Validates LinearGaussianTransition.fit performs correct system identification.
+
+    Given: Rollouts generated by a known next = A@state + B@action + b (no noise).
+    When: LinearGaussianTransition.fit is applied to the rollouts.
+    Then: The fitted mean reproduces the true next state for held-out (state, action) pairs.
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(3)
+    dim, action_dim, n = 4, 2, 400
+    true_a = rng.standard_normal((dim, dim)) * 0.3
+    true_b = rng.standard_normal((dim, action_dim)) * 0.5
+    true_bias = rng.standard_normal(dim) * 0.1
+    states = rng.standard_normal((n, dim))
+    actions = rng.standard_normal((n, action_dim))
+    next_states = states @ true_a.T + actions @ true_b.T + true_bias
+
+    transition = LinearGaussianTransition.fit(states, actions, next_states, regularization=0.0)
+    test_state = rng.standard_normal(dim)
+    test_action = rng.standard_normal(action_dim)
+    expected = true_a @ test_state + true_b @ test_action + true_bias
+    got = transition.sample_next_state(test_state, test_action, n_samples=6000).mean(axis=0)
+    assert np.allclose(got, expected, atol=0.01)
+
+
+def test_linear_transition_is_action_conditioned():
+    """Different actions yield different predicted next states under the linear model.
+
+    Purpose: Validates the learned transition makes actions move the state (unlike the walk).
+
+    Given: A LinearGaussianTransition fit on action-dependent rollouts.
+    When: The transition log-density scores a next state under two different actions.
+    Then: The two log-densities differ, i.e. the action changes the predicted distribution.
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(4)
+    dim, action_dim, n = 3, 2, 300
+    true_b = np.array([[1.0, 0.0], [0.0, 1.0], [0.5, -0.5]])
+    states = rng.standard_normal((n, dim))
+    actions = rng.standard_normal((n, action_dim))
+    next_states = states + actions @ true_b.T
+    transition = LinearGaussianTransition.fit(states, actions, next_states)
+
+    state = np.zeros(dim)
+    candidate = np.array([1.0, 0.0, 0.5])
+    log_p_a = transition.log_probability(state, np.array([1.0, 0.0]), candidate)
+    log_p_b = transition.log_probability(state, np.array([-1.0, 0.0]), candidate)
+    assert not np.isclose(log_p_a[0], log_p_b[0])
+
+
+def test_linear_transition_fit_rejects_too_few_transitions():
+    """Fitting with fewer than two transitions raises.
+
+    Purpose: Validates the fit guard against under-determined system identification.
+
+    Given: A single transition sample.
+    When: LinearGaussianTransition.fit is called.
+    Then: A ValueError is raised.
+
+    Test type: unit
+    """
+    with pytest.raises(ValueError):
+        LinearGaussianTransition.fit(np.zeros((1, 3)), np.zeros((1, 2)), np.zeros((1, 3)))
+
+
+def test_model_accepts_injected_transition():
+    """An injected transition overrides the default random walk in the model.
+
+    Purpose: Validates the TransitionModel seam is wired through IsaacLabModelPOMDP.
+
+    Given: An IsaacLabModelPOMDP constructed with an explicit LinearGaussianTransition.
+    When: sample_next_state is called for two different actions from the same state.
+    Then: The predicted next-state means differ, proving the injected model is used.
+
+    Test type: integration
+    """
+    rng = np.random.default_rng(5)
+    dim, action_dim, n = 3, 3, 200
+    states = rng.standard_normal((n, dim))
+    actions = rng.standard_normal((n, action_dim))
+    next_states = states + actions  # action directly displaces the state
+    transition = LinearGaussianTransition.fit(states, actions, next_states)
+    presets = [np.zeros(action_dim), np.ones(action_dim)]
+    model = IsaacLabModelPOMDP(
+        observation_dim=dim, action_presets=presets, discount_factor=0.99, transition=transition
+    )
+    state = np.zeros(dim)
+    mean_zero = model.sample_next_state(state, presets[0], n_samples=6000).mean(axis=0)
+    mean_one = model.sample_next_state(state, presets[1], n_samples=6000).mean(axis=0)
+    assert np.allclose(mean_zero, np.zeros(dim), atol=0.05)
+    assert np.allclose(mean_one, np.ones(dim), atol=0.05)
+
+
+def test_pomcpow_plans_and_belief_updates_on_the_model():
+    """POMCPOW selects a preset action and the particle belief updates on the model.
+
+    Purpose: Validates the model is a drop-in generative model for POMCPOW + belief.
+
+    Given: An IsaacLabModelPOMDP, a jittered particle belief, and a POMCPOW planner.
+    When: The planner selects an action and the belief is updated with an observation.
+    Then: The action is one of the model's presets and the update returns a new belief.
+
+    Test type: integration
+    """
+    np.random.seed(0)
+    model = _build_model()
+    dim = model.observation_dim
+    particles = [np.random.normal(0.0, 0.1, size=dim) for _ in range(50)]
+    log_weights = np.log(np.ones(50) / 50)
+    belief = WeightedParticleBelief(particles=particles, log_weights=log_weights, resampling=True)
+    actions = model.get_actions()
+    planner = POMCPOW(
+        environment=model,
+        discount_factor=0.99,
+        depth=8,
+        exploration_constant=10.0,
+        k_o=4.0,
+        alpha_o=0.1,
+        k_a=float(len(actions)),
+        alpha_a=0.0,
+        name="POMCPOW-test",
+        action_sampler=DiscreteActionSampler(actions),
+        time_out_in_seconds=1,
+    )
+    selected, _ = planner.action(belief)
+    action = np.asarray(selected[0], dtype=float).reshape(-1)
+    assert any(np.array_equal(action, preset) for preset in actions)
+
+    updated = belief.update(
+        action=action,
+        observation=np.random.normal(0.0, 1.0, size=dim),
+        pomdp=model,
+        state=np.zeros(dim),
+    )
+    assert updated is not belief
+
+
+class _FakeSimEnv:
+    """Minimal fake IsaacLab env: remembers the written state and last action."""
+
+    def __init__(self, dynamics):
+        self._dynamics = dynamics
+        self.written = None
+        self.last_action = None
+        self.steps = 0
+
+    def step(self, action):
+        self.last_action = action
+        self.steps += 1
+        return None, 0.0, False, False, {}
+
+
+def _build_simulator_transition(monkeypatch, dynamics, dim, **kwargs):
+    """Wire an IsaacLabSimulatorTransition to a fake env with injected read/write."""
+    fake = _FakeSimEnv(dynamics)
+    monkeypatch.setattr(isaac_lab_model_pomdp, "_build_isaac_env", lambda *a, **k: fake)
+
+    def _writer(env, states):
+        env.written = np.asarray(states, dtype=float).copy()
+
+    def _reader(env):
+        return dynamics(env.written, env.last_action)
+
+    transition = IsaacLabSimulatorTransition(
+        task_id="Fake-Isaac-v0",
+        dim=dim,
+        state_writer=_writer,
+        state_reader=_reader,
+        device="cpu",
+        **kwargs,
+    )
+    return transition, fake
+
+
+def test_simulator_transition_uses_the_physics_step_as_the_mean(monkeypatch):
+    """The transition writes the state, steps once, and centers on the sim result.
+
+    Purpose: Validates IsaacLabSimulatorTransition samples f_sim(state, action) + noise.
+
+    Given: A fake env whose "physics" doubles the written state.
+    When: sample_next_state draws a large batch from a fixed state.
+    Then: The written state equals the input, the sim was stepped, and the empirical
+        mean equals the sim result (twice the state).
+
+    Test type: unit
+    """
+    dim = 4
+    transition, fake = _build_simulator_transition(
+        monkeypatch, lambda states, action: states * 2.0, dim, process_noise_std=0.01
+    )
+    state = np.arange(dim, dtype=float)
+    samples = transition.sample_next_state(state, np.ones(2), n_samples=6000)
+    assert samples.shape == (6000, dim)
+    assert np.allclose(np.asarray(fake.written)[0], state)
+    assert fake.steps >= 1
+    assert np.allclose(samples.mean(axis=0), state * 2.0, atol=0.03)
+
+
+def test_simulator_transition_log_probability_peaks_at_the_sim_step(monkeypatch):
+    """The transition log-density is a Gaussian centered on the physics step.
+
+    Purpose: Validates log_probability scores next states around f_sim(state, action).
+
+    Given: A fake env whose "physics" adds one to the written state.
+    When: log_probability scores the sim result and a point offset from it.
+    Then: The density at the sim result exceeds the density at the offset point.
+
+    Test type: unit
+    """
+    dim = 3
+    transition, _ = _build_simulator_transition(
+        monkeypatch, lambda states, action: states + 1.0, dim, process_noise_std=0.1
+    )
+    state = np.zeros(dim)
+    mean = state + 1.0
+    at_mean = transition.log_probability(state, np.ones(2), mean)
+    off_mean = transition.log_probability(state, np.ones(2), mean + 0.5)
+    assert at_mean.shape == (1,)
+    assert at_mean[0] > off_mean[0]
+
+
+def test_simulator_transition_drives_the_model_and_is_action_agnostic_mean(monkeypatch):
+    """An injected simulator transition overrides the default walk inside the model.
+
+    Purpose: Validates the TransitionModel seam accepts IsaacLabSimulatorTransition.
+
+    Given: A model built with a simulator transition whose physics negates the state.
+    When: sample_next_state is called through the model.
+    Then: The model's next-state mean equals the negated state.
+
+    Test type: integration
+    """
+    dim = 3
+    transition, _ = _build_simulator_transition(
+        monkeypatch, lambda states, action: -states, dim, process_noise_std=0.01
+    )
+    model = IsaacLabModelPOMDP(
+        observation_dim=dim,
+        action_presets=[np.zeros(2), np.ones(2)],
+        discount_factor=0.99,
+        transition=transition,
+    )
+    state = np.array([1.0, -2.0, 3.0])
+    mean = model.sample_next_state(state, model.get_actions()[1], n_samples=6000).mean(axis=0)
+    assert np.allclose(mean, -state, atol=0.03)
+
+
+def test_simulator_transition_default_reader_concatenates_scene_buffers(monkeypatch):
+    """The default reader stacks root pose/velocity and joint buffers per env.
+
+    Purpose: Validates _default_read_states mirrors the world's default extractor.
+
+    Given: A fake env exposing scene articulation buffers for a single env.
+    When: A next state is sampled with no explicit state_reader.
+    Then: The sampled mean matches the concatenated scene buffers.
+
+    Test type: unit
+    """
+
+    class _Data:
+        root_pos_w = np.array([[1.0, 2.0, 3.0]])
+        root_quat_w = np.array([[0.0, 0.0, 0.0, 1.0]])
+        root_lin_vel_w = np.array([[0.1, 0.2, 0.3]])
+        root_ang_vel_w = np.array([[0.0, 0.0, 0.0]])
+        joint_pos = np.array([[0.5, -0.5]])
+        joint_vel = np.array([[0.0, 0.0]])
+
+    class _Asset:
+        data = _Data()
+
+    class _Scene:
+        def __getitem__(self, key):
+            del key
+            return _Asset()
+
+    class _Unwrapped:
+        scene = _Scene()
+
+    class _SceneEnv:
+        unwrapped = _Unwrapped()
+
+        def step(self, action):
+            del action
+            return None, 0.0, False, False, {}
+
+    fake = _SceneEnv()
+    monkeypatch.setattr(isaac_lab_model_pomdp, "_build_isaac_env", lambda *a, **k: fake)
+    expected = np.concatenate(
+        [
+            _Data.root_pos_w[0],
+            _Data.root_quat_w[0],
+            _Data.root_lin_vel_w[0],
+            _Data.root_ang_vel_w[0],
+            _Data.joint_pos[0],
+            _Data.joint_vel[0],
+        ]
+    )
+    transition = IsaacLabSimulatorTransition(
+        task_id="Fake-Isaac-v0",
+        dim=expected.shape[0],
+        state_writer=lambda env, states: None,
+        device="cpu",
+        process_noise_std=0.001,
+    )
+    mean = transition.sample_next_state(
+        np.zeros(expected.shape[0]), np.ones(2), n_samples=4000
+    ).mean(axis=0)
+    assert np.allclose(mean, expected, atol=0.02)

--- a/POMDPPlanners/tests/test_environments/test_isaac_lab_pomdp/test_isaac_lab_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_isaac_lab_pomdp/test_isaac_lab_vectorized_model.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests for the Isaac Lab vectorized generative model.
+
+The suite pins the torch kernels of :class:`IsaacLabVectorizedModel` to the
+fitted numpy planner-side models (:class:`LinearGaussianTransition`,
+:class:`GaussianObservationModel`, :class:`LinearRewardModel`) they are built
+from. Deterministic kernels (transition mean, reward, observation
+log-likelihood, terminal) are compared exactly; the stochastic transition and
+observation kernels are compared by their empirical moments.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_model_pomdp import (
+    GaussianObservationModel,
+    LinearGaussianTransition,
+    LinearRewardModel,
+)
+from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_vectorized_model import (
+    IsaacLabVectorizedModel,
+)
+
+_STATE_DIM = 4
+_ACTION_DIM = 3
+_NUM_ACTIONS = 5
+
+
+def _fitted_models(seed: int = 0):
+    rng = np.random.default_rng(seed)
+    weight_state = np.eye(_STATE_DIM) + 0.05 * rng.standard_normal((_STATE_DIM, _STATE_DIM))
+    weight_action = 0.3 * rng.standard_normal((_STATE_DIM, _ACTION_DIM))
+    bias = 0.1 * rng.standard_normal(_STATE_DIM)
+    trans_cov = np.diag(0.01 + 0.02 * rng.random(_STATE_DIM))
+    transition = LinearGaussianTransition(weight_state, weight_action, bias, trans_cov)
+    observation = GaussianObservationModel(_STATE_DIM, noise_std=0.1)
+    reward = LinearRewardModel(
+        rng.standard_normal(_STATE_DIM),
+        rng.standard_normal(_ACTION_DIM),
+        rng.standard_normal(_STATE_DIM),
+        float(rng.standard_normal()),
+    )
+    presets = rng.standard_normal((_NUM_ACTIONS, _ACTION_DIM))
+    return transition, observation, reward, presets
+
+
+def _build_model(seed: int = 0) -> IsaacLabVectorizedModel:
+    transition, observation, reward, presets = _fitted_models(seed)
+    return IsaacLabVectorizedModel(
+        transition, observation, reward, presets, device=torch.device("cpu"), dtype=torch.float64
+    )
+
+
+def _random_batch(num: int, seed: int = 1):
+    rng = np.random.default_rng(seed)
+    states = torch.as_tensor(rng.standard_normal((num, _STATE_DIM)), dtype=torch.float64)
+    actions = torch.as_tensor(rng.integers(0, _NUM_ACTIONS, size=num), dtype=torch.int64)
+    return states, actions
+
+
+def test_transition_mean_matches_native():
+    """Test that the batched transition mean matches the native model.
+
+    Purpose: Validates the linear-Gaussian transition mean kernel.
+
+    Given: A fitted transition and a random batch of states and action indices
+    When: The torch transition mean is compared to the native ``_mean`` per row
+    Then: They agree to floating tolerance
+
+    Test type: unit
+    """
+    transition, observation, reward, presets = _fitted_models()
+    model = IsaacLabVectorizedModel(
+        transition, observation, reward, presets, device=torch.device("cpu"), dtype=torch.float64
+    )
+    states, actions = _random_batch(64)
+    mean = model._transition_mean(states, actions)  # pylint: disable=protected-access
+    for row in range(states.shape[0]):
+        native = transition._mean(  # pylint: disable=protected-access
+            states[row].numpy(), presets[int(actions[row])]
+        )
+        assert np.allclose(mean[row].numpy(), native, atol=1e-9)
+
+
+def test_reward_matches_native():
+    """Test that the batched reward matches the native linear reward model.
+
+    Purpose: Validates the linear reward kernel.
+
+    Given: A fitted reward model and random states / actions / next states
+    When: The torch reward is compared to the native ``reward`` per row
+    Then: They agree to floating tolerance
+
+    Test type: unit
+    """
+    transition, observation, reward, presets = _fitted_models()
+    model = IsaacLabVectorizedModel(
+        transition, observation, reward, presets, device=torch.device("cpu"), dtype=torch.float64
+    )
+    states, actions = _random_batch(64, seed=2)
+    next_states, _ = _random_batch(64, seed=3)
+    rewards = model.rewards(states, actions, next_states)
+    for row in range(states.shape[0]):
+        native = reward.reward(
+            states[row].numpy(), presets[int(actions[row])], next_states[row].numpy()
+        )
+        assert np.isclose(float(rewards[row]), native, atol=1e-9)
+
+
+def test_observation_log_probs_match_native():
+    """Test that observation log-likelihoods match the native model.
+
+    Purpose: Validates the additive-Gaussian observation likelihood kernel.
+
+    Given: A fitted observation model and random next states / observations
+    When: The torch ``observation_log_probs`` is compared to the native
+        ``log_probability`` per row
+    Then: They agree to floating tolerance
+
+    Test type: unit
+    """
+    transition, observation, reward, presets = _fitted_models()
+    model = IsaacLabVectorizedModel(
+        transition, observation, reward, presets, device=torch.device("cpu"), dtype=torch.float64
+    )
+    next_states, actions = _random_batch(48, seed=4)
+    observations, _ = _random_batch(48, seed=5)
+    log_probs = model.observation_log_probs(next_states, actions, observations)
+    for row in range(next_states.shape[0]):
+        native = observation.log_probability(next_states[row].numpy(), observations[row].numpy())
+        assert np.isclose(float(log_probs[row]), float(np.asarray(native).ravel()[0]), atol=1e-9)
+
+
+def test_terminal_mask_is_all_false():
+    """Test that the terminal mask is always false.
+
+    Purpose: Validates that the Isaac velocity model never terminates.
+
+    Given: A vectorized model and a random batch of states
+    When: ``terminal_mask`` is queried
+    Then: Every entry is ``False``
+
+    Test type: unit
+    """
+    model = _build_model()
+    states, _ = _random_batch(32)
+    assert not bool(model.terminal_mask(states).any())
+
+
+def test_transition_sample_moments_match_native():
+    """Test that sampled transitions reproduce the native mean and covariance.
+
+    Purpose: Validates the stochastic transition kernel by empirical moments.
+
+    Given: A fixed state and action repeated across a large batch
+    When: The torch transition samples are summarised by mean and covariance
+    Then: They match the native transition mean and covariance to tolerance
+
+    Test type: integration
+    """
+    transition, observation, reward, presets = _fitted_models()
+    model = IsaacLabVectorizedModel(
+        transition, observation, reward, presets, device=torch.device("cpu"), dtype=torch.float64
+    )
+    torch.manual_seed(0)
+    state = torch.as_tensor(np.linspace(-1.0, 1.0, _STATE_DIM), dtype=torch.float64)
+    states = state.repeat(200000, 1)
+    actions = torch.full((200000,), 2, dtype=torch.int64)
+    samples = model.sample_next_states(states, actions)
+    native_mean = transition._mean(state.numpy(), presets[2])  # pylint: disable=protected-access
+    assert np.allclose(samples.mean(dim=0).numpy(), native_mean, atol=2e-2)
+    empirical_cov = np.cov(samples.numpy(), rowvar=False)
+    native_cov = transition._normal.covariance  # pylint: disable=protected-access
+    assert np.allclose(empirical_cov, native_cov, atol=2e-2)
+
+
+def test_observation_sample_moments_match_noise():
+    """Test that sampled observations reproduce the additive-noise covariance.
+
+    Purpose: Validates the stochastic observation kernel by empirical moments.
+
+    Given: A fixed next state repeated across a large batch
+    When: The torch observation samples are summarised by mean and covariance
+    Then: The mean matches the next state and the covariance matches the noise
+
+    Test type: integration
+    """
+    transition, observation, reward, presets = _fitted_models()
+    model = IsaacLabVectorizedModel(
+        transition, observation, reward, presets, device=torch.device("cpu"), dtype=torch.float64
+    )
+    torch.manual_seed(1)
+    next_state = torch.as_tensor(np.linspace(0.0, 2.0, _STATE_DIM), dtype=torch.float64)
+    next_states = next_state.repeat(200000, 1)
+    actions = torch.zeros(200000, dtype=torch.int64)
+    samples = model.sample_observations(next_states, actions)
+    assert np.allclose(samples.mean(dim=0).numpy(), next_state.numpy(), atol=2e-3)
+    empirical_cov = np.cov(samples.numpy(), rowvar=False)
+    native_cov = observation._normal.covariance  # pylint: disable=protected-access
+    assert np.allclose(empirical_cov, native_cov, atol=5e-3)
+
+
+def test_action_and_observation_keys_are_deterministic():
+    """Test that action and observation keys are deterministic integer keys.
+
+    Purpose: Validates the integer tree-key kernels.
+
+    Given: A batch of actions and observations
+    When: ``action_keys`` and ``observation_keys`` are computed twice
+    Then: Both are int64 and identical across the two calls, and action keys
+        equal the action indices
+
+    Test type: unit
+    """
+    model = _build_model()
+    _, actions = _random_batch(20)
+    observations, _ = _random_batch(20, seed=9)
+    action_keys = model.action_keys(actions)
+    obs_keys_a = model.observation_keys(observations)
+    obs_keys_b = model.observation_keys(observations)
+    assert action_keys.dtype == torch.int64
+    assert obs_keys_a.dtype == torch.int64
+    assert torch.equal(action_keys, actions)
+    assert torch.equal(obs_keys_a, obs_keys_b)
+
+
+@pytest.mark.parametrize("observation_resolution", [0.0, -1.0])
+def test_non_positive_observation_resolution_raises(observation_resolution):
+    """Test that a non-positive observation resolution is rejected.
+
+    Purpose: Validates the observation-resolution guard.
+
+    Given: Fitted models and a non-positive observation resolution
+    When: A vectorized model is constructed
+    Then: ``ValueError`` is raised
+
+    Test type: unit
+    """
+    transition, observation, reward, presets = _fitted_models()
+    with pytest.raises(ValueError):
+        IsaacLabVectorizedModel(
+            transition,
+            observation,
+            reward,
+            presets,
+            device=torch.device("cpu"),
+            observation_resolution=observation_resolution,
+        )
+
+
+def test_mismatched_action_preset_dim_raises():
+    """Test that action presets of the wrong action dim are rejected.
+
+    Purpose: Validates the action-preset dimension guard.
+
+    Given: A transition with action dim 3 and presets with action dim 2
+    When: A vectorized model is constructed
+    Then: ``ValueError`` is raised
+
+    Test type: unit
+    """
+    transition, observation, reward, _ = _fitted_models()
+    bad_presets = np.zeros((_NUM_ACTIONS, _ACTION_DIM - 1))
+    with pytest.raises(ValueError):
+        IsaacLabVectorizedModel(
+            transition, observation, reward, bad_presets, device=torch.device("cpu")
+        )

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_vectorized_model.py
@@ -1,0 +1,374 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests: torch vectorized model vs. the native discrete LaserTag env.
+
+These tests pin :class:`LaserTagVectorizedModel` to the environment's native
+scalar/numpy kernels so the two implementations cannot drift. The parity
+checks run over a sweep of supported configurations (varying measurement
+noise, walls, and dangerous areas) so a wiring bug that default parameters
+would hide is caught. Log-densities, rewards, and terminal flags are compared
+exactly; the stochastic transition kernel is compared against the env's
+analytic ``transition_log_probability`` over the empirical support, and the
+stochastic observation kernel is compared by empirical moments.
+"""
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp import (
+    LaserTagPOMDP,
+    RewardModelType,
+)
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils import (
+    OpponentPolicy,
+)
+from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_vectorized_model import (
+    LaserTagVectorizedModel,
+)
+
+# Each entry is a supported env-kwargs dict (constant-hazard reward, EVADE
+# opponent, deterministic motion, non-terminal hazards).
+_SUPPORTED_CASES = [
+    {},
+    {"measurement_noise": 2.0},
+    {
+        "walls": {(1, 1), (2, 3), (4, 2)},
+        "dangerous_areas": set(),
+        "measurement_noise": 0.5,
+    },
+]
+_CASE_IDS = ["default", "noisy", "custom-walls-no-danger"]
+
+
+@dataclass
+class _Case:
+    env: LaserTagPOMDP
+    model: LaserTagVectorizedModel
+    valid_cells: List[Tuple[int, int]]
+
+
+def _valid_cells(env: LaserTagPOMDP) -> List[Tuple[int, int]]:
+    rows, cols = env.floor_shape
+    return [(row, col) for row in range(rows) for col in range(cols) if (row, col) not in env.walls]
+
+
+@pytest.fixture(params=_SUPPORTED_CASES, ids=_CASE_IDS, name="case")
+def case_fixture(request: pytest.FixtureRequest) -> _Case:
+    env = LaserTagPOMDP(discount_factor=0.95, **request.param)
+    model = LaserTagVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    return _Case(env=env, model=model, valid_cells=_valid_cells(env))
+
+
+def _tensor(array: np.ndarray) -> torch.Tensor:
+    return torch.as_tensor(array, dtype=torch.float64)
+
+
+def _random_states(case: _Case, count: int, rng: np.random.Generator) -> np.ndarray:
+    cells = np.asarray(case.valid_cells, dtype=np.float64)
+    robots = cells[rng.integers(0, cells.shape[0], size=count)]
+    opps = cells[rng.integers(0, cells.shape[0], size=count)]
+    terminal = rng.integers(0, 2, size=(count, 1)).astype(np.float64)
+    return np.concatenate([robots, opps, terminal], axis=1)
+
+
+def test_model_satisfies_protocol_for_every_supported_config(case: _Case) -> None:
+    """Every supported config yields a conforming VectorizedGenerativeModel.
+
+    Purpose: Validates structural protocol conformance across configs
+
+    Given: A model built from each supported environment configuration
+    When: It is checked against the runtime-checkable protocol
+    Then: isinstance reports conformance and the action count is five
+
+    Test type: unit
+    """
+    assert isinstance(case.model, VectorizedGenerativeModel)
+    assert case.model.num_actions == 5
+
+
+def test_reward_matches_native_exactly(case: _Case) -> None:
+    """Batched rewards match the env's scalar reward kernel exactly.
+
+    Purpose: Validates the deterministic constant-hazard reward path
+
+    Given: Random states, actions, and realised next states per config
+    When: The model reward is compared to env.reward row by row
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(1)
+    states = _random_states(case, 300, rng)
+    next_states = _random_states(case, 300, rng)
+    actions = rng.integers(0, 5, size=300)
+    expected = np.array(
+        [
+            case.env.reward(states[i], int(actions[i]), next_states[i])
+            for i in range(states.shape[0])
+        ]
+    )
+    actual = case.model.rewards(
+        _tensor(states), torch.as_tensor(actions), _tensor(next_states)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_terminal_mask_matches_native(case: _Case) -> None:
+    """Terminal flags match the env's per-state terminal check across configs.
+
+    Purpose: Validates the batched terminal mask against env.is_terminal
+
+    Given: Random states with mixed terminal flags
+    When: The model terminal mask is compared to env.is_terminal per row
+    Then: Every entry agrees
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(2)
+    states = _random_states(case, 200, rng)
+    expected = np.array([case.env.is_terminal(states[i]) for i in range(states.shape[0])])
+    actual = case.model.terminal_mask(_tensor(states)).numpy()
+    assert np.array_equal(expected, actual)
+
+
+def test_observation_log_probs_match_native_exactly(case: _Case) -> None:
+    """Observation log-likelihoods match the env kernel to float64 precision.
+
+    Purpose: Validates the 8-direction laser likelihood kernel across configs
+
+    Given: Non-terminal next states and realistic sampled observations
+    When: The model's observation_log_probs is compared to the env per row
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(3)
+    next_states = _random_states(case, 200, rng)
+    next_states[:, 4] = 0.0  # non-terminal so lasers are emitted
+    observations = np.array(
+        [
+            np.asarray(case.env.sample_observation(next_states[i], 0), dtype=np.float64)
+            for i in range(next_states.shape[0])
+        ]
+    )
+    expected = np.array(
+        [
+            case.env.observation_log_probability(next_states[i], 0, [observations[i]])[0]
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actual = case.model.observation_log_probs(
+        _tensor(next_states), torch.zeros(200, dtype=torch.int64), _tensor(observations)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_terminal_observation_log_probs_match_native(case: _Case) -> None:
+    """Terminal-state observation likelihoods honor the sentinel semantics.
+
+    Purpose: Validates the terminal sentinel branch of the likelihood kernel
+
+    Given: A terminal next state scored against the sentinel and a real reading
+    When: observation_log_probs is evaluated for both observations
+    Then: The sentinel scores 0.0 and a non-sentinel scores -inf
+
+    Test type: unit
+    """
+    next_states = _tensor(np.array([[3.0, 3.0, 6.0, 5.0, 1.0], [3.0, 3.0, 6.0, 5.0, 1.0]]))
+    sentinel = [-1.0] * 8
+    reading = [3.0] * 8
+    observations = _tensor(np.array([sentinel, reading]))
+    logp = case.model.observation_log_probs(
+        next_states, torch.zeros(2, dtype=torch.int64), observations
+    ).numpy()
+    assert logp[0] == pytest.approx(0.0)
+    assert np.isneginf(logp[1])
+
+
+@pytest.mark.parametrize(
+    "state, action",
+    [
+        (np.array([2.0, 2.0, 6.0, 5.0, 0.0]), 0),
+        (np.array([4.0, 3.0, 4.0, 1.0, 0.0]), 2),
+        (np.array([5.0, 2.0, 3.0, 2.0, 0.0]), 4),
+        (np.array([3.0, 3.0, 3.0, 3.0, 0.0]), 4),
+    ],
+)
+def test_transition_distribution_matches_native(state: np.ndarray, action: int) -> None:
+    """Sampled next-state frequencies match the env's analytic transition.
+
+    Purpose: Validates the EVADE opponent-move + robot-move categorical
+
+    Given: A fixed state/action sampled many times by the torch model
+    When: Empirical frequencies of each distinct next state are compared to
+        the env's transition_log_probability over the same support
+    Then: Every outcome agrees within a Monte Carlo tolerance and the env
+        support probabilities sum to one
+
+    Test type: unit
+    """
+    torch.manual_seed(0)
+    env = LaserTagPOMDP(discount_factor=0.95)
+    model = LaserTagVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    count = 60000
+    samples = model.sample_next_states(
+        _tensor(np.tile(state, (count, 1))), torch.full((count,), action, dtype=torch.int64)
+    ).numpy()
+    unique, counts = np.unique(samples, axis=0, return_counts=True)
+    freqs = counts / count
+    total_prob = 0.0
+    for row, freq in zip(unique, freqs):
+        prob = float(np.exp(env.transition_log_probability(state, action, [row])[0]))
+        total_prob += prob
+        assert abs(freq - prob) < 0.01
+    assert abs(total_prob - 1.0) < 1e-9
+
+
+def test_observation_sampling_matches_native_moments(case: _Case) -> None:
+    """Sampled laser observations match the env sampler's mean and noise level.
+
+    Purpose: Validates the laser-geometry and Gaussian noise of the sampler
+
+    Given: A next state whose lasers are far from walls and the opponent
+    When: Many observations are drawn by both the model and the env
+    Then: Per-direction means agree within 0.1 and the model std tracks sigma
+
+    Test type: unit
+    """
+    torch.manual_seed(1)
+    next_state = np.array([5.0, 3.0, 0.0, 0.0, 0.0])
+    count = 40000
+    env_obs = np.asarray(
+        case.env.sample_observation(next_state, 0, n_samples=count), dtype=np.float64
+    )
+    model_obs = case.model.sample_observations(
+        _tensor(np.tile(next_state, (count, 1))), torch.zeros(count, dtype=torch.int64)
+    ).numpy()
+    assert np.max(np.abs(env_obs.mean(axis=0) - model_obs.mean(axis=0))) < 0.1
+    unclipped = model_obs.mean(axis=0) > 2.0 * case.env.measurement_noise
+    if unclipped.any():
+        std_gap = np.abs(model_obs.std(axis=0)[unclipped] - case.env.measurement_noise)
+        assert np.max(std_gap) < 0.1
+
+
+def test_method_shapes_and_dtypes(case: _Case) -> None:
+    """Every protocol method returns the documented shape and dtype.
+
+    Purpose: Validates the tensor contract of all eight protocol methods
+
+    Given: A random batch of states, actions, and next states
+    When: Each generative method is invoked
+    Then: Shapes match [N, ds]/[N, do]/[N] and key/mask dtypes are correct
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(4)
+    states = _tensor(_random_states(case, 16, rng))
+    next_states = _tensor(_random_states(case, 16, rng))
+    actions = torch.as_tensor(rng.integers(0, 5, size=16))
+    next_sampled = case.model.sample_next_states(states, actions)
+    observations = case.model.sample_observations(next_states, actions)
+    assert next_sampled.shape == (16, 5)
+    assert observations.shape == (16, 8)
+    assert case.model.rewards(states, actions, next_states).shape == (16,)
+    assert case.model.terminal_mask(states).dtype == torch.bool
+    assert case.model.observation_log_probs(next_states, actions, observations).shape == (16,)
+    assert case.model.action_keys(actions).dtype == torch.int64
+    assert case.model.observation_keys(observations).dtype == torch.int64
+
+
+def test_keys_are_deterministic_and_discriminating(case: _Case) -> None:
+    """Action and observation keys are stable and separate distinct inputs.
+
+    Purpose: Validates the integer tree-key mappings
+
+    Given: Repeated actions and observations, some identical and some distinct
+    When: action_keys and observation_keys are called twice
+    Then: Identical inputs map to identical keys and distinct inputs differ
+
+    Test type: unit
+    """
+    actions = torch.tensor([0, 4, 2])
+    assert torch.equal(case.model.action_keys(actions), actions.to(torch.int64))
+    observations = _tensor(
+        np.array([[1.0] * 8, [1.0] * 8, [2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]])
+    )
+    keys_first = case.model.observation_keys(observations)
+    keys_second = case.model.observation_keys(observations)
+    assert torch.equal(keys_first, keys_second)
+    assert keys_first[0] == keys_first[1]
+    assert keys_first[0] != keys_first[2]
+
+
+def test_unsupported_reward_model_raises() -> None:
+    """Constructing on an unsupported reward model is rejected.
+
+    Purpose: Validates the scope guard on reward model type
+
+    Given: An env configured with the distance-decayed hazard reward model
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = LaserTagPOMDP(
+        discount_factor=0.95,
+        reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
+    )
+    with pytest.raises(NotImplementedError):
+        LaserTagVectorizedModel(env)
+
+
+def test_unsupported_opponent_policy_raises() -> None:
+    """Constructing on a non-EVADE opponent policy is rejected.
+
+    Purpose: Validates the scope guard on the opponent policy
+
+    Given: An env configured with the PURSUE opponent policy
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = LaserTagPOMDP(discount_factor=0.95, opponent_policy=OpponentPolicy.PURSUE)
+    with pytest.raises(NotImplementedError):
+        LaserTagVectorizedModel(env)
+
+
+def test_unsupported_transition_error_raises() -> None:
+    """Constructing on stochastic robot motion is rejected.
+
+    Purpose: Validates the scope guard on transition_error_prob
+
+    Given: An env configured with a positive transition_error_prob
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = LaserTagPOMDP(discount_factor=0.95, transition_error_prob=0.1)
+    with pytest.raises(NotImplementedError):
+        LaserTagVectorizedModel(env)
+
+
+def test_hazard_terminal_config_raises() -> None:
+    """The draw-coupled hazard-terminal config is rejected.
+
+    Purpose: Validates the scope guard on the hazard-terminal absorbing slot
+
+    Given: An env configured with is_dangerous_area_hit_terminal=True
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = LaserTagPOMDP(discount_factor=0.95, is_dangerous_area_hit_terminal=True)
+    with pytest.raises(NotImplementedError):
+        LaserTagVectorizedModel(env)

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_vectorized_model.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests: torch vectorized model vs. the native Continuous Light-Dark env.
+
+These tests pin :class:`ContinuousLightDarkVectorizedModel` to the
+environment's native (C++/numba) kernels so the two implementations cannot
+drift. The parity checks run over a *sweep of supported configurations*
+(varying covariances, goal / obstacle / beacon layout, costs, grid size, and
+the action table) so a wiring bug that default parameters would hide is
+caught. Log-densities and free-space rewards are compared exactly in float64;
+stochastic kernels (sampling, hazard reward) are compared by empirical
+moments over a large batch.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ContinuousLightDarkPOMDP,
+    ObservationModelType,
+    RewardModelType,
+)
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_vectorized_model import (
+    ContinuousLightDarkVectorizedModel,
+)
+
+_DEFAULT_ACTIONS = np.array([[0.0, 1.0], [0.0, -1.0], [1.0, 0.0], [-1.0, 0.0]])
+_EIGHT_ACTIONS = np.array(
+    [
+        [1.0, 0.0],
+        [-1.0, 0.0],
+        [0.0, 1.0],
+        [0.0, -1.0],
+        [0.7, 0.7],
+        [-0.7, 0.7],
+        [0.7, -0.7],
+        [-0.7, -0.7],
+    ]
+)
+
+# Each case is (env kwargs, optional action_vectors). All are *supported*
+# configurations: constant-hazard reward, normal-noise observation,
+# is_obstacle_hit_terminal=False. Parameters otherwise vary widely.
+_SUPPORTED_CASES = [
+    ({}, None),
+    (
+        {
+            "state_transition_cov_matrix": np.array([[0.08, 0.02], [0.02, 0.06]]),
+            "observation_cov_matrix": np.array([[0.10, 0.0], [0.0, 0.03]]),
+            "goal_state": np.array([3, 8]),
+            "obstacles": [(2, 2), (7, 7), (4, 9)],
+            "obstacle_hit_probability": 0.35,
+            "obstacle_reward": -15.0,
+            "goal_reward": 25.0,
+            "fuel_cost": 1.0,
+            "grid_size": 12,
+            "goal_state_radius": 1.0,
+            "obstacle_radius": 1.0,
+            "beacon_radius": 1.5,
+        },
+        None,
+    ),
+    (
+        {
+            "state_transition_cov_matrix": np.eye(2) * 0.2,
+            "obstacles": [],
+            "grid_size": 15,
+        },
+        None,
+    ),
+    (
+        {
+            "beacons": [(1, 1), (6, 6), (9, 2)],
+            "beacon_radius": 2.0,
+        },
+        _EIGHT_ACTIONS,
+    ),
+]
+_CASE_IDS = ["default", "anisotropic-shifted", "no-obstacles-noisy", "custom-actions-beacons"]
+
+
+@dataclass
+class _Case:
+    env: ContinuousLightDarkPOMDP
+    model: ContinuousLightDarkVectorizedModel
+    action_vectors: np.ndarray
+
+
+@pytest.fixture(params=_SUPPORTED_CASES, ids=_CASE_IDS, name="case")
+def case_fixture(request: pytest.FixtureRequest) -> _Case:
+    env_kwargs, action_vectors = request.param
+    env = ContinuousLightDarkPOMDP(
+        discount_factor=0.95, is_obstacle_hit_terminal=False, **env_kwargs
+    )
+    model = ContinuousLightDarkVectorizedModel(
+        env, action_vectors=action_vectors, device=torch.device("cpu"), dtype=torch.float64
+    )
+    vectors = _DEFAULT_ACTIONS if action_vectors is None else np.asarray(action_vectors)
+    return _Case(env=env, model=model, action_vectors=vectors)
+
+
+def _free_space_mask(env: ContinuousLightDarkPOMDP, points: np.ndarray) -> np.ndarray:
+    """Points where the reward is deterministic (no goal/obstacle/edge draw)."""
+    margin = 0.5
+    goal = np.asarray(env.goal_state, dtype=np.float64)
+    not_goal = np.linalg.norm(points - goal, axis=1) > env.goal_state_radius + margin
+    obstacles = np.asarray(env.obstacles, dtype=np.float64)
+    if obstacles.size:
+        deltas = points[:, :, None] - obstacles[None, :, :]
+        min_dist = np.linalg.norm(deltas, axis=1).min(axis=1)
+        not_obstacle = min_dist > env.obstacle_radius + margin
+    else:
+        not_obstacle = np.ones(points.shape[0], dtype=bool)
+    in_grid = (points > margin).all(axis=1) & (points < env.grid_size - margin).all(axis=1)
+    return not_goal & not_obstacle & in_grid
+
+
+def _tensor(array: np.ndarray) -> torch.Tensor:
+    return torch.as_tensor(array, dtype=torch.float64)
+
+
+def _action_indices(count: int) -> torch.Tensor:
+    return torch.zeros(count, dtype=torch.int64)
+
+
+def test_model_satisfies_protocol_for_every_supported_config(case: _Case) -> None:
+    """Every supported config yields a conforming VectorizedGenerativeModel.
+
+    Purpose: Validates structural protocol conformance across configs
+
+    Given: A model built from each supported environment configuration
+    When: It is checked against the runtime-checkable protocol
+    Then: isinstance reports conformance and the action count matches
+
+    Test type: unit
+    """
+    assert isinstance(case.model, VectorizedGenerativeModel)
+    assert case.model.num_actions == case.action_vectors.shape[0]
+
+
+def test_observation_log_probs_match_native_exactly(case: _Case) -> None:
+    """Observation log-likelihoods match the native kernel to float64 precision.
+
+    Purpose: Validates the observation likelihood kernel across configs
+
+    Given: (next_state, observation) pairs spanning near/far beacons per config
+    When: The model's observation_log_probs is compared to the env per pair
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(3)
+    next_states = rng.uniform(0.0, float(case.env.grid_size), size=(256, 2))
+    observations = next_states + rng.normal(scale=0.1, size=(256, 2))
+    action_vector = case.action_vectors[0]
+    expected = np.array(
+        [
+            case.env.observation_log_probability_single(
+                next_states[i], action_vector, observations[i]
+            )
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actual = case.model.observation_log_probs(
+        _tensor(next_states), _action_indices(256), _tensor(observations)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_reward_matches_native_in_free_space(case: _Case) -> None:
+    """Free-space rewards match the native kernel exactly across configs.
+
+    Purpose: Validates the deterministic reward path (fuel + goal distance)
+
+    Given: Next states filtered to the config's obstacle/goal/edge-free region
+    When: The model reward is compared to env.reward_batch on those states
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(5)
+    points = rng.uniform(0.0, float(case.env.grid_size), size=(1024, 2))
+    free = points[_free_space_mask(case.env, points)]
+    assert free.shape[0] > 20
+    action_vector = case.action_vectors[0]
+    expected = case.env.reward_batch(free, action_vector, next_states=free)
+    actual = case.model.rewards(
+        _tensor(free), _action_indices(free.shape[0]), _tensor(free)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_transition_sampling_matches_native_moments(case: _Case) -> None:
+    """Sampled next-state moments match the native transition kernel per config.
+
+    Purpose: Validates transition mean/covariance for each config's covariance
+
+    Given: A fixed mid-grid state and action sampled many times by both
+    When: Empirical mean and covariance are compared
+    Then: Mean gap < 0.05 and covariance gap < 0.03
+
+    Test type: unit
+    """
+    torch.manual_seed(1)
+    center = float(case.env.grid_size) / 2.0
+    state = np.array([center, center])
+    action_vector = case.action_vectors[0]
+    native = case.env.sample_next_state_batch(np.tile(state, (40000, 1)), action_vector)
+    twin = case.model.sample_next_states(
+        _tensor(np.tile(state, (40000, 1))), _action_indices(40000)
+    ).numpy()
+    assert np.max(np.abs(native.mean(0) - twin.mean(0))) < 0.05
+    assert np.max(np.abs(np.cov(native.T) - np.cov(twin.T))) < 0.03
+
+
+def test_observation_sampling_uses_near_beacon_covariance(case: _Case) -> None:
+    """Observation sampling reproduces the near-beacon (halved) covariance.
+
+    Purpose: Validates the near/far covariance switch across configs
+
+    Given: A next state on one of the config's beacons (near) sampled many times
+    When: The empirical covariance is compared to obs_cov * 0.5
+    Then: The covariance gap is below 0.02
+
+    Test type: unit
+    """
+    torch.manual_seed(2)
+    beacon_point = np.asarray(case.env.beacons, dtype=np.float64)[:, 0]
+    twin = case.model.sample_observations(
+        _tensor(np.tile(beacon_point, (40000, 1))), _action_indices(40000)
+    ).numpy()
+    expected_cov = case.env.observation_cov_matrix * 0.5
+    assert np.max(np.abs(np.cov(twin.T) - expected_cov)) < 0.02
+
+
+def test_terminal_mask_matches_native(case: _Case) -> None:
+    """Terminal flags match the native per-state terminal check across configs.
+
+    Purpose: Validates the batched terminal mask against env.is_terminal
+
+    Given: States on the goal, just outside the goal radius, and far away
+    When: The model terminal mask is compared to env.is_terminal per row
+    Then: Every entry agrees
+
+    Test type: unit
+    """
+    goal = np.asarray(case.env.goal_state, dtype=np.float64)
+    radius = case.env.goal_state_radius
+    states = np.array(
+        [goal, goal + np.array([radius + 0.5, 0.0]), goal + np.array([radius - 0.2, 0.0])]
+    )
+    expected = np.array([case.env.is_terminal(s) for s in states])
+    actual = case.model.terminal_mask(_tensor(states)).numpy()
+    assert np.array_equal(expected, actual)
+
+
+def test_reward_hazard_expectation_matches_native() -> None:
+    """Mean hazard reward inside an obstacle matches the native kernel.
+
+    Purpose: Validates the stochastic obstacle-hit contribution in expectation
+
+    Given: Many repeats of a next state sitting on an obstacle centre
+    When: Mean rewards from the env and the model are compared over the repeats
+    Then: The means agree within a Monte Carlo tolerance of 0.1
+
+    Test type: unit
+    """
+    np.random.seed(7)
+    torch.manual_seed(7)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, is_obstacle_hit_terminal=False)
+    model = ContinuousLightDarkVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    batch = np.tile(np.array([5.0, 5.0]), (20000, 1))
+    env_mean = float(np.mean(env.reward_batch(batch, np.array([1.0, 0.0]), next_states=batch)))
+    model_mean = float(model.rewards(_tensor(batch), _action_indices(20000), _tensor(batch)).mean())
+    assert abs(env_mean - model_mean) < 0.1
+
+
+def test_unsupported_reward_model_raises() -> None:
+    """Constructing on an unsupported reward model is rejected.
+
+    Purpose: Validates the scope guard on reward model type
+
+    Given: An env configured with the distance-decayed hazard reward model
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    other = ContinuousLightDarkPOMDP(
+        discount_factor=0.95,
+        is_obstacle_hit_terminal=False,
+        reward_model_type=RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY,
+    )
+    with pytest.raises(NotImplementedError):
+        ContinuousLightDarkVectorizedModel(other)
+
+
+def test_unsupported_observation_model_raises() -> None:
+    """Constructing on an unsupported observation model is rejected.
+
+    Purpose: Validates the scope guard on observation model type
+
+    Given: An env configured with the no-observation-in-dark model
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    other = ContinuousLightDarkPOMDP(
+        discount_factor=0.95,
+        is_obstacle_hit_terminal=False,
+        observation_model_type=ObservationModelType.NORMAL_NOISE_NO_OBS_IN_DARK,
+    )
+    with pytest.raises(NotImplementedError):
+        ContinuousLightDarkVectorizedModel(other)
+
+
+def test_default_hazard_terminal_config_raises() -> None:
+    """The default draw-coupled hazard-terminal config is rejected.
+
+    Purpose: Validates the scope guard on the hazard-terminal absorbing slot
+
+    Given: An env left at the default is_obstacle_hit_terminal=True
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    other = ContinuousLightDarkPOMDP(discount_factor=0.95)
+    with pytest.raises(NotImplementedError):
+        ContinuousLightDarkVectorizedModel(other)
+
+
+def test_observation_keys_are_deterministic_and_discriminating() -> None:
+    """Observation keys are stable per input and separate distinct cells.
+
+    Purpose: Validates the continuous-observation to integer-key hashing
+
+    Given: Observations, some identical and some in different grid cells
+    When: observation_keys is called twice
+    Then: Identical inputs map to identical keys and distinct cells differ
+
+    Test type: unit
+    """
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, is_obstacle_hit_terminal=False)
+    model = ContinuousLightDarkVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    observations = torch.tensor([[0.05, 0.05], [0.05, 0.05], [3.2, 7.8], [-1.0, -1.0]])
+    keys_first = model.observation_keys(observations)
+    keys_second = model.observation_keys(observations)
+    assert torch.equal(keys_first, keys_second)
+    assert keys_first[0] == keys_first[1]
+    assert keys_first[0] != keys_first[2]
+    assert keys_first[2] != keys_first[3]

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp_vectorized_model.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests: torch vectorized model vs. the native Mountain Car env.
+
+These tests pin :class:`MountainCarVectorizedModel` to the environment's
+native (C++) kernels so the two implementations cannot drift. The parity
+checks run over a *sweep of supported configurations* (varying the state
+transition covariance) so a wiring bug that default parameters would hide is
+caught. Deterministic paths (the physics transition mean including clamping /
+the min-position corner, observation log-densities, reward, and terminal) are
+compared exactly in float64; the stochastic transition and observation kernels
+are compared by empirical moments over a large batch.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.environments.mountain_car_pomdp import _native
+from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_pomdp import (
+    MountainCarPOMDP,
+)
+from POMDPPlanners.environments.mountain_car_pomdp.mountain_car_vectorized_model import (
+    MountainCarVectorizedModel,
+)
+
+# Each case is a state-transition covariance; ``None`` keeps the env default.
+_SUPPORTED_CASES = [
+    None,
+    np.diag([1e-4, 1e-5]),
+    np.array([[2.0e-4, 5.0e-5], [5.0e-5, 4.0e-5]]),
+]
+_CASE_IDS = ["default-cov", "diagonal-cov", "correlated-cov"]
+
+
+@dataclass
+class _Case:
+    env: MountainCarPOMDP
+    model: MountainCarVectorizedModel
+
+
+@pytest.fixture(params=_SUPPORTED_CASES, ids=_CASE_IDS, name="case")
+def case_fixture(request: pytest.FixtureRequest) -> _Case:
+    cov = request.param
+    env = MountainCarPOMDP(discount_factor=0.99, state_transition_cov=cov)
+    model = MountainCarVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    return _Case(env=env, model=model)
+
+
+def _tensor(array: np.ndarray) -> torch.Tensor:
+    return torch.as_tensor(array, dtype=torch.float64)
+
+
+def _random_states(rng: np.random.Generator, count: int) -> np.ndarray:
+    positions = rng.uniform(-1.2, 0.6, size=count)
+    velocities = rng.uniform(-0.07, 0.07, size=count)
+    return np.stack((positions, velocities), axis=1)
+
+
+def _native_deterministic_next(env: MountainCarPOMDP, state: np.ndarray, action: int) -> np.ndarray:
+    kernel = _native.MountainCarTransitionCpp(
+        state=state,
+        action=action,
+        power=env.power,
+        gravity=env.gravity,
+        max_speed=env.max_speed,
+        min_position=env.min_position,
+        max_position=env.max_position,
+        covariance=env.state_transition_cov,
+    )
+    return np.asarray(
+        kernel._compute_deterministic_next_state()
+    )  # pylint: disable=protected-access
+
+
+def test_model_satisfies_protocol_for_every_supported_config(case: _Case) -> None:
+    """Every supported config yields a conforming VectorizedGenerativeModel.
+
+    Purpose: Validates structural protocol conformance across configs
+
+    Given: A model built from each supported environment configuration
+    When: It is checked against the runtime-checkable protocol
+    Then: isinstance reports conformance and the action count matches the env
+
+    Test type: unit
+    """
+    assert isinstance(case.model, VectorizedGenerativeModel)
+    assert case.model.num_actions == len(case.env.get_actions())
+
+
+def test_deterministic_transition_mean_matches_native(case: _Case) -> None:
+    """The physics transition mean matches the native kernel exactly.
+
+    Purpose: Validates the deterministic step (hill, gravity, force, clamping)
+
+    Given: Random states spanning the full position/velocity range per config
+    When: The model's deterministic next state is compared to the native kernel
+    Then: The maximum absolute difference is below 1e-12 for every action
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(11)
+    states = _random_states(rng, 256)
+    for action_index, action_value in enumerate(case.env.get_actions()):
+        expected = np.array([_native_deterministic_next(case.env, s, action_value) for s in states])
+        actions = torch.full((states.shape[0],), action_index, dtype=torch.int64)
+        actual = case.model._deterministic_next(  # pylint: disable=protected-access
+            _tensor(states), actions
+        ).numpy()
+        assert np.max(np.abs(expected - actual)) < 1e-12
+
+
+def test_min_position_corner_is_reproduced(case: _Case) -> None:
+    """The min-position floor rule zeroes negative velocity exactly as native.
+
+    Purpose: Validates the ``p == min_position and v < 0 -> v = 0`` corner
+
+    Given: A state pinned at the minimum position with strong reverse action
+    When: The model's deterministic next state is compared to the native kernel
+    Then: The clamped position and zeroed velocity agree exactly
+
+    Test type: unit
+    """
+    state = np.array([case.env.min_position, -0.05])
+    action_value = -1
+    action_index = case.env.get_actions().index(action_value)
+    expected = _native_deterministic_next(case.env, state, action_value)
+    actual = case.model._deterministic_next(  # pylint: disable=protected-access
+        _tensor(state[None, :]), torch.tensor([action_index], dtype=torch.int64)
+    ).numpy()[0]
+    assert np.allclose(expected, actual, atol=1e-12)
+    assert actual[1] == 0.0
+
+
+def test_observation_log_probs_match_native_exactly(case: _Case) -> None:
+    """Observation log-likelihoods match the native kernel to float64 precision.
+
+    Purpose: Validates the Gaussian observation likelihood kernel
+
+    Given: (next_state, observation) pairs spanning the state range per config
+    When: The model's observation_log_probs is compared to the env per pair
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(3)
+    next_states = _random_states(rng, 256)
+    observations = next_states + rng.normal(scale=0.05, size=(256, 2))
+    action_value = case.env.get_actions()[0]
+    expected = np.array(
+        [
+            case.env.observation_log_probability(
+                next_states[i], action_value, observations[i][None, :]
+            )[0]
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actions = torch.zeros(next_states.shape[0], dtype=torch.int64)
+    actual = case.model.observation_log_probs(
+        _tensor(next_states), actions, _tensor(observations)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_reward_matches_native(case: _Case) -> None:
+    """Sparse step rewards match the native reward across the state range.
+
+    Purpose: Validates the -1 / 0 goal reward kernel
+
+    Given: States on both sides of the goal position per config
+    When: The model reward is compared to env.reward_batch on those states
+    Then: Every reward agrees exactly
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(5)
+    states = _random_states(rng, 512)
+    states[:10, 0] = case.env.goal_position + 0.05  # force some goal-reaching rows
+    action_value = case.env.get_actions()[0]
+    expected = case.env.reward_batch(states, action_value)
+    actions = torch.zeros(states.shape[0], dtype=torch.int64)
+    actual = case.model.rewards(_tensor(states), actions, _tensor(states)).numpy()
+    assert np.array_equal(expected, actual)
+
+
+def test_terminal_mask_matches_native(case: _Case) -> None:
+    """Terminal flags match the native per-state terminal check.
+
+    Purpose: Validates the batched terminal mask against env.is_terminal
+
+    Given: States at, just below, and above the goal position
+    When: The model terminal mask is compared to env.is_terminal per row
+    Then: Every entry agrees
+
+    Test type: unit
+    """
+    goal = case.env.goal_position
+    states = np.array([[goal, 0.0], [goal - 0.01, 0.0], [goal + 0.1, 0.0], [-0.5, 0.0]])
+    expected = np.array([case.env.is_terminal(tuple(s)) for s in states])
+    actual = case.model.terminal_mask(_tensor(states)).numpy()
+    assert np.array_equal(expected, actual)
+
+
+def test_transition_sampling_matches_native_moments(case: _Case) -> None:
+    """Sampled next-state moments match the native transition kernel per config.
+
+    Purpose: Validates transition mean/covariance for each config's covariance
+
+    Given: A mid-range state and forward action sampled many times by both
+    When: Empirical mean and covariance are compared
+    Then: Mean gap < 1e-3 and covariance gap < 1e-4
+
+    Test type: unit
+    """
+    torch.manual_seed(1)
+    state = np.array([-0.5, 0.0])
+    action_value = case.env.get_actions()[2]
+    action_index = 2
+    native = case.env.sample_next_state_batch(np.tile(state, (60000, 1)), action_value)
+    twin = case.model.sample_next_states(
+        _tensor(np.tile(state, (60000, 1))),
+        torch.full((60000,), action_index, dtype=torch.int64),
+    ).numpy()
+    assert np.max(np.abs(native.mean(0) - twin.mean(0))) < 1e-3
+    assert np.max(np.abs(np.cov(native.T) - np.cov(twin.T))) < 1e-4
+
+
+def test_observation_sampling_matches_native_covariance(case: _Case) -> None:
+    """Observation sampling reproduces the observation-noise covariance.
+
+    Purpose: Validates the Gaussian observation sampler's covariance
+
+    Given: A next state sampled many times through the observation kernel
+    When: The empirical covariance is compared to env.cov_matrix
+    Then: The covariance gap is below a Monte Carlo tolerance of 5e-4
+
+    Test type: unit
+    """
+    torch.manual_seed(2)
+    next_state = np.array([-0.3, 0.02])
+    twin = case.model.sample_observations(
+        _tensor(np.tile(next_state, (60000, 1))),
+        torch.zeros(60000, dtype=torch.int64),
+    ).numpy()
+    empirical_mean = twin.mean(0)
+    assert np.max(np.abs(empirical_mean - next_state)) < 1e-3
+    assert np.max(np.abs(np.cov(twin.T) - case.env.cov_matrix)) < 5e-4
+
+
+def test_method_shapes_and_dtypes(case: _Case) -> None:
+    """Every protocol method returns the documented shape and dtype.
+
+    Purpose: Validates output shapes/dtypes of the batched kernels
+
+    Given: A small random batch of states, actions, and observations
+    When: Each generative method is invoked
+    Then: Shapes are [N, .] / [N] and key dtypes are int64
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(9)
+    states = _tensor(_random_states(rng, 7))
+    actions = torch.tensor([0, 1, 2, 0, 1, 2, 0], dtype=torch.int64)
+    next_states = case.model.sample_next_states(states, actions)
+    observations = case.model.sample_observations(next_states, actions)
+    assert next_states.shape == (7, 2)
+    assert observations.shape == (7, 2)
+    assert case.model.rewards(states, actions, next_states).shape == (7,)
+    assert case.model.terminal_mask(states).shape == (7,)
+    assert case.model.observation_log_probs(next_states, actions, observations).shape == (7,)
+    assert case.model.action_keys(actions).dtype == torch.int64
+    assert case.model.observation_keys(observations).dtype == torch.int64
+
+
+def test_action_and_observation_keys_are_deterministic() -> None:
+    """Action and observation keys are stable and discriminating.
+
+    Purpose: Validates integer-key mapping for actions and continuous obs
+
+    Given: Repeated action indices and observations, some identical, some not
+    When: action_keys / observation_keys are called twice
+    Then: Identical inputs map to identical keys and distinct cells differ
+
+    Test type: unit
+    """
+    env = MountainCarPOMDP(discount_factor=0.99)
+    model = MountainCarVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    actions = torch.tensor([0, 1, 2, 1], dtype=torch.int64)
+    assert torch.equal(model.action_keys(actions), actions)
+    observations = torch.tensor([[-0.3, 0.02], [-0.3, 0.02], [0.4, -0.05], [-1.1, 0.06]])
+    keys_first = model.observation_keys(observations)
+    keys_second = model.observation_keys(observations)
+    assert torch.equal(keys_first, keys_second)
+    assert keys_first[0] == keys_first[1]
+    assert keys_first[0] != keys_first[2]
+    assert keys_first[2] != keys_first[3]
+
+
+def test_non_scalar_action_set_raises() -> None:
+    """Constructing on a non-scalar action set is rejected.
+
+    Purpose: Validates the scope guard on the scalar action-set assumption
+
+    Given: An env whose action set has been replaced by non-scalar actions
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = MountainCarPOMDP(discount_factor=0.99)
+    env.actions = [(-1, 0), (0, 0), (1, 0)]  # type: ignore[assignment]  # force unsupported set
+    with pytest.raises(NotImplementedError):
+        MountainCarVectorizedModel(env)
+
+
+def test_non_positive_observation_resolution_raises() -> None:
+    """A non-positive observation resolution is rejected.
+
+    Purpose: Validates the observation-resolution guard
+
+    Given: A valid env and a zero observation resolution
+    When: A vectorized model is constructed with it
+    Then: ValueError is raised
+
+    Test type: unit
+    """
+    env = MountainCarPOMDP(discount_factor=0.99)
+    with pytest.raises(ValueError):
+        MountainCarVectorizedModel(env, observation_resolution=0.0)

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp_beliefs/test_pacman_vectorized_model.py
@@ -1,0 +1,413 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests: torch vectorized model vs. the native PacMan environment.
+
+These tests pin :class:`PacManVectorizedModel` to the environment's native
+(C++) kernels so the two implementations cannot drift. The parity checks run
+over a sweep of supported configurations (varying maze walls, ghost count,
+aggressiveness, and dangerous-area geometry) so a wiring bug that default
+parameters would hide is caught. Rewards and observation log-likelihoods are
+deterministic given (state, next_state, observation) and compared exactly in
+float64; the deterministic PacMan fields of the stochastic transition are
+compared exactly, while the stochastic ghost move and observation sampler are
+compared by empirical frequencies over a large batch.
+"""
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import (
+    PacManPOMDP,
+    RewardModelType,
+)
+from POMDPPlanners.environments.pacman_pomdp.pacman_vectorized_model import (
+    PacManVectorizedModel,
+)
+
+_SUPPORTED_CASES = [
+    {},
+    {
+        "maze_size": (6, 6),
+        "walls": {(2, 2), (3, 3), (1, 4)},
+        "num_ghosts": 2,
+        "initial_ghost_positions": [(5, 5), (0, 5)],
+        "initial_pellets": [(0, 0), (5, 0), (2, 5)],
+        "initial_pacman_pos": (3, 0),
+        "ghost_aggressiveness": 1.5,
+    },
+    {
+        "dangerous_areas": {(2, 1), (4, 4)},
+        "dangerous_area_radius": 1.0,
+        "dangerous_area_penalty": 7.0,
+    },
+]
+_CASE_IDS = ["default", "walls-two-ghosts", "dangerous-areas"]
+
+
+@dataclass
+class _Case:
+    env: PacManPOMDP
+    model: PacManVectorizedModel
+
+
+@pytest.fixture(params=_SUPPORTED_CASES, ids=_CASE_IDS, name="case")
+def case_fixture(request: pytest.FixtureRequest) -> _Case:
+    env = PacManPOMDP(**request.param)
+    model = PacManVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    return _Case(env=env, model=model)
+
+
+def _state_dim(env: PacManPOMDP) -> int:
+    return len(env.initial_state_dist().sample()[0])
+
+
+def _valid_cells(env: PacManPOMDP) -> List[Tuple[int, int]]:
+    rows, cols = env.maze_size
+    return [(r, c) for r in range(rows) for c in range(cols) if (r, c) not in env.walls]
+
+
+def _random_states(env: PacManPOMDP, count: int, rng: np.random.Generator) -> np.ndarray:
+    cells = _valid_cells(env)
+    states = np.zeros((count, _state_dim(env)), dtype=np.float64)
+    for i in range(count):
+        pacman = cells[rng.integers(len(cells))]
+        ghosts = tuple(cells[rng.integers(len(cells))] for _ in range(env.num_ghosts))
+        states[i] = env.make_state(
+            pacman_pos=pacman,
+            ghost_positions=ghosts,
+            pellets=None,
+            score=float(rng.integers(0, 40)),
+            terminal=False,
+        )
+    return states
+
+
+def _tensor(array: np.ndarray) -> torch.Tensor:
+    return torch.as_tensor(array, dtype=torch.float64)
+
+
+def _cell_frequencies(positions: np.ndarray) -> dict:
+    unique, counts = np.unique(positions.astype(int), axis=0, return_counts=True)
+    return {tuple(cell): count / positions.shape[0] for cell, count in zip(unique, counts)}
+
+
+def test_model_satisfies_protocol_for_every_supported_config(case: _Case) -> None:
+    """Every supported config yields a conforming VectorizedGenerativeModel.
+
+    Purpose: Validates structural protocol conformance across configs
+
+    Given: A model built from each supported environment configuration
+    When: It is checked against the runtime-checkable protocol
+    Then: isinstance reports conformance and the action count is five
+
+    Test type: unit
+    """
+    assert isinstance(case.model, VectorizedGenerativeModel)
+    assert case.model.num_actions == 5
+
+
+def test_reward_matches_native_exactly(case: _Case) -> None:
+    """Rewards match the native reward kernel to float64 precision.
+
+    Purpose: Validates the deterministic reward path across configs
+
+    Given: Random non-terminal states and their realised native next states
+    When: The model reward is compared to env.reward_batch on those pairs
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(5)
+    states = _random_states(case.env, 600, rng)
+    next_states = case.env.sample_next_state_batch(states, 1)
+    expected = case.env.reward_batch(states, 1, next_states=next_states)
+    actions = torch.ones(states.shape[0], dtype=torch.int64)
+    actual = case.model.rewards(_tensor(states), actions, _tensor(next_states)).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_observation_log_probs_match_native_exactly(case: _Case) -> None:
+    """Observation log-likelihoods match the native kernel to float64 precision.
+
+    Purpose: Validates the observation likelihood kernel across configs
+
+    Given: Realised next states and observations drawn from the native sampler
+    When: The model's observation_log_probs is compared to the env per row
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(7)
+    next_states = _random_states(case.env, 400, rng)
+    observations = np.stack(
+        [
+            case.env.observation_to_array(case.env.sample_observation(next_states[i], 1))
+            for i in range(next_states.shape[0])
+        ]
+    ).astype(np.float64)
+    expected = np.array(
+        [
+            case.env.observation_log_probability_per_state(
+                next_states[i : i + 1], 1, observations[i]
+            )[0]
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actions = torch.ones(next_states.shape[0], dtype=torch.int64)
+    actual = case.model.observation_log_probs(
+        _tensor(next_states), actions, _tensor(observations)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_transition_pacman_fields_are_deterministic_and_match_native(case: _Case) -> None:
+    """Deterministic transition fields match the native kernel exactly.
+
+    Purpose: Validates PacMan move, pellet collection, score, and terminal
+
+    Given: States with all ghosts far from PacMan so no collision can occur
+    When: Both kernels transition the batch under the same action
+    Then: PacMan position, pellet mask, score, and terminal flag match exactly
+
+    Test type: unit
+    """
+    cells = _valid_cells(case.env)
+    far_ghost = max(cells, key=lambda cell: abs(cell[0]) + abs(cell[1]))
+    pacman = min(cells, key=lambda cell: cell[0] + cell[1])
+    ghosts = tuple([far_ghost] * case.env.num_ghosts)
+    state = case.env.make_state(
+        pacman_pos=pacman, ghost_positions=ghosts, pellets=None, score=0.0, terminal=False
+    )
+    batch = np.tile(state, (200, 1))
+    native = case.env.sample_next_state_batch(batch, 1)
+    twin = case.model.sample_next_states(_tensor(batch), torch.ones(200, dtype=torch.int64)).numpy()
+    trans = case.env.get_transition_cpp_ctor_kwargs()
+    pac_cols = [trans["idx_pac_row"], trans["idx_pac_col"]]
+    pellet_slice = slice(trans["idx_pellets_start"], trans["idx_pellets_end"])
+    assert np.array_equal(native[:, pac_cols], twin[:, pac_cols])
+    assert np.array_equal(native[:, pellet_slice], twin[:, pellet_slice])
+    assert np.array_equal(native[:, trans["idx_score"]], twin[:, trans["idx_score"]])
+    assert np.array_equal(native[:, trans["idx_terminal"]], twin[:, trans["idx_terminal"]])
+
+
+def test_ghost_move_distribution_matches_native(case: _Case) -> None:
+    """Sampled ghost moves reproduce the native softmax move distribution.
+
+    Purpose: Validates the aggressive-ghost softmax transition kernel
+
+    Given: A fixed non-terminal state sampled many times under the stay action
+    When: Empirical next-position frequencies of ghost 0 are compared
+    Then: Every cell frequency agrees within a Monte Carlo tolerance of 0.02
+
+    Test type: unit
+    """
+    torch.manual_seed(1)
+    cells = _valid_cells(case.env)
+    pacman = cells[0]
+    ghosts = tuple(cells[min(3 + i, len(cells) - 1)] for i in range(case.env.num_ghosts))
+    state = case.env.make_state(
+        pacman_pos=pacman, ghost_positions=ghosts, pellets=None, score=0.0, terminal=False
+    )
+    batch = np.tile(state, (40000, 1))
+    native = case.env.sample_next_state_batch(batch, 4)
+    twin = case.model.sample_next_states(
+        _tensor(batch), torch.full((40000,), 4, dtype=torch.int64)
+    ).numpy()
+    trans = case.env.get_transition_cpp_ctor_kwargs()
+    start = trans["idx_ghosts_start"]
+    native_freq = _cell_frequencies(native[:, start : start + 2])
+    twin_freq = _cell_frequencies(twin[:, start : start + 2])
+    keys = set(native_freq) | set(twin_freq)
+    assert max(abs(native_freq.get(k, 0.0) - twin_freq.get(k, 0.0)) for k in keys) < 0.02
+
+
+def test_observation_sampling_matches_native(case: _Case) -> None:
+    """Sampled observations reproduce the native round-and-clamp distribution.
+
+    Purpose: Validates the per-ghost Gaussian observation sampler
+
+    Given: A fixed next state sampled many times by both observation kernels
+    When: Empirical frequencies of ghost 0's observed cell are compared
+    Then: Every cell frequency agrees within a Monte Carlo tolerance of 0.02
+
+    Test type: unit
+    """
+    torch.manual_seed(2)
+    cells = _valid_cells(case.env)
+    pacman = cells[0]
+    ghosts = tuple(cells[len(cells) // 2] for _ in range(case.env.num_ghosts))
+    next_state = case.env.make_state(
+        pacman_pos=pacman, ghost_positions=ghosts, pellets=None, score=0.0, terminal=False
+    )
+    native = np.stack(
+        [
+            case.env.observation_to_array(case.env.sample_observation(next_state, 0))
+            for _ in range(20000)
+        ]
+    )
+    batch = np.tile(next_state, (20000, 1))
+    twin = case.model.sample_observations(
+        _tensor(batch), torch.zeros(20000, dtype=torch.int64)
+    ).numpy()
+    native_freq = _cell_frequencies(native[:, 0:2])
+    twin_freq = _cell_frequencies(twin[:, 0:2])
+    keys = set(native_freq) | set(twin_freq)
+    assert max(abs(native_freq.get(k, 0.0) - twin_freq.get(k, 0.0)) for k in keys) < 0.02
+
+
+def test_terminal_mask_matches_native(case: _Case) -> None:
+    """Terminal flags match the native per-state terminal check across configs.
+
+    Purpose: Validates the batched terminal mask against env.is_terminal
+
+    Given: A batch mixing terminal and non-terminal states
+    When: The model terminal mask is compared to env.is_terminal per row
+    Then: Every entry agrees
+
+    Test type: unit
+    """
+    cells = _valid_cells(case.env)
+    ghosts = tuple([cells[-1]] * case.env.num_ghosts)
+    non_terminal = case.env.make_state(
+        pacman_pos=cells[0], ghost_positions=ghosts, pellets=None, score=0.0, terminal=False
+    )
+    terminal = case.env.make_state(
+        pacman_pos=cells[0], ghost_positions=ghosts, pellets=None, score=0.0, terminal=True
+    )
+    states = np.stack([non_terminal, terminal, non_terminal])
+    expected = np.array([case.env.is_terminal(s) for s in states])
+    actual = case.model.terminal_mask(_tensor(states)).numpy()
+    assert np.array_equal(expected, actual)
+
+
+def test_terminal_state_produces_sentinel_observation(case: _Case) -> None:
+    """A terminal next state yields the all-minus-one sentinel observation.
+
+    Purpose: Validates the terminal-state branch of the observation sampler
+
+    Given: A terminal next state
+    When: The model samples an observation for it
+    Then: Every observation coordinate is -1
+
+    Test type: unit
+    """
+    cells = _valid_cells(case.env)
+    ghosts = tuple([cells[-1]] * case.env.num_ghosts)
+    terminal = case.env.make_state(
+        pacman_pos=cells[0], ghost_positions=ghosts, pellets=None, score=0.0, terminal=True
+    )
+    observation = case.model.sample_observations(
+        _tensor(terminal).unsqueeze(0), torch.zeros(1, dtype=torch.int64)
+    )
+    assert torch.all(observation == -1.0)
+
+
+def test_action_keys_are_identity(case: _Case) -> None:
+    """Action keys pass discrete action indices through as int64 keys.
+
+    Purpose: Validates the discrete action-to-key mapping
+
+    Given: The five discrete action indices
+    When: action_keys is called
+    Then: The output is the identical int64 indices
+
+    Test type: unit
+    """
+    actions = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64)
+    keys = case.model.action_keys(actions)
+    assert keys.dtype == torch.int64
+    assert torch.equal(keys, actions)
+
+
+def test_observation_keys_are_deterministic_and_discriminating(case: _Case) -> None:
+    """Observation keys are stable per input and separate distinct observations.
+
+    Purpose: Validates the discrete-observation to integer-key hashing
+
+    Given: Observations, some identical and some at different ghost positions
+    When: observation_keys is called twice
+    Then: Identical inputs map to identical keys and distinct ones differ
+
+    Test type: unit
+    """
+    width = 2 * case.env.num_ghosts
+    obs_a = torch.zeros(width, dtype=torch.float64)
+    obs_b = torch.zeros(width, dtype=torch.float64)
+    obs_b[0] = 3.0
+    observations = torch.stack([obs_a, obs_a, obs_b])
+    keys_first = case.model.observation_keys(observations)
+    keys_second = case.model.observation_keys(observations)
+    assert torch.equal(keys_first, keys_second)
+    assert keys_first[0] == keys_first[1]
+    assert keys_first[0] != keys_first[2]
+
+
+def test_unsupported_ghost_coordination_raises() -> None:
+    """Constructing on a non-independent coordination mode is rejected.
+
+    Purpose: Validates the scope guard on ghost coordination
+
+    Given: An env configured with coordinated ghost coordination
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = PacManPOMDP(ghost_coordination="coordinated")
+    with pytest.raises(NotImplementedError):
+        PacManVectorizedModel(env)
+
+
+def test_unsupported_ghost_strategy_raises() -> None:
+    """Constructing on a non-aggressive ghost strategy is rejected.
+
+    Purpose: Validates the scope guard on ghost strategy
+
+    Given: An env configured with the patrol ghost strategy
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = PacManPOMDP(num_ghosts=1, ghost_strategies=["patrol"])
+    with pytest.raises(NotImplementedError):
+        PacManVectorizedModel(env)
+
+
+def test_unsupported_reward_model_raises() -> None:
+    """Constructing on an unsupported reward model is rejected.
+
+    Purpose: Validates the scope guard on reward model type
+
+    Given: An env configured with the zero-mean hazard shock reward model
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = PacManPOMDP(reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK)
+    with pytest.raises(NotImplementedError):
+        PacManVectorizedModel(env)
+
+
+def test_hazard_terminal_config_raises() -> None:
+    """The draw-coupled hazard-terminal config is rejected.
+
+    Purpose: Validates the scope guard on the hazard-terminal absorbing slot
+
+    Given: An env configured with is_dangerous_area_hit_terminal=True
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = PacManPOMDP(dangerous_areas={(2, 2)}, is_dangerous_area_hit_terminal=True)
+    with pytest.raises(NotImplementedError):
+        PacManVectorizedModel(env)

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_vectorized_model.py
@@ -1,0 +1,379 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests: torch vectorized model vs. the native discrete Push env.
+
+These tests pin :class:`PushVectorizedModel` to the environment's own kernels
+(the closed-form Python transition reference, the ``DiscretePushRewardModel``
+reward, the Gaussian object-position observation likelihood, and the terminal
+check) so the two implementations cannot drift. The checks run over a sweep of
+supported configurations (varying grid size, push threshold, friction,
+observation noise, obstacles, and dangerous areas) so a wiring bug that default
+parameters would hide is caught. Deterministic quantities (transition, reward,
+terminal, log-density) are compared exactly in float64; the stochastic
+observation sample is checked by its exact (robot/target) slice and clamp
+bounds.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.environments.push_pomdp.push_pomdp import PushPOMDP
+from POMDPPlanners.environments.push_pomdp.push_pomdp_utils.push_reward_models import (
+    RewardModelType,
+)
+from POMDPPlanners.environments.push_pomdp.push_vectorized_model import PushVectorizedModel
+
+# Each case is a set of PushPOMDP kwargs. All use the supported
+# CONSTANT_HAZARD_PENALTY reward model with deterministic (probability 1.0)
+# penalties and no transition error, so every kernel compared is deterministic.
+_SUPPORTED_CASES = [
+    {"discount_factor": 0.99},
+    {
+        "discount_factor": 0.95,
+        "obstacles": [(3.0, 3.0), (6.0, 6.0)],
+        "obstacle_radius": 0.8,
+        "obstacle_penalty": -12.0,
+    },
+    {
+        "discount_factor": 0.9,
+        "grid_size": 12,
+        "push_threshold": 1.5,
+        "friction_coefficient": 0.5,
+        "observation_noise": 0.2,
+    },
+    {
+        "discount_factor": 0.95,
+        "dangerous_areas": [(4.0, 4.0)],
+        "dangerous_area_radius": 1.0,
+        "dangerous_area_penalty": -8.0,
+    },
+]
+_CASE_IDS = ["default", "obstacles", "custom-physics", "dangerous-areas"]
+
+
+@dataclass
+class _Case:
+    env: PushPOMDP
+    model: PushVectorizedModel
+
+
+@pytest.fixture(params=_SUPPORTED_CASES, ids=_CASE_IDS, name="case")
+def case_fixture(request: pytest.FixtureRequest) -> _Case:
+    env = PushPOMDP(**request.param)
+    model = PushVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    return _Case(env=env, model=model)
+
+
+def _tensor(array: np.ndarray) -> torch.Tensor:
+    return torch.as_tensor(array, dtype=torch.float64)
+
+
+def _random_states(env: PushPOMDP, count: int, rng: np.random.Generator) -> np.ndarray:
+    """States with the robot near the object so the push path is exercised."""
+    grid_max = float(env.grid_size - 1)
+    obj = rng.uniform(0.0, grid_max, size=(count, 2))
+    robot = np.clip(obj + rng.uniform(-1.5, 1.5, size=(count, 2)), 0.0, grid_max)
+    target = rng.uniform(0.0, grid_max, size=(count, 2))
+    return np.concatenate([robot, obj, target], axis=1)
+
+
+def _random_actions(count: int, rng: np.random.Generator) -> np.ndarray:
+    return rng.integers(0, 4, size=count)
+
+
+def test_model_satisfies_protocol_for_every_supported_config(case: _Case) -> None:
+    """Every supported config yields a conforming VectorizedGenerativeModel.
+
+    Purpose: Validates structural protocol conformance across configs
+
+    Given: A model built from each supported environment configuration
+    When: It is checked against the runtime-checkable protocol
+    Then: isinstance reports conformance and the action count is four
+
+    Test type: unit
+    """
+    assert isinstance(case.model, VectorizedGenerativeModel)
+    assert case.model.num_actions == 4
+
+
+def test_transition_matches_native_exactly(case: _Case) -> None:
+    """Deterministic transitions match the env's closed-form kernel per row.
+
+    Purpose: Validates the batched push transition against the env reference
+
+    Given: Random near-object states and per-row actions in each config
+    When: The model transition is compared to the env's per-row Python kernel
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(11)
+    states = _random_states(case.env, 512, rng)
+    actions = _random_actions(512, rng)
+    expected = np.array(
+        [
+            case.env._compute_next_state_for_action_python(  # pylint: disable=protected-access
+                states[i], case.env.actions[int(actions[i])]
+            )
+            for i in range(states.shape[0])
+        ]
+    )
+    actual = case.model.sample_next_states(
+        _tensor(states), torch.as_tensor(actions, dtype=torch.int64)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_reward_matches_native_exactly(case: _Case) -> None:
+    """Rewards match the deterministic native reward kernel per row.
+
+    Purpose: Validates the reward kernel (distance, goal, obstacle, danger)
+
+    Given: Random next states and per-row actions in each config
+    When: The model reward is compared to the env reward model per row
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(13)
+    next_states = _random_states(case.env, 512, rng)
+    actions = _random_actions(512, rng)
+    expected = np.array(
+        [
+            case.env.reward_model.compute_reward(
+                next_states[i], case.env.actions[int(actions[i])], next_states[i]
+            )
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actual = case.model.rewards(
+        _tensor(next_states), torch.as_tensor(actions, dtype=torch.int64), _tensor(next_states)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_observation_log_probs_match_native_exactly(case: _Case) -> None:
+    """Observation log-likelihoods match the native kernel to float64 precision.
+
+    Purpose: Validates the object-position Gaussian likelihood across configs
+
+    Given: (next_state, observation) pairs with noisy object positions
+    When: The model observation_log_probs is compared to the env per pair
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(17)
+    next_states = _random_states(case.env, 256, rng)
+    observations = next_states.copy()
+    observations[:, 2:4] += rng.normal(scale=0.15, size=(256, 2))
+    expected = np.array(
+        [
+            case.env.observation_log_probability_single(
+                next_states[i], case.env.actions[0], observations[i]
+            )
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actual = case.model.observation_log_probs(
+        _tensor(next_states), torch.zeros(256, dtype=torch.int64), _tensor(observations)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_terminal_mask_matches_native(case: _Case) -> None:
+    """Terminal flags match the native per-state terminal check across configs.
+
+    Purpose: Validates the batched terminal mask against env.is_terminal
+
+    Given: States with the object on, just inside, and outside the goal radius
+    When: The model terminal mask is compared to env.is_terminal per row
+    Then: Every entry agrees
+
+    Test type: unit
+    """
+    target = np.array([case.env.grid_size - 1, case.env.grid_size - 1], dtype=np.float64)
+    offsets = np.array([[0.0, 0.0], [0.4, 0.0], [0.6, 0.0], [3.0, 3.0]])
+    states = np.array([[0.0, 0.0, *(target + off), *target] for off in offsets], dtype=np.float64)
+    expected = np.array([case.env.is_terminal(s) for s in states])
+    actual = case.model.terminal_mask(_tensor(states)).numpy()
+    assert np.array_equal(expected, actual)
+
+
+def test_observation_sample_preserves_exact_dims_and_clamps(case: _Case) -> None:
+    """Observation sampling keeps robot/target exact and clamps the object slice.
+
+    Purpose: Validates the stochastic observation sampler's structure
+
+    Given: A batch of next states sampled many times
+    When: sample_observations is drawn for the batch
+    Then: Robot/target dims are exact and the object slice stays within grid
+
+    Test type: unit
+    """
+    torch.manual_seed(3)
+    rng = np.random.default_rng(19)
+    next_states = _random_states(case.env, 4096, rng)
+    grid_max = float(case.env.grid_size - 1)
+    observations = case.model.sample_observations(
+        _tensor(next_states), torch.zeros(4096, dtype=torch.int64)
+    ).numpy()
+    assert np.allclose(observations[:, [0, 1, 4, 5]], next_states[:, [0, 1, 4, 5]])
+    assert observations[:, 2:4].min() >= 0.0
+    assert observations[:, 2:4].max() <= grid_max
+
+
+def test_observation_sampling_matches_native_moments(case: _Case) -> None:
+    """Sampled object-observation noise matches the native Gaussian in moments.
+
+    Purpose: Validates the observation noise covariance against the env sigma
+
+    Given: A fixed mid-grid next state sampled many times by the model
+    When: The empirical object-position covariance is computed
+    Then: It matches an isotropic observation_noise**2 covariance
+
+    Test type: unit
+    """
+    torch.manual_seed(5)
+    center = float(case.env.grid_size - 1) / 2.0
+    next_state = np.array([center, center, center, center, center, center])
+    twin = case.model.sample_observations(
+        _tensor(np.tile(next_state, (40000, 1))), torch.zeros(40000, dtype=torch.int64)
+    ).numpy()
+    empirical = np.cov(twin[:, 2:4].T)
+    expected = np.eye(2) * (case.env.observation_noise**2)
+    assert np.max(np.abs(empirical - expected)) < 0.01
+
+
+def test_method_shapes_and_dtypes(case: _Case) -> None:
+    """Every kernel returns the documented shape and dtype.
+
+    Purpose: Validates output shapes/dtypes of the full generative interface
+
+    Given: A small batch of states, actions, and observations
+    When: Each protocol method is invoked
+    Then: Shapes match [N, ds]/[N, do]/[N] and key/mask dtypes are correct
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(23)
+    states = _tensor(_random_states(case.env, 8, rng))
+    actions = torch.as_tensor(_random_actions(8, rng), dtype=torch.int64)
+    next_states = case.model.sample_next_states(states, actions)
+    observations = case.model.sample_observations(next_states, actions)
+    assert next_states.shape == (8, 6)
+    assert observations.shape == (8, 6)
+    assert case.model.rewards(states, actions, next_states).shape == (8,)
+    assert case.model.terminal_mask(states).dtype == torch.bool
+    assert case.model.action_keys(actions).dtype == torch.int64
+    assert case.model.observation_keys(observations).dtype == torch.int64
+
+
+def test_transition_error_prob_is_stochastic() -> None:
+    """A positive transition-error probability makes the transition stochastic.
+
+    Purpose: Validates the per-particle action-error branch in the transition
+
+    Given: An env with transition_error_prob=0.5 and a fixed state/action batch
+    When: Two transitions are sampled from the same inputs
+    Then: The two batches differ on at least one row
+
+    Test type: unit
+    """
+    torch.manual_seed(7)
+    env = PushPOMDP(discount_factor=0.99, transition_error_prob=0.5)
+    model = PushVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    states = _tensor(np.tile(np.array([2.0, 2.0, 2.5, 2.0, 9.0, 9.0]), (256, 1)))
+    actions = torch.full((256,), 2, dtype=torch.int64)
+    first = model.sample_next_states(states, actions).numpy()
+    second = model.sample_next_states(states, actions).numpy()
+    assert not np.array_equal(first, second)
+
+
+def test_unsupported_reward_model_raises() -> None:
+    """Constructing on an unsupported reward model is rejected.
+
+    Purpose: Validates the scope guard on reward model type
+
+    Given: An env configured with the zero-mean-shock hazard reward model
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    other = PushPOMDP(
+        discount_factor=0.99,
+        reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+    )
+    with pytest.raises(NotImplementedError):
+        PushVectorizedModel(other)
+
+
+def test_non_positive_observation_resolution_raises() -> None:
+    """A non-positive observation resolution is rejected at construction.
+
+    Purpose: Validates the observation-resolution argument guard
+
+    Given: A default env and observation_resolution=0.0
+    When: A vectorized model is constructed
+    Then: ValueError is raised
+
+    Test type: unit
+    """
+    env = PushPOMDP(discount_factor=0.99)
+    with pytest.raises(ValueError):
+        PushVectorizedModel(env, observation_resolution=0.0)
+
+
+def test_observation_keys_are_deterministic_and_discriminating() -> None:
+    """Observation keys are stable per input and separate distinct cells.
+
+    Purpose: Validates the continuous-observation to integer-key hashing
+
+    Given: Observations, some identical and some with distinct object cells
+    When: observation_keys is called twice
+    Then: Identical inputs map to identical keys and distinct cells differ
+
+    Test type: unit
+    """
+    env = PushPOMDP(discount_factor=0.99)
+    model = PushVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    observations = torch.tensor(
+        [
+            [0.0, 0.0, 1.05, 2.05, 9.0, 9.0],
+            [0.0, 0.0, 1.05, 2.05, 9.0, 9.0],
+            [0.0, 0.0, 3.2, 7.8, 9.0, 9.0],
+            [0.0, 0.0, 8.0, 1.0, 9.0, 9.0],
+        ]
+    )
+    keys_first = model.observation_keys(observations)
+    keys_second = model.observation_keys(observations)
+    assert torch.equal(keys_first, keys_second)
+    assert keys_first[0] == keys_first[1]
+    assert keys_first[0] != keys_first[2]
+    assert keys_first[2] != keys_first[3]
+
+
+def test_action_keys_are_identity() -> None:
+    """Action keys pass discrete action indices through as int64.
+
+    Purpose: Validates the discrete-action passthrough keying
+
+    Given: A tensor of the four discrete action indices
+    When: action_keys is called
+    Then: The result equals the input indices as int64
+
+    Test type: unit
+    """
+    env = PushPOMDP(discount_factor=0.99)
+    model = PushVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    actions = torch.tensor([0, 1, 2, 3], dtype=torch.int64)
+    keys = model.action_keys(actions)
+    assert keys.dtype == torch.int64
+    assert torch.equal(keys, actions)

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_vectorized_model.py
@@ -1,0 +1,349 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests: torch vectorized model vs. the native RockSample env.
+
+These tests pin :class:`RockSampleVectorizedModel` to the environment's
+native (C++) transition / observation kernels and its numpy reward kernel so
+the two implementations cannot drift. The parity checks run over a *sweep of
+supported configurations* (varying grid size, rock layout, sensor efficiency,
+costs, and dangerous-area geometry) so a wiring bug that default parameters
+would hide is caught. The RockSample transition is deterministic and the
+reward is deterministic in every swept config (no dangerous areas, or a
+dangerous area with hit-probability 1.0), so those are compared exactly in
+float64; the noisy Bernoulli sensor and the sub-unit hit-probability hazard
+are compared by empirical moments over a large batch.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import (
+    RewardModelType,
+    RockSamplePOMDP,
+)
+from POMDPPlanners.environments.rock_sample_pomdp.rocksample_vectorized_model import (
+    RockSampleVectorizedModel,
+)
+
+_OBS_STRINGS = ("none", "good", "bad")
+
+# Each case is a dict of RockSamplePOMDP kwargs. All are *supported*
+# configurations: constant-hazard reward, is_dangerous_area_hit_terminal=False.
+# Dangerous-area cases keep hit-probability 1.0 so the reward stays
+# deterministic and can be pinned exactly.
+_SUPPORTED_CASES = [
+    {"map_size": (5, 5), "rock_positions": [(0, 0), (2, 2), (3, 3)]},
+    {
+        "map_size": (7, 6),
+        "rock_positions": [(0, 1), (3, 3), (5, 4), (6, 0)],
+        "sensor_efficiency": 4.0,
+        "step_penalty": -0.1,
+        "sensor_use_penalty": -0.3,
+        "good_rock_reward": 12.0,
+        "bad_rock_penalty": -8.0,
+        "exit_reward": 15.0,
+    },
+    {
+        "map_size": (6, 6),
+        "rock_positions": [(1, 1), (4, 4)],
+        "sensor_efficiency": 6.0,
+        "dangerous_areas": [(2, 2), (3, 3)],
+        "dangerous_area_radius": 1.5,
+        "dangerous_area_penalty": -4.0,
+        "dangerous_area_hit_probability": 1.0,
+    },
+]
+_CASE_IDS = ["default", "large-costs", "danger-deterministic"]
+
+
+@dataclass
+class _Case:
+    env: RockSamplePOMDP
+    model: RockSampleVectorizedModel
+
+
+@pytest.fixture(params=_SUPPORTED_CASES, ids=_CASE_IDS, name="case")
+def case_fixture(request: pytest.FixtureRequest) -> _Case:
+    env = RockSamplePOMDP(discount_factor=0.95, **request.param)
+    model = RockSampleVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    return _Case(env=env, model=model)
+
+
+def _random_states(env: RockSamplePOMDP, count: int, seed: int) -> np.ndarray:
+    """Random valid states: in-grid robot position + random rock qualities."""
+    rng = np.random.default_rng(seed)
+    num_rocks = len(env.rock_positions)
+    rows = rng.integers(0, env.map_size[0], count)
+    cols = rng.integers(0, env.map_size[1], count)
+    rocks = rng.integers(0, 2, (count, num_rocks)).astype(np.float64)
+    return np.concatenate([rows[:, None], cols[:, None], rocks], axis=1).astype(np.float64)
+
+
+def _tensor(array: np.ndarray) -> torch.Tensor:
+    return torch.as_tensor(array, dtype=torch.float64)
+
+
+def _action_col(action: int, count: int) -> torch.Tensor:
+    return torch.full((count,), action, dtype=torch.int64)
+
+
+def test_model_satisfies_protocol_for_every_supported_config(case: _Case) -> None:
+    """Every supported config yields a conforming VectorizedGenerativeModel.
+
+    Purpose: Validates structural protocol conformance across configs
+
+    Given: A model built from each supported environment configuration
+    When: It is checked against the runtime-checkable protocol
+    Then: isinstance reports conformance and num_actions equals 5 + num_rocks
+
+    Test type: unit
+    """
+    assert isinstance(case.model, VectorizedGenerativeModel)
+    assert case.model.num_actions == 5 + len(case.env.rock_positions)
+
+
+def test_transition_matches_native_exactly(case: _Case) -> None:
+    """Sampled next states match the native transition kernel exactly.
+
+    Purpose: Validates the deterministic grid / sample transition across actions
+
+    Given: A random batch of valid states, transitioned under each action
+    When: model.sample_next_states is compared to env.sample_next_state_batch
+    Then: The two next-state arrays are identical for every action
+
+    Test type: unit
+    """
+    states = _random_states(case.env, 256, seed=1)
+    for action in range(case.model.num_actions):
+        native = case.env.sample_next_state_batch(states, action)
+        twin = case.model.sample_next_states(
+            _tensor(states), _action_col(action, states.shape[0])
+        ).numpy()
+        assert np.array_equal(native, twin)
+
+
+def test_observation_log_probs_match_native_exactly(case: _Case) -> None:
+    """Observation log-likelihoods match the native kernel to float64 precision.
+
+    Purpose: Validates the noisy-sensor likelihood kernel across actions / obs
+
+    Given: Post-transition states and every (action, observation-code) pair
+    When: model.observation_log_probs is compared to the env per-state kernel
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    states = _random_states(case.env, 256, seed=2)
+    max_diff = 0.0
+    for action in range(case.model.num_actions):
+        next_states = case.env.sample_next_state_batch(states, action)
+        for code, obs_str in enumerate(_OBS_STRINGS):
+            expected = case.env.observation_log_probability_per_state(next_states, action, obs_str)
+            actual = case.model.observation_log_probs(
+                _tensor(next_states),
+                _action_col(action, states.shape[0]),
+                torch.full((states.shape[0], 1), float(code), dtype=torch.float64),
+            ).numpy()
+            max_diff = max(max_diff, float(np.max(np.abs(expected - actual))))
+    assert max_diff < 1e-9
+
+
+def test_reward_matches_native_exactly(case: _Case) -> None:
+    """Deterministic rewards match the native numpy reward kernel exactly.
+
+    Purpose: Validates the base + deterministic-hazard reward across actions
+
+    Given: A random batch of states with their realised next states per action
+    When: model.rewards is compared to env.reward_model.compute_reward_batch
+    Then: The two reward arrays are identical for every action
+
+    Test type: unit
+    """
+    states = _random_states(case.env, 400, seed=3)
+    for action in range(case.model.num_actions):
+        next_states = case.env.sample_next_state_batch(states, action)
+        expected = case.env.reward_model.compute_reward_batch(
+            states, action, next_states=next_states
+        )
+        actual = case.model.rewards(
+            _tensor(states), _action_col(action, states.shape[0]), _tensor(next_states)
+        ).numpy()
+        assert np.array_equal(expected, actual)
+
+
+def test_terminal_mask_matches_native(case: _Case) -> None:
+    """Terminal flags match the native per-state terminal check across configs.
+
+    Purpose: Validates the batched terminal mask against env.is_terminal
+
+    Given: The exit sentinel row and several live in-grid rows
+    When: model.terminal_mask is compared to env.is_terminal per row
+    Then: Every entry agrees
+
+    Test type: unit
+    """
+    num_rocks = len(case.env.rock_positions)
+    sentinel = np.concatenate([[-1.0, -1.0], np.ones(num_rocks)])
+    live = _random_states(case.env, 8, seed=4)
+    states = np.concatenate([sentinel[None, :], live], axis=0)
+    expected = np.array([case.env.is_terminal(row) for row in states])
+    actual = case.model.terminal_mask(_tensor(states)).numpy()
+    assert np.array_equal(expected, actual)
+
+
+def test_observation_sampling_reproduces_sensor_efficiency() -> None:
+    """Check-action sampling reproduces the exp(-dist/eff) sensor accuracy.
+
+    Purpose: Validates the stochastic Bernoulli sensor in expectation
+
+    Given: A robot one cell from a good rock, checked many times
+    When: The empirical fraction of correct ("good") observations is measured
+    Then: It matches exp(-distance / sensor_efficiency) within 0.02
+
+    Test type: unit
+    """
+    torch.manual_seed(0)
+    env = RockSamplePOMDP(map_size=(5, 5), rock_positions=[(2, 2)], sensor_efficiency=3.0)
+    model = RockSampleVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    next_state = np.array([2.0, 1.0, 1.0])  # one cell west of the good rock
+    batch = np.tile(next_state, (40000, 1))
+    observations = model.sample_observations(_tensor(batch), _action_col(5, 40000))
+    frac_good = float((observations[:, 0] == 1).to(torch.float64).mean())
+    expected = float(np.exp(-1.0 / 3.0))
+    assert abs(frac_good - expected) < 0.02
+
+
+def test_reward_hazard_expectation_matches_native() -> None:
+    """Mean hazard reward with sub-unit hit-probability matches the env.
+
+    Purpose: Validates the stochastic dangerous-area contribution in expectation
+
+    Given: Next states sitting inside a dangerous area with hit-probability 0.4
+    When: Mean rewards from the model and the numpy reward kernel are compared
+    Then: The means agree within a Monte Carlo tolerance of 0.1
+
+    Test type: unit
+    """
+    np.random.seed(7)
+    torch.manual_seed(7)
+    env = RockSamplePOMDP(
+        map_size=(6, 6),
+        rock_positions=[(0, 0)],
+        dangerous_areas=[(3, 3)],
+        dangerous_area_radius=1.0,
+        dangerous_area_penalty=-5.0,
+        dangerous_area_hit_probability=0.4,
+    )
+    model = RockSampleVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    states = np.tile(np.array([3.0, 2.0, 1.0]), (20000, 1))
+    next_states = np.tile(np.array([3.0, 3.0, 1.0]), (20000, 1))  # in-zone, action west
+    action = 4
+    env_mean = float(
+        np.mean(env.reward_model.compute_reward_batch(states, action, next_states=next_states))
+    )
+    model_mean = float(
+        model.rewards(_tensor(states), _action_col(action, 20000), _tensor(next_states)).mean()
+    )
+    assert abs(env_mean - model_mean) < 0.1
+
+
+def test_method_shapes_and_dtypes(case: _Case) -> None:
+    """Every generative method returns the documented shape and dtype.
+
+    Purpose: Validates the tensor contract of the protocol methods
+
+    Given: A small batch of states, actions, next states, and observations
+    When: Each vectorized method is invoked
+    Then: Shapes are [N, ds] / [N, 1] / [N] and key dtypes are int64
+
+    Test type: unit
+    """
+    states = _tensor(_random_states(case.env, 16, seed=5))
+    actions = _action_col(5, 16)
+    next_states = case.model.sample_next_states(states, actions)
+    observations = case.model.sample_observations(next_states, actions)
+    rewards = case.model.rewards(states, actions, next_states)
+    log_probs = case.model.observation_log_probs(next_states, actions, observations)
+    assert next_states.shape == states.shape
+    assert observations.shape == (16, 1)
+    assert rewards.shape == (16,)
+    assert log_probs.shape == (16,)
+    assert case.model.terminal_mask(states).dtype == torch.bool
+    assert case.model.action_keys(actions).dtype == torch.int64
+    assert case.model.observation_keys(observations).dtype == torch.int64
+
+
+def test_action_and_observation_keys_are_deterministic() -> None:
+    """Action and observation keys are stable and discriminating.
+
+    Purpose: Validates the discrete key mappings used by the belief tree
+
+    Given: A set of actions and categorical observation codes
+    When: action_keys / observation_keys are each called twice
+    Then: Repeated calls agree, keys equal the underlying integer codes, and
+        distinct codes map to distinct keys
+
+    Test type: unit
+    """
+    env = RockSamplePOMDP(map_size=(5, 5), rock_positions=[(0, 0), (2, 2)])
+    model = RockSampleVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    actions = torch.tensor([0, 2, 5, 6], dtype=torch.int64)
+    observations = torch.tensor([[0.0], [1.0], [2.0], [1.0]], dtype=torch.float64)
+    assert torch.equal(model.action_keys(actions), model.action_keys(actions))
+    assert torch.equal(model.action_keys(actions), actions)
+    obs_keys = model.observation_keys(observations)
+    assert torch.equal(obs_keys, model.observation_keys(observations))
+    assert torch.equal(obs_keys, torch.tensor([0, 1, 2, 1], dtype=torch.int64))
+    assert obs_keys[0] != obs_keys[1]
+
+
+@pytest.mark.parametrize(
+    "reward_model_type",
+    [RewardModelType.ZERO_MEAN_HAZARD_SHOCK, RewardModelType.DISTANCE_DECAYED_HAZARD_PENALTY],
+)
+def test_unsupported_reward_model_raises(reward_model_type: RewardModelType) -> None:
+    """Constructing on an unsupported reward model is rejected.
+
+    Purpose: Validates the scope guard on reward model type
+
+    Given: An env configured with a non-constant-hazard reward model
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = RockSamplePOMDP(
+        map_size=(5, 5),
+        rock_positions=[(0, 0), (2, 2)],
+        dangerous_areas=[(1, 1)],
+        reward_model_type=reward_model_type,
+    )
+    with pytest.raises(NotImplementedError):
+        RockSampleVectorizedModel(env)
+
+
+def test_hazard_terminal_config_raises() -> None:
+    """The draw-coupled hazard-terminal config is rejected.
+
+    Purpose: Validates the scope guard on the hazard-terminal absorbing slot
+
+    Given: An env with is_dangerous_area_hit_terminal=True
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = RockSamplePOMDP(
+        map_size=(5, 5),
+        rock_positions=[(0, 0), (2, 2)],
+        dangerous_areas=[(1, 1)],
+        is_dangerous_area_hit_terminal=True,
+    )
+    with pytest.raises(NotImplementedError):
+        RockSampleVectorizedModel(env)

--- a/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_vectorized_model.py
@@ -1,0 +1,300 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests: torch vectorized model vs. the native Safety Ant Velocity env.
+
+These tests pin :class:`SafetyAntVelocityVectorizedModel` to the environment's
+native (C++) kernels so the two implementations cannot drift. The parity
+checks run over a *sweep of supported configurations* (varying physics, noise,
+and reward parameters) so a wiring bug that default parameters would hide is
+caught. Observation log-densities and rewards are compared exactly in float64;
+the stochastic transition and observation kernels are compared by empirical
+moments over a large batch.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.environments.safety_ant_velocity_pomdp import _native
+from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_pomdp import (
+    SafeAntVelocityPOMDP,
+)
+from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_vectorized_model import (
+    SafetyAntVelocityVectorizedModel,
+)
+
+# Each dict is a *supported* configuration: the default discrete force-level
+# action set with physics / noise / reward parameters otherwise varying widely.
+_SUPPORTED_CASES = [
+    {},
+    {"mass": 2.0, "damping": 0.3, "max_force": 2.0, "dt": 0.05},
+    {"position_noise": 0.2, "velocity_noise": 0.1, "safe_velocity_threshold": 1.0},
+    {"movement_reward_scale": 2.0, "safety_violation_penalty": -50.0},
+]
+_CASE_IDS = ["default", "heavy-damped", "noisy-tight-threshold", "scaled-reward"]
+
+
+@dataclass
+class _Case:
+    env: SafeAntVelocityPOMDP
+    model: SafetyAntVelocityVectorizedModel
+
+
+@pytest.fixture(params=_SUPPORTED_CASES, ids=_CASE_IDS, name="case")
+def case_fixture(request: pytest.FixtureRequest) -> _Case:
+    env = SafeAntVelocityPOMDP(discount_factor=0.99, **request.param)
+    model = SafetyAntVelocityVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    return _Case(env=env, model=model)
+
+
+def _tensor(array: np.ndarray) -> torch.Tensor:
+    return torch.as_tensor(array, dtype=torch.float64)
+
+
+def _action_indices(count: int, action: int = 0) -> torch.Tensor:
+    return torch.full((count,), action, dtype=torch.int64)
+
+
+def test_model_satisfies_protocol_for_every_supported_config(case: _Case) -> None:
+    """Every supported config yields a conforming VectorizedGenerativeModel.
+
+    Purpose: Validates structural protocol conformance across configs
+
+    Given: A model built from each supported environment configuration
+    When: It is checked against the runtime-checkable protocol
+    Then: isinstance reports conformance and the action count matches the env
+
+    Test type: unit
+    """
+    assert isinstance(case.model, VectorizedGenerativeModel)
+    assert case.model.num_actions == len(case.env.get_actions())
+
+
+def test_observation_log_probs_match_native_exactly(case: _Case) -> None:
+    """Observation log-likelihoods match the native kernel to float64 precision.
+
+    Purpose: Validates the diagonal-Gaussian observation likelihood kernel
+
+    Given: (next_state, observation) pairs spanning the 4-D state per config
+    When: The model's observation_log_probs is compared to the env per pair
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(3)
+    next_states = rng.uniform(-2.0, 2.0, size=(128, 4))
+    observations = next_states + rng.normal(scale=0.1, size=(128, 4))
+    expected = np.array(
+        [
+            case.env.observation_log_probability_per_state(next_states[i], 0, observations[i])[0]
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actual = case.model.observation_log_probs(
+        _tensor(next_states), _action_indices(128), _tensor(observations)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_reward_matches_native_exactly(case: _Case) -> None:
+    """Rewards match the native reward kernel exactly across configs.
+
+    Purpose: Validates the speed-based reward with the safety-violation penalty
+
+    Given: Next states with velocities spanning safe and unsafe speeds
+    When: The model reward is compared to env.reward_batch on those states
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(5)
+    next_states = rng.uniform(-1.0, 1.0, size=(512, 4))
+    next_states[:, 2:4] = rng.uniform(-3.0, 3.0, size=(512, 2))
+    expected = case.env.reward_batch(next_states, 0)
+    actual = case.model.rewards(
+        _tensor(next_states), _action_indices(512), _tensor(next_states)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_terminal_mask_matches_native(case: _Case) -> None:
+    """Terminal flags match the native per-state terminal check across configs.
+
+    Purpose: Validates the batched terminal mask against env.is_terminal
+
+    Given: States with velocities below, just above, and far above the cutoff
+    When: The model terminal mask is compared to env.is_terminal per row
+    Then: Every entry agrees
+
+    Test type: unit
+    """
+    cutoff = case.env.safe_velocity_threshold * 1.5
+    speeds = np.array([0.0, cutoff * 0.5, cutoff - 0.01, cutoff + 0.01, cutoff * 2.0])
+    states = np.zeros((speeds.shape[0], 4))
+    states[:, 2] = speeds  # velocity_x carries the whole speed
+    expected = np.array([case.env.is_terminal(s) for s in states])
+    actual = case.model.terminal_mask(_tensor(states)).numpy()
+    assert np.array_equal(expected, actual)
+
+
+def test_transition_sampling_matches_native_moments(case: _Case) -> None:
+    """Sampled next-state moments match the native transition kernel per config.
+
+    Purpose: Validates transition mean/covariance for each config's physics
+
+    Given: A fixed moving state and a nonzero-force action sampled many times
+    When: Empirical mean and covariance are compared for both implementations
+    Then: Mean gap < 0.02 and covariance gap < 0.01
+
+    Test type: unit
+    """
+    _native.set_seed(11)
+    torch.manual_seed(11)
+    state = np.array([0.5, -0.5, 0.4, 0.2])
+    native = case.env.sample_next_state_batch(np.tile(state, (40000, 1)), 3)
+    twin = case.model.sample_next_states(
+        _tensor(np.tile(state, (40000, 1))), _action_indices(40000, action=3)
+    ).numpy()
+    assert np.max(np.abs(native.mean(0) - twin.mean(0))) < 0.02
+    assert np.max(np.abs(np.cov(native.T) - np.cov(twin.T))) < 0.01
+
+
+def test_observation_sampling_matches_native_covariance(case: _Case) -> None:
+    """Observation sampling reproduces the diagonal observation covariance.
+
+    Purpose: Validates the identity-mean diagonal-Gaussian observation noise
+
+    Given: A fixed next state sampled many times by the model
+    When: The empirical covariance is compared to the env's diagonal covariance
+    Then: The covariance gap is below 0.01
+
+    Test type: unit
+    """
+    torch.manual_seed(2)
+    next_state = np.array([1.0, 2.0, 0.3, -0.4])
+    twin = case.model.sample_observations(
+        _tensor(np.tile(next_state, (40000, 1))), _action_indices(40000)
+    ).numpy()
+    expected_cov = np.diag(
+        [
+            case.env.position_noise**2,
+            case.env.position_noise**2,
+            case.env.velocity_noise**2,
+            case.env.velocity_noise**2,
+        ]
+    )
+    assert np.max(np.abs(np.cov(twin.T) - expected_cov)) < 0.01
+
+
+def test_method_shapes_and_dtypes(case: _Case) -> None:
+    """Every generative method returns the documented shape and dtype.
+
+    Purpose: Validates the batched output contract of each protocol method
+
+    Given: A random batch of states, actions, and observations
+    When: Each generative / key method is invoked on the batch
+    Then: Shapes match [N, ds]/[N, do]/[N] and key/mask dtypes are int64/bool
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(9)
+    states = _tensor(rng.uniform(-1.0, 1.0, size=(32, 4)))
+    next_states = _tensor(rng.uniform(-1.0, 1.0, size=(32, 4)))
+    observations = _tensor(rng.uniform(-1.0, 1.0, size=(32, 4)))
+    actions = _action_indices(32, action=1)
+    assert case.model.sample_next_states(states, actions).shape == (32, 4)
+    assert case.model.sample_observations(next_states, actions).shape == (32, 4)
+    assert case.model.rewards(states, actions, next_states).shape == (32,)
+    assert case.model.observation_log_probs(next_states, actions, observations).shape == (32,)
+    assert case.model.terminal_mask(states).dtype == torch.bool
+    assert case.model.action_keys(actions).dtype == torch.int64
+    assert case.model.observation_keys(observations).dtype == torch.int64
+
+
+def test_action_keys_pass_through_indices() -> None:
+    """Action keys are the integer action indices unchanged.
+
+    Purpose: Validates the discrete-action passthrough key mapping
+
+    Given: A batch of discrete force-level action indices
+    When: action_keys is called on the batch
+    Then: The returned int64 keys equal the input indices
+
+    Test type: unit
+    """
+    env = SafeAntVelocityPOMDP(discount_factor=0.99)
+    model = SafetyAntVelocityVectorizedModel(env, device=torch.device("cpu"))
+    actions = torch.tensor([0, 1, 2, 3, 2, 0], dtype=torch.int64)
+    keys = model.action_keys(actions)
+    assert keys.dtype == torch.int64
+    assert torch.equal(keys, actions)
+
+
+def test_observation_keys_are_deterministic_and_discriminating() -> None:
+    """Observation keys are stable per input and separate distinct cells.
+
+    Purpose: Validates the continuous-observation to integer-key hashing
+
+    Given: Observations, some identical and some in different grid cells
+    When: observation_keys is called twice
+    Then: Identical inputs map to identical keys and distinct cells differ
+
+    Test type: unit
+    """
+    env = SafeAntVelocityPOMDP(discount_factor=0.99)
+    model = SafetyAntVelocityVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    observations = torch.tensor(
+        [
+            [0.05, 0.05, 0.05, 0.05],
+            [0.05, 0.05, 0.05, 0.05],
+            [3.2, 7.8, -1.0, 2.0],
+            [-1.0, -1.0, -1.0, -1.0],
+        ]
+    )
+    keys_first = model.observation_keys(observations)
+    keys_second = model.observation_keys(observations)
+    assert torch.equal(keys_first, keys_second)
+    assert keys_first[0] == keys_first[1]
+    assert keys_first[0] != keys_first[2]
+    assert keys_first[2] != keys_first[3]
+
+
+def test_unsupported_action_set_raises() -> None:
+    """Constructing on a non-default action set is rejected.
+
+    Purpose: Validates the scope guard on the force-index action assumption
+
+    Given: An env whose discrete action set is not range(len(force_scales))
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env = SafeAntVelocityPOMDP(discount_factor=0.99)
+    env.actions = [0, 1, 2]
+    with pytest.raises(NotImplementedError):
+        SafetyAntVelocityVectorizedModel(env)
+
+
+def test_non_positive_resolution_and_mass_raise() -> None:
+    """Non-positive observation resolution or mass is rejected.
+
+    Purpose: Validates the numeric-parameter guards in the constructor
+
+    Given: A valid env plus, separately, an env with zero mass
+    When: A model is built with a non-positive resolution / from the zero-mass env
+    Then: ValueError is raised in both cases
+
+    Test type: unit
+    """
+    env = SafeAntVelocityPOMDP(discount_factor=0.99)
+    with pytest.raises(ValueError):
+        SafetyAntVelocityVectorizedModel(env, observation_resolution=0.0)
+    zero_mass_env = SafeAntVelocityPOMDP(discount_factor=0.99, mass=0.0)
+    with pytest.raises(ValueError):
+        SafetyAntVelocityVectorizedModel(zero_mass_env)

--- a/POMDPPlanners/tests/test_environments/test_sanity_pomdp_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_sanity_pomdp_vectorized_model.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests: torch vectorized model vs. the native Sanity POMDP env.
+
+These tests pin :class:`SanityVectorizedModel` to the environment's native
+scalar kernels so the two implementations cannot drift. The Sanity POMDP is
+deterministic and perfectly observable, so every kernel (transition,
+observation, reward, terminal, observation likelihood) is compared exactly
+over random batches of the two states and two actions.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.environments.sanity_pomdp import SanityPOMDP
+from POMDPPlanners.environments.sanity_pomdp_vectorized_model import (
+    SanityVectorizedModel,
+)
+
+
+@pytest.fixture(name="env")
+def env_fixture() -> SanityPOMDP:
+    return SanityPOMDP(discount_factor=0.95)
+
+
+@pytest.fixture(name="model")
+def model_fixture(env: SanityPOMDP) -> SanityVectorizedModel:
+    return SanityVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+
+
+def _random_states(rng: np.random.Generator, count: int) -> np.ndarray:
+    return rng.integers(0, 2, size=count).astype(np.float64)
+
+
+def _random_actions(rng: np.random.Generator, count: int) -> np.ndarray:
+    return rng.integers(0, 2, size=count)
+
+
+def test_model_satisfies_protocol(model: SanityVectorizedModel) -> None:
+    """The model conforms to the VectorizedGenerativeModel protocol.
+
+    Purpose: Validates structural protocol conformance and the action count
+
+    Given: A vectorized model built from the Sanity POMDP
+    When: It is checked against the runtime-checkable protocol
+    Then: isinstance reports conformance and num_actions is 2
+
+    Test type: unit
+    """
+    assert isinstance(model, VectorizedGenerativeModel)
+    assert model.num_actions == 2
+
+
+def test_next_states_match_native(env: SanityPOMDP, model: SanityVectorizedModel) -> None:
+    """Sampled next states match the native transition kernel exactly.
+
+    Purpose: Validates the deterministic transition against env.sample_next_state
+
+    Given: A random batch of states and actions in the two-state/two-action set
+    When: The batched next states are compared to the env per row
+    Then: Every entry agrees and the shape is [N, 1]
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(0)
+    states = _random_states(rng, 128)
+    actions = _random_actions(rng, 128)
+    expected = np.array(
+        [env.sample_next_state(int(states[i]), int(actions[i])) for i in range(states.shape[0])]
+    )
+    actual = model.sample_next_states(
+        torch.as_tensor(states, dtype=torch.float64).unsqueeze(-1),
+        torch.as_tensor(actions, dtype=torch.int64),
+    )
+    assert tuple(actual.shape) == (128, 1)
+    assert np.array_equal(actual.squeeze(-1).numpy(), expected)
+
+
+def test_observations_match_native(env: SanityPOMDP, model: SanityVectorizedModel) -> None:
+    """Sampled observations match the native perfect-observation kernel exactly.
+
+    Purpose: Validates the observation kernel against env.sample_observation
+
+    Given: A random batch of next states and actions
+    When: The batched observations are compared to the env per row
+    Then: Every entry equals the next state and the shape is [N, 1]
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(1)
+    next_states = _random_states(rng, 128)
+    actions = _random_actions(rng, 128)
+    expected = np.array(
+        [
+            env.sample_observation(int(next_states[i]), int(actions[i]))
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actual = model.sample_observations(
+        torch.as_tensor(next_states, dtype=torch.float64).unsqueeze(-1),
+        torch.as_tensor(actions, dtype=torch.int64),
+    )
+    assert tuple(actual.shape) == (128, 1)
+    assert np.array_equal(actual.squeeze(-1).numpy(), expected)
+
+
+def test_rewards_match_native(env: SanityPOMDP, model: SanityVectorizedModel) -> None:
+    """Rewards match the native reward kernel exactly across the batch.
+
+    Purpose: Validates the reward kernel against env.reward
+
+    Given: A random batch of states, actions, and next states
+    When: The batched rewards are compared to the env per row
+    Then: Every entry agrees and the shape is [N]
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(2)
+    states = _random_states(rng, 128)
+    actions = _random_actions(rng, 128)
+    next_states = _random_states(rng, 128)
+    expected = np.array(
+        [env.reward(int(states[i]), int(actions[i])) for i in range(states.shape[0])]
+    )
+    actual = model.rewards(
+        torch.as_tensor(states, dtype=torch.float64).unsqueeze(-1),
+        torch.as_tensor(actions, dtype=torch.int64),
+        torch.as_tensor(next_states, dtype=torch.float64).unsqueeze(-1),
+    )
+    assert tuple(actual.shape) == (128,)
+    assert np.array_equal(actual.numpy(), expected)
+
+
+def test_terminal_mask_matches_native(env: SanityPOMDP, model: SanityVectorizedModel) -> None:
+    """Terminal flags match the native terminal check (always False).
+
+    Purpose: Validates the batched terminal mask against env.is_terminal
+
+    Given: States covering both state values
+    When: The model terminal mask is compared to the env per row
+    Then: Every entry agrees and the dtype is bool
+
+    Test type: unit
+    """
+    states = np.array([0.0, 1.0, 0.0, 1.0])
+    expected = np.array([env.is_terminal(int(s)) for s in states])
+    actual = model.terminal_mask(torch.as_tensor(states, dtype=torch.float64).unsqueeze(-1))
+    assert actual.dtype == torch.bool
+    assert np.array_equal(actual.numpy(), expected)
+
+
+def test_observation_log_probs_match_native(env: SanityPOMDP, model: SanityVectorizedModel) -> None:
+    """Observation log-likelihoods match the native kernel exactly.
+
+    Purpose: Validates observation_log_probs against env.observation_log_probability
+
+    Given: Random next states and observations, some matching and some not
+    When: The batched log-likelihoods are compared to the env per row
+    Then: Every entry agrees (0.0 on a match, -inf otherwise)
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(3)
+    next_states = _random_states(rng, 128)
+    observations = _random_states(rng, 128)
+    actions = _random_actions(rng, 128)
+    expected = np.array(
+        [
+            env.observation_log_probability(
+                int(next_states[i]), int(actions[i]), [int(observations[i])]
+            )[0]
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actual = model.observation_log_probs(
+        torch.as_tensor(next_states, dtype=torch.float64).unsqueeze(-1),
+        torch.as_tensor(actions, dtype=torch.int64),
+        torch.as_tensor(observations, dtype=torch.float64).unsqueeze(-1),
+    ).numpy()
+    assert np.array_equal(actual, expected)
+
+
+def test_action_keys_are_identity_int64(model: SanityVectorizedModel) -> None:
+    """Action keys are the action indices as int64.
+
+    Purpose: Validates the discrete action-to-key mapping
+
+    Given: A batch of action indices
+    When: action_keys is called
+    Then: The keys equal the input indices with int64 dtype
+
+    Test type: unit
+    """
+    actions = torch.tensor([0, 1, 1, 0], dtype=torch.int64)
+    keys = model.action_keys(actions)
+    assert keys.dtype == torch.int64
+    assert torch.equal(keys, actions)
+
+
+def test_observation_keys_are_deterministic_and_discriminating(
+    model: SanityVectorizedModel,
+) -> None:
+    """Observation keys are stable per input and separate distinct states.
+
+    Purpose: Validates the discrete-observation to integer-key mapping
+
+    Given: Observations covering both state values, some repeated
+    When: observation_keys is called twice
+    Then: Identical inputs map to identical keys and distinct states differ
+
+    Test type: unit
+    """
+    observations = torch.tensor([[0.0], [0.0], [1.0]], dtype=torch.float64)
+    keys_first = model.observation_keys(observations)
+    keys_second = model.observation_keys(observations)
+    assert keys_first.dtype == torch.int64
+    assert torch.equal(keys_first, keys_second)
+    assert keys_first[0] == keys_first[1]
+    assert keys_first[0] != keys_first[2]
+
+
+def test_unsupported_action_set_raises() -> None:
+    """Constructing on a non-standard action set is rejected.
+
+    Purpose: Validates the scope guard on the action set
+
+    Given: A Sanity POMDP subclass exposing a three-action set
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+
+    class _ThreeActionSanity(SanityPOMDP):
+        def get_actions(self) -> list[int]:
+            return [0, 1, 2]
+
+    with pytest.raises(NotImplementedError):
+        SanityVectorizedModel(_ThreeActionSanity(discount_factor=0.95))

--- a/POMDPPlanners/tests/test_environments/test_tiger_pomdp_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_tiger_pomdp_vectorized_model.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests: torch vectorized model vs. the native Tiger POMDP env.
+
+These tests pin :class:`TigerVectorizedModel` to the environment's native
+scalar kernels so the two implementations cannot drift. Deterministic kernels
+(reward, terminal, observation log-likelihood) are compared exactly in
+float64; the stochastic kernels (transition and observation sampling) are
+compared by empirical frequencies over a large batch, since the Tiger problem
+is fully discrete.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.environments.tiger_pomdp import (
+    ACTIONS,
+    OBSERVATIONS,
+    STATES,
+    TigerPOMDP,
+)
+from POMDPPlanners.environments.tiger_pomdp_vectorized_model import (
+    TigerVectorizedModel,
+)
+
+
+@pytest.fixture(name="env")
+def env_fixture() -> TigerPOMDP:
+    return TigerPOMDP(discount_factor=0.95)
+
+
+@pytest.fixture(name="model")
+def model_fixture(env: TigerPOMDP) -> TigerVectorizedModel:
+    return TigerVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+
+
+def _coded(indices: np.ndarray) -> torch.Tensor:
+    return torch.as_tensor(indices.reshape(-1, 1), dtype=torch.int64)
+
+
+def test_model_satisfies_protocol(model: TigerVectorizedModel) -> None:
+    """The model conforms to the vectorized generative model protocol.
+
+    Purpose: Validates structural protocol conformance and action count
+
+    Given: A Tiger vectorized model on CPU
+    When: It is checked against the runtime-checkable protocol
+    Then: isinstance reports conformance and num_actions equals three
+
+    Test type: unit
+    """
+    assert isinstance(model, VectorizedGenerativeModel)
+    assert model.num_actions == len(ACTIONS)
+    assert model.num_states == len(STATES)
+    assert model.num_observations == len(OBSERVATIONS)
+
+
+def test_reward_matches_native(env: TigerPOMDP, model: TigerVectorizedModel) -> None:
+    """Rewards match the native scalar reward across all state/action pairs.
+
+    Purpose: Validates the reward lookup table against env.reward
+
+    Given: A random batch of integer-coded states and action indices
+    When: The model reward is compared to env.reward per row
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(0)
+    s_idx = rng.integers(0, len(STATES), size=256)
+    a_idx = rng.integers(0, len(ACTIONS), size=256)
+    expected = np.array([env.reward(STATES[s], ACTIONS[a]) for s, a in zip(s_idx, a_idx)])
+    states = _coded(s_idx)
+    actual = model.rewards(states, torch.as_tensor(a_idx), states).numpy()
+    assert np.max(np.abs(expected - actual)) < 1e-9
+
+
+def test_observation_log_probs_match_native(env: TigerPOMDP, model: TigerVectorizedModel) -> None:
+    """Observation log-likelihoods match the native kernel exactly.
+
+    Purpose: Validates the observation log-probability table over all combos
+
+    Given: Every (action, next_state, observation) index combination
+    When: The model log-prob is compared to env.observation_log_probability
+    Then: The tensors are exactly equal (including -inf entries)
+
+    Test type: unit
+    """
+    combos = [
+        (a, ns, o)
+        for a in range(len(ACTIONS))
+        for ns in range(len(STATES))
+        for o in range(len(OBSERVATIONS))
+    ]
+    a_idx = np.array([c[0] for c in combos])
+    ns_idx = np.array([c[1] for c in combos])
+    o_idx = np.array([c[2] for c in combos])
+    expected = np.array(
+        [
+            env.observation_log_probability(STATES[ns], ACTIONS[a], [OBSERVATIONS[o]])[0]
+            for a, ns, o in combos
+        ]
+    )
+    actual = model.observation_log_probs(
+        _coded(ns_idx), torch.as_tensor(a_idx), _coded(o_idx)
+    ).numpy()
+    assert np.array_equal(expected, actual)
+
+
+def test_terminal_mask_matches_native(env: TigerPOMDP, model: TigerVectorizedModel) -> None:
+    """Terminal flags match the native per-state terminal check.
+
+    Purpose: Validates the batched terminal mask against env.is_terminal
+
+    Given: A random batch of integer-coded states
+    When: The model terminal mask is compared to env.is_terminal per row
+    Then: Every entry agrees (all False for the Tiger problem)
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(1)
+    s_idx = rng.integers(0, len(STATES), size=64)
+    expected = np.array([env.is_terminal(STATES[s]) for s in s_idx])
+    actual = model.terminal_mask(_coded(s_idx)).numpy()
+    assert np.array_equal(expected, actual)
+
+
+def test_transition_sampling_matches_native_frequencies(
+    env: TigerPOMDP, model: TigerVectorizedModel
+) -> None:
+    """Sampled next-state frequencies match the native transition kernel.
+
+    Purpose: Validates the stochastic transition for open and listen actions
+
+    Given: A large batch in tiger_left sampled under open_left and under listen
+    When: Empirical next-state frequencies are compared to the native kernel
+    Then: The open reset frequency gap is below 0.02 and listen is a no-op
+
+    Test type: unit
+    """
+    torch.manual_seed(1)
+    n = 40000
+    states = _coded(np.zeros(n, dtype=np.int64))  # tiger_left
+    open_actions = torch.full((n,), ACTIONS.index("open_left"), dtype=torch.int64)
+    twin = model.sample_next_states(states, open_actions).numpy().reshape(-1)
+    native = env.sample_next_state_batch([STATES[0]] * n, "open_left")
+    native_idx = np.array([STATES.index(s) for s in native])
+    assert abs(twin.mean() - native_idx.mean()) < 0.02
+    listen_actions = torch.full((n,), ACTIONS.index("listen"), dtype=torch.int64)
+    kept = model.sample_next_states(states, listen_actions)
+    assert torch.equal(kept, states)
+
+
+def test_observation_sampling_matches_native_frequencies(
+    env: TigerPOMDP, model: TigerVectorizedModel
+) -> None:
+    """Sampled observation frequencies match the native observation kernel.
+
+    Purpose: Validates the stochastic observation model for listen and open
+
+    Given: A large batch in tiger_left sampled under listen and under open_left
+    When: Empirical observation frequencies are compared to the native kernel
+    Then: The hear_left frequency gap is below 0.02 and open yields hear_nothing
+
+    Test type: unit
+    """
+    torch.manual_seed(2)
+    n = 40000
+    next_states = _coded(np.zeros(n, dtype=np.int64))  # tiger_left
+    listen_actions = torch.zeros(n, dtype=torch.int64)
+    twin = model.sample_observations(next_states, listen_actions).numpy().reshape(-1)
+    native = env.sample_observation(STATES[0], "listen", n_samples=n)
+    native_freq = float(np.mean([o == "hear_left" for o in native]))
+    twin_freq = float(np.mean(twin == OBSERVATIONS.index("hear_left")))
+    assert abs(twin_freq - native_freq) < 0.02
+    open_actions = torch.full((n,), ACTIONS.index("open_left"), dtype=torch.int64)
+    silent = model.sample_observations(next_states, open_actions).numpy().reshape(-1)
+    assert np.all(silent == OBSERVATIONS.index("hear_nothing"))
+
+
+def test_method_shapes_and_dtypes(model: TigerVectorizedModel) -> None:
+    """Every kernel returns the documented shape and dtype.
+
+    Purpose: Validates output contracts of all vectorized methods
+
+    Given: A small integer-coded batch of states, actions, and observations
+    When: Each kernel is invoked on the batch
+    Then: Shapes are [N,1] or [N] and dtypes are int64/float64/bool as specified
+
+    Test type: unit
+    """
+    n = 5
+    states = _coded(np.array([0, 1, 0, 1, 0]))
+    actions = torch.as_tensor(np.array([0, 1, 2, 0, 1]))
+    observations = _coded(np.array([0, 2, 2, 1, 2]))
+    next_states = model.sample_next_states(states, actions)
+    sampled_obs = model.sample_observations(next_states, actions)
+    assert next_states.shape == (n, 1) and next_states.dtype == torch.int64
+    assert sampled_obs.shape == (n, 1) and sampled_obs.dtype == torch.int64
+    rewards = model.rewards(states, actions, next_states)
+    assert rewards.shape == (n,) and rewards.dtype == torch.float64
+    terminal = model.terminal_mask(states)
+    assert terminal.shape == (n,) and terminal.dtype == torch.bool
+    log_probs = model.observation_log_probs(next_states, actions, observations)
+    assert log_probs.shape == (n,) and log_probs.dtype == torch.float64
+    assert model.action_keys(actions).dtype == torch.int64
+    assert model.observation_keys(observations).dtype == torch.int64
+
+
+def test_action_and_observation_keys_are_deterministic(
+    model: TigerVectorizedModel,
+) -> None:
+    """Action and observation keys are stable and discriminate distinct inputs.
+
+    Purpose: Validates the discrete key mapping used by the belief tree
+
+    Given: Action indices and integer-coded observations
+    When: action_keys and observation_keys are called twice
+    Then: Keys are stable, equal the coded index, and distinct inputs differ
+
+    Test type: unit
+    """
+    actions = torch.as_tensor(np.array([0, 1, 2, 1]))
+    observations = _coded(np.array([0, 1, 2, 1]))
+    assert torch.equal(model.action_keys(actions), model.action_keys(actions))
+    assert torch.equal(model.action_keys(actions), actions.to(torch.int64))
+    obs_keys = model.observation_keys(observations)
+    assert torch.equal(obs_keys, model.observation_keys(observations))
+    assert obs_keys[0] != obs_keys[1]
+    assert obs_keys[1] == obs_keys[3]
+
+
+def test_unsupported_labels_raise(env: TigerPOMDP) -> None:
+    """Constructing on a reconfigured label set is rejected.
+
+    Purpose: Validates the scope guard on the state/action/observation labels
+
+    Given: A Tiger environment whose state labels have been reconfigured
+    When: A vectorized model is constructed from it
+    Then: NotImplementedError is raised
+
+    Test type: unit
+    """
+    env.states = ["den_left", "den_right"]
+    with pytest.raises(NotImplementedError):
+        TigerVectorizedModel(env)

--- a/POMDPPlanners/tests/test_planners/test_vectorized_planners/__init__.py
+++ b/POMDPPlanners/tests/test_planners/test_vectorized_planners/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/POMDPPlanners/tests/test_planners/test_vectorized_planners/test_vopp.py
+++ b/POMDPPlanners/tests/test_planners/test_vectorized_planners/test_vopp.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the Vectorized Online POMDP Planner (VOPP / PORPP).
+
+The suite covers construction and validation, the forward-search /
+preference-backup control flow driven by a fully controllable mock generative
+model, and a smoke / geometry integration test against the real Continuous
+Light-Dark vectorized model.
+"""
+
+import pytest
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ContinuousLightDarkPOMDP,
+)
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_vectorized_model import (
+    ContinuousLightDarkVectorizedModel,
+)
+from POMDPPlanners.planners.vectorized_planners import VOPPPlanner
+
+
+class MockGenerativeModel:
+    """Deterministic, fully controllable vectorized generative model.
+
+    States are 1-D scalars left unchanged by every transition, so all episodes
+    from a belief share one observation key and the search grows a compact,
+    predictable path. Immediate reward is a per-action constant read from
+    ``reward_table``, letting a test pin which action must win. Termination is
+    toggled by ``always_terminal``.
+    """
+
+    def __init__(
+        self,
+        reward_table: Tensor,
+        *,
+        device: torch.device,
+        always_terminal: bool = False,
+    ) -> None:
+        self._device = device
+        self._reward_table = reward_table.to(device)
+        self.num_actions = int(reward_table.shape[0])
+        self._always_terminal = always_terminal
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        del actions
+        return states.clone()
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions
+        return next_states.clone()
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        del states, next_states
+        return self._reward_table[actions]
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        return torch.full(
+            (states.shape[0],), self._always_terminal, dtype=torch.bool, device=self._device
+        )
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions, observations
+        return torch.zeros(next_states.shape[0], device=self._device)
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        return torch.floor(observations[:, 0] * 10.0).to(torch.int64)
+
+
+def _mock_planner(reward_table: Tensor, **kwargs) -> VOPPPlanner:
+    device = torch.device("cpu")
+    model = MockGenerativeModel(reward_table, device=device)
+    defaults = {
+        "num_particles": 256,
+        "max_depth": 4,
+        "num_planning_iterations": 6,
+        "discount_factor": 0.95,
+    }
+    defaults.update(kwargs)
+    return VOPPPlanner(model, num_actions=model.num_actions, **defaults)
+
+
+def _light_dark_planner(**kwargs) -> VOPPPlanner:
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, is_obstacle_hit_terminal=False)
+    model = ContinuousLightDarkVectorizedModel(env, device=torch.device("cpu"))
+    defaults = {
+        "num_particles": 512,
+        "max_depth": 6,
+        "num_planning_iterations": 12,
+        "discount_factor": 0.95,
+    }
+    defaults.update(kwargs)
+    return VOPPPlanner(model, num_actions=model.num_actions, **defaults)
+
+
+def test_vopp_registers_preference_and_value_fields():
+    """Test that construction registers correctly shaped preference/value fields.
+
+    Purpose: Validates that the planner registers a per-action preference field
+        and a scalar value field on its belief tree.
+
+    Given: A VOPP planner built for a three-action mock model
+    When: The registered belief fields are inspected on the root belief
+    Then: ``preferences`` has one column per action (initialised to zero) and
+        ``value`` is a scalar field
+
+    Test type: unit
+    """
+    planner = _mock_planner(torch.tensor([1.0, 0.0, 0.0]))
+    preferences = planner.tree.belief_field("preferences")
+    value = planner.tree.belief_field("value")
+    assert preferences.shape == (1, 3)
+    assert value.shape == (1,)
+    assert bool((preferences == 0.0).all())
+
+
+def test_vopp_plan_returns_valid_action_index():
+    """Test that planning returns an in-range integer action index.
+
+    Purpose: Validates the greedy root action returned by :meth:`plan`.
+
+    Given: A VOPP planner for a three-action mock model
+    When: ``plan`` is called on a particle-set root belief
+    Then: The returned action is an ``int`` in ``[0, num_actions)``
+
+    Test type: unit
+    """
+    torch.manual_seed(0)
+    planner = _mock_planner(torch.tensor([1.0, 0.0, 0.0]))
+    root = torch.zeros(64, 1)
+    action = planner.plan(root)
+    assert isinstance(action, int)
+    assert 0 <= action < 3
+
+
+def test_vopp_plan_is_deterministic_under_fixed_seed():
+    """Test that planning is reproducible when the RNG seed is fixed.
+
+    Purpose: Validates that a fixed torch seed yields identical planning output.
+
+    Given: The same planner configuration and root belief
+    When: ``plan`` is run twice, each preceded by the same manual seed
+    Then: Both runs return the same action and identical root preferences
+
+    Test type: unit
+    """
+    root = torch.zeros(64, 1)
+    torch.manual_seed(7)
+    planner_a = _mock_planner(torch.tensor([0.0, 1.0, 0.0]))
+    action_a = planner_a.plan(root)
+    prefs_a = planner_a.tree.belief_field("preferences")[0].clone()
+    torch.manual_seed(7)
+    planner_b = _mock_planner(torch.tensor([0.0, 1.0, 0.0]))
+    action_b = planner_b.plan(root)
+    prefs_b = planner_b.tree.belief_field("preferences")[0].clone()
+    assert action_a == action_b
+    assert torch.allclose(prefs_a, prefs_b)
+
+
+def test_vopp_selects_dominant_reward_action():
+    """Test that the planner selects the action with dominant immediate reward.
+
+    Purpose: Validates that preference backups push the greedy root action to
+        the clearly best-rewarded action.
+
+    Given: A mock model where only action 1 yields positive reward
+    When: The planner runs its full budget of forward-search / backup passes
+    Then: The greedy root action is action 1 and it has the highest preference
+
+    Test type: unit
+    """
+    torch.manual_seed(1)
+    planner = _mock_planner(torch.tensor([0.0, 1.0, 0.0]), num_planning_iterations=10)
+    action = planner.plan(torch.zeros(256, 1))
+    preferences = planner.tree.belief_field("preferences")[0]
+    assert action == 1
+    assert int(torch.argmax(preferences).item()) == 1
+
+
+def test_vopp_forward_search_expands_tree_and_accumulates_statistics():
+    """Test that the forward search grows the tree and accumulates action stats.
+
+    Purpose: Validates that planning expands beyond the root and records visit
+        counts and reward sums on action nodes.
+
+    Given: A non-terminating mock model and a modest planning budget
+    When: ``plan`` completes
+    Then: The tree contains action and non-root belief nodes, and total action
+        visits are positive
+
+    Test type: integration
+    """
+    torch.manual_seed(2)
+    planner = _mock_planner(torch.tensor([1.0, 0.0, 0.0]))
+    planner.plan(torch.zeros(128, 1))
+    tree = planner.tree
+    num_actions = tree.num_action_nodes
+    assert num_actions > 0
+    assert tree.num_belief_nodes > 1
+    assert int(tree.action_visit_count[:num_actions].sum().item()) > 0
+
+
+def test_vopp_terminal_transitions_stop_expansion():
+    """Test that fully terminal transitions prevent successor belief creation.
+
+    Purpose: Validates the terminal-filtering step of the forward search.
+
+    Given: A mock model whose transitions are always terminal
+    When: ``plan`` runs
+    Then: No belief node beyond the root is created, yet the root's action
+        nodes still recorded their immediate rewards
+
+    Test type: unit
+    """
+    torch.manual_seed(3)
+    device = torch.device("cpu")
+    model = MockGenerativeModel(torch.tensor([1.0, 0.0]), device=device, always_terminal=True)
+    planner = VOPPPlanner(
+        model, num_actions=2, num_particles=64, max_depth=4, num_planning_iterations=3
+    )
+    planner.plan(torch.zeros(64, 1))
+    tree = planner.tree
+    assert tree.num_belief_nodes == 1
+    assert tree.num_action_nodes > 0
+    assert int(tree.action_visit_count[: tree.num_action_nodes].sum().item()) > 0
+
+
+@pytest.mark.parametrize(
+    "temperature, num_particles, max_depth, num_planning_iterations",
+    [
+        (0.0, 8, 4, 4),
+        (1.0, 0, 4, 4),
+        (1.0, 8, 0, 4),
+        (1.0, 8, 4, 0),
+    ],
+)
+def test_vopp_invalid_hyperparameters_raise(
+    temperature, num_particles, max_depth, num_planning_iterations
+):
+    """Test that non-positive hyperparameters are rejected at construction.
+
+    Purpose: Validates constructor guards on temperature, particle count,
+        depth, and iteration budget.
+
+    Given: A mock model and one non-positive hyperparameter
+    When: A planner is constructed with that value
+    Then: ``ValueError`` is raised
+
+    Test type: unit
+    """
+    model = MockGenerativeModel(torch.tensor([1.0, 0.0]), device=torch.device("cpu"))
+    with pytest.raises(ValueError):
+        VOPPPlanner(
+            model,
+            num_actions=2,
+            temperature=temperature,
+            num_particles=num_particles,
+            max_depth=max_depth,
+            num_planning_iterations=num_planning_iterations,
+        )
+
+
+def test_vopp_invalid_num_actions_raises():
+    """Test that a non-positive action count is rejected at construction.
+
+    Purpose: Validates the ``num_actions`` guard.
+
+    Given: A mock model
+    When: A planner is constructed with ``num_actions=0``
+    Then: ``ValueError`` is raised
+
+    Test type: unit
+    """
+    model = MockGenerativeModel(torch.tensor([1.0, 0.0]), device=torch.device("cpu"))
+    with pytest.raises(ValueError):
+        VOPPPlanner(model, num_actions=0)
+
+
+def test_vopp_rejects_non_2d_root_particles():
+    """Test that ``plan`` rejects a root belief that is not 2-D.
+
+    Purpose: Validates the root-particle shape guard.
+
+    Given: A VOPP planner and a 1-D root-particle tensor
+    When: ``plan`` is called with it
+    Then: ``ValueError`` is raised
+
+    Test type: unit
+    """
+    planner = _mock_planner(torch.tensor([1.0, 0.0]))
+    with pytest.raises(ValueError):
+        planner.plan(torch.zeros(8))
+
+
+def test_vopp_light_dark_moves_toward_goal():
+    """Test that VOPP prefers the action pointing toward the goal.
+
+    Purpose: Validates end-to-end planning on the real Continuous Light-Dark
+        vectorized model produces a sensible greedy action.
+
+    Given: A root belief concentrated to the left of the goal (goal at x=10)
+    When: The planner plans a step
+    Then: The greedy action is the +x move (action index 2) that reduces the
+        distance to the goal
+
+    Test type: integration
+    """
+    torch.manual_seed(0)
+    planner = _light_dark_planner()
+    root_particles = torch.tensor([[2.0, 5.0]]).repeat(512, 1)
+    action = planner.plan(root_particles)
+    assert action == 2
+
+
+def test_vopp_tree_metrics_report_expected_names_and_values():
+    """Test that tree metrics mirror the MCTS metric set after planning.
+
+    Purpose: Validates that :meth:`VOPPPlanner.tree_metrics` reports the same
+        analysis metrics the MCTS planners emit, with sensible values.
+
+    Given: A non-terminating mock model planned for a fixed budget
+    When: ``tree_metrics`` is queried after ``plan``
+    Then: The standard metric names are present, the root is not a leaf, the
+        root visit count equals particles times iterations, and the number of
+        root actions does not exceed the action set size
+
+    Test type: integration
+    """
+    torch.manual_seed(4)
+    planner = _mock_planner(
+        torch.tensor([1.0, 0.0, 0.0]), num_particles=128, num_planning_iterations=5
+    )
+    planner.plan(torch.zeros(128, 1))
+    metrics = {variable.name: variable.value for variable in planner.tree_metrics()}
+    for name in (
+        "min_actions_visit_count",
+        "max_actions_visit_count",
+        "actions_visit_count_entropy",
+        "n_actions_from_root",
+        "root_visit_count",
+        "tree_max_depth",
+        "is_leaf",
+    ):
+        assert name in metrics
+    assert metrics["is_leaf"] == 0
+    assert metrics["root_visit_count"] == 128 * 5
+    assert 0 < metrics["n_actions_from_root"] <= 3
+    assert metrics["tree_max_depth"] >= 1
+
+
+def test_vopp_tree_metrics_report_leaf_before_planning():
+    """Test that an unexpanded tree reports the leaf metric subset.
+
+    Purpose: Validates the leaf branch of the vectorized metric computation.
+
+    Given: A freshly constructed planner whose tree holds only the root
+    When: ``tree_metrics`` is queried before any planning
+    Then: ``is_leaf`` is 1 and the visit statistics are zero
+
+    Test type: unit
+    """
+    planner = _mock_planner(torch.tensor([1.0, 0.0, 0.0]))
+    metrics = {variable.name: variable.value for variable in planner.tree_metrics()}
+    assert metrics["is_leaf"] == 1
+    assert metrics["min_actions_visit_count"] == 0
+    assert metrics["max_actions_visit_count"] == 0
+
+
+def test_vopp_module_docstring_example():
+    """Test the runnable example from the module docstring.
+
+    Purpose: Validates that the documented usage example executes and returns a
+        valid action.
+
+    Given: The exact setup from the :mod:`vopp` module docstring
+    When: ``plan`` is called
+    Then: A valid in-range action index is returned
+
+    Test type: example
+    """
+    torch.manual_seed(0)
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, is_obstacle_hit_terminal=False)
+    model = ContinuousLightDarkVectorizedModel(env, device=torch.device("cpu"))
+    planner = VOPPPlanner(
+        model,
+        num_actions=model.num_actions,
+        num_particles=256,
+        max_depth=5,
+        num_planning_iterations=8,
+        discount_factor=0.95,
+    )
+    root_particles = torch.tensor([[2.0, 2.0]]).repeat(256, 1)
+    action = planner.plan(root_particles)
+    assert 0 <= action < model.num_actions

--- a/POMDPPlanners/tests/test_planners/test_vectorized_planners/test_vopp_episode_runner.py
+++ b/POMDPPlanners/tests/test_planners/test_vectorized_planners/test_vopp_episode_runner.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the VOPP closed-loop episode runner.
+
+The suite covers constructor validation, the recorded-trajectory bookkeeping,
+terminal-state handling, the ground-truth world-hook overrides, and an
+end-to-end integration run against the real Continuous Light-Dark vectorized
+model.
+"""
+
+import pytest
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp import (
+    ContinuousLightDarkPOMDP,
+)
+from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_vectorized_model import (
+    ContinuousLightDarkVectorizedModel,
+)
+from POMDPPlanners.planners.vectorized_planners import VOPPPlanner
+from POMDPPlanners.planners.vectorized_planners.vopp_episode_runner import (
+    VOPPEpisodeRunner,
+)
+
+
+class DriftModel:
+    """Deterministic 1-D model whose action 0 drifts the state toward a goal.
+
+    States are 1-D positions. Action 0 adds ``+1`` per step; a state is terminal
+    once it reaches ``goal``. Observations equal the next state. This makes an
+    episode's length and terminal step fully predictable.
+    """
+
+    def __init__(self, *, device: torch.device, goal: float = 3.0) -> None:
+        self._device = device
+        self._goal = goal
+        self.num_actions = 2
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        return states + (actions == 0).to(states.dtype).unsqueeze(1)
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions
+        return next_states.clone()
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        del states, actions
+        return next_states[:, 0].clone()
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        return states[:, 0] >= self._goal
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions
+        return -torch.abs(observations[:, 0] - next_states[:, 0])
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        return torch.floor(observations[:, 0]).to(torch.int64)
+
+
+def _drift_runner(
+    device: torch.device, *, num_belief_particles: int = 64, max_steps: int = 10
+) -> VOPPEpisodeRunner:
+    model = DriftModel(device=device)
+    planner = VOPPPlanner(
+        model,
+        num_actions=model.num_actions,
+        num_particles=64,
+        max_depth=4,
+        num_planning_iterations=4,
+    )
+    return VOPPEpisodeRunner(
+        planner, model, num_belief_particles=num_belief_particles, max_steps=max_steps
+    )
+
+
+@pytest.mark.parametrize("num_belief_particles, max_steps", [(0, 5), (16, 0)])
+def test_runner_rejects_non_positive_configuration(num_belief_particles, max_steps):
+    """Test that non-positive runner configuration is rejected.
+
+    Purpose: Validates the constructor guards on particle count and step budget.
+
+    Given: A valid planner/model and one non-positive configuration value
+    When: A runner is constructed with that value
+    Then: ``ValueError`` is raised
+
+    Test type: unit
+    """
+    device = torch.device("cpu")
+    model = DriftModel(device=device)
+    planner = VOPPPlanner(model, num_actions=model.num_actions)
+    with pytest.raises(ValueError):
+        VOPPEpisodeRunner(
+            planner,
+            model,
+            num_belief_particles=num_belief_particles,
+            max_steps=max_steps,
+        )
+
+
+def test_runner_rejects_non_single_initial_state():
+    """Test that a non-single initial state is rejected.
+
+    Purpose: Validates the initial-state shape guard.
+
+    Given: A runner and a two-row initial-state tensor
+    When: ``run_episode`` is called with it
+    Then: ``ValueError`` is raised
+
+    Test type: unit
+    """
+    runner = _drift_runner(torch.device("cpu"))
+    with pytest.raises(ValueError):
+        runner.run_episode(torch.zeros(2, 1))
+
+
+def test_runner_records_consistent_trajectory_lengths():
+    """Test that the recorded trajectory has internally consistent lengths.
+
+    Purpose: Validates the per-step bookkeeping of the episode result.
+
+    Given: A deterministic drift model and a single-state root belief
+    When: An episode is run
+    Then: There is one more state than actions, and beliefs / rewards /
+        plan-times / root-visit-counts all match the number of actions
+
+    Test type: integration
+    """
+    torch.manual_seed(0)
+    runner = _drift_runner(torch.device("cpu"))
+    result = runner.run_episode(torch.zeros(1, 1))
+    steps = result.num_steps
+    assert len(result.states) == steps + 1
+    assert len(result.beliefs) == steps
+    assert len(result.rewards) == steps
+    assert len(result.plan_times) == steps
+    assert len(result.root_visit_counts) == steps
+
+
+def test_runner_reaches_terminal_state():
+    """Test that reaching a terminal world state ends the episode as a goal.
+
+    Purpose: Validates terminal detection and the ``reached_goal`` flag,
+        independent of planner optimality.
+
+    Given: A world transition that deterministically advances the true state by
+        ``+1`` each step, reaching the goal at 3.0 on the third step
+    When: An episode is run from the origin with a generous step budget
+    Then: The episode reaches the goal in exactly three steps and the final
+        recorded state is at the goal
+
+    Test type: integration
+    """
+    device = torch.device("cpu")
+    model = DriftModel(device=device)
+    planner = VOPPPlanner(model, num_actions=model.num_actions, num_planning_iterations=2)
+
+    def world_transition(states: Tensor, actions: Tensor) -> Tensor:
+        del actions
+        return states + 1.0
+
+    runner = VOPPEpisodeRunner(
+        planner, model, num_belief_particles=32, max_steps=10, world_transition=world_transition
+    )
+    torch.manual_seed(0)
+    result = runner.run_episode(torch.zeros(1, 1))
+    assert result.reached_goal
+    assert result.num_steps == 3
+    assert float(result.states[-1][0]) == pytest.approx(3.0)
+
+
+def test_runner_honors_world_hooks():
+    """Test that injected world hooks override the ground-truth dynamics.
+
+    Purpose: Validates that ``world_transition`` / ``world_observation`` replace
+        the model's default dynamics for the ground-truth rollout.
+
+    Given: A world transition that always advances the true state by ``+5``
+    When: An episode is run for a single step
+    Then: The realised next true state reflects the injected ``+5`` transition
+        rather than the model's ``+1`` drift
+
+    Test type: unit
+    """
+    device = torch.device("cpu")
+    model = DriftModel(device=device)
+    planner = VOPPPlanner(model, num_actions=model.num_actions, num_planning_iterations=2)
+
+    def world_transition(states: Tensor, actions: Tensor) -> Tensor:
+        del actions
+        return states + 5.0
+
+    runner = VOPPEpisodeRunner(
+        planner,
+        model,
+        num_belief_particles=32,
+        max_steps=1,
+        world_transition=world_transition,
+    )
+    torch.manual_seed(0)
+    result = runner.run_episode(torch.zeros(1, 1))
+    assert float(result.states[-1][0]) == pytest.approx(5.0)
+
+
+class DegenerateObservationModel(DriftModel):
+    """Drift model whose observation likelihood is ``-inf`` for every particle.
+
+    Reproduces the total-degeneracy case where no particle explains the
+    observation, which must not crash the SIR belief filter.
+    """
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions, observations
+        return torch.full((next_states.shape[0],), float("-inf"), device=next_states.device)
+
+
+def test_filter_belief_survives_all_zero_likelihood():
+    """Test that the SIR filter falls back to uniform on total degeneracy.
+
+    Purpose: Validates that an observation with zero likelihood under every
+        particle resamples uniformly instead of producing NaN weights.
+
+    Given: A model whose observation log-probs are all ``-inf``
+    When: An episode is run for several steps
+    Then: The episode completes without error and every belief keeps the
+        configured particle count and stays finite
+
+    Test type: unit
+    """
+    device = torch.device("cpu")
+    model = DegenerateObservationModel(device=device)
+    planner = VOPPPlanner(model, num_actions=model.num_actions, num_planning_iterations=2)
+    runner = VOPPEpisodeRunner(planner, model, num_belief_particles=32, max_steps=4)
+    torch.manual_seed(0)
+    result = runner.run_episode(torch.zeros(1, 1))
+    assert result.num_steps >= 1
+    assert all(bool(torch.isfinite(belief).all()) for belief in result.beliefs)
+    assert all(belief.shape == (32, 1) for belief in result.beliefs)
+
+
+def test_runner_light_dark_end_to_end_reaches_goal():
+    """Test an end-to-end VOPP episode on the real light-dark vectorized model.
+
+    Purpose: Validates that the runner drives a full closed-loop episode on the
+        real Continuous Light-Dark vectorized model and reaches the goal.
+
+    Given: The light-dark vectorized model and a start belief at ``(0, 5)``
+    When: A VOPP episode is run with a modest planning budget
+    Then: The episode reaches the goal and every belief carries the configured
+        number of particles
+
+    Test type: integration
+    """
+    torch.manual_seed(0)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    env = ContinuousLightDarkPOMDP(discount_factor=0.95, is_obstacle_hit_terminal=False)
+    model = ContinuousLightDarkVectorizedModel(env, device=device)
+    planner = VOPPPlanner(
+        model,
+        num_actions=model.num_actions,
+        num_particles=256,
+        max_depth=10,
+        num_planning_iterations=16,
+    )
+    runner = VOPPEpisodeRunner(planner, model, num_belief_particles=256, max_steps=40)
+    result = runner.run_episode(torch.tensor([[0.0, 5.0]]))
+    assert result.reached_goal
+    assert all(belief.shape == (256, 2) for belief in result.beliefs)

--- a/POMDPPlanners/utils/tree_statistics.py
+++ b/POMDPPlanners/utils/tree_statistics.py
@@ -4,11 +4,13 @@ from enum import Enum
 from typing import List
 
 import numpy as np
+import torch
 from scipy.stats import entropy
 
 from POMDPPlanners.core.policy import PolicyInfoVariable
 from POMDPPlanners.core.tree import ActionNode, BeliefNode
 from POMDPPlanners.core.tree.arena import Tree
+from POMDPPlanners.core.tree.vectorized_belief_tree import VectorizedBeliefTree
 
 
 class TreeMetrics(Enum):
@@ -194,6 +196,86 @@ def compute_tree_metrics(tree: BeliefNode) -> List[PolicyInfoVariable]:
     ]
 
 
+def _leaf_tree_metrics() -> List[PolicyInfoVariable]:
+    return [
+        PolicyInfoVariable(name=TreeMetrics.MIN_ACTIONS_VISIT_COUNT.value, value=0),
+        PolicyInfoVariable(name=TreeMetrics.MAX_ACTIONS_VISIT_COUNT.value, value=0),
+        PolicyInfoVariable(name=TreeMetrics.ACTIONS_VISIT_COUNT_ENTROPY.value, value=0),
+        PolicyInfoVariable(name=TreeMetrics.IS_LEAF.value, value=1),
+    ]
+
+
+def compute_vectorized_tree_metrics(tree: VectorizedBeliefTree) -> List[PolicyInfoVariable]:
+    """Compute root-tree statistics for a flat-tensor belief tree.
+
+    Produces the same :class:`TreeMetrics` set as :func:`compute_tree_metrics`
+    and :func:`compute_arena_tree_metrics`, so a vectorized planner (VOPP /
+    PORPP) is directly comparable to the MCTS planners. The metrics summarise
+    the root belief's action children: their visit counts drive the
+    min / max / entropy statistics, while the root visit count is the total of
+    those action visits and the max depth is the deepest belief-node depth.
+
+    Args:
+        tree: The belief tree built by a vectorized planning run.
+
+    Returns:
+        List of :class:`PolicyInfoVariable` holding the computed metrics. When
+        the root has no expanded actions, a leaf-marked subset is returned
+        (mirroring the MCTS variants).
+    """
+    root = tree.root_index
+    num_actions = tree.num_action_nodes
+    root_action_ids = _root_action_ids(tree, root, num_actions)
+    if root_action_ids.numel() == 0:
+        return _leaf_tree_metrics()
+
+    visit_counts = tree.action_visit_count[root_action_ids].cpu().numpy()
+    total_visits = int(visit_counts.sum())
+    if total_visits > 0:
+        entropy_value = float(entropy(visit_counts / total_visits, base=2))
+    else:
+        entropy_value = 0.0
+    max_depth = int(tree.belief_depth[: tree.num_belief_nodes].max().item())
+
+    return [
+        PolicyInfoVariable(
+            name=TreeMetrics.MIN_ACTIONS_VISIT_COUNT.value,
+            value=int(np.min(visit_counts)),
+        ),
+        PolicyInfoVariable(
+            name=TreeMetrics.MAX_ACTIONS_VISIT_COUNT.value,
+            value=int(np.max(visit_counts)),
+        ),
+        PolicyInfoVariable(
+            name=TreeMetrics.ACTIONS_VISIT_COUNT_ENTROPY.value,
+            value=entropy_value,
+        ),
+        PolicyInfoVariable(
+            name=TreeMetrics.N_ACTIONS_FROM_ROOT.value,
+            value=int(visit_counts.shape[0]),
+        ),
+        PolicyInfoVariable(
+            name=TreeMetrics.ROOT_VISIT_COUNT.value,
+            value=total_visits,
+        ),
+        PolicyInfoVariable(
+            name=TreeMetrics.TREE_MAX_DEPTH.value,
+            value=max_depth,
+        ),
+        PolicyInfoVariable(
+            name=TreeMetrics.IS_LEAF.value,
+            value=0,
+        ),
+    ]
+
+
+def _root_action_ids(tree: VectorizedBeliefTree, root: int, num_actions: int) -> torch.Tensor:
+    if num_actions == 0:
+        return torch.empty(0, dtype=torch.int64, device=tree.device)
+    parents = tree.action_parent_belief[:num_actions]
+    return torch.nonzero(parents == root, as_tuple=False).flatten()
+
+
 def compute_arena_tree_metrics(tree: Tree, root_id: int) -> List[PolicyInfoVariable]:
     """Arena variant of :func:`compute_tree_metrics`.
 
@@ -224,8 +306,7 @@ def compute_arena_tree_metrics(tree: Tree, root_id: int) -> List[PolicyInfoVaria
     frontier = [(root_id, 0)]
     while frontier:
         node_id, depth = frontier.pop()
-        if depth > max_depth:
-            max_depth = depth
+        max_depth = max(max_depth, depth)
         for cid in tree.children_ids[node_id]:
             frontier.append((cid, depth + 1))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,7 @@ ignore-imports = false
 # the binary is missing.
 ignored-modules = [
     "numpy",
+    "torch",
     "cvxopt",
     "carla",
     "nuplan",


### PR DESCRIPTION
## Summary

Adds the **Vectorized Online POMDP Planner (VOPP / PORPP)** and the batched, on-device generative models it searches on the GPU.

- **core** — `VectorizedGenerativeModel` protocol (batched `G(S,A)` kernels).
- **planners** — `VOPPPlanner` (softmax-preference forward search + log-sum-exp preference backup, fully vectorized) and `VOPPEpisodeRunner` (closed-loop SIR episode driver with optional real-simulator world hooks).
- **environments** — a torch `VectorizedGenerativeModel` **+ native-parity test** for each of: light-dark, tiger, sanity, rocksample, pacman, lasertag, cartpole, mountaincar, push, safety-ant-velocity, **carla** (kinematic), and **isaac-lab** (linear-Gaussian surrogate).
- **utils** — `compute_vectorized_tree_metrics` for the flat-tensor belief tree (same metric set as the MCTS planners).

This PR is library-only: the demo / example / analysis scripts used to produce the results below are intentionally **not** included.

## Results (produced locally, not in this PR)

- **Light-Dark iteration analysis** — goal-reaching rate rises 0.10 → 1.00 once planning iterations ≥ 8; planning time scales ~linearly with the iteration budget (recorded with #simulations/step, ms/step, goal-rate, plus a goal-reaching session gif).
- **CARLA session** — VOPP drives in Town02 (real CARLA 0.9.16 world; VOPP plans on the torch kinematic model, CARLA's particle belief filters).
- **Isaac Sim session** — VOPP on the Unitree-Go2 flat-velocity task (real Isaac Lab world; linear-Gaussian surrogate + SIR belief filter).

## Testing

- Whole-tree `pyright POMDPPlanners/`: **0 errors, 0 warnings**.
- `pylint`: **10.00/10** on all new source and tests (pre-commit black/pylint/pyright hooks pass).
- Vectorized planner suite (63 tests) + per-environment parity suites (310 tests) pass.

## Codex review

`codex exec review` over the diff. One finding fixed here: the SIR belief filter now falls back to uniform resampling when every particle assigns zero observation-likelihood (with a regression test). One latent finding documented: a `value_heuristic` accounting mismatch that only affects a **nonzero** leaf heuristic — the default zero-heuristic path (used by all results above) is unaffected.