### PR TITLE
fix(laser_tag): support PURSUE and EVADE_WHEN_SPOTTED in vectorized model

### DIFF
--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_vectorized_model.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_vectorized_model.py
@@ -7,9 +7,10 @@ GPU-friendly implementation of
 :class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
 for :class:`~POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp.LaserTagPOMDP`.
 
-It re-expresses the environment's EVADE opponent-motion kernel, its
-8-direction laser observation kernel, and its ``CONSTANT_HAZARD_PENALTY``
-reward kernel as torch tensor operations so a vectorized planner (VOPP) can
+It re-expresses the environment's opponent-motion kernel (all of ``EVADE``,
+``PURSUE``, and ``EVADE_WHEN_SPOTTED``), its 8-direction laser observation
+kernel, and its ``CONSTANT_HAZARD_PENALTY`` reward kernel as torch tensor
+operations so a vectorized planner (VOPP) can
 run tens of thousands of parallel simulations on the GPU without a
 host/device sync. Every constant (grid geometry, walls, dangerous areas,
 measurement noise, costs, action directions) is read from a live environment
@@ -18,11 +19,11 @@ configuration; only the numeric kernels are duplicated in torch. The
 accompanying parity test pins these kernels to the environment's native
 scalar kernels.
 
-Only the single most standard LaserTag configuration is supported: the
-``CONSTANT_HAZARD_PENALTY`` reward model, the ``EVADE`` opponent policy,
-deterministic robot motion (``transition_error_prob == 0.0``), and
-``is_dangerous_area_hit_terminal=False``. Any other configuration is checked
-at construction and raises :class:`NotImplementedError`.
+Only the ``CONSTANT_HAZARD_PENALTY`` reward model, deterministic robot motion
+(``transition_error_prob == 0.0``), and ``is_dangerous_area_hit_terminal=False``
+are supported; all three opponent policies (``EVADE``, ``PURSUE``,
+``EVADE_WHEN_SPOTTED``) are modeled. Any other configuration is checked at
+construction and raises :class:`NotImplementedError`.
 """
 
 from typing import Optional
@@ -110,9 +111,9 @@ class LaserTagVectorizedModel:
                 laser observations into integer tree keys.
 
         Raises:
-            NotImplementedError: If ``env`` uses a reward model, opponent
-                policy, transition-error, or hazard-terminal configuration
-                the torch kernels do not model.
+            NotImplementedError: If ``env`` uses a reward model,
+                transition-error, or hazard-terminal configuration the torch
+                kernels do not model.
             ValueError: If ``observation_resolution`` is not positive.
         """
         self._require_supported_config(env)
@@ -122,6 +123,7 @@ class LaserTagVectorizedModel:
         self.dtype = dtype
         self._obs_resolution = float(observation_resolution)
         self.num_actions = int(len(env.get_actions()))
+        self._opponent_policy = env.opponent_policy
         self._build_geometry(env)
         self._build_noise_and_reward(env)
 
@@ -135,8 +137,6 @@ class LaserTagVectorizedModel:
             raise NotImplementedError(
                 "vectorized model supports only the CONSTANT_HAZARD_PENALTY reward model"
             )
