### PR TITLE
feat(carla): headless server pool for parallel episode simulation

### DIFF
--- a/POMDPPlanners/environments/carla_pomdp/__init__.py
+++ b/POMDPPlanners/environments/carla_pomdp/__init__.py
@@ -13,9 +13,16 @@ Classes:
     DreamerCarlaModelPOMDP: Concrete CARLA model backed by a Dreamer world model.
     PerceivedAgentsBelief: Particle belief that stamps the perception pipeline's agent block.
     CarlaPerceptionPipeline: Standalone, swappable perception + prediction stage.
+    CarlaServerPool: Context manager owning N headless CARLA servers for parallel episodes.
+    CarlaServerLease: Connection endpoints of one leased pool server.
 """
 
 from POMDPPlanners.environments.carla_pomdp.carla_pomdp import CarlaPOMDP
+from POMDPPlanners.environments.carla_pomdp.carla_server_pool import (
+    CarlaServerLease,
+    CarlaServerPool,
+    acquire_pool_lease,
+)
 from POMDPPlanners.environments.carla_pomdp.carla_belief import PerceivedAgentsBelief
 from POMDPPlanners.environments.carla_pomdp.carla_perception import (
     CarlaPerceptionPipeline,
@@ -41,4 +48,7 @@ __all__ = [
     "MotionTracker",
     "LidarCameraPerceptionModel",
     "OracleAgentPerceptionModel",
+    "CarlaServerPool",
+    "CarlaServerLease",
+    "acquire_pool_lease",
 ]

--- a/POMDPPlanners/environments/carla_pomdp/carla_pomdp.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_pomdp.py
@@ -94,13 +94,14 @@ from collections.abc import Hashable
 from enum import Enum
 from pathlib import Path
 from queue import Queue
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import numpy as np
 
 from POMDPPlanners.core.distributions import Distribution
 from POMDPPlanners.core.environment import Environment, SpaceInfo, SpaceType
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.environments.carla_pomdp.carla_server_pool import acquire_pool_lease
 from POMDPPlanners.utils.statistics_utils import confidence_interval
 
 # Default discrete control presets as ``(throttle, steer, brake)`` triples.
@@ -855,6 +856,7 @@ class CarlaPOMDP(Environment):
         num_walkers: int = DEFAULT_NUM_WALKERS,
         max_tracked_agents: int = DEFAULT_MAX_TRACKED_AGENTS,
         traffic_manager_port: int = DEFAULT_TRAFFIC_MANAGER_PORT,
+        server_pool_dir: Optional[Union[str, Path]] = None,
         randomize_spawn: bool = True,
         observation_extractor: Optional[Callable[[Dict[str, np.ndarray]], Any]] = None,
         vehicle_filter: str = "vehicle.tesla.model3",
@@ -910,6 +912,12 @@ class CarlaPOMDP(Environment):
                 :data:`DEFAULT_MAX_TRACKED_AGENTS`.
             traffic_manager_port: CARLA Traffic Manager RPC port used to drive the
                 traffic vehicles. Defaults to :data:`DEFAULT_TRAFFIC_MANAGER_PORT`.
+            server_pool_dir: Optional directory of a
+                :class:`~POMDPPlanners.environments.carla_pomdp.carla_server_pool.CarlaServerPool`.
+                When set, ``host``/``port``/``traffic_manager_port`` are overridden
+                by a per-process server lease acquired lazily on first session
+                build, so parallel workers each connect to their own pool server.
+                The pool must outlive the environment. Defaults to None.
             randomize_spawn: If True, sample a random ego spawn point (and weather)
                 each reset instead of a fixed one. Defaults to True.
             observation_extractor: Optional callable applied to the full
@@ -957,6 +965,7 @@ class CarlaPOMDP(Environment):
         self.num_walkers = num_walkers
         self.max_tracked_agents = max_tracked_agents
         self.traffic_manager_port = traffic_manager_port
+        self.server_pool_dir = str(server_pool_dir) if server_pool_dir is not None else None
         self.randomize_spawn = randomize_spawn
         self.observation_extractor = observation_extractor
         self.vehicle_filter = vehicle_filter
@@ -1013,11 +1022,20 @@ class CarlaPOMDP(Environment):
         self._served_roles = set()
 
     # ── Live simulator management ───────────────────────────────────────
+    def _resolve_connection(self) -> Tuple[str, int, int]:
+        # Without a pool the static endpoints apply; with one, this process's
+        # lease (acquired once, cached for the process lifetime) overrides them.
+        if self.server_pool_dir is None:
+            return self.host, self.port, self.traffic_manager_port
+        lease = acquire_pool_lease(self.server_pool_dir)
+        return lease.host, lease.rpc_port, lease.traffic_manager_port
+
     def _get_session(self) -> Any:
         if self._session is None:
+            host, port, traffic_manager_port = self._resolve_connection()
             self._session = _CarlaSession(
-                host=self.host,
-                port=self.port,
+                host=host,
+                port=port,
                 town=self.town,
                 fixed_delta_seconds=self.fixed_delta_seconds,
                 sensor_config=self.sensor_config,
@@ -1033,7 +1051,7 @@ class CarlaPOMDP(Environment):
                 num_vehicles=self.num_vehicles,
                 num_walkers=self.num_walkers,
                 max_tracked_agents=self.max_tracked_agents,
-                traffic_manager_port=self.traffic_manager_port,
+                traffic_manager_port=traffic_manager_port,
                 randomize_spawn=self.randomize_spawn,
                 observation_extractor=self.observation_extractor,
             )

--- a/POMDPPlanners/environments/carla_pomdp/carla_server_pool.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_server_pool.py
@@ -1,0 +1,544 @@
+# SPDX-License-Identifier: MIT
+
+"""Headless CARLA server pool for parallel episode simulation.
+
+A single CARLA server serves one client at a time, so parallel episode execution
+(e.g. :class:`~POMDPPlanners.simulations.simulations_deployment.task_managers.JoblibTaskManager`
+with ``n_jobs > 1``) needs one server per worker process. This module provides:
+
+- :class:`CarlaServerPool` — a context manager that launches ``n_servers`` headless
+  CARLA servers (``CarlaUE4.sh -RenderOffScreen -nosound -carla-rpc-port=<port>``),
+  each on its own RPC port, and terminates them on exit.
+- :func:`acquire_pool_lease` — the worker-side counterpart: a process claims exactly
+  one server from the pool via an ``flock``-based lease and reuses it for the
+  lifetime of the process.
+
+Pool directory layout (written by :meth:`CarlaServerPool.start`):
+
+- ``pool.json`` — the pool spec: host and per-server ``rpc_port`` /
+  ``traffic_manager_port`` / lease-file name.
+- ``server_<i>.lease`` — one lock file per server. A worker holds a server by
+  holding an exclusive ``flock`` on its lease file; the kernel releases the lock
+  automatically when the worker process dies, so a recycled joblib worker frees
+  its server for the replacement worker.
+- ``server_<i>.log`` — each server's combined stdout/stderr, for diagnosing
+  startup failures.
+
+Wiring into the episode loop is transparent: pass ``server_pool_dir=pool.pool_dir``
+to :class:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp.CarlaPOMDP` and its
+lazily-built session resolves its connection ports from the per-process lease
+instead of the static ``host``/``port``/``traffic_manager_port``.
+
+Limitation: the lease is per *process*, so all CARLA environments in one worker
+process that share a pool directory share one server. This matches the simulator's
+one-world-per-episode design.
+
+Classes:
+    CarlaServerLease: Connection endpoints of one leased pool server.
+    CarlaServerHandle: One spawned headless CARLA server subprocess.
+    CarlaServerPool: Context manager owning N headless CARLA servers.
+
+Example:
+    Launch four headless servers and run parallel episodes against them
+    (illustrative — requires a CARLA installation at ``$CARLA_ROOT``)::
+
+        from POMDPPlanners.environments.carla_pomdp import CarlaPOMDP, CarlaServerPool
+
+        with CarlaServerPool(n_servers=4) as pool:
+            env = CarlaPOMDP(discount_factor=0.95, server_pool_dir=pool.pool_dir)
+            # Hand ``env`` to POMDPSimulator with JoblibConfig(n_jobs=4); each
+            # joblib worker process leases its own server on first connection.
+
+    Or manage a long-lived pool manually from the command line::
+
+        python -m POMDPPlanners.environments.carla_pomdp.carla_server_pool --n-servers 4
+"""
+
+import argparse
+import atexit
+import fcntl
+import json
+import os
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+# Each CARLA server claims its RPC port plus the next two (streaming and secondary
+# server), so consecutive servers must be spaced at least 3 ports apart.
+RPC_PORT_STRIDE = 4
+DEFAULT_RPC_PORT_BASE = 2000
+DEFAULT_TM_PORT_BASE = 8000
+DEFAULT_READY_TIMEOUT_SECONDS = 120.0
+POOL_SPEC_FILENAME = "pool.json"
+
+# Builds the server launch argv from (rpc_port, traffic_manager_port, gpu_index).
+CommandFactory = Callable[[int, int, Optional[int]], List[str]]
+
+# Per-process lease cache, keyed by resolved pool directory. The lock fd is kept
+# open for the process lifetime; the kernel releases the flock on process death.
+_PROCESS_LEASES: Dict[str, "CarlaServerLease"] = {}
+_PROCESS_LEASE_FDS: Dict[str, int] = {}
+
+
+@dataclass(frozen=True)
+class CarlaServerLease:
+    """Connection endpoints of one leased pool server.
+
+    Attributes:
+        host: Hostname the pool's servers listen on.
+        rpc_port: CARLA RPC port of the leased server.
+        traffic_manager_port: Client-side Traffic Manager port reserved for the
+            lease holder (unique per server so parallel clients never collide).
+    """
+
+    host: str
+    rpc_port: int
+    traffic_manager_port: int
+
+
+class CarlaServerHandle:
+    """One spawned headless CARLA server subprocess.
+
+    Owns the process for its lifetime: readiness polling on the RPC port and
+    process-group termination. Instances are created by :class:`CarlaServerPool`.
+
+    Attributes:
+        process: The spawned server subprocess (its own session/process group).
+        rpc_port: RPC port the server was asked to listen on.
+        traffic_manager_port: Traffic Manager port reserved for this server's client.
+        log_path: File receiving the server's combined stdout/stderr.
+        gpu_index: GPU the server was pinned to, or ``None``.
+    """
+
+    def __init__(
+        self,
+        process: "subprocess.Popen[bytes]",
+        rpc_port: int,
+        traffic_manager_port: int,
+        log_path: Path,
+        gpu_index: Optional[int] = None,
+    ) -> None:
+        self.process = process
+        self.rpc_port = rpc_port
+        self.traffic_manager_port = traffic_manager_port
+        self.log_path = log_path
+        self.gpu_index = gpu_index
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the server process is still alive."""
+        return self.process.poll() is None
+
+    def wait_until_ready(self, timeout: float = DEFAULT_READY_TIMEOUT_SECONDS) -> None:
+        """Block until the server accepts TCP connections on its RPC port.
+
+        Args:
+            timeout: Maximum seconds to wait.
+
+        Raises:
+            RuntimeError: If the server process exits before becoming ready.
+            TimeoutError: If the port is not accepting connections within ``timeout``.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if not self.is_running:
+                raise RuntimeError(
+                    f"CARLA server on port {self.rpc_port} exited with code "
+                    f"{self.process.returncode} before becoming ready; see "
+                    f"{self.log_path}:\n{self._log_tail()}"
+                )
+            if self._rpc_port_accepts_connection():
+                return
+            time.sleep(1.0)
+        raise TimeoutError(
+            f"CARLA server on port {self.rpc_port} not ready after {timeout:.0f}s; "
+            f"see {self.log_path}:\n{self._log_tail()}"
+        )
+
+    def terminate(self, grace_seconds: float = 10.0) -> None:
+        """Terminate the server's process group (SIGTERM, then SIGKILL).
+
+        Args:
+            grace_seconds: Seconds to wait after SIGTERM before escalating.
+        """
+        if not self.is_running:
+            return
+        if not self._signal_process_group(signal.SIGTERM):
+            return
+        try:
+            self.process.wait(timeout=grace_seconds)
+        except subprocess.TimeoutExpired:
+            self._signal_process_group(signal.SIGKILL)
+            self.process.wait()
+
+    def _rpc_port_accepts_connection(self) -> bool:
+        try:
+            with socket.create_connection(("127.0.0.1", self.rpc_port), timeout=1.0):
+                return True
+        except OSError:
+            return False
+
+    def _signal_process_group(self, signum: int) -> bool:
+        # The launch script spawns the UE4 binary as a child, so signal the whole
+        # group (the server runs in its own session, see CarlaServerPool).
+        try:
+            os.killpg(self.process.pid, signum)
+            return True
+        except ProcessLookupError:
+            return False
+
+    def _log_tail(self, max_lines: int = 20) -> str:
+        try:
+            lines = self.log_path.read_text(errors="replace").splitlines()
+        except OSError:
+            return "<log unavailable>"
+        return "\n".join(lines[-max_lines:])
+
+
+class CarlaServerPool:
+    """Context manager owning N headless CARLA servers plus their lease directory.
+
+    On :meth:`start` (or ``with`` entry) it spawns ``n_servers`` headless CARLA
+    servers — RPC ports ``rpc_port_base + RPC_PORT_STRIDE * i``, Traffic Manager
+    ports ``tm_port_base + i`` — writes the pool spec and lease files into
+    ``pool_dir``, and waits for every server to accept connections. On
+    :meth:`shutdown` (or ``with`` exit, or interpreter exit) it terminates them.
+
+    Worker processes claim a server with :func:`acquire_pool_lease`, or
+    transparently by constructing
+    :class:`~POMDPPlanners.environments.carla_pomdp.carla_pomdp.CarlaPOMDP` with
+    ``server_pool_dir=pool.pool_dir``. Run at most ``n_servers`` workers (e.g.
+    ``JoblibConfig(n_jobs=n_servers)`` — the default ``n_jobs=-1`` uses all cores
+    and will exhaust the pool).
+
+    Attributes:
+        n_servers: Number of servers the pool launches.
+        handles: Live :class:`CarlaServerHandle` objects (empty until started).
+
+    Example:
+        Illustrative — requires a CARLA installation at ``$CARLA_ROOT``::
+
+            with CarlaServerPool(n_servers=2, gpu_indices=[0, 1]) as pool:
+                env = CarlaPOMDP(discount_factor=0.95, server_pool_dir=pool.pool_dir)
+    """
+
+    def __init__(
+        self,
+        n_servers: int,
+        pool_dir: Optional[Union[str, Path]] = None,
+        carla_root: Optional[Union[str, Path]] = None,
+        rpc_port_base: int = DEFAULT_RPC_PORT_BASE,
+        tm_port_base: int = DEFAULT_TM_PORT_BASE,
+        gpu_indices: Optional[Sequence[int]] = None,
+        extra_args: Optional[Sequence[str]] = None,
+        ready_timeout: float = DEFAULT_READY_TIMEOUT_SECONDS,
+        command_factory: Optional[CommandFactory] = None,
+    ) -> None:
+        """Configure a pool (no servers are launched until :meth:`start`).
+
+        Args:
+            n_servers: Number of headless servers to launch.
+            pool_dir: Directory for the spec/lease/log files. Defaults to a fresh
+                temporary directory.
+            carla_root: CARLA installation directory containing ``CarlaUE4.sh``.
+                Defaults to the ``CARLA_ROOT`` environment variable. Only used by
+                the default launch command; ignored when ``command_factory`` is given.
+            rpc_port_base: RPC port of server 0; server ``i`` gets
+                ``rpc_port_base + RPC_PORT_STRIDE * i``.
+            tm_port_base: Traffic Manager port of server 0; server ``i`` gets
+                ``tm_port_base + i``.
+            gpu_indices: GPUs to pin servers to (``-graphicsadapter=<gpu>``),
+                cycled across servers. ``None`` leaves GPU selection to CARLA.
+            extra_args: Extra CLI arguments appended to the default launch command.
+            ready_timeout: Seconds to wait for each server to accept connections.
+            command_factory: Override for the launch command; called with
+                ``(rpc_port, traffic_manager_port, gpu_index)`` and must return the
+                argv to spawn. Intended for tests and non-standard installs.
+
+        Raises:
+            ValueError: If ``n_servers`` is not positive.
+        """
+        if n_servers <= 0:
+            raise ValueError(f"n_servers must be positive, got {n_servers}")
+        self.n_servers = n_servers
+        self.handles: List[CarlaServerHandle] = []
+        self._pool_dir = Path(pool_dir) if pool_dir is not None else None
+        self._carla_root = Path(carla_root) if carla_root is not None else None
+        self._rpc_port_base = rpc_port_base
+        self._tm_port_base = tm_port_base
+        self._gpu_indices = list(gpu_indices) if gpu_indices is not None else None
+        self._extra_args = list(extra_args) if extra_args is not None else []
+        self._ready_timeout = ready_timeout
+        self._command_factory = command_factory
+        self._owner_pid: Optional[int] = None
+
+    @property
+    def pool_dir(self) -> Path:
+        """The pool directory holding the spec, lease, and log files.
+
+        Raises:
+            RuntimeError: If accessed before :meth:`start` and no explicit
+                ``pool_dir`` was configured.
+        """
+        if self._pool_dir is None:
+            raise RuntimeError("Pool directory is allocated on start(); call start() first.")
+        return self._pool_dir
+
+    def start(self) -> "CarlaServerPool":
+        """Launch all servers, write the pool spec, and wait until every one is ready.
+
+        Launches every server first so their (slow) startups overlap, then blocks
+        on readiness. On any failure the already-launched servers are terminated
+        before the error propagates.
+
+        Returns:
+            This pool, for chaining.
+
+        Raises:
+            RuntimeError: If a server process exits before becoming ready.
+            TimeoutError: If a server is not ready within ``ready_timeout``.
+        """
+        if self._pool_dir is None:
+            self._pool_dir = Path(tempfile.mkdtemp(prefix="carla_pool_"))
+        self._pool_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self.handles = [self._launch_server(index) for index in range(self.n_servers)]
+            self._write_pool_spec()
+            for handle in self.handles:
+                handle.wait_until_ready(timeout=self._ready_timeout)
+        except BaseException:
+            self.shutdown()
+            raise
+        self._owner_pid = os.getpid()
+        atexit.register(self._atexit_shutdown)
+        return self
+
+    def shutdown(self) -> None:
+        """Terminate every server in the pool. Idempotent."""
+        for handle in self.handles:
+            handle.terminate()
+        self.handles = []
+
+    def __enter__(self) -> "CarlaServerPool":
+        return self.start()
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        del exc_type, exc_value, traceback
+        self.shutdown()
+
+    def _rpc_port(self, index: int) -> int:
+        return self._rpc_port_base + RPC_PORT_STRIDE * index
+
+    def _tm_port(self, index: int) -> int:
+        return self._tm_port_base + index
+
+    def _gpu_index(self, index: int) -> Optional[int]:
+        if not self._gpu_indices:
+            return None
+        return self._gpu_indices[index % len(self._gpu_indices)]
+
+    def _build_command(self, index: int) -> List[str]:
+        rpc_port, tm_port, gpu = self._rpc_port(index), self._tm_port(index), self._gpu_index(index)
+        if self._command_factory is not None:
+            return self._command_factory(rpc_port, tm_port, gpu)
+        return self._default_command(rpc_port, gpu)
+
+    def _default_command(self, rpc_port: int, gpu_index: Optional[int]) -> List[str]:
+        carla_root = self._carla_root
+        if carla_root is None:
+            carla_root_env = os.environ.get("CARLA_ROOT")
+            if carla_root_env is None:
+                raise RuntimeError(
+                    "CARLA installation not found: pass carla_root= or set the "
+                    "CARLA_ROOT environment variable to the directory containing "
+                    "CarlaUE4.sh."
+                )
+            carla_root = Path(carla_root_env)
+        command = [
+            str(carla_root / "CarlaUE4.sh"),
+            "-RenderOffScreen",
+            "-nosound",
+            f"-carla-rpc-port={rpc_port}",
+        ]
+        if gpu_index is not None:
+            command.append(f"-graphicsadapter={gpu_index}")
+        command.extend(self._extra_args)
+        return command
+
+    def _launch_server(self, index: int) -> CarlaServerHandle:
+        command = self._build_command(index)
+        log_path = self.pool_dir / f"server_{index}.log"
+        with open(log_path, "wb") as log_file:
+            # The handle owns the process; start_new_session puts the launch
+            # script and the UE4 binary it spawns into one killable group.
+            process = subprocess.Popen(  # pylint: disable=consider-using-with
+                command,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+        return CarlaServerHandle(
+            process=process,
+            rpc_port=self._rpc_port(index),
+            traffic_manager_port=self._tm_port(index),
+            log_path=log_path,
+            gpu_index=self._gpu_index(index),
+        )
+
+    def _write_pool_spec(self) -> None:
+        servers = []
+        for index, handle in enumerate(self.handles):
+            lease_file = f"server_{index}.lease"
+            (self.pool_dir / lease_file).touch()
+            servers.append(
+                {
+                    "index": index,
+                    "rpc_port": handle.rpc_port,
+                    "traffic_manager_port": handle.traffic_manager_port,
+                    "lease_file": lease_file,
+                }
+            )
+        spec = {"host": "127.0.0.1", "servers": servers}
+        (self.pool_dir / POOL_SPEC_FILENAME).write_text(json.dumps(spec, indent=2))
+
+    def _atexit_shutdown(self) -> None:
+        # Guard so forked/spawned children that inherited this object never kill
+        # the launcher's servers.
+        if self._owner_pid == os.getpid():
+            self.shutdown()
+
+
+def acquire_pool_lease(pool_dir: Union[str, Path]) -> CarlaServerLease:
+    """Claim one server from a :class:`CarlaServerPool` for the current process.
+
+    The first call locks a free server's lease file (exclusive non-blocking
+    ``flock``) and caches the result; subsequent calls from the same process with
+    the same pool directory return the cached lease. The lock is held for the
+    process lifetime and released by the kernel when the process exits, so a
+    recycled worker's server returns to the pool automatically.
+
+    Args:
+        pool_dir: Directory written by :meth:`CarlaServerPool.start`.
+
+    Returns:
+        The leased server's connection endpoints.
+
+    Raises:
+        FileNotFoundError: If ``pool_dir`` does not contain a pool spec.
+        RuntimeError: If every server in the pool is already leased by another
+            process (run at most ``n_servers`` workers).
+    """
+    key = str(Path(pool_dir).resolve())
+    if key in _PROCESS_LEASES:
+        return _PROCESS_LEASES[key]
+    spec = _read_pool_spec(Path(key))
+    lease_and_fd = _lease_first_free_server(Path(key), spec)
+    if lease_and_fd is None:
+        n_servers = len(spec["servers"])
+        raise RuntimeError(
+            f"All {n_servers} CARLA server(s) in the pool at {key} are already "
+            f"leased by other processes. Run at most {n_servers} parallel workers "
+            f"(e.g. JoblibConfig(n_jobs={n_servers}) — the default n_jobs=-1 uses "
+            f"all cores), or start a larger CarlaServerPool."
+        )
+    lease, fd = lease_and_fd
+    _PROCESS_LEASES[key] = lease
+    _PROCESS_LEASE_FDS[key] = fd
+    return lease
+
+
+def _lease_first_free_server(
+    pool_dir: Path, spec: Dict[str, Any]
+) -> Optional[Tuple[CarlaServerLease, int]]:
+    for server in spec["servers"]:
+        fd = _try_acquire_lease_file(pool_dir / server["lease_file"])
+        if fd is not None:
+            lease = CarlaServerLease(
+                host=spec["host"],
+                rpc_port=server["rpc_port"],
+                traffic_manager_port=server["traffic_manager_port"],
+            )
+            return lease, fd
+    return None
+
+
+def _try_acquire_lease_file(lease_path: Path) -> Optional[int]:
+    fd = os.open(lease_path, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        os.close(fd)
+        return None
+    return fd
+
+
+def _read_pool_spec(pool_dir: Path) -> Dict[str, Any]:
+    spec_path = pool_dir / POOL_SPEC_FILENAME
+    if not spec_path.is_file():
+        raise FileNotFoundError(
+            f"No CARLA pool spec at {spec_path}; is the CarlaServerPool started "
+            f"and pointing at this directory?"
+        )
+    spec = json.loads(spec_path.read_text())
+    if not isinstance(spec, dict):
+        raise ValueError(f"Malformed pool spec at {spec_path}: expected a JSON object.")
+    return spec
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Launch a pool of headless CARLA servers and keep it up until "
+        "SIGINT/SIGTERM."
+    )
+    parser.add_argument("--n-servers", type=int, required=True, help="Number of servers.")
+    parser.add_argument("--pool-dir", type=Path, default=None, help="Pool directory.")
+    parser.add_argument(
+        "--carla-root", type=Path, default=None, help="CARLA install dir (default: $CARLA_ROOT)."
+    )
+    parser.add_argument("--rpc-port-base", type=int, default=DEFAULT_RPC_PORT_BASE)
+    parser.add_argument("--tm-port-base", type=int, default=DEFAULT_TM_PORT_BASE)
+    parser.add_argument(
+        "--gpus", type=str, default=None, help="Comma-separated GPU indices to cycle over."
+    )
+    parser.add_argument("--ready-timeout", type=float, default=DEFAULT_READY_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--extra-args", nargs=argparse.REMAINDER, default=None, help="Extra server CLI args."
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entry point: start a pool, print its directory, run until interrupted.
+
+    Args:
+        argv: CLI arguments; defaults to ``sys.argv[1:]``.
+
+    Returns:
+        Process exit code (0 on clean shutdown).
+    """
+    args = _build_arg_parser().parse_args(argv)
+    gpu_indices = [int(gpu) for gpu in args.gpus.split(",")] if args.gpus else None
+    pool = CarlaServerPool(
+        n_servers=args.n_servers,
+        pool_dir=args.pool_dir,
+        carla_root=args.carla_root,
+        rpc_port_base=args.rpc_port_base,
+        tm_port_base=args.tm_port_base,
+        gpu_indices=gpu_indices,
+        extra_args=args.extra_args,
+        ready_timeout=args.ready_timeout,
+    )
+    with pool:
+        print(f"CARLA server pool ready: {pool.pool_dir}")
+        print("Press Ctrl-C (or send SIGTERM) to shut the pool down.")
+        signal.sigwait({signal.SIGINT, signal.SIGTERM})
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
@@ -11,6 +11,7 @@ CARLA-specific assertion that the observation differs from the state.
 
 # pylint: disable=protected-access,too-many-lines  # Tests inspect live-session internals
 
+import json
 import pickle
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
@@ -1081,6 +1082,107 @@ def test_include_flags_thread_into_session(fake_session: FakeCarlaSession) -> No
     assert env.include_lidar is False
     assert env.observation_camera_config["image_size_x"] == "128"
     assert env.lidar_config["channels"] == "32"
+
+
+def _write_single_server_pool(pool_dir: Path, rpc_port: int, tm_port: int) -> None:
+    """Hand-write a one-server pool spec + lease file (no server processes)."""
+    (pool_dir / "server_0.lease").touch()
+    spec = {
+        "host": "127.0.0.1",
+        "servers": [
+            {
+                "index": 0,
+                "rpc_port": rpc_port,
+                "traffic_manager_port": tm_port,
+                "lease_file": "server_0.lease",
+            }
+        ],
+    }
+    (pool_dir / "pool.json").write_text(json.dumps(spec))
+
+
+def test_server_pool_dir_survives_pickle_roundtrip(
+    fake_session: FakeCarlaSession, tmp_path: Path
+) -> None:
+    """server_pool_dir is plain config, so it survives pickling to workers.
+
+    Purpose: Validates that the pool wiring reaches joblib workers, which receive
+        the environment via pickle and must re-resolve their lease lazily.
+
+    Given: A CarlaPOMDP constructed with a server_pool_dir
+    When: It is pickled and unpickled
+    Then: server_pool_dir is preserved and the live session is dropped
+
+    Test type: unit
+    """
+    del fake_session
+    env = CarlaPOMDP(discount_factor=0.95, server_pool_dir=tmp_path)
+    restored = pickle.loads(pickle.dumps(env))
+
+    assert restored.server_pool_dir == str(tmp_path)
+    assert restored._session is None
+
+
+def test_get_session_resolves_ports_from_pool_lease(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With a pool configured, the session connects to the leased server's ports.
+
+    Purpose: Validates that _get_session overrides the static host/port/
+        traffic_manager_port with the per-process pool lease.
+
+    Given: A hand-written one-server pool directory and a recording _CarlaSession
+        stub, and a CarlaPOMDP constructed with server_pool_dir and default ports
+    When: The environment builds its session via _get_session
+    Then: _CarlaSession receives the leased rpc/traffic-manager ports and host,
+        not the constructor defaults
+
+    Test type: unit
+    """
+    captured: Dict[str, Any] = {}
+
+    def _recording_session(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "session"
+
+    monkeypatch.setattr(carla_pomdp, "_CarlaSession", _recording_session)
+    _write_single_server_pool(tmp_path, rpc_port=2404, tm_port=8321)
+    env = CarlaPOMDP(discount_factor=0.95, server_pool_dir=tmp_path)
+
+    assert env._get_session() == "session"
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 2404
+    assert captured["traffic_manager_port"] == 8321
+
+
+def test_get_session_uses_static_ports_without_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a pool, the session connects to the constructor's static ports.
+
+    Purpose: Validates the default (no-pool) connection path forwards the
+        configured host/port/traffic_manager_port to _CarlaSession.
+
+    Given: A recording _CarlaSession stub and a CarlaPOMDP with explicit
+        host/port/traffic_manager_port and no server_pool_dir
+    When: The environment builds its session via _get_session
+    Then: _CarlaSession receives exactly the configured endpoints
+
+    Test type: unit
+    """
+    captured: Dict[str, Any] = {}
+
+    def _recording_session(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "session"
+
+    monkeypatch.setattr(carla_pomdp, "_CarlaSession", _recording_session)
+    env = CarlaPOMDP(discount_factor=0.95, host="myhost", port=2345, traffic_manager_port=8123)
+
+    assert env._get_session() == "session"
+    assert captured["host"] == "myhost"
+    assert captured["port"] == 2345
+    assert captured["traffic_manager_port"] == 8123
 
 
 def test_hash_observation_handles_dict_observations(world: CarlaPOMDP) -> None:

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_server_pool.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_server_pool.py
@@ -1,0 +1,397 @@
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the headless CARLA server pool.
+
+These tests never launch CARLA: the pool's ``command_factory`` seam substitutes tiny
+``python -c`` subprocesses (a TCP listener standing in for a ready server, a sleeper
+for a hung one, an immediate exit for a crashed one), and the lease tests operate on
+hand-written pool directories with no processes at all.
+"""
+
+# pylint: disable=protected-access  # Tests exercise module internals directly
+
+import fcntl
+import json
+import multiprocessing
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, List, Optional
+
+import pytest
+
+from POMDPPlanners.environments.carla_pomdp import carla_server_pool
+from POMDPPlanners.environments.carla_pomdp.carla_server_pool import (
+    DEFAULT_READY_TIMEOUT_SECONDS,
+    DEFAULT_RPC_PORT_BASE,
+    DEFAULT_TM_PORT_BASE,
+    RPC_PORT_STRIDE,
+    CarlaServerHandle,
+    CarlaServerPool,
+    acquire_pool_lease,
+)
+
+# Fake-server one-liners spawned in place of CarlaUE4.sh.
+_LISTENER_CODE = (
+    "import socket, sys, time\n"
+    "server = socket.socket()\n"
+    "server.bind(('127.0.0.1', int(sys.argv[1])))\n"
+    "server.listen()\n"
+    "time.sleep(60)\n"
+)
+_SLEEPER_CODE = "import time; time.sleep(60)"
+
+
+def _listener_command(rpc_port: int, tm_port: int, gpu_index: Optional[int]) -> List[str]:
+    """Command factory: a subprocess that listens on the RPC port (a 'ready' server)."""
+    del tm_port, gpu_index
+    return [sys.executable, "-c", _LISTENER_CODE, str(rpc_port)]
+
+
+def _sleeper_command(rpc_port: int, tm_port: int, gpu_index: Optional[int]) -> List[str]:
+    """Command factory: a subprocess that stays alive but never listens."""
+    del rpc_port, tm_port, gpu_index
+    return [sys.executable, "-c", _SLEEPER_CODE]
+
+
+def _free_port_base() -> int:
+    """Pick a port that is free right now (the small span above it is a good bet too)."""
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def _spawn(command: List[str], log_path: Path) -> "subprocess.Popen[bytes]":
+    with open(log_path, "wb") as log_file:
+        return subprocess.Popen(  # pylint: disable=consider-using-with
+            command, stdout=log_file, stderr=subprocess.STDOUT, start_new_session=True
+        )
+
+
+def _write_fake_pool(pool_dir: Path, n_servers: int, rpc_base: int = 3000) -> None:
+    """Hand-write a pool spec + lease files (no server processes)."""
+    servers = []
+    for index in range(n_servers):
+        lease_file = f"server_{index}.lease"
+        (pool_dir / lease_file).touch()
+        servers.append(
+            {
+                "index": index,
+                "rpc_port": rpc_base + RPC_PORT_STRIDE * index,
+                "traffic_manager_port": 9000 + index,
+                "lease_file": lease_file,
+            }
+        )
+    spec = {"host": "127.0.0.1", "servers": servers}
+    (pool_dir / carla_server_pool.POOL_SPEC_FILENAME).write_text(json.dumps(spec))
+
+
+def _hold_lease_in_child(pool_dir: str, port_queue: Any, release_event: Any) -> None:
+    """Child-process target: acquire a lease, report its port, hold until released."""
+    lease = acquire_pool_lease(pool_dir)
+    port_queue.put(lease.rpc_port)
+    release_event.wait(timeout=30)
+
+
+class TestCarlaServerHandle:
+    """Readiness polling and process-group termination of one server subprocess."""
+
+    def test_server_handle_wait_until_ready_succeeds_for_listening_process(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that readiness returns once the server accepts TCP connections.
+
+        Purpose: Validates the TCP readiness probe against a genuinely listening process
+
+        Given: A subprocess that binds and listens on the handle's RPC port
+        When: wait_until_ready is called with a generous timeout
+        Then: It returns without raising, well before the timeout
+
+        Test type: unit
+        """
+        port = _free_port_base()
+        log_path = tmp_path / "server.log"
+        process = _spawn([sys.executable, "-c", _LISTENER_CODE, str(port)], log_path)
+        handle = CarlaServerHandle(
+            process=process, rpc_port=port, traffic_manager_port=9000, log_path=log_path
+        )
+        try:
+            handle.wait_until_ready(timeout=20.0)
+        finally:
+            handle.terminate()
+
+    def test_server_handle_wait_until_ready_fails_fast_when_process_dies(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that a crashed server is reported immediately, not after the timeout.
+
+        Purpose: Validates fail-fast diagnosis of a server that exits during startup
+
+        Given: A subprocess that writes to its log and exits immediately with code 3
+        When: wait_until_ready is called with a long timeout
+        Then: RuntimeError naming the exit code and log path (with its content) is
+            raised in a fraction of the timeout
+
+        Test type: unit
+        """
+        port = _free_port_base()
+        log_path = tmp_path / "server.log"
+        process = _spawn(
+            [sys.executable, "-c", "print('vulkan missing'); import sys; sys.exit(3)"],
+            log_path,
+        )
+        handle = CarlaServerHandle(
+            process=process, rpc_port=port, traffic_manager_port=9000, log_path=log_path
+        )
+        start = time.monotonic()
+        with pytest.raises(RuntimeError, match="exited with code 3") as exc_info:
+            handle.wait_until_ready(timeout=60.0)
+        assert time.monotonic() - start < 30.0
+        assert str(log_path) in str(exc_info.value)
+        assert "vulkan missing" in str(exc_info.value)
+
+    def test_server_handle_wait_until_ready_times_out_for_silent_process(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that a live but never-listening server raises TimeoutError.
+
+        Purpose: Validates the readiness timeout for a hung server process
+
+        Given: A subprocess that stays alive but never opens the RPC port
+        When: wait_until_ready is called with a ~2 second timeout
+        Then: TimeoutError naming the port and log path is raised
+
+        Test type: unit
+        """
+        port = _free_port_base()
+        log_path = tmp_path / "server.log"
+        process = _spawn([sys.executable, "-c", _SLEEPER_CODE], log_path)
+        handle = CarlaServerHandle(
+            process=process, rpc_port=port, traffic_manager_port=9000, log_path=log_path
+        )
+        try:
+            with pytest.raises(TimeoutError, match=str(port)):
+                handle.wait_until_ready(timeout=2.0)
+        finally:
+            handle.terminate()
+
+    def test_server_handle_terminate_kills_process_group(self, tmp_path: Path) -> None:
+        """Test that terminate stops the spawned process.
+
+        Purpose: Validates that terminate signals the server's process group and reaps it
+
+        Given: A running sleeper subprocess in its own session
+        When: terminate is called
+        Then: The process is no longer running and terminate is idempotent
+
+        Test type: unit
+        """
+        log_path = tmp_path / "server.log"
+        process = _spawn([sys.executable, "-c", _SLEEPER_CODE], log_path)
+        handle = CarlaServerHandle(
+            process=process, rpc_port=3000, traffic_manager_port=9000, log_path=log_path
+        )
+        assert handle.is_running
+        handle.terminate(grace_seconds=5.0)
+        assert not handle.is_running
+        handle.terminate(grace_seconds=5.0)  # idempotent
+
+
+class TestCarlaServerPool:
+    """Launch, spec/lease bookkeeping, and shutdown of the pool."""
+
+    def test_pool_assigns_stride_spaced_rpc_and_sequential_tm_ports(self, tmp_path: Path) -> None:
+        """Test the pool's port assignment scheme.
+
+        Purpose: Validates that RPC ports are stride-spaced (CARLA claims port..port+2)
+            and Traffic Manager ports are sequential
+
+        Given: A three-server pool with fake listener servers and known port bases
+        When: The pool is started and its spec is read back
+        Then: Server i has rpc_port base + 4*i and traffic_manager_port tm_base + i
+
+        Test type: unit
+        """
+        rpc_base = _free_port_base()
+        pool = CarlaServerPool(
+            n_servers=3,
+            pool_dir=tmp_path,
+            rpc_port_base=rpc_base,
+            tm_port_base=8100,
+            ready_timeout=20.0,
+            command_factory=_listener_command,
+        )
+        with pool:
+            spec = carla_server_pool._read_pool_spec(tmp_path)
+        assert [server["rpc_port"] for server in spec["servers"]] == [
+            rpc_base + RPC_PORT_STRIDE * i for i in range(3)
+        ]
+        assert [server["traffic_manager_port"] for server in spec["servers"]] == [
+            8100 + i for i in range(3)
+        ]
+
+    def test_pool_writes_spec_and_lease_files_and_cleans_up_servers(self, tmp_path: Path) -> None:
+        """Test the pool's directory contents and shutdown behavior.
+
+        Purpose: Validates that the pool writes pool.json plus one lease file per
+            server, runs all servers, and terminates them on context exit
+
+        Given: A two-server pool with fake listener servers
+        When: The pool context is entered and then exited
+        Then: Inside the context the spec and lease files exist and both servers run;
+            after exit both server processes are terminated
+
+        Test type: unit
+        """
+        rpc_base = _free_port_base()
+        pool = CarlaServerPool(
+            n_servers=2,
+            pool_dir=tmp_path,
+            rpc_port_base=rpc_base,
+            ready_timeout=20.0,
+            command_factory=_listener_command,
+        )
+        with pool:
+            assert (tmp_path / carla_server_pool.POOL_SPEC_FILENAME).is_file()
+            assert (tmp_path / "server_0.lease").is_file()
+            assert (tmp_path / "server_1.lease").is_file()
+            handles = list(pool.handles)
+            assert all(handle.is_running for handle in handles)
+        assert all(not handle.is_running for handle in handles)
+
+    def test_pool_start_cleans_up_when_a_server_dies(self, tmp_path: Path) -> None:
+        """Test that a failed start terminates the already-launched servers.
+
+        Purpose: Validates that start() does not leak sibling server processes when
+            one server never becomes ready
+
+        Given: A two-server pool whose servers never listen, with a short timeout
+        When: start() is invoked
+        Then: TimeoutError propagates and no launched server process is left running
+
+        Test type: unit
+        """
+        pool = CarlaServerPool(
+            n_servers=2,
+            pool_dir=tmp_path,
+            rpc_port_base=_free_port_base(),
+            ready_timeout=2.0,
+            command_factory=_sleeper_command,
+        )
+        with pytest.raises(TimeoutError):
+            pool.start()
+        assert pool.handles == []
+
+    def test_cli_parser_defaults(self) -> None:
+        """Test the CLI argument parser's defaults.
+
+        Purpose: Validates that the module CLI defaults match the module constants
+
+        Given: The pool module's argument parser
+        When: Only the required --n-servers flag is parsed
+        Then: Port bases and ready timeout default to the module constants and the
+            optional paths/GPUs default to None
+
+        Test type: unit
+        """
+        args = carla_server_pool._build_arg_parser().parse_args(["--n-servers", "4"])
+        assert args.n_servers == 4
+        assert args.pool_dir is None
+        assert args.carla_root is None
+        assert args.rpc_port_base == DEFAULT_RPC_PORT_BASE
+        assert args.tm_port_base == DEFAULT_TM_PORT_BASE
+        assert args.gpus is None
+        assert args.ready_timeout == DEFAULT_READY_TIMEOUT_SECONDS
+
+
+class TestAcquirePoolLease:
+    """The flock-based worker-side lease protocol."""
+
+    def test_acquire_pool_lease_is_cached_within_process(self, tmp_path: Path) -> None:
+        """Test that one process reuses its lease for a pool directory.
+
+        Purpose: Validates the per-process lease cache so all episodes in a reused
+            worker share one server
+
+        Given: A hand-written two-server pool directory
+        When: acquire_pool_lease is called twice with the same directory
+        Then: Both calls return the same lease (same server), leaving the second
+            server free for another process
+
+        Test type: unit
+        """
+        _write_fake_pool(tmp_path, n_servers=2)
+        first = acquire_pool_lease(tmp_path)
+        second = acquire_pool_lease(tmp_path)
+        assert first is second
+
+    def test_acquire_pool_lease_exclusive_across_processes(self, tmp_path: Path) -> None:
+        """Test that two processes lease two different servers.
+
+        Purpose: Validates cross-process exclusivity of the flock lease
+
+        Given: A hand-written two-server pool directory and a child process holding
+            a lease on it
+        When: The parent process acquires a lease on the same pool
+        Then: The parent's server differs from the child's
+
+        Test type: integration
+        """
+        _write_fake_pool(tmp_path, n_servers=2)
+        context = multiprocessing.get_context("spawn")
+        port_queue = context.Queue()
+        release_event = context.Event()
+        child = context.Process(
+            target=_hold_lease_in_child, args=(str(tmp_path), port_queue, release_event)
+        )
+        child.start()
+        try:
+            child_port = port_queue.get(timeout=30)
+            parent_lease = acquire_pool_lease(tmp_path)
+            assert parent_lease.rpc_port != child_port
+        finally:
+            release_event.set()
+            child.join(timeout=30)
+
+    def test_acquire_pool_lease_raises_informative_error_when_exhausted(
+        self, tmp_path: Path
+    ) -> None:
+        """Test the error raised when every server is already leased.
+
+        Purpose: Validates that pool exhaustion produces an actionable error naming
+            the n_jobs <= n_servers requirement
+
+        Given: A hand-written one-server pool whose only lease file is already
+            flock-ed through an independent file descriptor
+        When: acquire_pool_lease is called
+        Then: RuntimeError naming the pool directory and 'n_jobs' is raised
+
+        Test type: unit
+        """
+        _write_fake_pool(tmp_path, n_servers=1)
+        blocker_fd = os.open(tmp_path / "server_0.lease", os.O_RDWR)
+        fcntl.flock(blocker_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            with pytest.raises(RuntimeError, match="n_jobs") as exc_info:
+                acquire_pool_lease(tmp_path)
+            assert str(tmp_path) in str(exc_info.value)
+        finally:
+            os.close(blocker_fd)
+
+    def test_acquire_pool_lease_raises_for_missing_spec(self, tmp_path: Path) -> None:
+        """Test the error for a directory that is not a pool.
+
+        Purpose: Validates the guard against pointing server_pool_dir at a
+            directory with no pool spec
+
+        Given: An empty directory
+        When: acquire_pool_lease is called on it
+        Then: FileNotFoundError naming the expected spec path is raised
+
+        Test type: unit
+        """
+        with pytest.raises(FileNotFoundError, match=carla_server_pool.POOL_SPEC_FILENAME):
+            acquire_pool_lease(tmp_path)


### PR DESCRIPTION
## Summary

One CARLA server serves one client at a time, so parallel episode runs (JoblibTaskManager with `n_jobs > 1`) were impossible. This PR adds a server pool: N headless CARLA servers, one leased per worker process, wired transparently into the existing pickle-per-episode task design.

- **`CarlaServerPool`** (new `carla_server_pool.py`) — context manager launching N headless servers (`CarlaUE4.sh -RenderOffScreen -nosound -carla-rpc-port=<port>`). RPC ports are stride-4 spaced (CARLA claims port..port+2), Traffic Manager ports sequential (client-side, one per worker). Per-server log files, TCP readiness polling with fail-fast on server death, process-group termination (SIGTERM → SIGKILL), pid-guarded atexit cleanup. Optional GPU pinning via `-graphicsadapter`.
- **`acquire_pool_lease`** — worker-side flock-based lease on the pool directory, acquired lazily, cached per process, kernel-released on worker death so recycled loky workers free their server automatically.
- **`CarlaPOMDP`** — new optional `server_pool_dir` parameter; `_get_session` resolves `(host, port, traffic_manager_port)` from the per-process lease when set. Without it the connection path is unchanged.
- **CLI** — `python -m POMDPPlanners.environments.carla_pomdp.carla_server_pool --n-servers 4` for long-lived manually-managed pools.

No changes to task managers or the simulator: each joblib task already pickles the env (session nulled) and reconnects lazily in the worker, so the lease slots in at session build time.

## Usage

```python
from POMDPPlanners.environments.carla_pomdp import CarlaPOMDP, CarlaServerPool

with CarlaServerPool(n_servers=4) as pool:          # needs $CARLA_ROOT
    env = CarlaPOMDP(discount_factor=0.95, server_pool_dir=pool.pool_dir)
    # POMDPSimulator with JoblibConfig(n_jobs=4): each worker leases its own server
```

Note: `n_jobs` must be ≤ `n_servers` (joblib's default `n_jobs=-1` exhausts the pool; the error message says so explicitly).

## Limitations

- Lease is per process: all CARLA envs in one worker sharing a pool dir share one server (matches the simulator's design).
- Linux-only (`fcntl.flock`, `os.killpg`), same as the CARLA deployment itself.

## Testing

- 12 new tests for handle/pool/lease using fake `python -c` servers via the `command_factory` seam (no CARLA needed), incl. cross-process lease exclusivity and pool-exhaustion error.
- 3 new `CarlaPOMDP` tests: `server_pool_dir` pickle roundtrip, lease-resolved vs static port forwarding into `_CarlaSession`.
- Full `test_carla_pomdp` directory: 210 passed. Whole-tree pyright: 0 errors, 0 warnings. Pylint: 10.00/10.
- Real-CARLA multi-server run not yet exercised (needs a machine with $CARLA_ROOT).