### PR TITLE
docs(vopp): cite the Vectorized Online POMDP Planning paper

### DIFF
--- a/POMDPPlanners/planners/vectorized_planners/vopp/vopp.py
+++ b/POMDPPlanners/planners/vectorized_planners/vopp/vopp.py
@@ -44,6 +44,10 @@ VOPP assumes a fixed, finite *representative* action set indexed
 ``0 .. num_actions - 1``; the model's ``action_keys`` must return exactly that
 integer index so it can address a column of the dense ``preferences`` field.
 
+References:
+    Hoerger, M., Sudrajat, M., & Kurniawati, H. (2026). Vectorized Online POMDP
+    Planning. arXiv:2510.27191. https://arxiv.org/abs/2510.27191
+
 Example:
     Planning one step in Continuous Light-Dark::
 


### PR DESCRIPTION
Adds a `References:` section to the VOPP module docstring citing Hoerger, Sudrajat & Kurniawati (2026), *Vectorized Online POMDP Planning* (arXiv:2510.27191).

Formatted to match the existing citation convention in the repo (prose reference block placed before the Example section, as in `pomcp.py`, `pomcpow.py`, `icvar_pomcpow.py`).

Docs-only change; pyright/pylint clean and the module doctest passes.