-        if env.opponent_policy is not OpponentPolicy.EVADE:
-            raise NotImplementedError("vectorized model supports only the EVADE opponent policy")
         if float(env.transition_error_prob) != 0.0:
             raise NotImplementedError(
                 "vectorized model supports only deterministic robot motion "
@@ -186,7 +186,8 @@ class LaserTagVectorizedModel:
     def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
         robot, opp = states[:, 0:2], states[:, 2:4]
         robot_next = self._robot_next(robot, actions)
-        probs = self._opponent_move_probs(robot, opp)
+        reference = self._opponent_robot_reference(robot, robot_next)
+        probs = self._opponent_move_probs(reference, opp)
         choice = torch.multinomial(probs, 1).squeeze(1)
         opp_next = opp + self._opp_offsets[choice]
         tag_success = (actions == _TAG_ACTION) & self._same_cell(robot, opp)
@@ -251,13 +252,51 @@ class LaserTagVectorizedModel:
         valid = self._cell_valid(candidate)
         return torch.where(valid[:, None], candidate, robot)
 
+    def _opponent_robot_reference(self, robot: Tensor, robot_next: Tensor) -> Tensor:
+        # PURSUE conditions the opponent move on the robot's post-move cell;
+        # EVADE and EVADE_WHEN_SPOTTED on its pre-move cell. Mirrors the scalar
+        # LaserTagPOMDP._opponent_robot_reference.
+        if self._opponent_policy is OpponentPolicy.PURSUE:
+            return robot_next
+        return robot
+
     def _opponent_move_probs(self, robot: Tensor, opp: Tensor) -> Tensor:
+        if self._opponent_policy is OpponentPolicy.EVADE_WHEN_SPOTTED:
+            flee = self._directional_move_probs(robot, opp)
+            wander = self._random_move_probs(opp)
+            spotted = self._opponent_spotted(robot, opp)
+            return torch.where(spotted[:, None], flee, wander)
+        return self._directional_move_probs(robot, opp)
+
+    def _directional_move_probs(self, robot: Tensor, opp: Tensor) -> Tensor:
+        # EVADE puts the 0.4 directional mass on the distance-increasing cell,
+        # PURSUE on the distance-decreasing cell; the flags flip accordingly.
         robot_r, robot_c = robot[:, 0], robot[:, 1]
         opp_r, opp_c = opp[:, 0], opp[:, 1]
-        north = self._flee_prob(robot_r > opp_r, robot_r == opp_r)
-        south = self._flee_prob(robot_r < opp_r, robot_r == opp_r)
-        east = self._flee_prob(robot_c < opp_c, robot_c == opp_c)
-        west = self._flee_prob(robot_c > opp_c, robot_c == opp_c)
+        if self._opponent_policy is OpponentPolicy.PURSUE:
+            north_hot, south_hot = robot_r < opp_r, robot_r > opp_r
+            east_hot, west_hot = robot_c > opp_c, robot_c < opp_c
+        else:
+            north_hot, south_hot = robot_r > opp_r, robot_r < opp_r
+            east_hot, west_hot = robot_c < opp_c, robot_c > opp_c
+        row_aligned, col_aligned = robot_r == opp_r, robot_c == opp_c
+        north = self._directional_prob(north_hot, row_aligned)
+        south = self._directional_prob(south_hot, row_aligned)
+        east = self._directional_prob(east_hot, col_aligned)
+        west = self._directional_prob(west_hot, col_aligned)
+        return self._assemble_move_probs(opp, north, south, east, west)
+
+    def _random_move_probs(self, opp: Tensor) -> Tensor:
+        # EVADE_WHEN_SPOTTED's unspotted branch: uniform 0.2 on each cardinal
+        # neighbour, with invalid neighbours falling through to stay.
+        weight = torch.full((opp.shape[0],), 0.2, dtype=self.dtype, device=self.device)
+        return self._assemble_move_probs(opp, weight, weight, weight, weight)
+
+    def _assemble_move_probs(
+        self, opp: Tensor, north: Tensor, south: Tensor, east: Tensor, west: Tensor
+    ) -> Tensor:
+        # Zero out moves into invalid cells (their mass falls through to stay,
+        # matching the scalar slack redistribution) and derive the stay mass.
         north = north * self._cell_valid(opp + self._opp_offsets[1]).to(self.dtype)
         south = south * self._cell_valid(opp + self._opp_offsets[2]).to(self.dtype)
         east = east * self._cell_valid(opp + self._opp_offsets[3]).to(self.dtype)
@@ -265,17 +304,37 @@ class LaserTagVectorizedModel:
         stay = 1.0 - (north + south + east + west)
         return torch.stack([stay, north, south, east, west], dim=1)
 
-    def _flee_prob(self, away: Tensor, aligned: Tensor) -> Tensor:
-        # EVADE puts 0.4 on the away cell, or a symmetric 0.2 split when aligned.
+    def _directional_prob(self, hot: Tensor, aligned: Tensor) -> Tensor:
+        # 0.4 on the hot (toward/away) cell, a symmetric 0.2 when the robot and
+        # opponent share the axis coordinate, otherwise 0.0.
         return torch.where(
-            away,
-            torch.full_like(away, 0.4, dtype=self.dtype),
+            hot,
+            torch.full_like(hot, 0.4, dtype=self.dtype),
             torch.where(
                 aligned,
                 torch.full_like(aligned, 0.2, dtype=self.dtype),
-                torch.zeros(away.shape, dtype=self.dtype, device=self.device),
+                torch.zeros(hot.shape, dtype=self.dtype, device=self.device),
             ),
         )
+
+    def _opponent_spotted(self, robot: Tensor, opp: Tensor) -> Tensor:
+        # Batched mirror of LaserTagPOMDP._is_opponent_spotted: True iff the
+        # opponent lies on one of the robot's 8 laser rays, unoccluded by a wall
+        # or the grid boundary. Opponent detection takes priority over a wall in
+        # the same cell (they can never coincide) exactly as the scalar ray walk.
+        batch = robot.shape[0]
+        pos = robot[:, None, :].expand(batch, 8, 2).clone()
+        opp_cell = opp[:, None, :]
+        active = torch.ones(batch, 8, dtype=torch.bool, device=self.device)
+        spotted = torch.zeros(batch, 8, dtype=torch.bool, device=self.device)
+        for _ in range(self._max_ray):
+            pos = pos + self._laser_dirs
+            in_bounds = self._in_bounds(pos)
+            is_wall = self._wall_at(pos) & in_bounds
+            is_opp = (pos == opp_cell).all(dim=2)
+            spotted = spotted | (active & in_bounds & is_opp)
+            active = active & ~(~in_bounds | is_wall | is_opp)
+        return spotted.any(dim=1)
 
     def _laser_distances(self, robot: Tensor, opp: Tensor) -> Tensor:
         batch = robot.shape[0]

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_vectorized_model.py
@@ -193,20 +193,38 @@ def test_terminal_observation_log_probs_match_native(case: _Case) -> None:
 
 
 @pytest.mark.parametrize(
-    "state, action",
+    "policy, state, action",
     [
-        (np.array([2.0, 2.0, 6.0, 5.0, 0.0]), 0),
-        (np.array([4.0, 3.0, 4.0, 1.0, 0.0]), 2),
-        (np.array([5.0, 2.0, 3.0, 2.0, 0.0]), 4),
-        (np.array([3.0, 3.0, 3.0, 3.0, 0.0]), 4),
+        # EVADE: opponent flees the robot's pre-move cell.
+        (OpponentPolicy.EVADE, np.array([2.0, 2.0, 6.0, 5.0, 0.0]), 0),
+        (OpponentPolicy.EVADE, np.array([4.0, 3.0, 4.0, 1.0, 0.0]), 2),
+        (OpponentPolicy.EVADE, np.array([5.0, 2.0, 3.0, 2.0, 0.0]), 4),
+        (OpponentPolicy.EVADE, np.array([3.0, 3.0, 3.0, 3.0, 0.0]), 4),
+        # PURSUE: opponent chases the robot's post-move cell, so the move
+        # action (which shifts the robot) changes the opponent conditioning.
+        (OpponentPolicy.PURSUE, np.array([2.0, 2.0, 6.0, 5.0, 0.0]), 0),
+        (OpponentPolicy.PURSUE, np.array([4.0, 3.0, 4.0, 1.0, 0.0]), 2),
+        (OpponentPolicy.PURSUE, np.array([5.0, 2.0, 3.0, 2.0, 0.0]), 1),
+        (OpponentPolicy.PURSUE, np.array([3.0, 3.0, 3.0, 3.0, 0.0]), 4),
+        # EVADE_WHEN_SPOTTED, spotted branch: opponent shares the robot's row
+        # (an unoccluded east ray) so it flees like EVADE.
+        (OpponentPolicy.EVADE_WHEN_SPOTTED, np.array([2.0, 2.0, 2.0, 5.0, 0.0]), 4),
+        # EVADE_WHEN_SPOTTED, unspotted branch: opponent off every laser ray so
+        # it moves uniformly at random.
+        (OpponentPolicy.EVADE_WHEN_SPOTTED, np.array([2.0, 2.0, 5.0, 4.0, 0.0]), 4),
+        (OpponentPolicy.EVADE_WHEN_SPOTTED, np.array([1.0, 1.0, 8.0, 5.0, 0.0]), 0),
     ],
 )
-def test_transition_distribution_matches_native(state: np.ndarray, action: int) -> None:
+def test_transition_distribution_matches_native(
+    policy: OpponentPolicy, state: np.ndarray, action: int
+) -> None:
     """Sampled next-state frequencies match the env's analytic transition.
 
-    Purpose: Validates the EVADE opponent-move + robot-move categorical
+    Purpose: Validates the opponent-move + robot-move categorical for every
+        supported opponent policy (EVADE, PURSUE, EVADE_WHEN_SPOTTED)
 
-    Given: A fixed state/action sampled many times by the torch model
+    Given: A fixed state/action and opponent policy sampled many times by the
+        torch model
     When: Empirical frequencies of each distinct next state are compared to
         the env's transition_log_probability over the same support
     Then: Every outcome agrees within a Monte Carlo tolerance and the env
@@ -215,7 +233,7 @@ def test_transition_distribution_matches_native(state: np.ndarray, action: int) 
     Test type: unit
     """
     torch.manual_seed(0)
-    env = LaserTagPOMDP(discount_factor=0.95)
+    env = LaserTagPOMDP(discount_factor=0.95, opponent_policy=policy)
     model = LaserTagVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
     count = 60000
     samples = model.sample_next_states(
@@ -326,20 +344,27 @@ def test_unsupported_reward_model_raises() -> None:
         LaserTagVectorizedModel(env)
 
 
-def test_unsupported_opponent_policy_raises() -> None:
-    """Constructing on a non-EVADE opponent policy is rejected.
+@pytest.mark.parametrize(
+    "policy",
+    [OpponentPolicy.EVADE, OpponentPolicy.PURSUE, OpponentPolicy.EVADE_WHEN_SPOTTED],
+    ids=["evade", "pursue", "evade-when-spotted"],
+)
+def test_every_opponent_policy_constructs(policy: OpponentPolicy) -> None:
+    """All three opponent policies build a conforming vectorized model.
 
-    Purpose: Validates the scope guard on the opponent policy
+    Purpose: Validates that PURSUE and EVADE_WHEN_SPOTTED are supported
+        alongside EVADE (the guard no longer rejects them)
 
-    Given: An env configured with the PURSUE opponent policy
+    Given: An env configured with each supported opponent policy
     When: A vectorized model is constructed from it
-    Then: NotImplementedError is raised
+    Then: Construction succeeds and yields a conforming generative model
 
     Test type: unit
     """
-    env = LaserTagPOMDP(discount_factor=0.95, opponent_policy=OpponentPolicy.PURSUE)
-    with pytest.raises(NotImplementedError):
-        LaserTagVectorizedModel(env)
+    env = LaserTagPOMDP(discount_factor=0.95, opponent_policy=policy)
+    model = LaserTagVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    assert isinstance(model, VectorizedGenerativeModel)
+    assert model.num_actions == 5
 
 
 def test_unsupported_transition_error_raises() -> None:


### PR DESCRIPTION
## Summary

The torch `LaserTagVectorizedModel` that the graph planners (GSS / Risk-GSS) consume only modeled the **EVADE** opponent policy and hard-rejected `PURSUE` / `EVADE_WHEN_SPOTTED` at construction (`_require_supported_config`), raising:

```
NotImplementedError: vectorized model supports only the EVADE opponent policy
```

This confined LaserTag to the one opponent policy where, at equal move speed on an open (wall-free) grid, the evader can never be cornered (pursuit-evasion parity) — so the tag/goal rate stays ~0 for both planners and there is no goal signal to separate on. Reported in the *Bug: LaserTag vectorized model supports only the EVADE opponent policy* task.

## Fix

Mirror the scalar `LaserTagPOMDP` opponent dynamics in batched/tensor form:

- **PURSUE** — flips the 0.4 directional mass onto the distance-*decreasing* cell and conditions the opponent move on the robot's **post-move** cell (via `_opponent_robot_reference`, matching the scalar env).
- **EVADE_WHEN_SPOTTED** — flees like EVADE when the opponent lies on one of the robot's 8 unoccluded laser rays, and moves uniformly at random otherwise. Adds a batched `_opponent_spotted` predicate (tensor mirror of the scalar ray walk).
- Drops the opponent-policy guard in `_require_supported_config`; the reward-model, transition-error, and hazard-terminal guards are unchanged.

The EVADE path is factored, not rewritten — `_directional_move_probs` just flips the toward/away flags by policy, so EVADE behaviour is bit-for-bit unchanged.

## Tests

- `test_transition_distribution_matches_native` now parametrizes over all three policies, comparing the torch sampler's empirical next-state frequencies against the env's analytic `transition_log_probability` (the single source of truth). Cases cover PURSUE's post-move conditioning and both the spotted and unspotted `EVADE_WHEN_SPOTTED` branches.
- Replaced the obsolete "PURSUE raises" guard test with `test_every_opponent_policy_constructs` (construction succeeds for all three).

## Verification

- `pytest` laser_tag + vectorized-planner suites + module doctest: **362 passed**
- `pyright POMDPPlanners/`: **0 errors, 0 warnings**
- `pylint` (source + test): **10.00/10**