### PR TITLE
feat(belief): add torch BatchedParticleBelief for batched GPU belief filtering

### DIFF
--- a/POMDPPlanners/core/belief/__init__.py
+++ b/POMDPPlanners/core/belief/__init__.py
@@ -2,6 +2,7 @@
 
 # Import all classes to maintain backward compatibility
 from POMDPPlanners.core.belief.base_belief import Belief
+from POMDPPlanners.core.belief.batched_particle_belief import BatchedParticleBelief
 from POMDPPlanners.core.belief.particle_beliefs import (
     UnweightedParticleBelief,
     WeightedParticleBelief,
@@ -36,6 +37,7 @@ from POMDPPlanners.core.belief.belief_utils import (
 
 __all__ = [
     "Belief",
+    "BatchedParticleBelief",
     "UnweightedParticleBelief",
     "WeightedParticleBelief",
     "WeightedParticleBeliefReinvigoration",

--- a/POMDPPlanners/core/belief/batched_particle_belief.py
+++ b/POMDPPlanners/core/belief/batched_particle_belief.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: MIT
+
+"""Batched, on-device weighted particle belief for vectorized POMDP planners.
+
+This module provides :class:`BatchedParticleBelief`, a torch-based belief
+representation that holds a *batch* of ``B`` independent weighted particle
+beliefs as on-device tensors and performs every step of the
+predict-reweight-resample cycle as a single batched call to a
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`.
+
+It is the belief-side counterpart of the vectorized generative model: the
+model batches the per-particle kernels (transition, observation, likelihood),
+and this class batches the per-belief filtering algebra on top of them, so a
+vectorized planner can propagate, reweight, and resample many beliefs at once
+with no Python loop over beliefs or particles and no host/device
+synchronization.
+
+Like the model protocol it consumes, this class is opt-in and standalone: it
+does not subclass :class:`~POMDPPlanners.core.belief.base_belief.Belief`,
+whose scalar ``update(action, observation, pomdp)`` / ``sample() -> state``
+interface is built around a single belief over NumPy states. The batched
+equivalent of ``update`` is :meth:`BatchedParticleBelief.update`; the batched
+equivalent of ``sample`` is :meth:`BatchedParticleBelief.sample_states`.
+
+Conventions (shared with the vectorized model protocol):
+    * ``B`` is the number of beliefs in the batch, ``Np`` the number of
+      particles per belief, ``ds``/``do`` the state/observation dimensions.
+    * ``particles`` is ``[B, Np, ds]`` and ``log_weights`` is ``[B, Np]``;
+      both live on the model's device.
+    * Actions are per-belief integer indices of shape ``[B]``; observations
+      are per-belief tensors of shape ``[B, do]``.
+
+Classes:
+    BatchedParticleBelief: Batch of weighted particle beliefs on a device.
+"""
+
+import math
+
+import torch
+from torch import Tensor
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+
+
+class BatchedParticleBelief:
+    """Batch of ``B`` weighted particle beliefs stored as on-device tensors.
+
+    Every operation is expressed as batched torch tensor algebra plus at most
+    one flattened ``[B * Np, ...]`` call into the vectorized generative model,
+    so the full filtering cycle for all ``B`` beliefs runs in a constant
+    number of kernels regardless of the batch size.
+
+    Attributes:
+        particles: Particle tensor of shape ``[B, Np, ds]``.
+        log_weights: Log-weight tensor of shape ``[B, Np]``.
+        model: The :class:`VectorizedGenerativeModel` providing the kernels.
+        resampling: Whether :meth:`update` applies per-belief ESS resampling.
+        ess_factor: Fraction of ``Np`` used as the ESS resampling threshold.
+
+    Example:
+        >>> import torch
+        >>> _ = torch.manual_seed(0)
+        >>> class DriftModel:
+        ...     @property
+        ...     def device(self):
+        ...         return torch.device("cpu")
+        ...     def sample_next_states(self, states, actions):
+        ...         return states + actions.to(states.dtype).unsqueeze(1)
+        ...     def sample_observations(self, next_states, actions):
+        ...         return next_states.clone()
+        ...     def rewards(self, states, actions, next_states):
+        ...         return torch.zeros(states.shape[0])
+        ...     def terminal_mask(self, states):
+        ...         return torch.zeros(states.shape[0], dtype=torch.bool)
+        ...     def observation_log_probs(self, next_states, actions, observations):
+        ...         return -((next_states - observations) ** 2).sum(dim=1)
+        ...     def action_keys(self, actions):
+        ...         return actions.to(torch.int64)
+        ...     def observation_keys(self, observations):
+        ...         return torch.zeros(observations.shape[0], dtype=torch.int64)
+        >>> belief = BatchedParticleBelief(
+        ...     particles=torch.zeros(3, 8, 2),
+        ...     log_weights=torch.zeros(3, 8),
+        ...     model=DriftModel(),
+        ... )
+        >>> actions = torch.ones(3, dtype=torch.int64)
+        >>> observations = torch.ones(3, 2)
+        >>> updated = belief.update(actions, observations)
+        >>> updated.particles.shape
+        torch.Size([3, 8, 2])
+        >>> updated.sample_states(4).shape
+        torch.Size([3, 4, 2])
+    """
+
+    def __init__(
+        self,
+        particles: Tensor,
+        log_weights: Tensor,
+        model: VectorizedGenerativeModel,
+        resampling: bool = False,
+        ess_factor: float = 0.5,
+    ):
+        """Initialize a batched particle belief.
+
+        Args:
+            particles: Tensor of shape ``[B, Np, ds]``.
+            log_weights: Tensor of shape ``[B, Np]``.
+            model: Vectorized generative model providing the batched kernels.
+            resampling: Enable per-belief ESS-based resampling inside
+                :meth:`update`. Defaults to False.
+            ess_factor: ESS threshold as a fraction of ``Np``. Defaults to 0.5.
+
+        Raises:
+            ValueError: If shapes are inconsistent or log_weights contains
+                NaN or +inf entries.
+        """
+        self._validate_init_args(particles, log_weights)
+        self.particles = particles.to(model.device)
+        self.log_weights = log_weights.to(model.device)
+        self.model = model
+        self.resampling = resampling
+        self.ess_factor = ess_factor
+        self.ess_threshold = particles.shape[1] * ess_factor
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_root(
+        cls,
+        root_particles: Tensor,
+        model: VectorizedGenerativeModel,
+        batch_size: int = 1,
+        resampling: bool = False,
+        ess_factor: float = 0.5,
+    ) -> "BatchedParticleBelief":
+        """Build a batch of identical uniform-weight beliefs from one root.
+
+        Args:
+            root_particles: Tensor of shape ``[Np, ds]`` holding one belief's
+                particles (e.g. the planner's root belief).
+            model: Vectorized generative model providing the batched kernels.
+            batch_size: Number of belief copies ``B``. Defaults to 1.
+            resampling: Passed through to the constructor. Defaults to False.
+            ess_factor: Passed through to the constructor. Defaults to 0.5.
+
+        Returns:
+            A :class:`BatchedParticleBelief` with ``[B, Np, ds]`` particles
+            and uniform log-weights.
+
+        Raises:
+            ValueError: If root_particles is not 2-D or batch_size < 1.
+        """
+        if root_particles.dim() != 2:
+            raise ValueError(f"root_particles must be 2-D [Np, ds], got {root_particles.dim()}-D")
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+        particles = root_particles.to(model.device).unsqueeze(0).repeat(batch_size, 1, 1)
+        num_particles = root_particles.shape[0]
+        log_weights = torch.full(
+            (batch_size, num_particles), -math.log(num_particles), device=model.device
+        )
+        return cls(particles, log_weights, model, resampling=resampling, ess_factor=ess_factor)
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def propagate(self, actions: Tensor) -> "BatchedParticleBelief":
+        """Push every particle through the transition model (predict step).
+
+        Args:
+            actions: ``[B]`` integer action indices, one per belief.
+
+        Returns:
+            A new belief whose particles are the sampled next states; the
+            log-weights are carried over unchanged.
+        """
+        self._validate_actions(actions)
+        next_flat = self.model.sample_next_states(
+            self._flat_particles(), self._per_particle_actions(actions)
+        )
+        next_particles = next_flat.reshape(self.batch_size, self.num_particles, -1)
+        return self._derived(next_particles, self.log_weights.clone())
+
+    def reweight(self, actions: Tensor, observations: Tensor) -> "BatchedParticleBelief":
+        """Add each particle's observation log-likelihood to its log-weight.
+
+        Call on an already-propagated belief: the current particles are
+        treated as the post-transition states that emitted the observation.
+
+        Args:
+            actions: ``[B]`` integer action indices, one per belief.
+            observations: ``[B, do]`` received observations, one per belief.
+
+        Returns:
+            A new belief with the same particles and updated log-weights.
+        """
+        self._validate_actions(actions)
+        self._validate_observations(observations)
+        flat_observations = observations.to(self.device).repeat_interleave(
+            self.num_particles, dim=0
+        )
+        log_probs = self.model.observation_log_probs(
+            self._flat_particles(), self._per_particle_actions(actions), flat_observations
+        )
+        next_log_weights = self.log_weights + log_probs.reshape(self.batch_size, self.num_particles)
+        return self._derived(self.particles, next_log_weights)
+
+    def update(self, actions: Tensor, observations: Tensor) -> "BatchedParticleBelief":
+        """Full Bayesian belief update: propagate, reweight, and resample.
+
+        This is the batched equivalent of
+        :meth:`POMDPPlanners.core.belief.base_belief.Belief.update`. The
+        resample step runs only when the belief was constructed with
+        ``resampling=True``, and then only for the rows whose effective
+        sample size fell below ``ess_factor * Np``.
+
+        Args:
+            actions: ``[B]`` integer action indices, one per belief.
+            observations: ``[B, do]`` received observations, one per belief.
+
+        Returns:
+            A new :class:`BatchedParticleBelief` reflecting the posterior.
+        """
+        posterior = self.propagate(actions).reweight(actions, observations)
+        if self.resampling:
+            return posterior.resample_degenerate_rows()
+        return posterior
+
+    def sample_states(self, num_samples: int) -> Tensor:
+        """Sample states from every belief in the batch.
+
+        Args:
+            num_samples: Number of states to draw per belief.
+
+        Returns:
+            ``[B, num_samples, ds]`` states drawn with replacement according
+            to each belief's normalized weights.
+        """
+        indices = torch.multinomial(self.normalized_weights, num_samples, replacement=True)
+        gather_indices = indices.unsqueeze(-1).expand(-1, -1, self.state_dim)
+        return torch.gather(self.particles, 1, gather_indices)
+
+    def sample_observations(self, actions: Tensor) -> Tensor:
+        """Sample one observation per particle from the observation model.
+
+        Call on an already-propagated belief: the current particles are
+        treated as the post-transition states that emit the observations.
+
+        Args:
+            actions: ``[B]`` integer action indices, one per belief.
+
+        Returns:
+            ``[B, Np, do]`` sampled observations.
+        """
+        self._validate_actions(actions)
+        flat_observations = self.model.sample_observations(
+            self._flat_particles(), self._per_particle_actions(actions)
+        )
+        return flat_observations.reshape(self.batch_size, self.num_particles, -1)
+
+    def resample(self) -> "BatchedParticleBelief":
+        """Systematically resample every belief back to uniform weights.
+
+        Returns:
+            A new belief whose particles are drawn (per belief, with low
+            variance) according to the current weights and whose log-weights
+            are uniform.
+        """
+        indices = self._systematic_resample_indices(self.normalized_weights)
+        return self._derived(self._gather_particles(indices), self._uniform_log_weights())
+
+    def resample_degenerate_rows(self) -> "BatchedParticleBelief":
+        """Resample only the beliefs whose ESS fell below the threshold.
+
+        The selection is branchless — rows at or above ``ess_factor * Np``
+        keep their particles and weights via a batched ``where`` — so no
+        host/device synchronization is needed to decide whether any row
+        resamples.
+
+        Returns:
+            A new belief in which degenerate rows are systematically
+            resampled to uniform weights and healthy rows are unchanged.
+        """
+        needs_resample = (self.effective_sample_size() < self.ess_threshold).unsqueeze(1)
+        resampled_indices = self._systematic_resample_indices(self.normalized_weights)
+        identity_indices = (
+            torch.arange(self.num_particles, device=self.device)
+            .unsqueeze(0)
+            .expand(self.batch_size, -1)
+        )
+        indices = torch.where(needs_resample, resampled_indices, identity_indices)
+        log_weights = torch.where(needs_resample, self._uniform_log_weights(), self.log_weights)
+        return self._derived(self._gather_particles(indices), log_weights)
+
+    def effective_sample_size(self) -> Tensor:
+        """Return each belief's effective sample size ``1 / sum(w_i^2)``.
+
+        Returns:
+            ``[B]`` effective sample sizes, in ``(0, Np]``.
+        """
+        weights = self.normalized_weights
+        return 1.0 / (weights**2).sum(dim=1)
+
+    @property
+    def normalized_weights(self) -> Tensor:
+        """Per-belief probability weights of shape ``[B, Np]``.
+
+        Rows whose log-weights are all ``-inf`` (every particle assigns zero
+        likelihood) carry no information and fall back to uniform weights.
+        """
+        finite_rows = torch.isfinite(self.log_weights).any(dim=1, keepdim=True)
+        safe_log_weights = torch.where(
+            finite_rows, self.log_weights, torch.zeros_like(self.log_weights)
+        )
+        return torch.softmax(safe_log_weights, dim=1)
+
+    @property
+    def batch_size(self) -> int:
+        """Number of beliefs ``B`` in the batch."""
+        return self.particles.shape[0]
+
+    @property
+    def num_particles(self) -> int:
+        """Number of particles ``Np`` per belief."""
+        return self.particles.shape[1]
+
+    @property
+    def state_dim(self) -> int:
+        """State dimensionality ``ds``."""
+        return self.particles.shape[2]
+
+    @property
+    def device(self) -> torch.device:
+        """Device the belief tensors live on."""
+        return self.model.device
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_init_args(particles: Tensor, log_weights: Tensor) -> None:
+        if particles.dim() != 3:
+            raise ValueError(f"particles must be 3-D [B, Np, ds], got {particles.dim()}-D")
+        if log_weights.dim() != 2:
+            raise ValueError(f"log_weights must be 2-D [B, Np], got {log_weights.dim()}-D")
+        if particles.shape[:2] != log_weights.shape:
+            raise ValueError(
+                f"particles batch/particle shape {tuple(particles.shape[:2])} does not "
+                f"match log_weights shape {tuple(log_weights.shape)}"
+            )
+        if bool(torch.isnan(log_weights).any()) or bool(torch.isposinf(log_weights).any()):
+            raise ValueError("log_weights must not contain NaN or +inf values")
+
+    def _validate_actions(self, actions: Tensor) -> None:
+        if actions.dim() != 1 or actions.shape[0] != self.batch_size:
+            raise ValueError(
+                f"actions must be 1-D with one entry per belief "
+                f"[{self.batch_size}], got shape {tuple(actions.shape)}"
+            )
+
+    def _validate_observations(self, observations: Tensor) -> None:
+        if observations.dim() != 2 or observations.shape[0] != self.batch_size:
+            raise ValueError(
+                f"observations must be 2-D with one row per belief "
+                f"[{self.batch_size}, do], got shape {tuple(observations.shape)}"
+            )
+
+    def _flat_particles(self) -> Tensor:
+        return self.particles.reshape(self.batch_size * self.num_particles, self.state_dim)
+
+    def _per_particle_actions(self, actions: Tensor) -> Tensor:
+        return actions.to(self.device).repeat_interleave(self.num_particles)
+
+    def _derived(self, particles: Tensor, log_weights: Tensor) -> "BatchedParticleBelief":
+        return BatchedParticleBelief(
+            particles=particles,
+            log_weights=log_weights,
+            model=self.model,
+            resampling=self.resampling,
+            ess_factor=self.ess_factor,
+        )
+
+    def _uniform_log_weights(self) -> Tensor:
+        return torch.full_like(self.log_weights, -math.log(self.num_particles))
+
+    def _systematic_resample_indices(self, weights: Tensor) -> Tensor:
+        cumulative = torch.cumsum(weights, dim=1)
+        offsets = torch.rand(self.batch_size, 1, device=self.device)
+        strata = torch.arange(self.num_particles, device=self.device).unsqueeze(0)
+        positions = (strata + offsets) / self.num_particles
+        indices = torch.searchsorted(cumulative.contiguous(), positions)
+        return indices.clamp_(max=self.num_particles - 1)
+
+    def _gather_particles(self, indices: Tensor) -> Tensor:
+        gather_indices = indices.unsqueeze(-1).expand(-1, -1, self.state_dim)
+        return torch.gather(self.particles, 1, gather_indices)

--- a/POMDPPlanners/planners/vectorized_planners/vopp/vopp_episode_runner.py
+++ b/POMDPPlanners/planners/vectorized_planners/vopp/vopp_episode_runner.py
@@ -36,6 +36,7 @@ from typing import Callable, List, Optional
 import torch
 from torch import Tensor
 
+from POMDPPlanners.core.belief.batched_particle_belief import BatchedParticleBelief
 from POMDPPlanners.core.environment.vectorized_generative_model import (
     VectorizedGenerativeModel,
 )
@@ -241,25 +242,18 @@ class VOPPEpisodeRunner:
         return 0
 
     def _filter_belief(self, particles: Tensor, action_index: int, observation: Tensor) -> Tensor:
-        """Propagate, weight, and resample the belief (a SIR particle filter)."""
-        actions = torch.full(
-            (particles.shape[0],), action_index, dtype=torch.int64, device=self.device
-        )
-        propagated = self._model.sample_next_states(particles, actions)
-        observations = observation.expand(particles.shape[0], -1)
-        log_weights = self._model.observation_log_probs(propagated, actions, observations)
-        weights = self._normalize_weights(log_weights)
-        resampled = torch.multinomial(weights, particles.shape[0], replacement=True)
-        return propagated[resampled]
+        """Propagate, weight, and resample the belief (a SIR particle filter).
 
-    def _normalize_weights(self, log_weights: Tensor) -> Tensor:
-        """Softmax the log-weights, falling back to uniform on total degeneracy.
-
-        If every particle assigns zero likelihood to the observation (all
-        log-weights ``-inf``), the softmax would be all-NaN and resampling would
-        fail; in that case the belief carries no information and we resample
-        uniformly instead.
+        Delegates to a batch-of-one :class:`BatchedParticleBelief`: propagate
+        through the model transition, reweight by the observation likelihood
+        (with the all-``-inf`` degeneracy falling back to uniform weights),
+        and resample back to an unweighted ``[num_particles, ds]`` cloud.
         """
-        if not bool(torch.isfinite(log_weights).any()):
-            return torch.full_like(log_weights, 1.0 / log_weights.shape[0])
-        return torch.softmax(log_weights, dim=0)
+        belief = BatchedParticleBelief(
+            particles=particles.unsqueeze(0),
+            log_weights=torch.zeros(1, particles.shape[0], device=self.device),
+            model=self._model,
+        )
+        actions = torch.tensor([action_index], dtype=torch.int64, device=self.device)
+        posterior = belief.propagate(actions).reweight(actions, observation.reshape(1, -1))
+        return posterior.sample_states(particles.shape[0]).squeeze(0)

--- a/POMDPPlanners/tests/test_core/test_belief/test_batched_particle_belief.py
+++ b/POMDPPlanners/tests/test_core/test_belief/test_batched_particle_belief.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the batched, on-device weighted particle belief.
+
+The suite drives :class:`BatchedParticleBelief` with a deterministic mock
+vectorized generative model so every step of the predict-reweight-resample
+cycle can be pinned to exact tensor values, including that per-belief actions
+and observations are applied row-wise and never leak across the batch.
+"""
+
+import math
+
+import pytest
+import torch
+from torch import Tensor
+
+from POMDPPlanners.core.belief import BatchedParticleBelief
+
+
+class DriftModel:
+    """Deterministic, fully controllable vectorized generative model.
+
+    Transitions add the (float-cast) action index to every state coordinate,
+    observations echo the next state, and the observation log-likelihood is a
+    scaled negative squared distance ``-scale * ||s' - o||^2``, so weights
+    after a reweight are known in closed form.
+    """
+
+    def __init__(self, scale: float = 1.0) -> None:
+        self._device = torch.device("cpu")
+        self._scale = scale
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        return states + actions.to(states.dtype).unsqueeze(1)
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        del actions
+        return next_states.clone()
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        del actions, next_states
+        return torch.zeros(states.shape[0], device=self._device)
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        return torch.zeros(states.shape[0], dtype=torch.bool, device=self._device)
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        del actions
+        return -self._scale * ((next_states - observations) ** 2).sum(dim=1)
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        return torch.zeros(observations.shape[0], dtype=torch.int64, device=self._device)
+
+
+def _line_belief(
+    batch_size: int = 3,
+    num_particles: int = 8,
+    state_dim: int = 2,
+    **kwargs,
+) -> BatchedParticleBelief:
+    """Uniform-weight belief whose particle i in every row is the point (i, i, ...)."""
+    line = torch.arange(num_particles, dtype=torch.float32).unsqueeze(1).repeat(1, state_dim)
+    particles = line.unsqueeze(0).repeat(batch_size, 1, 1)
+    log_weights = torch.zeros(batch_size, num_particles)
+    return BatchedParticleBelief(particles, log_weights, DriftModel(), **kwargs)
+
+
+def test_init_rejects_malformed_tensors():
+    """Test that construction validates particle and log-weight shapes.
+
+    Purpose: Validates that malformed inputs fail fast with a clear error
+
+    Given: Particle/log-weight tensors that are 2-D, shape-mismatched, or
+        contain NaN log-weights
+    When: A BatchedParticleBelief is constructed from each of them
+    Then: A ValueError is raised in every case
+
+    Test type: unit
+    """
+    model = DriftModel()
+    with pytest.raises(ValueError, match="3-D"):
+        BatchedParticleBelief(torch.zeros(4, 2), torch.zeros(1, 4), model)
+    with pytest.raises(ValueError, match="2-D"):
+        BatchedParticleBelief(torch.zeros(1, 4, 2), torch.zeros(4), model)
+    with pytest.raises(ValueError, match="does not"):
+        BatchedParticleBelief(torch.zeros(2, 4, 2), torch.zeros(2, 5), model)
+    with pytest.raises(ValueError, match="NaN"):
+        BatchedParticleBelief(torch.zeros(1, 2, 2), torch.tensor([[0.0, float("nan")]]), model)
+
+
+def test_from_root_replicates_particles_with_uniform_weights():
+    """Test that from_root broadcasts one particle set across the batch.
+
+    Purpose: Validates the convenience constructor used to fan a planner's
+        root belief out into a batch
+
+    Given: A single [Np, ds] particle set and batch_size=4
+    When: from_root builds the batched belief
+    Then: Particles are [4, Np, ds] with every row equal to the root set and
+        log-weights are uniform at -log(Np)
+
+    Test type: unit
+    """
+    root = torch.randn(6, 3)
+    belief = BatchedParticleBelief.from_root(root, DriftModel(), batch_size=4)
+    assert belief.particles.shape == (4, 6, 3)
+    assert torch.equal(belief.particles[2], root)
+    assert torch.allclose(belief.log_weights, torch.full((4, 6), -math.log(6)))
+
+
+def test_propagate_applies_per_belief_actions_row_wise():
+    """Test that propagate shifts each belief by its own action only.
+
+    Purpose: Validates that the flatten-call-reshape round trip keeps each
+        belief's action on its own row of the batch
+
+    Given: Three identical beliefs and per-belief actions [0, 1, 2] under a
+        deterministic drift transition
+    When: propagate is called
+    Then: Row b's particles are shifted by exactly b and log-weights are
+        unchanged
+
+    Test type: unit
+    """
+    belief = _line_belief(batch_size=3)
+    actions = torch.tensor([0, 1, 2], dtype=torch.int64)
+    propagated = belief.propagate(actions)
+    for row, shift in enumerate([0.0, 1.0, 2.0]):
+        assert torch.equal(propagated.particles[row], belief.particles[row] + shift)
+    assert torch.equal(propagated.log_weights, belief.log_weights)
+
+
+def test_reweight_adds_observation_log_likelihoods_per_row():
+    """Test that reweight adds each row's own observation log-likelihood.
+
+    Purpose: Validates the Bayesian weighting step and its row alignment
+
+    Given: Beliefs with particles at (i, i) and per-belief observations equal
+        to particle 0 in row 0 and particle 1 in row 1
+    When: reweight is called
+    Then: New log-weights equal old log-weights plus -||p - o||^2 computed
+        against each row's own observation
+
+    Test type: unit
+    """
+    belief = _line_belief(batch_size=2)
+    actions = torch.zeros(2, dtype=torch.int64)
+    observations = torch.tensor([[0.0, 0.0], [1.0, 1.0]])
+    reweighted = belief.reweight(actions, observations)
+    expected = -((belief.particles - observations.unsqueeze(1)) ** 2).sum(dim=2)
+    assert torch.allclose(reweighted.log_weights, expected)
+    assert torch.equal(reweighted.particles, belief.particles)
+
+
+def test_update_matches_propagate_then_reweight():
+    """Test that update composes the predict and reweight steps.
+
+    Purpose: Validates that the one-call update equals the explicit
+        propagate + reweight pipeline when resampling is off
+
+    Given: A belief batch, per-belief actions, and per-belief observations
+    When: update is called and separately propagate followed by reweight
+    Then: Both paths produce identical particles and log-weights
+
+    Test type: unit
+    """
+    belief = _line_belief(batch_size=3)
+    actions = torch.tensor([1, 0, 2], dtype=torch.int64)
+    observations = torch.tensor([[1.0, 1.0], [3.0, 3.0], [5.0, 5.0]])
+    updated = belief.update(actions, observations)
+    explicit = belief.propagate(actions).reweight(actions, observations)
+    assert torch.equal(updated.particles, explicit.particles)
+    assert torch.allclose(updated.log_weights, explicit.log_weights)
+
+
+def test_update_with_resampling_resamples_only_degenerate_rows():
+    """Test per-belief ESS-gated resampling inside update.
+
+    Purpose: Validates that resampling triggers row-wise: collapsed rows are
+        resampled to uniform weights while healthy rows keep their weights
+
+    Given: A resampling-enabled belief where row 0's observation matches one
+        particle overwhelmingly (ESS ~ 1) and row 1's particles are identical
+        so all its weights stay equal (ESS = Np)
+    When: update is called
+    Then: Row 0 has uniform log-weights and (almost) all particles equal the
+        favoured one; row 1 keeps its particles and non-uniform-constant
+        log-weights untouched
+
+    Test type: unit
+    """
+    torch.manual_seed(0)
+    num_particles = 8
+    line = torch.arange(num_particles, dtype=torch.float32).unsqueeze(1).repeat(1, 2)
+    particles = torch.stack([line, torch.ones(num_particles, 2)])
+    log_weights = torch.zeros(2, num_particles)
+    belief = BatchedParticleBelief(particles, log_weights, DriftModel(scale=100.0), resampling=True)
+    actions = torch.zeros(2, dtype=torch.int64)
+    observations = torch.tensor([[3.0, 3.0], [0.0, 0.0]])
+    updated = belief.update(actions, observations)
+
+    uniform = torch.full((num_particles,), -math.log(num_particles))
+    assert torch.allclose(updated.log_weights[0], uniform)
+    assert torch.equal(updated.particles[0], torch.full((num_particles, 2), 3.0))
+    assert torch.equal(updated.particles[1], particles[1])
+    assert torch.allclose(updated.log_weights[1], torch.full((num_particles,), -200.0))
+
+
+def test_sample_states_shape_and_degenerate_support():
+    """Test batched state sampling shapes and weight fidelity.
+
+    Purpose: Validates that sample_states draws per row from that row's own
+        weight distribution
+
+    Given: Two beliefs whose weights put all mass on particle 2 (row 0) and
+        particle 5 (row 1)
+    When: sample_states(16) is called
+    Then: The result is [2, 16, ds] and every sample equals the row's
+        full-mass particle
+
+    Test type: unit
+    """
+    belief = _line_belief(batch_size=2)
+    log_weights = torch.full((2, belief.num_particles), -float("inf"))
+    log_weights[0, 2] = 0.0
+    log_weights[1, 5] = 0.0
+    peaked = BatchedParticleBelief(belief.particles, log_weights, DriftModel())
+    samples = peaked.sample_states(16)
+    assert samples.shape == (2, 16, 2)
+    assert torch.equal(samples[0], torch.full((16, 2), 2.0))
+    assert torch.equal(samples[1], torch.full((16, 2), 5.0))
+
+
+def test_sample_observations_shape_and_values():
+    """Test per-particle observation generation.
+
+    Purpose: Validates the observation fan-out used to generate candidate
+        futures during planning
+
+    Given: A belief batch and per-belief actions under an echo observation
+        model
+    When: sample_observations is called
+    Then: The result is [B, Np, do] and equals the particles themselves
+
+    Test type: unit
+    """
+    belief = _line_belief(batch_size=3)
+    observations = belief.sample_observations(torch.zeros(3, dtype=torch.int64))
+    assert observations.shape == (3, belief.num_particles, 2)
+    assert torch.equal(observations, belief.particles)
+
+
+def test_resample_returns_uniform_weights_from_weighted_support():
+    """Test full systematic resampling of the batch.
+
+    Purpose: Validates that resample redraws particles by weight and resets
+        weights to uniform
+
+    Given: A belief whose row puts all mass on particle 4
+    When: resample is called
+    Then: All resampled particles equal particle 4 and log-weights are
+        uniform at -log(Np)
+
+    Test type: unit
+    """
+    torch.manual_seed(0)
+    belief = _line_belief(batch_size=1)
+    log_weights = torch.full((1, belief.num_particles), -float("inf"))
+    log_weights[0, 4] = 0.0
+    peaked = BatchedParticleBelief(belief.particles, log_weights, DriftModel())
+    resampled = peaked.resample()
+    assert torch.equal(resampled.particles[0], torch.full((belief.num_particles, 2), 4.0))
+    uniform = torch.full((1, belief.num_particles), -math.log(belief.num_particles))
+    assert torch.allclose(resampled.log_weights, uniform)
+
+
+def test_effective_sample_size_uniform_and_degenerate():
+    """Test the per-belief effective sample size.
+
+    Purpose: Validates the ESS statistic that gates resampling
+
+    Given: A batch whose row 0 has uniform weights and row 1 has all mass on
+        one particle
+    When: effective_sample_size is called
+    Then: Row 0 yields Np and row 1 yields 1
+
+    Test type: unit
+    """
+    belief = _line_belief(batch_size=2)
+    log_weights = torch.zeros(2, belief.num_particles)
+    log_weights[1] = -float("inf")
+    log_weights[1, 0] = 0.0
+    mixed = BatchedParticleBelief(belief.particles, log_weights, DriftModel())
+    ess = mixed.effective_sample_size()
+    assert torch.allclose(ess, torch.tensor([float(belief.num_particles), 1.0]))
+
+
+def test_normalized_weights_degenerate_row_falls_back_to_uniform():
+    """Test the all--inf log-weight fallback.
+
+    Purpose: Validates that a belief row carrying zero likelihood everywhere
+        degrades to uniform weights instead of NaNs, per row
+
+    Given: A batch whose row 0 log-weights are all -inf and row 1 weights are
+        peaked on particle 1
+    When: normalized_weights is read
+    Then: Row 0 is uniform and row 1 keeps its peaked distribution
+
+    Test type: unit
+    """
+    belief = _line_belief(batch_size=2)
+    log_weights = torch.full((2, belief.num_particles), -float("inf"))
+    log_weights[1, 1] = 0.0
+    degenerate = BatchedParticleBelief(belief.particles, log_weights, DriftModel())
+    weights = degenerate.normalized_weights
+    uniform = torch.full((belief.num_particles,), 1.0 / belief.num_particles)
+    assert torch.allclose(weights[0], uniform)
+    assert torch.allclose(weights[1].sum(), torch.tensor(1.0))
+    assert weights[1, 1] == pytest.approx(1.0)
+
+
+def test_batched_methods_reject_misaligned_actions_and_observations():
+    """Test the per-call shape validation of actions and observations.
+
+    Purpose: Validates that batch-size mismatches fail fast instead of
+        silently broadcasting
+
+    Given: A batch of 3 beliefs
+    When: propagate receives 2 actions and reweight receives observations
+        with 2 rows
+    Then: Both calls raise ValueError
+
+    Test type: unit
+    """
+    belief = _line_belief(batch_size=3)
+    with pytest.raises(ValueError, match="actions"):
+        belief.propagate(torch.zeros(2, dtype=torch.int64))
+    with pytest.raises(ValueError, match="observations"):
+        belief.reweight(torch.zeros(3, dtype=torch.int64), torch.zeros(2, 2))
+
+
+def test_batched_particle_belief_usage_example():
+    """Test the usage example from the BatchedParticleBelief docstring.
+
+    Purpose: Validates that the documented example executes and produces the
+        shapes it claims
+
+    Given: The exact model and belief construction from the class docstring
+    When: update and sample_states are called as in the example
+    Then: The resulting shapes match the docstring output
+
+    Test type: example
+    """
+    torch.manual_seed(0)
+    belief = BatchedParticleBelief(
+        particles=torch.zeros(3, 8, 2),
+        log_weights=torch.zeros(3, 8),
+        model=DriftModel(),
+    )
+    actions = torch.ones(3, dtype=torch.int64)
+    observations = torch.ones(3, 2)
+    updated = belief.update(actions, observations)
+    assert updated.particles.shape == torch.Size([3, 8, 2])
+    assert updated.sample_states(4).shape == torch.Size([3, 4, 2])


### PR DESCRIPTION
## Summary

- Add `BatchedParticleBelief` (`POMDPPlanners/core/belief/batched_particle_belief.py`): a torch-based belief holding a batch of `B` weighted particle beliefs as on-device `[B, Np, ds]` particles + `[B, Np]` log-weights, driving the full predict-reweight-resample cycle through flattened `[B*Np, ...]` calls into any `VectorizedGenerativeModel` — so it works unchanged for every vectorized environment.
- Public API: `from_root`, `propagate`, `reweight`, `update` (propagate + reweight + optional per-row ESS resample), `sample_states`, `sample_observations`, `resample`, `resample_degenerate_rows`, `effective_sample_size`, `normalized_weights`.
- Per-belief ESS-gated resampling is branchless (batched `where`, no host/device sync); rows whose log-weights are all `-inf` fall back to uniform weights instead of NaNs.
- Refactor `VOPPEpisodeRunner._filter_belief` to delegate to a batch-of-one `BatchedParticleBelief`, removing the inline SIR filter (`_normalize_weights` folded into the belief's `normalized_weights`). Behavior is preserved: same kernels, same degeneracy fallback, same multinomial resample.

This is groundwork for risk-measure parallel planning, which needs belief batches sampled and updated on GPU alongside the existing vectorized generative models.

## Test plan

- [x] 13 new tests in `test_core/test_belief/test_batched_particle_belief.py` pinning exact tensor values (row-wise action/observation alignment, ESS-gated per-row resampling, degenerate-weight fallback, docstring example)
- [x] Full `test_core/test_belief/` suite: 317 passed
- [x] Full `test_planners/test_vectorized_planners/` suite: 24 passed (incl. seeded light-dark end-to-end and all-zero-likelihood degeneracy tests)
- [x] Docstring example passes under `--doctest-modules`
- [x] `pyright POMDPPlanners/`: 0 errors, 0 warnings (whole tree)
- [x] pylint 10.00/10 on all touched files