### PR TITLE
refactor(metrics): migrate environments onto the per-step metrics channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,12 @@ docs/examples/researcher_cache/
 # Local-only POMCPOW demo scripts (kept on disk, not tracked)
 carla_pomcpow_example.py
 nuplan_pomcpow_example.py
+
+# AI assistant working directories
+.claude/
+.codex/
+.cursor/
+.aider*
+.continue/
+.windsurf/
+CLAUDE.local.md

--- a/POMDPPlanners/core/environment/environment.py
+++ b/POMDPPlanners/core/environment/environment.py
@@ -396,10 +396,22 @@ class Environment(ABC):  # pylint: disable=too-many-public-methods
         arguments are typically used only to assert the request matches the
         transition actually taken.
 
+        This is also called once more per *terminated* episode, for the terminal
+        bookkeeping step, with ``action`` and ``next_state`` both ``None`` — that
+        step records the final state, which no transition ever produces a
+        successor for. Implementations must therefore tolerate ``None`` and
+        report a neutral value for any channel that describes the transition
+        rather than the state. Predicates written as
+        ``float(action == <something>)`` already do this, since ``None`` matches
+        nothing. Channels measured from ``state`` alone should still be reported,
+        because a metric that counts every visited state needs the final one.
+
         Args:
-            state: The state the step was taken from.
-            action: The action taken.
-            next_state: The realised successor state.
+            state: The state the step was taken from, or the final state on the
+                terminal bookkeeping step.
+            action: The action taken, or ``None`` on the terminal step.
+            next_state: The realised successor state, or ``None`` on the terminal
+                step.
 
         Returns:
             A flat mapping of channel name to scalar, e.g.
@@ -412,6 +424,15 @@ class Environment(ABC):  # pylint: disable=too-many-public-methods
             cross-environment channel vocabulary on purpose: a name like
             ``"impact"`` could mean a force, an impulse, an energy or a count,
             and a shared name would imply a comparability that does not hold.
+
+        Warning:
+            Implementations must be side-effect-free and must not consume
+            randomness. This runs inside the episode loop, between the transition
+            and the belief update, so a single ``np.random`` draw here shifts the
+            stream for every subsequent transition and observation — silently
+            changing seeded trajectories throughout the run, not just the
+            metrics. Where a value would have to be resampled to be reported, do
+            not report it.
         """
         return {}
 

--- a/POMDPPlanners/core/environment/environment.py
+++ b/POMDPPlanners/core/environment/environment.py
@@ -825,6 +825,14 @@ class Environment(ABC):  # pylint: disable=too-many-public-methods
 
         Returns:
             List of computed metrics with confidence intervals
+
+        Raises:
+            ValueError: If this environment declares metric specs and any
+                episode recorded transition steps while carrying none of the
+                declared channels — a history produced before the per-step
+                channel existed, or by a runner that does not call
+                :meth:`step_info`. Scoring those would report every metric as
+                zero rather than as unmeasured.
         """
         specs = self.get_metric_specs()
         if not specs:
@@ -836,8 +844,10 @@ class Environment(ABC):  # pylint: disable=too-many-public-methods
         from POMDPPlanners.core.simulation.step_info_metrics import (
             aggregate_step_info_metrics,
             extract_episode_step_infos,
+            require_measured_episodes,
         )
 
+        require_measured_episodes(histories, specs, type(self).__name__)
         return aggregate_step_info_metrics(extract_episode_step_infos(histories), specs)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/POMDPPlanners/core/environment/environment.py
+++ b/POMDPPlanners/core/environment/environment.py
@@ -827,16 +827,15 @@ class Environment(ABC):  # pylint: disable=too-many-public-methods
             List of computed metrics with confidence intervals
 
         Raises:
-            ValueError: If this environment declares metric specs and any
+            ValueError: If ``histories`` is empty — a metric over no episodes is
+                an average over nothing, so any value reported for it is
+                invented. Also if this environment declares metric specs and any
                 episode recorded transition steps while carrying none of the
                 declared channels — a history produced before the per-step
                 channel existed, or by a runner that does not call
                 :meth:`step_info`. Scoring those would report every metric as
                 zero rather than as unmeasured.
         """
-        specs = self.get_metric_specs()
-        if not specs:
-            return []
         # Imported here rather than at module scope: core.simulation pulls in
         # modules that reference Environment, so a top-level import would close
         # a cycle.
@@ -845,8 +844,13 @@ class Environment(ABC):  # pylint: disable=too-many-public-methods
             aggregate_step_info_metrics,
             extract_episode_step_infos,
             require_measured_episodes,
+            require_non_empty_histories,
         )
 
+        require_non_empty_histories(histories, type(self).__name__)
+        specs = self.get_metric_specs()
+        if not specs:
+            return []
         require_measured_episodes(histories, specs, type(self).__name__)
         return aggregate_step_info_metrics(extract_episode_step_infos(histories), specs)
 

--- a/POMDPPlanners/core/simulation/step_info_metrics.py
+++ b/POMDPPlanners/core/simulation/step_info_metrics.py
@@ -105,14 +105,14 @@ class StepInfoMetric:
             ``None`` (the default) means such steps are skipped entirely. Use
             0.0 only when a missing channel genuinely means zero — treating
             "not measured" as "did not happen" silently biases the metric.
-        empty_episode_value: Value contributed by an *episode* that reported the
-            channel on no step at all, such as one with no recorded steps.
-            ``None`` (the default) drops that episode from the average entirely.
-            Set it when an episode that measured nothing still has a defined
-            answer: a "never crashed" predicate is vacuously true over no steps,
-            so it contributes 1.0, while a count of occurrences contributes 0.0.
-            Note this is not the same as ``default``, which fills in a missing
-            *step* within an episode that did report the channel elsewhere.
+
+    Note:
+        An episode that reported the channel on no step at all contributes
+        nothing: it is dropped from the average rather than filled with a
+        stand-in. What an unmeasured episode "should" have measured is not a
+        property of the metric, so there is no per-spec knob for it. An episode
+        that ran but was never measured is a different matter, and is rejected
+        upstream by :func:`require_measured_episodes` rather than scored as zero.
     """
 
     name: str
@@ -120,7 +120,6 @@ class StepInfoMetric:
     per_episode: EpisodeReduction
     scale: float = 1.0
     default: Optional[float] = None
-    empty_episode_value: Optional[float] = None
 
 
 def extract_episode_step_infos(histories: Sequence["History"]) -> List[List[Dict[str, float]]]:
@@ -134,6 +133,97 @@ def extract_episode_step_infos(histories: Sequence["History"]) -> List[List[Dict
         the terminal bookkeeping step) contribute an empty mapping.
     """
     return [[step.info or {} for step in history.history] for history in histories]
+
+
+def unmeasured_episode_index(
+    histories: Sequence["History"], specs: Sequence[StepInfoMetric]
+) -> Optional[int]:
+    """Find the first episode that recorded transitions but no declared channel.
+
+    Such an episode was produced before the per-step channel existed, or by a
+    runner that does not call ``step_info``. Callers use this either to refuse it
+    (:func:`require_measured_episodes`) or to recompute it: the task manager
+    treats a cached episode that fails this check as a cache miss, so a resumed
+    run redoes the stale entries instead of scoring them as zero or aborting.
+
+    An episode with no transition steps is exempt. It measured nothing
+    legitimately, and an environment serving values cached during its own step
+    (a live simulator) has nothing to report for the terminal bookkeeping step
+    that such an episode consists of.
+
+    Args:
+        histories: The episode histories to check.
+        specs: The metric specs whose channels are required. No specs means
+            nothing is required, so every history passes.
+
+    Returns:
+        The index of the first unmeasured episode, or ``None`` if every episode
+        either carries a declared channel or is exempt.
+    """
+    declared = {spec.channel for spec in specs}
+    if not declared:
+        return None
+    for index, history in enumerate(histories):
+        steps = history.history
+        if not any(step.action is not None for step in steps):
+            continue
+        if any(declared & set(step.info or {}) for step in steps):
+            continue
+        return index
+    return None
+
+
+def require_measured_episodes(
+    histories: Sequence["History"],
+    specs: Sequence[StepInfoMetric],
+    environment_name: str,
+) -> None:
+    """Reject episodes that were never measured, instead of scoring them as zero.
+
+    An environment whose metrics come from the per-step channel reads nothing at
+    all out of a history recorded before ``step_info`` existed, or by a runner
+    that does not call it. Left alone that is not a missing result but a wrong
+    one: every channel is absent, so a rate reads 0.0 and a count reads 0 — "the
+    planner never reached the goal" is indistinguishable from "nobody measured".
+    Environments pinning a fixed declared name list through
+    :func:`order_and_fill_metrics` turn the omission into that zero explicitly.
+
+    The check is per episode, not over the batch: a partially warm cache yields
+    some measured episodes beside unmeasured ones, and one measured episode must
+    not vouch for the rest — they would silently drop out of every average.
+
+    It also keys on the *declared* channels rather than on ``info`` being
+    non-empty, so unrelated per-step bookkeeping cannot vouch for a measurement
+    that was never taken. Any one declared channel is enough: an environment
+    that declares a channel only when the corresponding sensor is configured
+    legitimately reports a subset, and :func:`aggregate_step_info_metrics` omits
+    the rest.
+
+    See :func:`unmeasured_episode_index` for exactly which episodes qualify,
+    including the exemption for one with no transition steps.
+
+    Args:
+        histories: The episode histories about to be scored.
+        specs: The metric specs whose channels are required.
+        environment_name: Name used in the error message.
+
+    Raises:
+        ValueError: If an episode recorded transition steps and not one of its
+            steps carries any declared channel.
+    """
+    index = unmeasured_episode_index(histories, specs)
+    if index is None:
+        return
+    raise ValueError(
+        f"{environment_name} derives its metrics from the per-step measurement "
+        f"channel, but episode {index} carries none of its channels "
+        f"({sorted(spec.channel for spec in specs)}) on any of its "
+        f"{len(histories[index].history)} recorded steps. That history was produced "
+        "before the channel existed, or by a runner that does not call step_info; "
+        "scoring it would report every metric as zero rather than as unmeasured. "
+        "Re-run the affected configs, clearing the simulation cache if they were "
+        "replayed from it."
+    )
 
 
 def _episode_values(
@@ -181,7 +271,8 @@ def aggregate_step_info_metrics(
         whose channel was reported by at least one episode, in spec order. A spec
         whose channel never appears is omitted rather than reported as zero, so a
         measurement that was never taken is never mistaken for a measurement of
-        zero.
+        zero. An individual episode that reported the channel on no step is
+        dropped from that spec's average for the same reason.
 
     Example:
         Task completion rate over three episodes::
@@ -212,8 +303,6 @@ def aggregate_step_info_metrics(
             values = _episode_values(episode, spec)
             if values is not None:
                 per_episode.append(_reduce_episode(spec.per_episode, values) * spec.scale)
-            elif spec.empty_episode_value is not None:
-                per_episode.append(spec.empty_episode_value * spec.scale)
         if per_episode:
             metrics.append(_metric_from_episode_values(spec, per_episode))
     return metrics
@@ -222,7 +311,6 @@ def aggregate_step_info_metrics(
 def order_and_fill_metrics(
     names: Sequence[str],
     metrics: Sequence[MetricValue],
-    optional: Sequence[str] = (),
 ) -> List[MetricValue]:
     """Impose a declared name order on computed metrics, filling any gap.
 
@@ -250,28 +338,20 @@ def order_and_fill_metrics(
         names: The declared metric names, in the order they must be emitted.
         metrics: The computed metrics, in any order. Entries whose name is not in
             ``names`` are dropped; duplicates resolve to the last occurrence.
-        optional: Names that are omitted rather than filled when absent, for
-            metrics whose historical behaviour is to disappear when nothing
-            contributed to them rather than to report a zero.
 
     Returns:
-        One metric per declared name, in ``names`` order, minus any optional
-        name that was not computed.
+        One metric per declared name, in ``names`` order.
     """
     by_name = {metric.name: metric for metric in metrics}
-    optional_names = set(optional)
     ordered: List[MetricValue] = []
     for name in names:
         metric = by_name.get(name)
-        if metric is not None:
-            ordered.append(metric)
-        elif name not in optional_names:
-            ordered.append(
-                MetricValue(
-                    name=name,
-                    value=0.0,
-                    lower_confidence_bound=float(_UNBOUNDED_INTERVAL[0]),
-                    upper_confidence_bound=float(_UNBOUNDED_INTERVAL[1]),
-                )
+        if metric is None:
+            metric = MetricValue(
+                name=name,
+                value=0.0,
+                lower_confidence_bound=float(_UNBOUNDED_INTERVAL[0]),
+                upper_confidence_bound=float(_UNBOUNDED_INTERVAL[1]),
             )
+        ordered.append(metric)
     return ordered

--- a/POMDPPlanners/core/simulation/step_info_metrics.py
+++ b/POMDPPlanners/core/simulation/step_info_metrics.py
@@ -27,6 +27,7 @@ Classes:
 Functions:
     aggregate_step_info_metrics: Reduce declared specs into MetricValues.
     extract_episode_step_infos: Pull per-step info mappings out of histories.
+    order_and_fill_metrics: Impose a declared name order, filling any gap.
 """
 
 from dataclasses import dataclass
@@ -104,6 +105,14 @@ class StepInfoMetric:
             ``None`` (the default) means such steps are skipped entirely. Use
             0.0 only when a missing channel genuinely means zero — treating
             "not measured" as "did not happen" silently biases the metric.
+        empty_episode_value: Value contributed by an *episode* that reported the
+            channel on no step at all, such as one with no recorded steps.
+            ``None`` (the default) drops that episode from the average entirely.
+            Set it when an episode that measured nothing still has a defined
+            answer: a "never crashed" predicate is vacuously true over no steps,
+            so it contributes 1.0, while a count of occurrences contributes 0.0.
+            Note this is not the same as ``default``, which fills in a missing
+            *step* within an episode that did report the channel elsewhere.
     """
 
     name: str
@@ -111,6 +120,7 @@ class StepInfoMetric:
     per_episode: EpisodeReduction
     scale: float = 1.0
     default: Optional[float] = None
+    empty_episode_value: Optional[float] = None
 
 
 def extract_episode_step_infos(histories: Sequence["History"]) -> List[List[Dict[str, float]]]:
@@ -202,6 +212,66 @@ def aggregate_step_info_metrics(
             values = _episode_values(episode, spec)
             if values is not None:
                 per_episode.append(_reduce_episode(spec.per_episode, values) * spec.scale)
+            elif spec.empty_episode_value is not None:
+                per_episode.append(spec.empty_episode_value * spec.scale)
         if per_episode:
             metrics.append(_metric_from_episode_values(spec, per_episode))
     return metrics
+
+
+def order_and_fill_metrics(
+    names: Sequence[str],
+    metrics: Sequence[MetricValue],
+    optional: Sequence[str] = (),
+) -> List[MetricValue]:
+    """Impose a declared name order on computed metrics, filling any gap.
+
+    Environments that combine spec-driven metrics with hand-written ones need
+    both halves emitted in their declared order, not concatenated: the position
+    of a metric is observable through
+    :func:`~POMDPPlanners.simulations.simulation_statistics.get_metric_names_from_environment_policy_pair`,
+    which feeds hyperparameter-tuning objective selection.
+
+    A declared name with no computed metric is filled with a zero-valued entry
+    on an unbounded interval, so the produced name list always equals the
+    declared one. That matters because
+    :func:`aggregate_step_info_metrics` deliberately omits a metric whose channel
+    no episode reported, which would otherwise shorten the list silently.
+
+    Note:
+        This is deliberately *not* applied by
+        :meth:`~POMDPPlanners.core.environment.environment.Environment.compute_metrics`.
+        For an environment that declares a channel only when the corresponding
+        sensor is configured, omission is meaningful — it distinguishes "never
+        measured" from "measured zero" — and filling would erase that. Use this
+        only where the declared name list is a fixed contract.
+
+    Args:
+        names: The declared metric names, in the order they must be emitted.
+        metrics: The computed metrics, in any order. Entries whose name is not in
+            ``names`` are dropped; duplicates resolve to the last occurrence.
+        optional: Names that are omitted rather than filled when absent, for
+            metrics whose historical behaviour is to disappear when nothing
+            contributed to them rather than to report a zero.
+
+    Returns:
+        One metric per declared name, in ``names`` order, minus any optional
+        name that was not computed.
+    """
+    by_name = {metric.name: metric for metric in metrics}
+    optional_names = set(optional)
+    ordered: List[MetricValue] = []
+    for name in names:
+        metric = by_name.get(name)
+        if metric is not None:
+            ordered.append(metric)
+        elif name not in optional_names:
+            ordered.append(
+                MetricValue(
+                    name=name,
+                    value=0.0,
+                    lower_confidence_bound=float(_UNBOUNDED_INTERVAL[0]),
+                    upper_confidence_bound=float(_UNBOUNDED_INTERVAL[1]),
+                )
+            )
+    return ordered

--- a/POMDPPlanners/core/simulation/step_info_metrics.py
+++ b/POMDPPlanners/core/simulation/step_info_metrics.py
@@ -28,6 +28,8 @@ Functions:
     aggregate_step_info_metrics: Reduce declared specs into MetricValues.
     extract_episode_step_infos: Pull per-step info mappings out of histories.
     order_and_fill_metrics: Impose a declared name order, filling any gap.
+    require_measured_episodes: Reject episodes that ran but were never measured.
+    require_non_empty_histories: Reject an empty episode batch.
 """
 
 from dataclasses import dataclass
@@ -171,6 +173,37 @@ def unmeasured_episode_index(
             continue
         return index
     return None
+
+
+def require_non_empty_histories(histories: Sequence["History"], environment_name: str) -> None:
+    """Reject an empty episode batch instead of scoring it.
+
+    Every metric over no episodes is an average over nothing. Whatever an
+    environment returns for it is invented: a zero-valued metric reads exactly
+    like a genuine measurement of zero, an omitted metric silently shortens the
+    declared name list, and an empty list claims the environment has no metrics
+    at all. None of the three is a measurement, and the three disagreed across
+    environments before this guard existed.
+
+    Nothing in the simulation pipeline produces an empty batch — episode
+    statistics are computed from the same histories and already fail earlier on
+    an empty list — so this is a caller error, not a degenerate run.
+
+    Args:
+        histories: The episode histories about to be scored.
+        environment_name: Name used in the error message.
+
+    Raises:
+        ValueError: If ``histories`` is empty.
+    """
+    if histories:
+        return
+    raise ValueError(
+        f"{environment_name}.compute_metrics received no episode histories. Every "
+        "metric would be an average over nothing, and any value reported for it "
+        "would be indistinguishable from a genuine measurement. Check that the "
+        "simulation produced episodes before computing metrics."
+    )
 
 
 def require_measured_episodes(

--- a/POMDPPlanners/core/simulation/tasks.py
+++ b/POMDPPlanners/core/simulation/tasks.py
@@ -276,6 +276,43 @@ class TaskManagerExternalDB(TaskManager):
             List[Any]: Results from executing the tasks
         """
 
+    def _cached_result_is_usable(self, task: SimulationTask, result: Any, task_id: str) -> bool:
+        """Decide whether a cached result can still be scored, or must be redone.
+
+        The cache key is the task's configuration, which says nothing about the
+        format of the episode it produced. An entry written before
+        :attr:`~POMDPPlanners.core.simulation.history.StepData.info` existed
+        therefore still hits, and unpickles cleanly with every measurement
+        missing -- which, for an environment deriving its metrics from that
+        channel, yields a full set of zero-valued metrics rather than an obvious
+        failure.
+
+        Such an entry is reported as unusable so the caller reruns that one task.
+        Only the stale entries are redone; everything recorded in the current
+        format is still reused, so a resumed run keeps its recovery.
+        """
+        environment = getattr(task, "environment", None)
+        if environment is None or not hasattr(environment, "get_metric_specs"):
+            return True
+        if not hasattr(result, "history"):
+            return True
+        # Imported here rather than at module scope: core.simulation.__init__
+        # imports this module, so a top-level import would close a cycle.
+        # pylint: disable-next=import-outside-toplevel
+        from POMDPPlanners.core.simulation.step_info_metrics import unmeasured_episode_index
+
+        if unmeasured_episode_index([result], environment.get_metric_specs()) is None:
+            return True
+
+        self.logger.warning(
+            "Cached result for task %s predates the per-step measurement channel: it carries "
+            "none of %s's channels, so its metrics would all read zero. Rerunning this task "
+            "and replacing the cache entry.",
+            task_id,
+            type(environment).__name__,
+        )
+        return False
+
     def run_tasks(
         self, tasks: List[SimulationTask], task_identifiers: list
     ) -> Tuple[List[Any], list]:
@@ -301,8 +338,9 @@ class TaskManagerExternalDB(TaskManager):
         cached_tasks = 0
         for i, task in enumerate(tasks):
             task_id = task.get_config_id()
-            if self.cache_db.is_key_in_cache(task_id):
-                results[i] = self.cache_db.get(task_id)
+            cached = self.cache_db.get(task_id) if self.cache_db.is_key_in_cache(task_id) else None
+            if cached is not None and self._cached_result_is_usable(task, cached, task_id):
+                results[i] = cached
                 cached_tasks += 1
             else:
                 tasks_to_run.append(task)

--- a/POMDPPlanners/environments/carla_pomdp/carla_pomdp.py
+++ b/POMDPPlanners/environments/carla_pomdp/carla_pomdp.py
@@ -103,6 +103,7 @@ import numpy as np
 from POMDPPlanners.core.distributions import Distribution
 from POMDPPlanners.core.environment import Environment, SpaceInfo, SpaceType
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.core.simulation.step_info_metrics import require_non_empty_histories
 from POMDPPlanners.environments.carla_pomdp.carla_server_pool import acquire_pool_lease
 from POMDPPlanners.utils.statistics_utils import confidence_interval
 
@@ -1435,8 +1436,7 @@ class CarlaPOMDP(Environment):
               vehicle, in metres (a safety-margin metric; episodes that saw no vehicle are
               excluded).
         """
-        if not histories:
-            return []
+        require_non_empty_histories(histories, type(self).__name__)
         outcomes = [self._episode_goal_outcome(h) for h in histories]
         successes = [success for success, _completion in outcomes]
         completions = [completion for _success, completion in outcomes]

--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
@@ -467,15 +467,20 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
         """Compute the CartPole metrics, always reporting every declared name.
 
         The shared aggregator omits a metric no episode reported, which happens
-        for an empty history list or an episode with no recorded steps. This
-        environment has always reported a zero-valued goal_reaching_rate in that case, so the
-        declared names are filled rather than dropped.
+        for an episode with no recorded steps. This environment has always
+        reported a zero-valued goal_reaching_rate in that case, so the declared
+        names are filled rather than dropped.
 
         Args:
             histories: List of simulation histories.
 
         Returns:
             One MetricValue per declared metric name, in declaration order.
+
+        Raises:
+            ValueError: If ``histories`` is empty, or if an episode ran without
+                being measured. See
+                :meth:`~POMDPPlanners.core.environment.environment.Environment.compute_metrics`.
         """
         return order_and_fill_metrics(self.get_metric_names(), super().compute_metrics(histories))
 

--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
@@ -35,9 +35,19 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue
+from POMDPPlanners.core.simulation.step_info_metrics import (
+    EpisodeReduction,
+    StepInfoMetric,
+    order_and_fill_metrics,
+)
 from POMDPPlanners.environments.cartpole_pomdp import _native
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
-from POMDPPlanners.utils.statistics_utils import confidence_interval
+
+
+class CartPoleStepChannel(Enum):
+    """Per-step measurement channels reported by :meth:`CartPolePOMDP.step_info`."""
+
+    UPRIGHT = "upright"
 
 
 class CartPolePOMDPMetrics(Enum):
@@ -438,40 +448,51 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
         # Discrete int actions (0, 1); already hashable.
         return action
 
-    def get_metric_names(self) -> List[str]:
-        """Get names of CartPole POMDP specific metrics.
-
-        Returns:
-            List containing metric names: goal_reaching_rate
-        """
-        return [metric.value for metric in CartPolePOMDPMetrics]
-
-    def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
-        """Compute CartPole POMDP specific metrics from simulation histories.
+    def step_info(self, state: Any, action: Any, next_state: Any) -> Dict[str, float]:
+        """Report whether the pole is still upright in this step's state.
 
         Args:
-            histories: List of simulation histories
+            state: The state the step was taken from, or the final state on the
+                terminal step.
+            action: Unused; balance is a property of the state alone.
+            next_state: Unused; each state is scored when it is recorded.
 
         Returns:
-            List of MetricValue objects containing the computed metrics
+            The ``upright`` indicator for this step's state.
         """
-        goal_reached = []
-        for history in histories:
-            goal_reached_in_history = True  # Goal is reached if episode didn't crash
-            for step in history.history:
-                if self.is_terminal(step.state):
-                    goal_reached_in_history = False
-                    break
-            goal_reached.append(1 if goal_reached_in_history else 0)
+        del action, next_state
+        return {CartPoleStepChannel.UPRIGHT.value: float(not self.is_terminal(state))}
 
-        avg_goal_reached = float(np.mean(goal_reached))
-        goal_reached_ci = confidence_interval(data=goal_reached, confidence=0.95)
+    def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
+        """Compute the CartPole metrics, always reporting every declared name.
 
+        The shared aggregator omits a metric no episode reported, which happens
+        for an empty history list or an episode with no recorded steps. This
+        environment has always reported a zero-valued goal_reaching_rate in that case, so the
+        declared names are filled rather than dropped.
+
+        Args:
+            histories: List of simulation histories.
+
+        Returns:
+            One MetricValue per declared metric name, in declaration order.
+        """
+        return order_and_fill_metrics(self.get_metric_names(), super().compute_metrics(histories))
+
+    def get_metric_specs(self) -> List[StepInfoMetric]:
+        """Declare the CartPole metric derived from the per-step channel.
+
+        Returns:
+            A spec for ``goal_reaching_rate``, which succeeds only if the pole
+            stayed upright for the whole episode. ``ALL`` rather than ``ANY`` is
+            what encodes that: a single crashed state fails the episode, and the
+            crash is normally the *last* state, recorded on the terminal step.
+        """
         return [
-            MetricValue(
+            StepInfoMetric(
                 name=CartPolePOMDPMetrics.GOAL_REACHING_RATE.value,
-                value=avg_goal_reached,
-                lower_confidence_bound=goal_reached_ci[0],
-                upper_confidence_bound=goal_reached_ci[1],
-            ),
+                channel=CartPoleStepChannel.UPRIGHT.value,
+                per_episode=EpisodeReduction.ALL,
+                empty_episode_value=1.0,
+            )
         ]

--- a/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
+++ b/POMDPPlanners/environments/cartpole_pomdp/cartpole_pomdp.py
@@ -493,6 +493,5 @@ class CartPolePOMDP(DiscreteActionsEnvironment):
                 name=CartPolePOMDPMetrics.GOAL_REACHING_RATE.value,
                 channel=CartPoleStepChannel.UPRIGHT.value,
                 per_episode=EpisodeReduction.ALL,
-                empty_episode_value=1.0,
             )
         ]

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -1031,10 +1031,13 @@ class ContinuousLaserTagPOMDP(Environment):  # pylint: disable=too-many-public-m
             histories: List of simulation histories.
 
         Returns:
-            All seven metrics, or an empty list when there are no histories.
+            All seven metrics, in declaration order.
+
+        Raises:
+            ValueError: If ``histories`` is empty, or if an episode ran without
+                being measured. See
+                :meth:`~POMDPPlanners.core.environment.environment.Environment.compute_metrics`.
         """
-        if not histories:
-            return []
         computed = list(super().compute_metrics(histories)) + self._reward_derived_metrics(
             histories
         )

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -52,6 +52,11 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.core.simulation.step_info_metrics import (
+    EpisodeReduction,
+    StepInfoMetric,
+    order_and_fill_metrics,
+)
 from POMDPPlanners.environments.laser_tag_pomdp import _native
 from POMDPPlanners.environments.laser_tag_pomdp.laser_tag_pomdp_utils import (
     OpponentPolicy,
@@ -92,6 +97,16 @@ _DEFAULT_DANGEROUS_AREAS: List[Tuple[float, float]] = [
     (7.0, 1.0),
     (2.0, 5.0),
 ]
+
+
+class ContinuousLaserTagStepChannel(Enum):
+    """Per-step channels reported by :meth:`ContinuousLaserTagPOMDP.step_info`."""
+
+    TAGGED = "tagged"
+    RECORDED_STEP = "recorded_step"
+    WALL_COLLISION = "wall_collision"
+    IN_DANGEROUS_AREA = "in_dangerous_area"
+    DANGEROUS_ENCOUNTER = "dangerous_encounter"
 
 
 class ContinuousLaserTagPOMDPMetrics(Enum):
@@ -937,13 +952,98 @@ class ContinuousLaserTagPOMDP(Environment):  # pylint: disable=too-many-public-m
     def get_metric_names(self) -> List[str]:
         return [m.value for m in ContinuousLaserTagPOMDPMetrics]
 
+    def step_info(self, state: Any, action: Any, next_state: Any) -> Dict[str, float]:
+        """Report tag status and hazard exposure for this step.
+
+        Args:
+            state: The state the step was taken from, or the final state on the
+                terminal step.
+            action: Unused; every channel here is a property of the state.
+            next_state: Unused; each state is scored when it is recorded.
+
+        Returns:
+            The per-step channels. ``recorded_step`` is a constant 1.0 so that
+            summing it reproduces ``len(history.history)``, terminal bookkeeping
+            step included.
+
+        Note:
+            ``tag_success_rate`` and ``average_failed_tag_attempts`` are defined
+            in terms of the realised reward, which ``step_info`` is not given, so
+            they stay in :meth:`compute_metrics`.
+        """
+        del action, next_state
+        is_state_valid = isinstance(state, np.ndarray) and len(state) == 5
+        in_dangerous_area = float(self._is_in_dangerous_area(state[:2])) if is_state_valid else 0.0
+        return {
+            ContinuousLaserTagStepChannel.TAGGED.value: (
+                float(bool(state[4])) if is_state_valid else 0.0
+            ),
+            ContinuousLaserTagStepChannel.RECORDED_STEP.value: 1.0,
+            # Constant zero, preserved deliberately: the historical counter was
+            # initialised to zero and never incremented, so average_wall_collisions
+            # has always reported 0.0. This is a preserved dead metric, not a
+            # measurement -- and it is why average_all_dangerous_encounters equals
+            # the dangerous-area count.
+            ContinuousLaserTagStepChannel.WALL_COLLISION.value: 0.0,
+            ContinuousLaserTagStepChannel.IN_DANGEROUS_AREA.value: in_dangerous_area,
+            ContinuousLaserTagStepChannel.DANGEROUS_ENCOUNTER.value: in_dangerous_area,
+        }
+
+    def get_metric_specs(self) -> List[StepInfoMetric]:
+        """Declare the metrics derived from the per-step channels.
+
+        Returns:
+            Specs for the five state-derived metrics, in enum order. The two
+            reward-derived metrics are produced by :meth:`compute_metrics`.
+        """
+        return [
+            StepInfoMetric(
+                name=ContinuousLaserTagPOMDPMetrics.GOAL_REACHING_RATE.value,
+                channel=ContinuousLaserTagStepChannel.TAGGED.value,
+                per_episode=EpisodeReduction.ANY,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=ContinuousLaserTagPOMDPMetrics.AVERAGE_EPISODE_LENGTH.value,
+                channel=ContinuousLaserTagStepChannel.RECORDED_STEP.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=ContinuousLaserTagPOMDPMetrics.AVERAGE_WALL_COLLISIONS.value,
+                channel=ContinuousLaserTagStepChannel.WALL_COLLISION.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=ContinuousLaserTagPOMDPMetrics.AVERAGE_DANGEROUS_AREA_STEPS.value,
+                channel=ContinuousLaserTagStepChannel.IN_DANGEROUS_AREA.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=ContinuousLaserTagPOMDPMetrics.AVERAGE_ALL_DANGEROUS_ENCOUNTERS.value,
+                channel=ContinuousLaserTagStepChannel.DANGEROUS_ENCOUNTER.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
+        ]
+
     def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
+        """Compute all seven metrics, in declaration order.
+
+        Args:
+            histories: List of simulation histories.
+
+        Returns:
+            All seven metrics, or an empty list when there are no histories.
+        """
         if not histories:
             return []
-
-        episode_data = self._collect_episode_data(histories)
-        cis = self._compute_confidence_intervals(episode_data)
-        return self._build_metrics(episode_data, cis)
+        computed = list(super().compute_metrics(histories)) + self._reward_derived_metrics(
+            histories
+        )
+        return order_and_fill_metrics(self.get_metric_names(), computed)
 
     # ------------------------------------------------------------------
     # Visualization
@@ -1023,88 +1123,52 @@ class ContinuousLaserTagPOMDP(Environment):  # pylint: disable=too-many-public-m
         dy = centers[:, 1] - float(position[1])
         return int(np.sum(dx * dx + dy * dy <= self.dangerous_area_radius**2))
 
-    def _collect_episode_data(self, histories: List[History]) -> Dict[str, list]:
-        data: Dict[str, list] = {
-            "lengths": [],
-            "success": [],
-            "goal_reached": [],
-            "failed_tags": [],
-            "wall_collisions": [],
-            "dangerous_steps": [],
-            "all_dangerous": [],
-        }
+    def _reward_derived_metrics(self, histories: List[History]) -> List[MetricValue]:
+        # Both are defined in terms of the realised reward recorded on the step,
+        # which the per-step channel cannot carry.
+        success_indicators: List[int] = []
+        failed_tags_per_episode: List[int] = []
         for history in histories:
             steps = history.history
-            data["lengths"].append(len(steps))
-            data["success"].append(
-                1 if steps and steps[-1].reward is not None and steps[-1].reward > 0 else 0
-            )
-            goal = any(
-                isinstance(s.state, np.ndarray) and len(s.state) == 5 and bool(s.state[4])
-                for s in steps
-            )
-            data["goal_reached"].append(1 if goal else 0)
+            # A terminated episode's last recorded step is the terminal
+            # bookkeeping step, whose reward is None, so it has never counted as
+            # a success. Preserved deliberately.
+            successful = bool(steps) and steps[-1].reward is not None and steps[-1].reward > 0
+            success_indicators.append(1 if successful else 0)
+            failed_tags_per_episode.append(self._count_failed_tags(steps))
 
-            failed, wall_col, danger_steps = self._count_episode_metrics(steps)
-            data["failed_tags"].append(failed)
-            data["wall_collisions"].append(wall_col)
-            data["dangerous_steps"].append(danger_steps)
-            data["all_dangerous"].append(wall_col + danger_steps)
-        return data
+        return [
+            self._metric_from_samples(
+                ContinuousLaserTagPOMDPMetrics.TAG_SUCCESS_RATE.value, success_indicators
+            ),
+            self._metric_from_samples(
+                ContinuousLaserTagPOMDPMetrics.AVERAGE_FAILED_TAG_ATTEMPTS.value,
+                failed_tags_per_episode,
+            ),
+        ]
 
-    def _count_episode_metrics(self, steps: List[StepData]) -> Tuple[int, int, int]:
+    def _count_failed_tags(self, steps: List[StepData]) -> int:
         failed_tags = 0
-        wall_collisions = 0
-        dangerous_steps = 0
-
         for step in steps:
             action = np.asarray(step.action, dtype=float) if step.action is not None else None
             if action is not None and len(action) >= 3 and action[2] > 0.5:
                 if step.reward is not None and step.reward < 0:
                     failed_tags += 1
+        return failed_tags
 
-            if isinstance(step.state, np.ndarray) and len(step.state) == 5:
-                if self._is_in_dangerous_area(step.state[:2]):
-                    dangerous_steps += 1
-
-        return failed_tags, wall_collisions, dangerous_steps
-
-    def _compute_confidence_intervals(
-        self, data: Dict[str, list]
-    ) -> Dict[str, Tuple[float, float]]:
-        n = len(data["lengths"])
-        if n < 2:
-            return {k: (-np.inf, np.inf) for k in data}
-        return {k: confidence_interval(data=v, confidence=0.95) for k, v in data.items()}
-
-    def _build_metrics(
-        self,
-        data: Dict[str, list],
-        cis: Dict[str, Tuple[float, float]],
-    ) -> List[MetricValue]:
-        n = len(data["lengths"])
-        metric_map = [
-            (ContinuousLaserTagPOMDPMetrics.TAG_SUCCESS_RATE, "success"),
-            (ContinuousLaserTagPOMDPMetrics.GOAL_REACHING_RATE, "goal_reached"),
-            (ContinuousLaserTagPOMDPMetrics.AVERAGE_EPISODE_LENGTH, "lengths"),
-            (ContinuousLaserTagPOMDPMetrics.AVERAGE_FAILED_TAG_ATTEMPTS, "failed_tags"),
-            (ContinuousLaserTagPOMDPMetrics.AVERAGE_WALL_COLLISIONS, "wall_collisions"),
-            (ContinuousLaserTagPOMDPMetrics.AVERAGE_DANGEROUS_AREA_STEPS, "dangerous_steps"),
-            (ContinuousLaserTagPOMDPMetrics.AVERAGE_ALL_DANGEROUS_ENCOUNTERS, "all_dangerous"),
-        ]
-        metrics = []
-        for metric_enum, key in metric_map:
-            val = float(np.mean(data[key])) if n > 0 else 0.0
-            ci = cis[key]
-            metrics.append(
-                MetricValue(
-                    name=metric_enum.value,
-                    value=val,
-                    lower_confidence_bound=ci[0],
-                    upper_confidence_bound=ci[1],
-                )
-            )
-        return metrics
+    @staticmethod
+    def _metric_from_samples(name: str, samples: List[int]) -> MetricValue:
+        mean_value = float(np.mean(samples))
+        if len(samples) >= 2:
+            lower, upper = confidence_interval(data=samples, confidence=0.95)
+        else:
+            lower, upper = (-np.inf, np.inf)
+        return MetricValue(
+            name=name,
+            value=mean_value,
+            lower_confidence_bound=float(lower),
+            upper_confidence_bound=float(upper),
+        )
 
 
 class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteActionsEnvironment):
@@ -1308,14 +1372,16 @@ class ContinuousLaserTagPOMDPDiscreteActions(ContinuousLaserTagPOMDP, DiscreteAc
             rows.append(self.action_to_vector[action_str])
         return np.ascontiguousarray(np.stack(rows, axis=0))
 
-    def _count_episode_metrics(self, steps: List[StepData]) -> Tuple[int, int, int]:
+    def _count_failed_tags(self, steps: List[StepData]) -> int:
+        # Actions are str labels here; the base counter reads the tag component
+        # of an action vector, so map them before delegating.
         converted = []
         for step in steps:
             if step.action is not None and isinstance(step.action, str):
                 converted.append(step._replace(action=self.action_to_vector[step.action]))
             else:
                 converted.append(step)
-        return super()._count_episode_metrics(converted)
+        return super()._count_failed_tags(converted)
 
     def hash_action(self, action: Any) -> Hashable:
         # Discrete-action variant: actions are str labels (e.g. "up").

--- a/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/continuous_laser_tag_pomdp.py
@@ -1001,31 +1001,26 @@ class ContinuousLaserTagPOMDP(Environment):  # pylint: disable=too-many-public-m
                 name=ContinuousLaserTagPOMDPMetrics.GOAL_REACHING_RATE.value,
                 channel=ContinuousLaserTagStepChannel.TAGGED.value,
                 per_episode=EpisodeReduction.ANY,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=ContinuousLaserTagPOMDPMetrics.AVERAGE_EPISODE_LENGTH.value,
                 channel=ContinuousLaserTagStepChannel.RECORDED_STEP.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=ContinuousLaserTagPOMDPMetrics.AVERAGE_WALL_COLLISIONS.value,
                 channel=ContinuousLaserTagStepChannel.WALL_COLLISION.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=ContinuousLaserTagPOMDPMetrics.AVERAGE_DANGEROUS_AREA_STEPS.value,
                 channel=ContinuousLaserTagStepChannel.IN_DANGEROUS_AREA.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=ContinuousLaserTagPOMDPMetrics.AVERAGE_ALL_DANGEROUS_ENCOUNTERS.value,
                 channel=ContinuousLaserTagStepChannel.DANGEROUS_ENCOUNTER.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
         ]
 

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -42,6 +42,11 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.core.simulation.step_info_metrics import (
+    EpisodeReduction,
+    StepInfoMetric,
+    order_and_fill_metrics,
+)
 from POMDPPlanners.environments.environment_utils.dangerous_areas_kernels import (
     CONSTANT_HAZARD_PENALTY_CODE,
     DISTANCE_DECAYED_HAZARD_PENALTY_CODE,
@@ -74,6 +79,21 @@ _LASER_DIRECTIONS: List[Tuple[int, int]] = [
     (0, -1),
     (-1, -1),
 ]
+
+
+# Action ids: 0=North, 1=South, 2=East, 3=West, 4=Tag.
+MOVE_ACTIONS = (0, 1, 2, 3)
+TAG_ACTION = 4
+
+
+class LaserTagStepChannel(Enum):
+    """Per-step measurement channels reported by :meth:`LaserTagPOMDP.step_info`."""
+
+    TAGGED = "tagged"
+    RECORDED_STEP = "recorded_step"
+    OBSTACLE_COLLISION = "obstacle_collision"
+    IN_DANGEROUS_AREA = "in_dangerous_area"
+    DANGEROUS_ENCOUNTER = "dangerous_encounter"
 
 
 class LaserTagPOMDPMetrics(Enum):
@@ -120,7 +140,7 @@ class RewardModelType(Enum):
 #   is_terminal = bool(state[4])
 
 
-class LaserTagPOMDP(DiscreteActionsEnvironment):
+class LaserTagPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-methods
     """LaserTag POMDP environment implementation.
 
     This is a pursuit-evasion problem where a robot must navigate a grid to tag
@@ -1344,276 +1364,178 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):
         clipped_c = np.clip(realised_c, 0, cols - 1)
         return in_bounds & self._hazard_wall_grid[clipped_r, clipped_c]
 
-    def _count_episode_metrics(
-        self, history: History, action_dirs: Dict[int, Tuple[int, int]]
-    ) -> Tuple[int, int, int, int]:
-        episode_failed_tags = 0
-        episode_obstacle_collisions = 0
-        episode_dangerous_area_steps = 0
+    def step_info(self, state: Any, action: Any, next_state: Any) -> Dict[str, float]:
+        """Report tag status, hazard exposure and wall collisions for this step.
 
-        for step in history.history:
-            if step.action == 4 and step.reward is not None and step.reward < 0:
-                episode_failed_tags += 1
+        Args:
+            state: The state the step was taken from, or the final state on the
+                terminal step.
+            action: The action taken, or ``None`` on the terminal step.
+            next_state: The realised successor state, or ``None`` on the terminal
+                step. Needed to tell a blocked move from a completed one.
 
-            if isinstance(step.state, np.ndarray) and len(step.state) == 5:
-                robot_pos = (int(step.state[0]), int(step.state[1]))
-                if self._is_in_dangerous_area(robot_pos):
-                    episode_dangerous_area_steps += 1
+        Returns:
+            The per-step channels. ``recorded_step`` is a constant 1.0 so that
+            summing it reproduces ``len(history.history)``, including the
+            terminal bookkeeping step, which the historical episode-length count
+            included.
 
-            if step.action in [0, 1, 2, 3]:
-                if (
-                    isinstance(step.state, np.ndarray)
-                    and len(step.state) == 5
-                    and hasattr(step, "next_state")
-                    and isinstance(step.next_state, np.ndarray)
-                    and len(step.next_state) == 5
-                ):
-                    if step.action in action_dirs:
-                        dr, dc = action_dirs[step.action]
-                        robot_pos = (int(step.state[0]), int(step.state[1]))
-                        next_robot_pos = (int(step.next_state[0]), int(step.next_state[1]))
-                        intended_pos = (robot_pos[0] + dr, robot_pos[1] + dc)
+        Note:
+            Nothing here reads the realised reward, which ``step_info`` is not
+            given. ``tag_success_rate`` and ``average_failed_tag_attempts`` are
+            defined in terms of it, so they stay in :meth:`compute_metrics`.
+            Recomputing the reward here is not an option: two of the reward
+            models draw from ``np.random``, so it would both return a different
+            number and shift the RNG stream for every later transition.
+        """
+        is_state_valid = isinstance(state, np.ndarray) and len(state) == 5
+        in_dangerous_area = 0.0
+        if is_state_valid:
+            robot_pos = (int(state[0]), int(state[1]))
+            in_dangerous_area = float(self._is_in_dangerous_area(robot_pos))
+        obstacle_collision = float(self._is_blocked_by_wall(state, action, next_state))
+        return {
+            LaserTagStepChannel.TAGGED.value: (float(bool(state[4])) if is_state_valid else 0.0),
+            LaserTagStepChannel.RECORDED_STEP.value: 1.0,
+            LaserTagStepChannel.OBSTACLE_COLLISION.value: obstacle_collision,
+            LaserTagStepChannel.IN_DANGEROUS_AREA.value: in_dangerous_area,
+            # Emitted as its own channel because the aggregator reduces one
+            # channel at a time and cannot add two. Summing the per-step sum
+            # equals summing each part, so this matches the historical
+            # collisions + dangerous-steps total exactly.
+            LaserTagStepChannel.DANGEROUS_ENCOUNTER.value: obstacle_collision + in_dangerous_area,
+        }
 
-                        if intended_pos in self.walls and next_robot_pos == robot_pos:
-                            episode_obstacle_collisions += 1
+    def _is_blocked_by_wall(self, state: Any, action: Any, next_state: Any) -> bool:
+        # A collision is a move action whose intended cell is a wall and which
+        # left the robot where it started. Both states must be well formed, and
+        # the terminal step (action None) is never a collision. Restricted to the
+        # movement actions: ``_action_directions`` also maps the tag action, to
+        # a zero displacement, which was never considered a collision candidate.
+        if action not in MOVE_ACTIONS:
+            return False
+        if not (isinstance(state, np.ndarray) and len(state) == 5):
+            return False
+        if not (isinstance(next_state, np.ndarray) and len(next_state) == 5):
+            return False
+        row_delta, col_delta = self._action_directions[action]
+        robot_pos = (int(state[0]), int(state[1]))
+        next_robot_pos = (int(next_state[0]), int(next_state[1]))
+        intended_pos = (robot_pos[0] + row_delta, robot_pos[1] + col_delta)
+        return intended_pos in self.walls and next_robot_pos == robot_pos
 
-        return (
-            episode_failed_tags,
-            episode_obstacle_collisions,
-            episode_dangerous_area_steps,
-            episode_obstacle_collisions + episode_dangerous_area_steps,
-        )
+    def get_metric_specs(self) -> List[StepInfoMetric]:
+        """Declare the LaserTag metrics derived from the per-step channels.
 
-    def _collect_episode_data(self, histories: List[History]) -> Tuple:
-        episode_lengths = []
-        success_indicators = []
-        goal_reached_indicators = []
-        failed_tags_per_episode = []
-        obstacle_collisions_per_episode = []
-        dangerous_area_steps_per_episode = []
-        all_dangerous_encounters_per_episode = []
-
-        action_dirs = {0: (-1, 0), 1: (1, 0), 2: (0, 1), 3: (0, -1)}
-
-        for history in histories:
-            episode_length = len(history.history)
-            episode_lengths.append(episode_length)
-
-            episode_successful = (
-                history.history
-                and history.history[-1].reward is not None
-                and history.history[-1].reward > 0
-            )
-            success_indicators.append(1 if episode_successful else 0)
-
-            # Check if goal was reached (opponent was tagged) by checking if any step reached terminal state
-            goal_reached = False
-            for step in history.history:
-                if isinstance(step.state, np.ndarray) and len(step.state) == 5:
-                    if bool(step.state[4]):  # Terminal flag is set when tag is successful
-                        goal_reached = True
-                        break
-            goal_reached_indicators.append(1 if goal_reached else 0)
-
-            (
-                episode_failed_tags,
-                episode_obstacle_collisions,
-                episode_dangerous_area_steps,
-                episode_all_dangerous_encounters,
-            ) = self._count_episode_metrics(history, action_dirs)
-
-            failed_tags_per_episode.append(episode_failed_tags)
-            obstacle_collisions_per_episode.append(episode_obstacle_collisions)
-            dangerous_area_steps_per_episode.append(episode_dangerous_area_steps)
-            all_dangerous_encounters_per_episode.append(episode_all_dangerous_encounters)
-
-        return (
-            episode_lengths,
-            success_indicators,
-            goal_reached_indicators,
-            failed_tags_per_episode,
-            obstacle_collisions_per_episode,
-            dangerous_area_steps_per_episode,
-            all_dangerous_encounters_per_episode,
-        )
-
-    def _calculate_confidence_intervals(
-        self,
-        total_episodes: int,
-        success_indicators: List[int],
-        goal_reached_indicators: List[int],
-        episode_lengths: List[int],
-        failed_tags_per_episode: List[int],
-        obstacle_collisions_per_episode: List[int],
-        dangerous_area_steps_per_episode: List[int],
-        all_dangerous_encounters_per_episode: List[int],
-    ) -> Tuple:
-        if total_episodes >= 2:
-            success_ci = confidence_interval(data=success_indicators, confidence=0.95)
-            goal_reached_ci = confidence_interval(data=goal_reached_indicators, confidence=0.95)
-            episode_length_ci = confidence_interval(data=episode_lengths, confidence=0.95)
-            failed_tags_ci = confidence_interval(data=failed_tags_per_episode, confidence=0.95)
-            obstacle_collisions_ci = confidence_interval(
-                data=obstacle_collisions_per_episode, confidence=0.95
-            )
-            dangerous_area_steps_ci = confidence_interval(
-                data=dangerous_area_steps_per_episode, confidence=0.95
-            )
-            all_dangerous_encounters_ci = confidence_interval(
-                data=all_dangerous_encounters_per_episode, confidence=0.95
-            )
-        else:
-            success_ci = (-np.inf, np.inf)
-            goal_reached_ci = (-np.inf, np.inf)
-            episode_length_ci = (-np.inf, np.inf)
-            failed_tags_ci = (-np.inf, np.inf)
-            obstacle_collisions_ci = (-np.inf, np.inf)
-            dangerous_area_steps_ci = (-np.inf, np.inf)
-            all_dangerous_encounters_ci = (-np.inf, np.inf)
-
-        return (
-            success_ci,
-            goal_reached_ci,
-            episode_length_ci,
-            failed_tags_ci,
-            obstacle_collisions_ci,
-            dangerous_area_steps_ci,
-            all_dangerous_encounters_ci,
-        )
+        Returns:
+            Specs for the five state- and transition-derived metrics, in the
+            same order the enum declares them. The two reward-derived metrics
+            are absent here and produced by :meth:`compute_metrics`.
+        """
+        return [
+            StepInfoMetric(
+                name=LaserTagPOMDPMetrics.GOAL_REACHING_RATE.value,
+                channel=LaserTagStepChannel.TAGGED.value,
+                per_episode=EpisodeReduction.ANY,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=LaserTagPOMDPMetrics.AVERAGE_EPISODE_LENGTH.value,
+                channel=LaserTagStepChannel.RECORDED_STEP.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=LaserTagPOMDPMetrics.AVERAGE_OBSTACLE_COLLISIONS.value,
+                channel=LaserTagStepChannel.OBSTACLE_COLLISION.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=LaserTagPOMDPMetrics.AVERAGE_DANGEROUS_AREA_STEPS.value,
+                channel=LaserTagStepChannel.IN_DANGEROUS_AREA.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=LaserTagPOMDPMetrics.AVERAGE_ALL_DANGEROUS_ENCOUNTERS.value,
+                channel=LaserTagStepChannel.DANGEROUS_ENCOUNTER.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
+        ]
 
     def get_metric_names(self) -> List[str]:
         """Get names of LaserTag POMDP specific metrics.
 
         Returns:
-            List containing metric names: tag_success_rate, average_episode_length,
-            average_failed_tag_attempts, average_obstacle_collisions,
-            average_dangerous_area_steps, and average_all_dangerous_encounters
+            All seven metric names in enum order: the five derived from per-step
+            channels plus the two reward-derived ones.
         """
         return [metric.value for metric in LaserTagPOMDPMetrics]
 
-    def _build_metric_values(
-        self,
-        success_rate: float,
-        goal_reaching_rate: float,
-        avg_episode_length: float,
-        avg_failed_tags: float,
-        avg_obstacle_collisions: float,
-        avg_dangerous_area_steps: float,
-        avg_all_dangerous_encounters: float,
-        success_ci: Tuple[float, float],
-        goal_reached_ci: Tuple[float, float],
-        episode_length_ci: Tuple[float, float],
-        failed_tags_ci: Tuple[float, float],
-        obstacle_collisions_ci: Tuple[float, float],
-        dangerous_area_steps_ci: Tuple[float, float],
-        all_dangerous_encounters_ci: Tuple[float, float],
-    ) -> List[MetricValue]:
+    def _reward_derived_metrics(self, histories: List[History]) -> List[MetricValue]:
+        # Both of these are defined in terms of the realised reward recorded on
+        # the step, which the per-step channel cannot carry.
+        success_indicators: List[int] = []
+        failed_tags_per_episode: List[int] = []
+        for history in histories:
+            steps = history.history
+            # The last recorded step of a terminated episode is the terminal
+            # bookkeeping step, whose reward is None -- so such an episode has
+            # never counted as a success. Preserved deliberately.
+            successful = bool(steps) and steps[-1].reward is not None and steps[-1].reward > 0
+            success_indicators.append(1 if successful else 0)
+            failed_tags_per_episode.append(
+                sum(
+                    1
+                    for step in steps
+                    if step.action == TAG_ACTION and step.reward is not None and step.reward < 0
+                )
+            )
+
         return [
-            MetricValue(
-                name=LaserTagPOMDPMetrics.TAG_SUCCESS_RATE.value,
-                value=success_rate,
-                lower_confidence_bound=success_ci[0],
-                upper_confidence_bound=success_ci[1],
+            self._metric_from_samples(
+                LaserTagPOMDPMetrics.TAG_SUCCESS_RATE.value, success_indicators
             ),
-            MetricValue(
-                name=LaserTagPOMDPMetrics.GOAL_REACHING_RATE.value,
-                value=goal_reaching_rate,
-                lower_confidence_bound=goal_reached_ci[0],
-                upper_confidence_bound=goal_reached_ci[1],
-            ),
-            MetricValue(
-                name=LaserTagPOMDPMetrics.AVERAGE_EPISODE_LENGTH.value,
-                value=avg_episode_length,
-                lower_confidence_bound=episode_length_ci[0],
-                upper_confidence_bound=episode_length_ci[1],
-            ),
-            MetricValue(
-                name=LaserTagPOMDPMetrics.AVERAGE_FAILED_TAG_ATTEMPTS.value,
-                value=avg_failed_tags,
-                lower_confidence_bound=failed_tags_ci[0],
-                upper_confidence_bound=failed_tags_ci[1],
-            ),
-            MetricValue(
-                name=LaserTagPOMDPMetrics.AVERAGE_OBSTACLE_COLLISIONS.value,
-                value=avg_obstacle_collisions,
-                lower_confidence_bound=obstacle_collisions_ci[0],
-                upper_confidence_bound=obstacle_collisions_ci[1],
-            ),
-            MetricValue(
-                name=LaserTagPOMDPMetrics.AVERAGE_DANGEROUS_AREA_STEPS.value,
-                value=avg_dangerous_area_steps,
-                lower_confidence_bound=dangerous_area_steps_ci[0],
-                upper_confidence_bound=dangerous_area_steps_ci[1],
-            ),
-            MetricValue(
-                name=LaserTagPOMDPMetrics.AVERAGE_ALL_DANGEROUS_ENCOUNTERS.value,
-                value=avg_all_dangerous_encounters,
-                lower_confidence_bound=all_dangerous_encounters_ci[0],
-                upper_confidence_bound=all_dangerous_encounters_ci[1],
+            self._metric_from_samples(
+                LaserTagPOMDPMetrics.AVERAGE_FAILED_TAG_ATTEMPTS.value, failed_tags_per_episode
             ),
         ]
 
+    @staticmethod
+    def _metric_from_samples(name: str, samples: List[int]) -> MetricValue:
+        mean_value = float(np.mean(samples))
+        if len(samples) >= 2:
+            lower, upper = confidence_interval(data=samples, confidence=0.95)
+        else:
+            lower, upper = (-np.inf, np.inf)
+        return MetricValue(
+            name=name,
+            value=mean_value,
+            lower_confidence_bound=float(lower),
+            upper_confidence_bound=float(upper),
+        )
+
     def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
-        """Compute LaserTag POMDP specific metrics from simulation histories."""
-        total_episodes = len(histories)
-        if total_episodes == 0:
+        """Compute LaserTag POMDP specific metrics from simulation histories.
+
+        Args:
+            histories: List of simulation histories.
+
+        Returns:
+            All seven metrics in declaration order, or an empty list when there
+            are no histories.
+        """
+        if not histories:
             return []
-
-        (
-            episode_lengths,
-            success_indicators,
-            goal_reached_indicators,
-            failed_tags_per_episode,
-            obstacle_collisions_per_episode,
-            dangerous_area_steps_per_episode,
-            all_dangerous_encounters_per_episode,
-        ) = self._collect_episode_data(histories)
-
-        successful_tags = sum(success_indicators)
-        success_rate = successful_tags / total_episodes
-        goals_reached = sum(goal_reached_indicators)
-        goal_reaching_rate = goals_reached / total_episodes
-        avg_episode_length = float(np.mean(episode_lengths))
-        avg_failed_tags = float(np.mean(failed_tags_per_episode))
-        avg_obstacle_collisions = float(np.mean(obstacle_collisions_per_episode))
-        avg_dangerous_area_steps = float(np.mean(dangerous_area_steps_per_episode))
-        avg_all_dangerous_encounters = float(np.mean(all_dangerous_encounters_per_episode))
-
-        (
-            success_ci,
-            goal_reached_ci,
-            episode_length_ci,
-            failed_tags_ci,
-            obstacle_collisions_ci,
-            dangerous_area_steps_ci,
-            all_dangerous_encounters_ci,
-        ) = self._calculate_confidence_intervals(
-            total_episodes,
-            success_indicators,
-            goal_reached_indicators,
-            episode_lengths,
-            failed_tags_per_episode,
-            obstacle_collisions_per_episode,
-            dangerous_area_steps_per_episode,
-            all_dangerous_encounters_per_episode,
+        computed = list(super().compute_metrics(histories)) + self._reward_derived_metrics(
+            histories
         )
-
-        return self._build_metric_values(
-            success_rate,
-            goal_reaching_rate,
-            avg_episode_length,
-            avg_failed_tags,
-            avg_obstacle_collisions,
-            avg_dangerous_area_steps,
-            avg_all_dangerous_encounters,
-            success_ci,
-            goal_reached_ci,
-            episode_length_ci,
-            failed_tags_ci,
-            obstacle_collisions_ci,
-            dangerous_area_steps_ci,
-            all_dangerous_encounters_ci,
-        )
+        # Ordered and gap-filled rather than concatenated: the declared name list
+        # is a fixed contract, and the aggregator drops a metric whose channel no
+        # episode reported.
+        return order_and_fill_metrics(self.get_metric_names(), computed)
 
     def cache_visualization(
         self, history: List[StepData], output_dir: Path, episode_index: int

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -1519,11 +1519,13 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-pub
             histories: List of simulation histories.
 
         Returns:
-            All seven metrics in declaration order, or an empty list when there
-            are no histories.
+            All seven metrics in declaration order.
+
+        Raises:
+            ValueError: If ``histories`` is empty, or if an episode ran without
+                being measured. See
+                :meth:`~POMDPPlanners.core.environment.environment.Environment.compute_metrics`.
         """
-        if not histories:
-            return []
         computed = list(super().compute_metrics(histories)) + self._reward_derived_metrics(
             histories
         )

--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -1437,31 +1437,26 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-pub
                 name=LaserTagPOMDPMetrics.GOAL_REACHING_RATE.value,
                 channel=LaserTagStepChannel.TAGGED.value,
                 per_episode=EpisodeReduction.ANY,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=LaserTagPOMDPMetrics.AVERAGE_EPISODE_LENGTH.value,
                 channel=LaserTagStepChannel.RECORDED_STEP.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=LaserTagPOMDPMetrics.AVERAGE_OBSTACLE_COLLISIONS.value,
                 channel=LaserTagStepChannel.OBSTACLE_COLLISION.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=LaserTagPOMDPMetrics.AVERAGE_DANGEROUS_AREA_STEPS.value,
                 channel=LaserTagStepChannel.IN_DANGEROUS_AREA.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=LaserTagPOMDPMetrics.AVERAGE_ALL_DANGEROUS_ENCOUNTERS.value,
                 channel=LaserTagStepChannel.DANGEROUS_ENCOUNTER.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
         ]
 

--- a/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/continuous_light_dark_pomdp.py
@@ -43,6 +43,7 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue
+from POMDPPlanners.core.simulation.step_info_metrics import require_non_empty_histories
 from POMDPPlanners.environments.light_dark_pomdp import (
     _native,  # pylint: disable=no-name-in-module
 )
@@ -888,6 +889,7 @@ class ContinuousLightDarkPOMDP(BaseLightDarkPOMDP):
         return [metric.value for metric in ContinuousLightDarkPOMDPMetrics]
 
     def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
+        require_non_empty_histories(histories, type(self).__name__)
         goal_reached = []
         obstacle_hits = []
         obstacle_hit_counter = []

--- a/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/environments/light_dark_pomdp/discrete_light_dark_pomdp.py
@@ -13,6 +13,7 @@ import numpy as np
 from POMDPPlanners.core.distributions import DiscreteDistribution
 from POMDPPlanners.core.environment import DiscreteActionsEnvironment
 from POMDPPlanners.core.simulation import History, MetricValue
+from POMDPPlanners.core.simulation.step_info_metrics import require_non_empty_histories
 from POMDPPlanners.environments.light_dark_pomdp import (
     _native,  # pylint: disable=no-name-in-module
 )
@@ -1019,6 +1020,7 @@ class DiscreteLightDarkPOMDP(BaseLightDarkPOMDPDiscreteActions, DiscreteActionsE
         return [metric.value for metric in DiscreteLightDarkPOMDPMetrics]
 
     def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
+        require_non_empty_histories(histories, type(self).__name__)
         goal_reached = []
         obstacle_hits = []
         obstacle_hit_counter = []

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
@@ -37,11 +37,21 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.core.simulation.step_info_metrics import (
+    EpisodeReduction,
+    StepInfoMetric,
+    order_and_fill_metrics,
+)
 from POMDPPlanners.environments.mountain_car_pomdp import _native
 from POMDPPlanners.utils.multivariate_normal import CovarianceParameterizedMultivariateNormal
-from POMDPPlanners.utils.statistics_utils import confidence_interval
 
 matplotlib.use("Agg")  # Use non-interactive backend
+
+
+class MountainCarStepChannel(Enum):
+    """Per-step measurement channels reported by :meth:`MountainCarPOMDP.step_info`."""
+
+    AT_GOAL = "at_goal"
 
 
 class MountainCarPOMDPMetrics(Enum):
@@ -382,41 +392,50 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
         # Discrete int actions (-1, 0, 1); already hashable.
         return action
 
-    def get_metric_names(self) -> List[str]:
-        """Get names of Mountain Car POMDP specific metrics.
-
-        Returns:
-            List containing metric names: goal_reaching_rate
-        """
-        return [metric.value for metric in MountainCarPOMDPMetrics]
-
-    def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
-        """Compute Mountain Car POMDP specific metrics from simulation histories.
+    def step_info(self, state: Any, action: Any, next_state: Any) -> Dict[str, float]:
+        """Report whether the car has reached the goal position in this state.
 
         Args:
-            histories: List of simulation histories
+            state: The ``(position, velocity)`` state the step was taken from,
+                or the final state on the terminal step.
+            action: Unused; reaching the goal is a property of the state alone.
+            next_state: Unused; each state is scored when it is recorded.
 
         Returns:
-            List of MetricValue objects containing the computed metrics
+            The ``at_goal`` indicator for this step's state.
         """
-        goal_reached = []
-        for history in histories:
-            goal_reached_in_history = False
-            for step in history.history:
-                position, _ = step.state
-                if position >= self.goal_position:
-                    goal_reached_in_history = True
-                    break
-            goal_reached.append(1 if goal_reached_in_history else 0)
+        del action, next_state
+        position, _ = state
+        return {MountainCarStepChannel.AT_GOAL.value: float(position >= self.goal_position)}
 
-        avg_goal_reached = float(np.mean(goal_reached))
-        goal_reached_ci = confidence_interval(data=goal_reached, confidence=0.95)
+    def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
+        """Compute the Mountain Car metrics, always reporting every declared name.
 
+        The shared aggregator omits a metric no episode reported, which happens
+        for an empty history list or an episode with no recorded steps. This
+        environment has always reported a zero-valued goal_reaching_rate in that case, so the
+        declared names are filled rather than dropped.
+
+        Args:
+            histories: List of simulation histories.
+
+        Returns:
+            One MetricValue per declared metric name, in declaration order.
+        """
+        return order_and_fill_metrics(self.get_metric_names(), super().compute_metrics(histories))
+
+    def get_metric_specs(self) -> List[StepInfoMetric]:
+        """Declare the Mountain Car metric derived from the per-step channel.
+
+        Returns:
+            A spec for ``goal_reaching_rate``. ``ANY`` reproduces the historical
+            scan, which stopped at the first state past the goal.
+        """
         return [
-            MetricValue(
+            StepInfoMetric(
                 name=MountainCarPOMDPMetrics.GOAL_REACHING_RATE.value,
-                value=avg_goal_reached,
-                lower_confidence_bound=goal_reached_ci[0],
-                upper_confidence_bound=goal_reached_ci[1],
-            ),
+                channel=MountainCarStepChannel.AT_GOAL.value,
+                per_episode=EpisodeReduction.ANY,
+                empty_episode_value=0.0,
+            )
         ]

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
@@ -436,6 +436,5 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
                 name=MountainCarPOMDPMetrics.GOAL_REACHING_RATE.value,
                 channel=MountainCarStepChannel.AT_GOAL.value,
                 per_episode=EpisodeReduction.ANY,
-                empty_episode_value=0.0,
             )
         ]

--- a/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
+++ b/POMDPPlanners/environments/mountain_car_pomdp/mountain_car_pomdp.py
@@ -412,15 +412,20 @@ class MountainCarPOMDP(DiscreteActionsEnvironment):
         """Compute the Mountain Car metrics, always reporting every declared name.
 
         The shared aggregator omits a metric no episode reported, which happens
-        for an empty history list or an episode with no recorded steps. This
-        environment has always reported a zero-valued goal_reaching_rate in that case, so the
-        declared names are filled rather than dropped.
+        for an episode with no recorded steps. This environment has always
+        reported a zero-valued goal_reaching_rate in that case, so the declared
+        names are filled rather than dropped.
 
         Args:
             histories: List of simulation histories.
 
         Returns:
             One MetricValue per declared metric name, in declaration order.
+
+        Raises:
+            ValueError: If ``histories`` is empty, or if an episode ran without
+                being measured. See
+                :meth:`~POMDPPlanners.core.environment.environment.Environment.compute_metrics`.
         """
         return order_and_fill_metrics(self.get_metric_names(), super().compute_metrics(histories))
 

--- a/POMDPPlanners/environments/nuplan_pomdp/nuplan_pomdp.py
+++ b/POMDPPlanners/environments/nuplan_pomdp/nuplan_pomdp.py
@@ -80,6 +80,7 @@ import numpy as np
 from POMDPPlanners.core.distributions import Distribution
 from POMDPPlanners.core.environment import Environment, SpaceInfo, SpaceType
 from POMDPPlanners.core.simulation import History, MetricValue
+from POMDPPlanners.core.simulation.step_info_metrics import require_non_empty_histories
 from POMDPPlanners.utils.statistics_utils import confidence_interval
 
 # Default discrete control presets as ``(acceleration, steering_angle)`` pairs, in
@@ -829,8 +830,7 @@ class NuPlanPOMDP(Environment):
             - ``min_vehicle_distance``: mean over episodes of the closest the ego came to any
               agent (m); episodes that saw no agent are excluded.
         """
-        if not histories:
-            return []
+        require_non_empty_histories(histories, type(self).__name__)
         collisions = [1.0 if history.reach_terminal_state else 0.0 for history in histories]
         path_lengths = [self._episode_path_length(h) for h in histories if h.history]
         mean_speeds = [self._episode_mean_speed(h) for h in histories if h.history]

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -20,6 +20,7 @@ Classes:
     PacManPOMDP: The main POMDP environment implementation
 """
 
+import dataclasses
 from enum import Enum
 from pathlib import Path
 from collections.abc import Hashable
@@ -34,6 +35,11 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.core.simulation.step_info_metrics import (
+    EpisodeReduction,
+    StepInfoMetric,
+    order_and_fill_metrics,
+)
 from POMDPPlanners.environments.pacman_pomdp import _native  # pylint: disable=no-name-in-module
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.pacman_reward_models import (
     BasePacManRewardModel,
@@ -45,6 +51,36 @@ from POMDPPlanners.utils.statistics_utils import confidence_interval
 
 _GHOST_COORDINATION_CODES = {"independent": 0, "coordinated": 1, "mixed": 2}
 _GHOST_STRATEGY_CODES = {"aggressive": 0, "patrol": 1, "ambush": 2}
+
+
+# Per-ghost distance channels are generated per ghost id, so they cannot be enum
+# members. The prefix is distinct from "ghost_collision" on purpose: the
+# malformed-episode neutralizer selects these channels by prefix.
+GHOST_DISTANCE_CHANNEL_PREFIX = "ghost_distance_"
+
+
+def ghost_distance_channel(ghost_id: int) -> str:
+    """Build the per-step channel name carrying the distance to one ghost.
+
+    Args:
+        ghost_id: Zero-based ghost index.
+
+    Returns:
+        The channel name, e.g. ``"ghost_distance_0"``.
+    """
+    return f"{GHOST_DISTANCE_CHANNEL_PREFIX}{ghost_id}"
+
+
+class PacManStepChannel(Enum):
+    """Per-step measurement channels reported by :meth:`PacManPOMDP.step_info`."""
+
+    RECORDED_STEP = "recorded_step"
+    WON = "won"
+    PELLETS_COLLECTED = "pellets_collected"
+    CLOSEST_GHOST_DISTANCE = "closest_ghost_distance"
+    GHOST_COLLISION = "ghost_collision"
+    IN_DANGEROUS_AREA = "in_dangerous_area"
+    DANGEROUS_ENCOUNTER = "dangerous_encounter"
 
 
 class PacManPOMDPMetrics(Enum):
@@ -1364,68 +1400,209 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             ghost-collision and dangerous-area-step events; a step that is both
             counts twice.
         """
-        # Start with standard metrics
-        metric_names = [metric.value for metric in PacManPOMDPMetrics]
+        return [spec.name for spec in self.get_metric_specs()]
 
-        # Add dynamic per-ghost metrics for multi-ghost scenarios
-        if self.num_ghosts > 1:
-            for ghost_id in range(self.num_ghosts):
-                metric_names.append(f"avg_pacman_ghost_{ghost_id}_distance")
+    def step_info(self, state: Any, action: Any, next_state: Any) -> Dict[str, float]:
+        """Report win status, pellets, ghost proximity and hazard exposure.
 
-        return metric_names
+        Args:
+            state: The state the step was taken from, or the final state on the
+                terminal step.
+            action: Unused; every channel here is a property of the state.
+            next_state: Unused; each state is scored when it is recorded.
 
-    def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
-        """Compute environment-specific metrics."""
-        if not histories:
-            return []
+        Returns:
+            The per-step channels. ``recorded_step`` is emitted even for a
+            malformed state, because the historical episode length counted every
+            recorded step regardless of state validity, while every other channel
+            is omitted for such a state, matching the historical ``continue``.
+        """
+        del action, next_state
+        # Emitted unconditionally: avg_episode_length is len(history.history),
+        # which never depended on the state being well formed.
+        info: Dict[str, float] = {PacManStepChannel.RECORDED_STEP.value: 1.0}
+        if not (isinstance(state, np.ndarray) and state.shape == (self._state_dim,)):
+            return info
 
-        # Collect metrics from all episodes
-        wins = []
-        pellets_collected = []
-        episode_lengths = []
-        pacman_ghost_distances = []
-        collision_encounters = []
-        dangerous_area_steps = []
-        all_dangerous_encounters = []
+        pacman_pos = self.get_pacman_pos(state)
+        ghost_positions = self.get_ghost_positions(state)
+        collision = float(self._is_collision(pacman_pos, ghost_positions))
+        in_dangerous_area = float(self._is_in_dangerous_area(pacman_pos))
+        info.update(
+            {
+                PacManStepChannel.WON.value: float(self._check_episode_win_status(state)),
+                PacManStepChannel.PELLETS_COLLECTED.value: float(
+                    self._count_pellets_collected(state)
+                ),
+                PacManStepChannel.GHOST_COLLISION.value: collision,
+                PacManStepChannel.IN_DANGEROUS_AREA.value: in_dangerous_area,
+                # Own channel: the aggregator cannot add two. A step that is both
+                # a collision and inside a dangerous area counts twice, as before.
+                PacManStepChannel.DANGEROUS_ENCOUNTER.value: collision + in_dangerous_area,
+            }
+        )
 
-        for history in histories:
-            episode_data = self._process_episode_metrics(history)
-            episode_lengths.append(episode_data["episode_length"])
-            wins.append(episode_data["won"])
-            pellets_collected.append(episode_data["pellets_collected"])
-            collision_encounters.append(episode_data["collisions"])
-            dangerous_area_steps.append(episode_data["dangerous_area_steps"])
-            all_dangerous_encounters.append(episode_data["all_dangerous_encounters"])
+        closest_distance = self._get_closest_ghost_distance(pacman_pos, ghost_positions)
+        if closest_distance is not None:
+            # Omitted rather than zeroed when there are no ghosts: the historical
+            # code appended no distance, so such a step never entered the mean.
+            info[PacManStepChannel.CLOSEST_GHOST_DISTANCE.value] = float(closest_distance)
 
-            if episode_data["avg_distance"] is not None:
-                pacman_ghost_distances.append(episode_data["avg_distance"])
+        for ghost_id, ghost_pos in enumerate(ghost_positions):
+            info[ghost_distance_channel(ghost_id)] = self._calculate_manhattan_distance(
+                pacman_pos, ghost_pos
+            )
+        return info
 
-        # Create standard metrics using helper
-        metrics = []
-        metric_definitions = [
-            (PacManPOMDPMetrics.WIN_RATE.value, wins),
-            (PacManPOMDPMetrics.AVG_PELLETS_COLLECTED.value, pellets_collected),
-            (PacManPOMDPMetrics.AVG_EPISODE_LENGTH.value, episode_lengths),
-            (PacManPOMDPMetrics.AVG_PACMAN_CLOSEST_GHOST_DISTANCE.value, pacman_ghost_distances),
-            (PacManPOMDPMetrics.AVG_COLLISION_ENCOUNTERS.value, collision_encounters),
-            (PacManPOMDPMetrics.AVG_DANGEROUS_AREA_STEPS.value, dangerous_area_steps),
-            (
-                PacManPOMDPMetrics.AVG_ALL_DANGEROUS_ENCOUNTERS.value,
-                all_dangerous_encounters,
+    def get_metric_specs(self) -> List[StepInfoMetric]:
+        """Declare the PacMan metrics derived from the per-step channels.
+
+        Returns:
+            The seven standard specs in enum order, followed by one per-ghost
+            distance spec per ghost when there is more than one ghost -- which
+            reproduces the historical name ordering exactly.
+        """
+        specs = [
+            StepInfoMetric(
+                name=PacManPOMDPMetrics.WIN_RATE.value,
+                channel=PacManStepChannel.WON.value,
+                per_episode=EpisodeReduction.LAST,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=PacManPOMDPMetrics.AVG_PELLETS_COLLECTED.value,
+                channel=PacManStepChannel.PELLETS_COLLECTED.value,
+                per_episode=EpisodeReduction.LAST,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=PacManPOMDPMetrics.AVG_EPISODE_LENGTH.value,
+                channel=PacManStepChannel.RECORDED_STEP.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=PacManPOMDPMetrics.AVG_PACMAN_CLOSEST_GHOST_DISTANCE.value,
+                channel=PacManStepChannel.CLOSEST_GHOST_DISTANCE.value,
+                per_episode=EpisodeReduction.MEAN,
+            ),
+            StepInfoMetric(
+                name=PacManPOMDPMetrics.AVG_COLLISION_ENCOUNTERS.value,
+                channel=PacManStepChannel.GHOST_COLLISION.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=PacManPOMDPMetrics.AVG_DANGEROUS_AREA_STEPS.value,
+                channel=PacManStepChannel.IN_DANGEROUS_AREA.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=PacManPOMDPMetrics.AVG_ALL_DANGEROUS_ENCOUNTERS.value,
+                channel=PacManStepChannel.DANGEROUS_ENCOUNTER.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
             ),
         ]
-
-        for name, values in metric_definitions:
-            metric = self._create_metric_value(name, values)
-            if metric:
-                metrics.append(metric)
-
-        # Multi-ghost specific metrics
         if self.num_ghosts > 1:
-            per_ghost_metrics = self._compute_per_ghost_distance_metrics(histories)
-            metrics.extend(per_ghost_metrics)
+            specs.extend(
+                StepInfoMetric(
+                    name=f"avg_pacman_ghost_{ghost_id}_distance",
+                    channel=ghost_distance_channel(ghost_id),
+                    per_episode=EpisodeReduction.MEAN,
+                )
+                for ghost_id in range(self.num_ghosts)
+            )
+        return specs
 
-        return metrics
+    def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
+        """Compute PacMan metrics, preserving the malformed-final-state rule.
+
+        Args:
+            histories: List of simulation histories.
+
+        Returns:
+            One MetricValue per declared metric name, in declaration order, or an
+            empty list when there are no histories.
+        """
+        if not histories:
+            return []
+        return order_and_fill_metrics(
+            self.get_metric_names(),
+            super().compute_metrics(self._neutralize_malformed_episodes(histories)),
+            optional=self._distance_metric_names(),
+        )
+
+    def _distance_metric_names(self) -> List[str]:
+        # Historically the distance metrics disappeared when nothing contributed
+        # to them, rather than being reported as zero: the closest-ghost mean was
+        # built from a list that stayed empty, and the per-ghost pass skipped
+        # episodes with no steps entirely. The other seven always appeared,
+        # backed by initialized zeros.
+        names = [PacManPOMDPMetrics.AVG_PACMAN_CLOSEST_GHOST_DISTANCE.value]
+        if self.num_ghosts > 1:
+            names.extend(
+                f"avg_pacman_ghost_{ghost_id}_distance" for ghost_id in range(self.num_ghosts)
+            )
+        return names
+
+    def _neutralize_malformed_episodes(self, histories: List[History]) -> List[History]:
+        # An episode whose *final* state is malformed has always reported zeros
+        # for the seven standard metrics -- the historical code discarded
+        # everything it had collected and returned its initialized defaults --
+        # while still counting the episode's length, and while leaving the
+        # per-ghost distances untouched, because those were computed by a
+        # separate pass that never consulted the final state.
+        #
+        # Zeroing must be explicit rather than by omission: an episode that
+        # reports no value for a channel is dropped from that metric's average,
+        # where this one contributed a 0.
+        neutralized: List[History] = []
+        for history in histories:
+            if not history.history or self._has_well_formed_final_state(history):
+                neutralized.append(history)
+                continue
+            steps = [
+                step._replace(info=self._neutralized_step_info(step.info))
+                for step in history.history
+            ]
+            # The per-ghost pass gave a non-empty episode with no well-formed
+            # state an average of 0.0 per ghost, rather than skipping it. Only
+            # a step-less episode was skipped, and those never reach here.
+            if self.num_ghosts > 1 and not any(
+                channel.startswith(GHOST_DISTANCE_CHANNEL_PREFIX)
+                for step in steps
+                for channel in (step.info or {})
+            ):
+                zeros = {
+                    ghost_distance_channel(ghost_id): 0.0 for ghost_id in range(self.num_ghosts)
+                }
+                steps[0] = steps[0]._replace(info={**(steps[0].info or {}), **zeros})
+            neutralized.append(dataclasses.replace(history, history=steps))
+        return neutralized
+
+    def _has_well_formed_final_state(self, history: History) -> bool:
+        final_state = history.history[-1].state
+        return isinstance(final_state, np.ndarray) and final_state.shape == (self._state_dim,)
+
+    @staticmethod
+    def _neutralized_step_info(step_info: Optional[Dict[str, float]]) -> Dict[str, float]:
+        zeroed = {
+            PacManStepChannel.RECORDED_STEP.value: 1.0,
+            PacManStepChannel.WON.value: 0.0,
+            PacManStepChannel.PELLETS_COLLECTED.value: 0.0,
+            PacManStepChannel.GHOST_COLLISION.value: 0.0,
+            PacManStepChannel.IN_DANGEROUS_AREA.value: 0.0,
+            PacManStepChannel.DANGEROUS_ENCOUNTER.value: 0.0,
+        }
+        # The closest-ghost distance is dropped rather than zeroed, matching the
+        # historical ``avg_distance = None`` that excluded the episode from that
+        # one mean. The per-ghost channels are carried through untouched.
+        for channel, value in (step_info or {}).items():
+            if channel.startswith(GHOST_DISTANCE_CHANNEL_PREFIX):
+                zeroed[channel] = value
+        return zeroed
 
     def visualize_path(self, path: List[np.ndarray], actions: List[int], cache_path: Path):
         """Visualize PacMan path through the maze using sprite-based rendering.

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -20,7 +20,6 @@ Classes:
     PacManPOMDP: The main POMDP environment implementation
 """
 
-import dataclasses
 from enum import Enum
 from pathlib import Path
 from collections.abc import Hashable
@@ -35,11 +34,6 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
-from POMDPPlanners.core.simulation.step_info_metrics import (
-    EpisodeReduction,
-    StepInfoMetric,
-    order_and_fill_metrics,
-)
 from POMDPPlanners.environments.pacman_pomdp import _native  # pylint: disable=no-name-in-module
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.pacman_reward_models import (
     BasePacManRewardModel,
@@ -51,36 +45,6 @@ from POMDPPlanners.utils.statistics_utils import confidence_interval
 
 _GHOST_COORDINATION_CODES = {"independent": 0, "coordinated": 1, "mixed": 2}
 _GHOST_STRATEGY_CODES = {"aggressive": 0, "patrol": 1, "ambush": 2}
-
-
-# Per-ghost distance channels are generated per ghost id, so they cannot be enum
-# members. The prefix is distinct from "ghost_collision" on purpose: the
-# malformed-episode neutralizer selects these channels by prefix.
-GHOST_DISTANCE_CHANNEL_PREFIX = "ghost_distance_"
-
-
-def ghost_distance_channel(ghost_id: int) -> str:
-    """Build the per-step channel name carrying the distance to one ghost.
-
-    Args:
-        ghost_id: Zero-based ghost index.
-
-    Returns:
-        The channel name, e.g. ``"ghost_distance_0"``.
-    """
-    return f"{GHOST_DISTANCE_CHANNEL_PREFIX}{ghost_id}"
-
-
-class PacManStepChannel(Enum):
-    """Per-step measurement channels reported by :meth:`PacManPOMDP.step_info`."""
-
-    RECORDED_STEP = "recorded_step"
-    WON = "won"
-    PELLETS_COLLECTED = "pellets_collected"
-    CLOSEST_GHOST_DISTANCE = "closest_ghost_distance"
-    GHOST_COLLISION = "ghost_collision"
-    IN_DANGEROUS_AREA = "in_dangerous_area"
-    DANGEROUS_ENCOUNTER = "dangerous_encounter"
 
 
 class PacManPOMDPMetrics(Enum):
@@ -1400,209 +1364,68 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
             ghost-collision and dangerous-area-step events; a step that is both
             counts twice.
         """
-        return [spec.name for spec in self.get_metric_specs()]
+        # Start with standard metrics
+        metric_names = [metric.value for metric in PacManPOMDPMetrics]
 
-    def step_info(self, state: Any, action: Any, next_state: Any) -> Dict[str, float]:
-        """Report win status, pellets, ghost proximity and hazard exposure.
-
-        Args:
-            state: The state the step was taken from, or the final state on the
-                terminal step.
-            action: Unused; every channel here is a property of the state.
-            next_state: Unused; each state is scored when it is recorded.
-
-        Returns:
-            The per-step channels. ``recorded_step`` is emitted even for a
-            malformed state, because the historical episode length counted every
-            recorded step regardless of state validity, while every other channel
-            is omitted for such a state, matching the historical ``continue``.
-        """
-        del action, next_state
-        # Emitted unconditionally: avg_episode_length is len(history.history),
-        # which never depended on the state being well formed.
-        info: Dict[str, float] = {PacManStepChannel.RECORDED_STEP.value: 1.0}
-        if not (isinstance(state, np.ndarray) and state.shape == (self._state_dim,)):
-            return info
-
-        pacman_pos = self.get_pacman_pos(state)
-        ghost_positions = self.get_ghost_positions(state)
-        collision = float(self._is_collision(pacman_pos, ghost_positions))
-        in_dangerous_area = float(self._is_in_dangerous_area(pacman_pos))
-        info.update(
-            {
-                PacManStepChannel.WON.value: float(self._check_episode_win_status(state)),
-                PacManStepChannel.PELLETS_COLLECTED.value: float(
-                    self._count_pellets_collected(state)
-                ),
-                PacManStepChannel.GHOST_COLLISION.value: collision,
-                PacManStepChannel.IN_DANGEROUS_AREA.value: in_dangerous_area,
-                # Own channel: the aggregator cannot add two. A step that is both
-                # a collision and inside a dangerous area counts twice, as before.
-                PacManStepChannel.DANGEROUS_ENCOUNTER.value: collision + in_dangerous_area,
-            }
-        )
-
-        closest_distance = self._get_closest_ghost_distance(pacman_pos, ghost_positions)
-        if closest_distance is not None:
-            # Omitted rather than zeroed when there are no ghosts: the historical
-            # code appended no distance, so such a step never entered the mean.
-            info[PacManStepChannel.CLOSEST_GHOST_DISTANCE.value] = float(closest_distance)
-
-        for ghost_id, ghost_pos in enumerate(ghost_positions):
-            info[ghost_distance_channel(ghost_id)] = self._calculate_manhattan_distance(
-                pacman_pos, ghost_pos
-            )
-        return info
-
-    def get_metric_specs(self) -> List[StepInfoMetric]:
-        """Declare the PacMan metrics derived from the per-step channels.
-
-        Returns:
-            The seven standard specs in enum order, followed by one per-ghost
-            distance spec per ghost when there is more than one ghost -- which
-            reproduces the historical name ordering exactly.
-        """
-        specs = [
-            StepInfoMetric(
-                name=PacManPOMDPMetrics.WIN_RATE.value,
-                channel=PacManStepChannel.WON.value,
-                per_episode=EpisodeReduction.LAST,
-                empty_episode_value=0.0,
-            ),
-            StepInfoMetric(
-                name=PacManPOMDPMetrics.AVG_PELLETS_COLLECTED.value,
-                channel=PacManStepChannel.PELLETS_COLLECTED.value,
-                per_episode=EpisodeReduction.LAST,
-                empty_episode_value=0.0,
-            ),
-            StepInfoMetric(
-                name=PacManPOMDPMetrics.AVG_EPISODE_LENGTH.value,
-                channel=PacManStepChannel.RECORDED_STEP.value,
-                per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
-            ),
-            StepInfoMetric(
-                name=PacManPOMDPMetrics.AVG_PACMAN_CLOSEST_GHOST_DISTANCE.value,
-                channel=PacManStepChannel.CLOSEST_GHOST_DISTANCE.value,
-                per_episode=EpisodeReduction.MEAN,
-            ),
-            StepInfoMetric(
-                name=PacManPOMDPMetrics.AVG_COLLISION_ENCOUNTERS.value,
-                channel=PacManStepChannel.GHOST_COLLISION.value,
-                per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
-            ),
-            StepInfoMetric(
-                name=PacManPOMDPMetrics.AVG_DANGEROUS_AREA_STEPS.value,
-                channel=PacManStepChannel.IN_DANGEROUS_AREA.value,
-                per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
-            ),
-            StepInfoMetric(
-                name=PacManPOMDPMetrics.AVG_ALL_DANGEROUS_ENCOUNTERS.value,
-                channel=PacManStepChannel.DANGEROUS_ENCOUNTER.value,
-                per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
-            ),
-        ]
+        # Add dynamic per-ghost metrics for multi-ghost scenarios
         if self.num_ghosts > 1:
-            specs.extend(
-                StepInfoMetric(
-                    name=f"avg_pacman_ghost_{ghost_id}_distance",
-                    channel=ghost_distance_channel(ghost_id),
-                    per_episode=EpisodeReduction.MEAN,
-                )
-                for ghost_id in range(self.num_ghosts)
-            )
-        return specs
+            for ghost_id in range(self.num_ghosts):
+                metric_names.append(f"avg_pacman_ghost_{ghost_id}_distance")
+
+        return metric_names
 
     def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
-        """Compute PacMan metrics, preserving the malformed-final-state rule.
-
-        Args:
-            histories: List of simulation histories.
-
-        Returns:
-            One MetricValue per declared metric name, in declaration order, or an
-            empty list when there are no histories.
-        """
+        """Compute environment-specific metrics."""
         if not histories:
             return []
-        return order_and_fill_metrics(
-            self.get_metric_names(),
-            super().compute_metrics(self._neutralize_malformed_episodes(histories)),
-            optional=self._distance_metric_names(),
-        )
 
-    def _distance_metric_names(self) -> List[str]:
-        # Historically the distance metrics disappeared when nothing contributed
-        # to them, rather than being reported as zero: the closest-ghost mean was
-        # built from a list that stayed empty, and the per-ghost pass skipped
-        # episodes with no steps entirely. The other seven always appeared,
-        # backed by initialized zeros.
-        names = [PacManPOMDPMetrics.AVG_PACMAN_CLOSEST_GHOST_DISTANCE.value]
-        if self.num_ghosts > 1:
-            names.extend(
-                f"avg_pacman_ghost_{ghost_id}_distance" for ghost_id in range(self.num_ghosts)
-            )
-        return names
+        # Collect metrics from all episodes
+        wins = []
+        pellets_collected = []
+        episode_lengths = []
+        pacman_ghost_distances = []
+        collision_encounters = []
+        dangerous_area_steps = []
+        all_dangerous_encounters = []
 
-    def _neutralize_malformed_episodes(self, histories: List[History]) -> List[History]:
-        # An episode whose *final* state is malformed has always reported zeros
-        # for the seven standard metrics -- the historical code discarded
-        # everything it had collected and returned its initialized defaults --
-        # while still counting the episode's length, and while leaving the
-        # per-ghost distances untouched, because those were computed by a
-        # separate pass that never consulted the final state.
-        #
-        # Zeroing must be explicit rather than by omission: an episode that
-        # reports no value for a channel is dropped from that metric's average,
-        # where this one contributed a 0.
-        neutralized: List[History] = []
         for history in histories:
-            if not history.history or self._has_well_formed_final_state(history):
-                neutralized.append(history)
-                continue
-            steps = [
-                step._replace(info=self._neutralized_step_info(step.info))
-                for step in history.history
-            ]
-            # The per-ghost pass gave a non-empty episode with no well-formed
-            # state an average of 0.0 per ghost, rather than skipping it. Only
-            # a step-less episode was skipped, and those never reach here.
-            if self.num_ghosts > 1 and not any(
-                channel.startswith(GHOST_DISTANCE_CHANNEL_PREFIX)
-                for step in steps
-                for channel in (step.info or {})
-            ):
-                zeros = {
-                    ghost_distance_channel(ghost_id): 0.0 for ghost_id in range(self.num_ghosts)
-                }
-                steps[0] = steps[0]._replace(info={**(steps[0].info or {}), **zeros})
-            neutralized.append(dataclasses.replace(history, history=steps))
-        return neutralized
+            episode_data = self._process_episode_metrics(history)
+            episode_lengths.append(episode_data["episode_length"])
+            wins.append(episode_data["won"])
+            pellets_collected.append(episode_data["pellets_collected"])
+            collision_encounters.append(episode_data["collisions"])
+            dangerous_area_steps.append(episode_data["dangerous_area_steps"])
+            all_dangerous_encounters.append(episode_data["all_dangerous_encounters"])
 
-    def _has_well_formed_final_state(self, history: History) -> bool:
-        final_state = history.history[-1].state
-        return isinstance(final_state, np.ndarray) and final_state.shape == (self._state_dim,)
+            if episode_data["avg_distance"] is not None:
+                pacman_ghost_distances.append(episode_data["avg_distance"])
 
-    @staticmethod
-    def _neutralized_step_info(step_info: Optional[Dict[str, float]]) -> Dict[str, float]:
-        zeroed = {
-            PacManStepChannel.RECORDED_STEP.value: 1.0,
-            PacManStepChannel.WON.value: 0.0,
-            PacManStepChannel.PELLETS_COLLECTED.value: 0.0,
-            PacManStepChannel.GHOST_COLLISION.value: 0.0,
-            PacManStepChannel.IN_DANGEROUS_AREA.value: 0.0,
-            PacManStepChannel.DANGEROUS_ENCOUNTER.value: 0.0,
-        }
-        # The closest-ghost distance is dropped rather than zeroed, matching the
-        # historical ``avg_distance = None`` that excluded the episode from that
-        # one mean. The per-ghost channels are carried through untouched.
-        for channel, value in (step_info or {}).items():
-            if channel.startswith(GHOST_DISTANCE_CHANNEL_PREFIX):
-                zeroed[channel] = value
-        return zeroed
+        # Create standard metrics using helper
+        metrics = []
+        metric_definitions = [
+            (PacManPOMDPMetrics.WIN_RATE.value, wins),
+            (PacManPOMDPMetrics.AVG_PELLETS_COLLECTED.value, pellets_collected),
+            (PacManPOMDPMetrics.AVG_EPISODE_LENGTH.value, episode_lengths),
+            (PacManPOMDPMetrics.AVG_PACMAN_CLOSEST_GHOST_DISTANCE.value, pacman_ghost_distances),
+            (PacManPOMDPMetrics.AVG_COLLISION_ENCOUNTERS.value, collision_encounters),
+            (PacManPOMDPMetrics.AVG_DANGEROUS_AREA_STEPS.value, dangerous_area_steps),
+            (
+                PacManPOMDPMetrics.AVG_ALL_DANGEROUS_ENCOUNTERS.value,
+                all_dangerous_encounters,
+            ),
+        ]
+
+        for name, values in metric_definitions:
+            metric = self._create_metric_value(name, values)
+            if metric:
+                metrics.append(metric)
+
+        # Multi-ghost specific metrics
+        if self.num_ghosts > 1:
+            per_ghost_metrics = self._compute_per_ghost_distance_metrics(histories)
+            metrics.extend(per_ghost_metrics)
+
+        return metrics
 
     def visualize_path(self, path: List[np.ndarray], actions: List[int], cache_path: Path):
         """Visualize PacMan path through the maze using sprite-based rendering.

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -34,6 +34,7 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.core.simulation.step_info_metrics import require_non_empty_histories
 from POMDPPlanners.environments.pacman_pomdp import _native  # pylint: disable=no-name-in-module
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp_utils.pacman_reward_models import (
     BasePacManRewardModel,
@@ -1250,9 +1251,11 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         metrics_data["pellets_collected"] = self._count_pellets_collected(final_state)
 
         # Collect distances, collisions, and danger-area steps from episode steps
-        episode_distances, episode_collisions, episode_danger_steps = (
-            self._collect_step_distances_and_collisions(history)
-        )
+        (
+            episode_distances,
+            episode_collisions,
+            episode_danger_steps,
+        ) = self._collect_step_distances_and_collisions(history)
 
         if episode_distances:
             metrics_data["avg_distance"] = float(np.mean(episode_distances))
@@ -1375,9 +1378,19 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         return metric_names
 
     def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
-        """Compute environment-specific metrics."""
-        if not histories:
-            return []
+        """Compute environment-specific metrics.
+
+        Args:
+            histories: List of simulation histories.
+
+        Returns:
+            One MetricValue per declared metric name.
+
+        Raises:
+            ValueError: If ``histories`` is empty. See
+                :meth:`~POMDPPlanners.core.environment.environment.Environment.compute_metrics`.
+        """
+        require_non_empty_histories(histories, type(self).__name__)
 
         # Collect metrics from all episodes
         wins = []

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -925,6 +925,11 @@ class ContinuousPushPOMDP(Environment):  # pylint: disable=too-many-public-metho
 
         Returns:
             One MetricValue per declared metric name, in declaration order.
+
+        Raises:
+            ValueError: If ``histories`` is empty, or if an episode ran without
+                being measured. See
+                :meth:`~POMDPPlanners.core.environment.environment.Environment.compute_metrics`.
         """
         computed = list(super().compute_metrics(histories)) + self._pooled_rate_metrics(histories)
         return order_and_fill_metrics(self.get_metric_names(), computed)

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -894,31 +894,26 @@ class ContinuousPushPOMDP(Environment):  # pylint: disable=too-many-public-metho
                 name=ContinuousPushPOMDPMetrics.GOAL_REACHING_RATE.value,
                 channel=ContinuousPushStepChannel.GOAL_REACHED.value,
                 per_episode=EpisodeReduction.ANY,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=ContinuousPushPOMDPMetrics.TOTAL_ROBOT_OBSTACLE_COLLISIONS.value,
                 channel=ContinuousPushStepChannel.ROBOT_OBSTACLE_COLLISION.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=ContinuousPushPOMDPMetrics.TOTAL_OBJECT_OBSTACLE_COLLISIONS.value,
                 channel=ContinuousPushStepChannel.OBJECT_OBSTACLE_COLLISION.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=ContinuousPushPOMDPMetrics.TOTAL_ALL_OBSTACLE_COLLISIONS.value,
                 channel=ContinuousPushStepChannel.ANY_OBSTACLE_COLLISION.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=ContinuousPushPOMDPMetrics.TOTAL_DANGEROUS_AREA_STEPS.value,
                 channel=ContinuousPushStepChannel.IN_DANGEROUS_AREA.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
         ]
 

--- a/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/continuous_push_pomdp.py
@@ -38,6 +38,12 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.core.simulation.step_info_metrics import (
+    EpisodeReduction,
+    StepInfoMetric,
+    extract_episode_step_infos,
+    order_and_fill_metrics,
+)
 from POMDPPlanners.environments.push_pomdp import _native
 from POMDPPlanners.planners.planners_utils.rollout import python_random_rollout
 from POMDPPlanners.environments.push_pomdp.continuous_push_geometry import (
@@ -56,6 +62,16 @@ from POMDPPlanners.utils.statistics_utils import confidence_interval
 from POMDPPlanners.environments.push_pomdp.continuous_push_pomdp_visualizer import (  # pylint: disable=import-outside-toplevel
     ContinuousPushPOMDPVisualizer,
 )
+
+
+class ContinuousPushStepChannel(Enum):
+    """Per-step channels reported by :meth:`ContinuousPushPOMDP.step_info`."""
+
+    GOAL_REACHED = "goal_reached"
+    ROBOT_OBSTACLE_COLLISION = "robot_obstacle_collision"
+    OBJECT_OBSTACLE_COLLISION = "object_obstacle_collision"
+    ANY_OBSTACLE_COLLISION = "any_obstacle_collision"
+    IN_DANGEROUS_AREA = "in_dangerous_area"
 
 
 class ContinuousPushPOMDPMetrics(Enum):
@@ -117,7 +133,7 @@ class _RandomInitialStateDistribution(Distribution):
     # pylint: enable=protected-access
 
 
-class ContinuousPushPOMDP(Environment):
+class ContinuousPushPOMDP(Environment):  # pylint: disable=too-many-public-methods
     """Continuous-action Push POMDP environment.
 
     A robot (circle) must push an object (point) to a target location on
@@ -832,128 +848,143 @@ class ContinuousPushPOMDP(Environment):
         """
         return [m.value for m in ContinuousPushPOMDPMetrics]
 
-    def compute_metrics(  # pylint: disable=too-many-locals
-        self, histories: List[History]
-    ) -> List[MetricValue]:
-        goal_reached_list: List[int] = []
-        robot_col_list: List[int] = []
-        obj_col_list: List[int] = []
-        total_col_list: List[int] = []
-        dangerous_steps_list: List[int] = []
+    def step_info(self, state: Any, action: Any, next_state: Any) -> Dict[str, float]:
+        """Report obstacle contact and hazard exposure for this step's state.
 
-        for history in histories:
-            goal_hit = False
-            r_cols = 0
-            o_cols = 0
-            d_steps = 0
+        Args:
+            state: The state the step was taken from, or the final state on the
+                terminal step.
+            action: Unused; every channel here is a property of the state.
+            next_state: Unused; each state is scored when it is recorded.
 
-            for step in history.history:
-                if self.is_terminal(step.state):
-                    goal_hit = True
-                if self._is_circle_colliding_with_obstacle(step.state[:2], self.robot_radius):
-                    r_cols += 1
-                if self._is_point_colliding_with_obstacle(step.state[2:4]):
-                    o_cols += 1
-                if self._is_robot_in_dangerous_area(step.state[:2]):
-                    d_steps += 1
-
-            goal_reached_list.append(1 if goal_hit else 0)
-            robot_col_list.append(r_cols)
-            obj_col_list.append(o_cols)
-            total_col_list.append(r_cols + o_cols)
-            dangerous_steps_list.append(d_steps)
-
-        total_steps = sum(len(h.history) for h in histories)
-        avg_r = sum(robot_col_list) / total_steps if total_steps > 0 else 0
-        avg_o = sum(obj_col_list) / total_steps if total_steps > 0 else 0
-        avg_t = sum(total_col_list) / total_steps if total_steps > 0 else 0
-        avg_d = sum(dangerous_steps_list) / total_steps if total_steps > 0 else 0
-
-        r_rates = [c / len(h.history) for c, h in zip(robot_col_list, histories) if len(h.history)]
-        o_rates = [c / len(h.history) for c, h in zip(obj_col_list, histories) if len(h.history)]
-        t_rates = [c / len(h.history) for c, h in zip(total_col_list, histories) if len(h.history)]
-        d_rates = [
-            c / len(h.history) for c, h in zip(dangerous_steps_list, histories) if len(h.history)
-        ]
-
-        r_ci = confidence_interval(data=r_rates, confidence=0.95) if r_rates else (0, 0)
-        o_ci = confidence_interval(data=o_rates, confidence=0.95) if o_rates else (0, 0)
-        t_ci = confidence_interval(data=t_rates, confidence=0.95) if t_rates else (0, 0)
-        d_ci = confidence_interval(data=d_rates, confidence=0.95) if d_rates else (0, 0)
-
-        tr_ci = (
-            confidence_interval(data=robot_col_list, confidence=0.95) if robot_col_list else (0, 0)
+        Returns:
+            The robot / object collision indicators, their sum, and the
+            dangerous-area indicator.
+        """
+        del action, next_state
+        robot_pos = state[:2]
+        robot_collision = float(
+            self._is_circle_colliding_with_obstacle(robot_pos, self.robot_radius)
         )
-        to_ci = confidence_interval(data=obj_col_list, confidence=0.95) if obj_col_list else (0, 0)
-        ta_ci = (
-            confidence_interval(data=total_col_list, confidence=0.95) if total_col_list else (0, 0)
-        )
-        td_ci = (
-            confidence_interval(data=dangerous_steps_list, confidence=0.95)
-            if dangerous_steps_list
-            else (0, 0)
-        )
+        object_collision = float(self._is_point_colliding_with_obstacle(state[2:4]))
+        return {
+            ContinuousPushStepChannel.GOAL_REACHED.value: float(self.is_terminal(state)),
+            ContinuousPushStepChannel.ROBOT_OBSTACLE_COLLISION.value: robot_collision,
+            ContinuousPushStepChannel.OBJECT_OBSTACLE_COLLISION.value: object_collision,
+            # Own channel: the aggregator reduces one channel at a time and
+            # cannot add two. A step where both collide counts twice, as before.
+            ContinuousPushStepChannel.ANY_OBSTACLE_COLLISION.value: (
+                robot_collision + object_collision
+            ),
+            ContinuousPushStepChannel.IN_DANGEROUS_AREA.value: float(
+                self._is_robot_in_dangerous_area(robot_pos)
+            ),
+        }
 
-        avg_goal = float(np.mean(goal_reached_list)) if goal_reached_list else 0.0
-        g_ci = (
-            confidence_interval(data=goal_reached_list, confidence=0.95)
-            if goal_reached_list
-            else (0, 0)
-        )
+    def get_metric_specs(self) -> List[StepInfoMetric]:
+        """Declare the metrics derived from the per-step channels.
 
+        Returns:
+            Specs for the goal rate and the four per-episode totals. The four
+            ``*_rate`` metrics are pooled across episodes and cannot be expressed
+            as a per-episode reduction, so :meth:`compute_metrics` produces them.
+        """
         return [
-            MetricValue(
-                ContinuousPushPOMDPMetrics.GOAL_REACHING_RATE.value, avg_goal, g_ci[0], g_ci[1]
+            StepInfoMetric(
+                name=ContinuousPushPOMDPMetrics.GOAL_REACHING_RATE.value,
+                channel=ContinuousPushStepChannel.GOAL_REACHED.value,
+                per_episode=EpisodeReduction.ANY,
+                empty_episode_value=0.0,
             ),
-            MetricValue(
-                ContinuousPushPOMDPMetrics.ROBOT_OBSTACLE_COLLISION_RATE.value,
-                avg_r,
-                r_ci[0],
-                r_ci[1],
+            StepInfoMetric(
+                name=ContinuousPushPOMDPMetrics.TOTAL_ROBOT_OBSTACLE_COLLISIONS.value,
+                channel=ContinuousPushStepChannel.ROBOT_OBSTACLE_COLLISION.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
             ),
-            MetricValue(
-                ContinuousPushPOMDPMetrics.OBJECT_OBSTACLE_COLLISION_RATE.value,
-                avg_o,
-                o_ci[0],
-                o_ci[1],
+            StepInfoMetric(
+                name=ContinuousPushPOMDPMetrics.TOTAL_OBJECT_OBSTACLE_COLLISIONS.value,
+                channel=ContinuousPushStepChannel.OBJECT_OBSTACLE_COLLISION.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
             ),
-            MetricValue(
-                ContinuousPushPOMDPMetrics.TOTAL_OBSTACLE_COLLISION_RATE.value,
-                avg_t,
-                t_ci[0],
-                t_ci[1],
+            StepInfoMetric(
+                name=ContinuousPushPOMDPMetrics.TOTAL_ALL_OBSTACLE_COLLISIONS.value,
+                channel=ContinuousPushStepChannel.ANY_OBSTACLE_COLLISION.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
             ),
-            MetricValue(
-                ContinuousPushPOMDPMetrics.TOTAL_ROBOT_OBSTACLE_COLLISIONS.value,
-                float(np.mean(robot_col_list)) if robot_col_list else 0.0,
-                tr_ci[0],
-                tr_ci[1],
-            ),
-            MetricValue(
-                ContinuousPushPOMDPMetrics.TOTAL_OBJECT_OBSTACLE_COLLISIONS.value,
-                float(np.mean(obj_col_list)) if obj_col_list else 0.0,
-                to_ci[0],
-                to_ci[1],
-            ),
-            MetricValue(
-                ContinuousPushPOMDPMetrics.TOTAL_ALL_OBSTACLE_COLLISIONS.value,
-                float(np.mean(total_col_list)) if total_col_list else 0.0,
-                ta_ci[0],
-                ta_ci[1],
-            ),
-            MetricValue(
-                ContinuousPushPOMDPMetrics.DANGEROUS_AREA_RATE.value,
-                avg_d,
-                d_ci[0],
-                d_ci[1],
-            ),
-            MetricValue(
-                ContinuousPushPOMDPMetrics.TOTAL_DANGEROUS_AREA_STEPS.value,
-                float(np.mean(dangerous_steps_list)) if dangerous_steps_list else 0.0,
-                td_ci[0],
-                td_ci[1],
+            StepInfoMetric(
+                name=ContinuousPushPOMDPMetrics.TOTAL_DANGEROUS_AREA_STEPS.value,
+                channel=ContinuousPushStepChannel.IN_DANGEROUS_AREA.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
             ),
         ]
+
+    def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
+        """Compute all nine metrics, in declaration order.
+
+        Args:
+            histories: List of simulation histories.
+
+        Returns:
+            One MetricValue per declared metric name, in declaration order.
+        """
+        computed = list(super().compute_metrics(histories)) + self._pooled_rate_metrics(histories)
+        return order_and_fill_metrics(self.get_metric_names(), computed)
+
+    def _pooled_rate_metrics(self, histories: List[History]) -> List[MetricValue]:
+        # Pooled over all steps of all episodes -- sum(counts) / sum(lengths) --
+        # which is not the mean of per-episode values unless every episode has
+        # the same length, so the shared aggregator cannot express these. Their
+        # confidence intervals come from per-episode rates while their point
+        # estimates are the pooled ratio; that predates this migration and is
+        # preserved rather than quietly fixed.
+        counts = self._per_episode_counts(histories)
+        total_steps = sum(len(history.history) for history in histories)
+
+        metrics: List[MetricValue] = []
+        for name, key in (
+            (ContinuousPushPOMDPMetrics.ROBOT_OBSTACLE_COLLISION_RATE.value, "robot"),
+            (ContinuousPushPOMDPMetrics.OBJECT_OBSTACLE_COLLISION_RATE.value, "object"),
+            (ContinuousPushPOMDPMetrics.TOTAL_OBSTACLE_COLLISION_RATE.value, "total"),
+            (ContinuousPushPOMDPMetrics.DANGEROUS_AREA_RATE.value, "dangerous"),
+        ):
+            episode_counts = counts[key]
+            value = sum(episode_counts) / total_steps if total_steps > 0 else 0
+            rates = [
+                count / len(history.history)
+                for count, history in zip(episode_counts, histories)
+                if len(history.history)
+            ]
+            lower, upper = confidence_interval(data=rates, confidence=0.95) if rates else (0, 0)
+            metrics.append(
+                MetricValue(
+                    name=name,
+                    value=value,
+                    lower_confidence_bound=lower,
+                    upper_confidence_bound=upper,
+                )
+            )
+        return metrics
+
+    def _per_episode_counts(self, histories: List[History]) -> Dict[str, List[float]]:
+        # Read back the same channels the specs consume, so a pooled rate and its
+        # matching total can never be computed from different measurements. Every
+        # episode contributes an entry, including one with no steps, matching the
+        # historical unconditional append.
+        counts: Dict[str, List[float]] = {"robot": [], "object": [], "total": [], "dangerous": []}
+        channels = {
+            "robot": ContinuousPushStepChannel.ROBOT_OBSTACLE_COLLISION.value,
+            "object": ContinuousPushStepChannel.OBJECT_OBSTACLE_COLLISION.value,
+            "total": ContinuousPushStepChannel.ANY_OBSTACLE_COLLISION.value,
+            "dangerous": ContinuousPushStepChannel.IN_DANGEROUS_AREA.value,
+        }
+        for episode in extract_episode_step_infos(histories):
+            for key, channel in channels.items():
+                counts[key].append(sum(step_info.get(channel, 0.0) for step_info in episode))
+        return counts
 
 
 class ContinuousPushPOMDPDiscreteActions(ContinuousPushPOMDP, DiscreteActionsEnvironment):

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -1029,6 +1029,11 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
 
         Returns:
             One MetricValue per declared metric name, in declaration order.
+
+        Raises:
+            ValueError: If ``histories`` is empty, or if an episode ran without
+                being measured. See
+                :meth:`~POMDPPlanners.core.environment.environment.Environment.compute_metrics`.
         """
         computed = list(super().compute_metrics(histories)) + self._pooled_rate_metrics(histories)
         return order_and_fill_metrics(self.get_metric_names(), computed)

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -998,7 +998,6 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
                 name=PushPOMDPMetrics.GOAL_REACHING_RATE.value,
                 channel=PushStepChannel.GOAL_REACHED.value,
                 per_episode=EpisodeReduction.ANY,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=PushPOMDPMetrics.TOTAL_ROBOT_OBSTACLE_COLLISIONS.value,

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -40,6 +40,12 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.core.simulation.step_info_metrics import (
+    EpisodeReduction,
+    StepInfoMetric,
+    extract_episode_step_infos,
+    order_and_fill_metrics,
+)
 from POMDPPlanners.environments.push_pomdp import _native
 from POMDPPlanners.environments.push_pomdp.push_pomdp_utils.push_reward_models import (
     BasePushRewardModel,
@@ -50,6 +56,16 @@ from POMDPPlanners.environments.push_pomdp.push_pomdp_utils.push_reward_models i
 )
 from POMDPPlanners.environments.push_pomdp.push_pomdp_visualizer import PushPOMDPVisualizer
 from POMDPPlanners.utils.statistics_utils import confidence_interval
+
+
+class PushStepChannel(Enum):
+    """Per-step measurement channels reported by :meth:`PushPOMDP.step_info`."""
+
+    GOAL_REACHED = "goal_reached"
+    ROBOT_OBSTACLE_COLLISION = "robot_obstacle_collision"
+    OBJECT_OBSTACLE_COLLISION = "object_obstacle_collision"
+    ANY_OBSTACLE_COLLISION = "any_obstacle_collision"
+    IN_DANGEROUS_AREA = "in_dangerous_area"
 
 
 class PushPOMDPMetrics(Enum):
@@ -941,147 +957,142 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         """
         return [metric.value for metric in PushPOMDPMetrics]
 
-    def compute_metrics(  # pylint: disable=too-many-locals
-        self, histories: List[History]
-    ) -> List[MetricValue]:
-        goal_reached = []
-        robot_collisions = []
-        object_collisions = []
-        total_collisions = []
-        dangerous_steps_per_history: List[int] = []
+    def step_info(self, state: Any, action: Any, next_state: Any) -> Dict[str, float]:
+        """Report obstacle contact and hazard exposure for this step's state.
 
-        for history in histories:
-            goal_reached_in_history = False
-            history_robot_collisions = 0
-            history_object_collisions = 0
-            history_dangerous_steps = 0
-            total_steps = len(history.history)
+        Args:
+            state: The state the step was taken from, or the final state on the
+                terminal step.
+            action: Unused; every channel here is a property of the state.
+            next_state: Unused; each state is scored when it is recorded.
 
-            for step in history.history:
-                # Check if goal was reached (object reached target)
-                if self.is_terminal(step.state):
-                    goal_reached_in_history = True
+        Returns:
+            The robot / object collision indicators, their sum, and the
+            dangerous-area indicator.
+        """
+        del action, next_state
+        robot_pos = state[:2]
+        object_pos = state[2:4]
+        robot_collision = float(self._is_colliding_with_obstacle(robot_pos))
+        object_collision = float(self._is_colliding_with_obstacle(object_pos))
+        return {
+            PushStepChannel.GOAL_REACHED.value: float(self.is_terminal(state)),
+            PushStepChannel.ROBOT_OBSTACLE_COLLISION.value: robot_collision,
+            PushStepChannel.OBJECT_OBSTACLE_COLLISION.value: object_collision,
+            # Own channel: the aggregator reduces one channel at a time and
+            # cannot add two. A step where both collide counts twice, as before.
+            PushStepChannel.ANY_OBSTACLE_COLLISION.value: robot_collision + object_collision,
+            PushStepChannel.IN_DANGEROUS_AREA.value: float(self._is_in_dangerous_area(robot_pos)),
+        }
 
-                robot_pos = step.state[:2]  # [robot_x, robot_y]
-                object_pos = step.state[2:4]  # [object_x, object_y]
+    def get_metric_specs(self) -> List[StepInfoMetric]:
+        """Declare the Push metrics derived from the per-step channels.
 
-                if self._is_colliding_with_obstacle(robot_pos):
-                    history_robot_collisions += 1
-
-                if self._is_colliding_with_obstacle(object_pos):
-                    history_object_collisions += 1
-
-                if self._is_in_dangerous_area(robot_pos):
-                    history_dangerous_steps += 1
-
-            goal_reached.append(1 if goal_reached_in_history else 0)
-            if total_steps > 0:
-                robot_collisions.append(history_robot_collisions)
-                object_collisions.append(history_object_collisions)
-                total_collisions.append(history_robot_collisions + history_object_collisions)
-                dangerous_steps_per_history.append(history_dangerous_steps)
-
-        total_steps_all = sum(len(history.history) for history in histories)
-        avg_robot_collisions = sum(robot_collisions) / total_steps_all if total_steps_all > 0 else 0
-        avg_object_collisions = (
-            sum(object_collisions) / total_steps_all if total_steps_all > 0 else 0
-        )
-        avg_total_collisions = sum(total_collisions) / total_steps_all if total_steps_all > 0 else 0
-        avg_dangerous_rate = (
-            sum(dangerous_steps_per_history) / total_steps_all if total_steps_all > 0 else 0
-        )
-
-        robot_collision_rates = [
-            c / len(history.history) for c, history in zip(robot_collisions, histories)
-        ]
-        object_collision_rates = [
-            c / len(history.history) for c, history in zip(object_collisions, histories)
-        ]
-        total_collision_rates = [
-            c / len(history.history) for c, history in zip(total_collisions, histories)
-        ]
-        dangerous_rates = [
-            c / len(history.history) for c, history in zip(dangerous_steps_per_history, histories)
-        ]
-
-        robot_collisions_ci = confidence_interval(data=robot_collision_rates, confidence=0.95)
-        object_collisions_ci = confidence_interval(data=object_collision_rates, confidence=0.95)
-        total_collisions_ci = confidence_interval(data=total_collision_rates, confidence=0.95)
-        dangerous_rate_ci = (
-            confidence_interval(data=dangerous_rates, confidence=0.95)
-            if dangerous_rates
-            else (0, 0)
-        )
-
-        total_robot_collisions_ci = confidence_interval(data=robot_collisions, confidence=0.95)
-        total_object_collisions_ci = confidence_interval(data=object_collisions, confidence=0.95)
-        total_all_collisions_ci = confidence_interval(data=total_collisions, confidence=0.95)
-        total_dangerous_steps_ci = (
-            confidence_interval(data=dangerous_steps_per_history, confidence=0.95)
-            if dangerous_steps_per_history
-            else (0, 0)
-        )
-
-        avg_goal_reached = float(np.mean(goal_reached))
-        goal_reached_ci = confidence_interval(data=goal_reached, confidence=0.95)
-
+        Returns:
+            Specs for the goal rate and the four per-episode totals. The four
+            ``*_rate`` metrics are pooled across episodes and cannot be expressed
+            as a per-episode reduction, so :meth:`compute_metrics` produces them.
+        """
         return [
-            MetricValue(
+            StepInfoMetric(
                 name=PushPOMDPMetrics.GOAL_REACHING_RATE.value,
-                value=avg_goal_reached,
-                lower_confidence_bound=goal_reached_ci[0],
-                upper_confidence_bound=goal_reached_ci[1],
+                channel=PushStepChannel.GOAL_REACHED.value,
+                per_episode=EpisodeReduction.ANY,
+                empty_episode_value=0.0,
             ),
-            MetricValue(
-                name=PushPOMDPMetrics.ROBOT_OBSTACLE_COLLISION_RATE.value,
-                value=avg_robot_collisions,
-                lower_confidence_bound=robot_collisions_ci[0],
-                upper_confidence_bound=robot_collisions_ci[1],
-            ),
-            MetricValue(
-                name=PushPOMDPMetrics.OBJECT_OBSTACLE_COLLISION_RATE.value,
-                value=avg_object_collisions,
-                lower_confidence_bound=object_collisions_ci[0],
-                upper_confidence_bound=object_collisions_ci[1],
-            ),
-            MetricValue(
-                name=PushPOMDPMetrics.TOTAL_OBSTACLE_COLLISION_RATE.value,
-                value=avg_total_collisions,
-                lower_confidence_bound=total_collisions_ci[0],
-                upper_confidence_bound=total_collisions_ci[1],
-            ),
-            MetricValue(
+            StepInfoMetric(
                 name=PushPOMDPMetrics.TOTAL_ROBOT_OBSTACLE_COLLISIONS.value,
-                value=float(np.mean(robot_collisions)) if robot_collisions else 0.0,
-                lower_confidence_bound=total_robot_collisions_ci[0],
-                upper_confidence_bound=total_robot_collisions_ci[1],
+                channel=PushStepChannel.ROBOT_OBSTACLE_COLLISION.value,
+                per_episode=EpisodeReduction.SUM,
             ),
-            MetricValue(
+            StepInfoMetric(
                 name=PushPOMDPMetrics.TOTAL_OBJECT_OBSTACLE_COLLISIONS.value,
-                value=float(np.mean(object_collisions)) if object_collisions else 0.0,
-                lower_confidence_bound=total_object_collisions_ci[0],
-                upper_confidence_bound=total_object_collisions_ci[1],
+                channel=PushStepChannel.OBJECT_OBSTACLE_COLLISION.value,
+                per_episode=EpisodeReduction.SUM,
             ),
-            MetricValue(
+            StepInfoMetric(
                 name=PushPOMDPMetrics.TOTAL_ALL_OBSTACLE_COLLISIONS.value,
-                value=float(np.mean(total_collisions)) if total_collisions else 0.0,
-                lower_confidence_bound=total_all_collisions_ci[0],
-                upper_confidence_bound=total_all_collisions_ci[1],
+                channel=PushStepChannel.ANY_OBSTACLE_COLLISION.value,
+                per_episode=EpisodeReduction.SUM,
             ),
-            MetricValue(
-                name=PushPOMDPMetrics.DANGEROUS_AREA_RATE.value,
-                value=avg_dangerous_rate,
-                lower_confidence_bound=dangerous_rate_ci[0],
-                upper_confidence_bound=dangerous_rate_ci[1],
-            ),
-            MetricValue(
+            StepInfoMetric(
                 name=PushPOMDPMetrics.TOTAL_DANGEROUS_AREA_STEPS.value,
-                value=(
-                    float(np.mean(dangerous_steps_per_history))
-                    if dangerous_steps_per_history
-                    else 0.0
-                ),
-                lower_confidence_bound=total_dangerous_steps_ci[0],
-                upper_confidence_bound=total_dangerous_steps_ci[1],
+                channel=PushStepChannel.IN_DANGEROUS_AREA.value,
+                per_episode=EpisodeReduction.SUM,
             ),
         ]
+
+    def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
+        """Compute all nine Push metrics, in declaration order.
+
+        Args:
+            histories: List of simulation histories.
+
+        Returns:
+            One MetricValue per declared metric name, in declaration order.
+        """
+        computed = list(super().compute_metrics(histories)) + self._pooled_rate_metrics(histories)
+        return order_and_fill_metrics(self.get_metric_names(), computed)
+
+    def _pooled_rate_metrics(self, histories: List[History]) -> List[MetricValue]:
+        # These four are pooled over all steps of all episodes -- sum(counts) /
+        # sum(episode lengths) -- which is not the mean of per-episode values
+        # unless every episode has the same length, so the shared aggregator
+        # cannot express them. Their confidence intervals are computed from a
+        # *different* statistic than their point estimate (per-episode rates vs.
+        # a pooled ratio); that inconsistency predates this migration and is
+        # preserved rather than quietly fixed.
+        counts = self._per_episode_counts(histories)
+        total_steps_all = sum(len(history.history) for history in histories)
+
+        metrics: List[MetricValue] = []
+        for name, key in (
+            (PushPOMDPMetrics.ROBOT_OBSTACLE_COLLISION_RATE.value, "robot"),
+            (PushPOMDPMetrics.OBJECT_OBSTACLE_COLLISION_RATE.value, "object"),
+            (PushPOMDPMetrics.TOTAL_OBSTACLE_COLLISION_RATE.value, "total"),
+            (PushPOMDPMetrics.DANGEROUS_AREA_RATE.value, "dangerous"),
+        ):
+            episode_counts = counts[key]
+            value = sum(episode_counts) / total_steps_all if total_steps_all > 0 else 0
+            # zip() against the full history list, not against the episodes that
+            # actually contributed a count: a zero-step history is excluded from
+            # episode_counts but not from histories, so the pairing shifts by one
+            # from that point on. That is a pre-existing defect, kept verbatim
+            # because fixing it here would change reported values.
+            per_episode_rates = [
+                count / len(history.history) for count, history in zip(episode_counts, histories)
+            ]
+            lower, upper = self._rate_interval(per_episode_rates)
+            metrics.append(
+                MetricValue(
+                    name=name,
+                    value=value,
+                    lower_confidence_bound=lower,
+                    upper_confidence_bound=upper,
+                )
+            )
+        return metrics
+
+    def _per_episode_counts(self, histories: List[History]) -> Dict[str, List[float]]:
+        # Read back the same channels the specs consume, so a pooled rate and its
+        # matching total can never be computed from different measurements.
+        counts: Dict[str, List[float]] = {"robot": [], "object": [], "total": [], "dangerous": []}
+        channels = {
+            "robot": PushStepChannel.ROBOT_OBSTACLE_COLLISION.value,
+            "object": PushStepChannel.OBJECT_OBSTACLE_COLLISION.value,
+            "total": PushStepChannel.ANY_OBSTACLE_COLLISION.value,
+            "dangerous": PushStepChannel.IN_DANGEROUS_AREA.value,
+        }
+        for episode in extract_episode_step_infos(histories):
+            if not episode:
+                # Historically a zero-step episode contributed no entry at all.
+                continue
+            for key, channel in channels.items():
+                counts[key].append(sum(step_info.get(channel, 0.0) for step_info in episode))
+        return counts
+
+    @staticmethod
+    def _rate_interval(rates: List[float]) -> Tuple[float, float]:
+        if not rates:
+            return (0, 0)
+        return confidence_interval(data=rates, confidence=0.95)

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -900,19 +900,16 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
                 name=RockSamplePOMDPMetrics.AVG_ROCKS_SAMPLED.value,
                 channel=RockSampleStepChannel.SAMPLED_ROCK.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=RockSamplePOMDPMetrics.EXIT_SUCCESS_RATE.value,
                 channel=RockSampleStepChannel.TERMINAL_STATE.value,
                 per_episode=EpisodeReduction.ANY,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=RockSamplePOMDPMetrics.AVERAGE_DANGEROUS_AREA_STEPS.value,
                 channel=RockSampleStepChannel.IN_DANGEROUS_AREA.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
         ]
 

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -876,14 +876,14 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
             histories: List of simulation histories.
 
         Returns:
-            One MetricValue per declared metric name, in declaration order, or an
-            empty list when there are no histories at all.
+            One MetricValue per declared metric name, in declaration order.
+
+        Raises:
+            ValueError: If ``histories`` is empty, or if an episode ran without
+                being measured. See
+                :meth:`~POMDPPlanners.core.environment.environment.Environment.compute_metrics`.
         """
-        # No histories has always meant no metrics here, unlike the zero-valued
-        # metrics other environments report. Preserved rather than unified.
-        if not histories:
-            return []
-        # Beyond that, every declared name is reported: the shared aggregator
+        # Every declared name is reported: the shared aggregator
         # omits a metric no episode reported, which an episode with no recorded
         # steps would trigger, where this environment counted a zero.
         return order_and_fill_metrics(self.get_metric_names(), super().compute_metrics(histories))

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -30,6 +30,11 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.core.simulation.step_info_metrics import (
+    EpisodeReduction,
+    StepInfoMetric,
+    order_and_fill_metrics,
+)
 from POMDPPlanners.environments.rock_sample_pomdp import _native
 from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_utils.rock_sample_reward_models import (
     BaseRockSampleRewardModel,
@@ -37,7 +42,18 @@ from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_utils.rock_s
     RockSampleZeroMeanHazardShockRewardModel,
     RockSampleRewardModel,
 )
-from POMDPPlanners.utils.statistics_utils import confidence_interval
+
+
+# Actions are plain ints: 0=sample, 1=north, 2=east, 3=south, 4=west, 5+=check_rock_i.
+SAMPLE_ACTION = 0
+
+
+class RockSampleStepChannel(Enum):
+    """Per-step measurement channels reported by :meth:`RockSamplePOMDP.step_info`."""
+
+    SAMPLED_ROCK = "sampled_rock"
+    TERMINAL_STATE = "terminal_state"
+    IN_DANGEROUS_AREA = "in_dangerous_area"
 
 
 class RockSamplePOMDPMetrics(Enum):
@@ -826,85 +842,79 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         # Discrete int actions; already hashable.
         return action
 
-    def get_metric_names(self) -> List[str]:
-        """Get names of RockSample POMDP specific metrics.
+    def step_info(self, state: Any, action: Any, next_state: Any) -> Dict[str, float]:
+        """Report the sampling action, terminal status and hazard exposure.
+
+        Args:
+            state: The state the step was taken from, or the final state on the
+                terminal step. On the terminal step this carries the exit
+                sentinel position, which the dangerous-area test is applied to
+                exactly as it always was.
+            action: The action taken, or ``None`` on the terminal step.
+            next_state: Unused; each state is scored when it is recorded.
 
         Returns:
-            List containing metric names: avg_rocks_sampled, exit_success_rate,
-            and average_dangerous_area_steps
+            The ``sampled_rock``, ``terminal_state`` and ``in_dangerous_area``
+            indicators for this step.
         """
-        return [metric.value for metric in RockSamplePOMDPMetrics]
+        del next_state
+        robot_pos = get_robot_pos(state)
+        return {
+            # ``action == SAMPLE_ACTION`` is False for the terminal step's None,
+            # which is how the historical scan counted it too.
+            RockSampleStepChannel.SAMPLED_ROCK.value: float(action == SAMPLE_ACTION),
+            RockSampleStepChannel.TERMINAL_STATE.value: float(self.is_terminal(state)),
+            RockSampleStepChannel.IN_DANGEROUS_AREA.value: float(
+                self._is_in_dangerous_area(robot_pos)
+            ),
+        }
 
     def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
-        """Compute environment-specific metrics."""
+        """Compute the RockSample metrics, always reporting every declared name.
+
+        Args:
+            histories: List of simulation histories.
+
+        Returns:
+            One MetricValue per declared metric name, in declaration order, or an
+            empty list when there are no histories at all.
+        """
+        # No histories has always meant no metrics here, unlike the zero-valued
+        # metrics other environments report. Preserved rather than unified.
         if not histories:
             return []
+        # Beyond that, every declared name is reported: the shared aggregator
+        # omits a metric no episode reported, which an episode with no recorded
+        # steps would trigger, where this environment counted a zero.
+        return order_and_fill_metrics(self.get_metric_names(), super().compute_metrics(histories))
 
-        metrics = []
+    def get_metric_specs(self) -> List[StepInfoMetric]:
+        """Declare the RockSample metrics derived from the per-step channels.
 
-        # Calculate average number of rocks sampled
-        rocks_sampled = []
-        for history in histories:
-            sampled_count = 0
-            for step in history.history:
-                if hasattr(step, "action") and step.action == 0:  # Sample action
-                    sampled_count += 1
-            rocks_sampled.append(sampled_count)
-
-        if rocks_sampled:
-            mean_rocks = float(np.mean(rocks_sampled))
-            ci_low, ci_high = confidence_interval(rocks_sampled)
-            metrics.append(
-                MetricValue(
-                    name=RockSamplePOMDPMetrics.AVG_ROCKS_SAMPLED.value,
-                    value=mean_rocks,
-                    lower_confidence_bound=ci_low,
-                    upper_confidence_bound=ci_high,
-                )
-            )
-
-        # Calculate exit success rate
-        exits = [
-            1 if any(self.is_terminal(step.state) for step in history.history) else 0
-            for history in histories
+        Returns:
+            Specs for ``avg_rocks_sampled``, ``exit_success_rate`` and
+            ``average_dangerous_area_steps``.
+        """
+        return [
+            StepInfoMetric(
+                name=RockSamplePOMDPMetrics.AVG_ROCKS_SAMPLED.value,
+                channel=RockSampleStepChannel.SAMPLED_ROCK.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=RockSamplePOMDPMetrics.EXIT_SUCCESS_RATE.value,
+                channel=RockSampleStepChannel.TERMINAL_STATE.value,
+                per_episode=EpisodeReduction.ANY,
+                empty_episode_value=0.0,
+            ),
+            StepInfoMetric(
+                name=RockSamplePOMDPMetrics.AVERAGE_DANGEROUS_AREA_STEPS.value,
+                channel=RockSampleStepChannel.IN_DANGEROUS_AREA.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
+            ),
         ]
-
-        if exits:
-            exit_rate = float(np.mean(exits))
-            ci_low, ci_high = confidence_interval(exits)
-            metrics.append(
-                MetricValue(
-                    name=RockSamplePOMDPMetrics.EXIT_SUCCESS_RATE.value,
-                    value=exit_rate,
-                    lower_confidence_bound=ci_low,
-                    upper_confidence_bound=ci_high,
-                )
-            )
-
-        # Calculate dangerous area metrics
-        dangerous_area_steps = []
-        for history in histories:
-            steps_in_danger = 0
-            for step in history.history:
-                robot_pos = get_robot_pos(step.state)
-                if self._is_in_dangerous_area(robot_pos):
-                    steps_in_danger += 1
-            dangerous_area_steps.append(steps_in_danger)
-
-        if dangerous_area_steps:
-            avg_dangerous_steps = float(np.mean(dangerous_area_steps))
-            ci_low, ci_high = confidence_interval(dangerous_area_steps)
-
-            metrics.append(
-                MetricValue(
-                    name=RockSamplePOMDPMetrics.AVERAGE_DANGEROUS_AREA_STEPS.value,
-                    value=avg_dangerous_steps,
-                    lower_confidence_bound=ci_low,
-                    upper_confidence_bound=ci_high,
-                )
-            )
-
-        return metrics
 
     def cache_visualization(
         self, history: List[StepData], output_dir: Path, episode_index: int

--- a/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
+++ b/POMDPPlanners/environments/safety_ant_velocity_pomdp/safety_ant_velocity_pomdp.py
@@ -39,6 +39,7 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
+from POMDPPlanners.core.simulation.step_info_metrics import require_non_empty_histories
 from POMDPPlanners.environments.safety_ant_velocity_pomdp import _native
 from POMDPPlanners.environments.safety_ant_velocity_pomdp.safety_ant_velocity_visualizer import (
     SafeAntVelocityVisualizer,
@@ -312,6 +313,7 @@ class SafeAntVelocityPOMDP(DiscreteActionsEnvironment):
         return [metric.value for metric in SafeAntVelocityPOMDPMetrics]
 
     def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
+        require_non_empty_histories(histories, type(self).__name__)
         # Initialize metrics
         safety_violations = []
         critical_violations = []

--- a/POMDPPlanners/environments/tiger_pomdp.py
+++ b/POMDPPlanners/environments/tiger_pomdp.py
@@ -23,7 +23,7 @@ Classes:
 from enum import Enum
 from pathlib import Path
 from collections.abc import Hashable
-from typing import Any, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 
@@ -34,10 +34,23 @@ from POMDPPlanners.core.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.simulation import History, MetricValue
+from POMDPPlanners.core.simulation.step_info_metrics import (
+    EpisodeReduction,
+    StepInfoMetric,
+    order_and_fill_metrics,
+)
 
 STATES = ["tiger_left", "tiger_right"]
 ACTIONS = ["listen", "open_left", "open_right"]
 OBSERVATIONS = ["hear_left", "hear_right", "hear_nothing"]
+OPEN_ACTIONS = ("open_left", "open_right")
+
+
+class TigerStepChannel(Enum):
+    """Per-step measurement channels reported by :meth:`TigerPOMDP.step_info`."""
+
+    CORRECT_DOOR_OPENED = "correct_door_opened"
+    LISTENED = "listened"
 
 
 class TigerPOMDPMetrics(Enum):
@@ -269,61 +282,65 @@ class TigerPOMDP(DiscreteActionsEnvironment):
         # Discrete-action env: actions are str labels (LISTEN/OPEN_LEFT/...).
         return action
 
-    def get_metric_names(self) -> List[str]:
-        """Get names of Tiger POMDP specific metrics.
-
-        Returns:
-            List containing metric names: success_rate and average_listens
-        """
-        return [metric.value for metric in TigerPOMDPMetrics]
-
-    def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
-        """Compute Tiger POMDP specific metrics from simulation histories.
+    def step_info(self, state: Any, action: Any, next_state: Any) -> Dict[str, float]:
+        """Report which door was opened and whether the agent listened.
 
         Args:
-            histories: List of simulation histories
+            state: The state the step was taken from, i.e. where the tiger is.
+            action: The action taken, or ``None`` on the terminal step.
+            next_state: Unused; the Tiger transition carries no extra signal.
 
         Returns:
-            List of MetricValue objects containing the computed metrics
+            The ``correct_door_opened`` and ``listened`` indicators.
         """
-        # Calculate success rate (opening correct door)
-        success_count = 0
-        total_episodes = len(histories)
+        del next_state
+        # Both channels are equality tests against ``action``, so the terminal
+        # bookkeeping step (``action is None``) reports 0.0 for each. That is
+        # what preserves the historical reading of ``history.history[-1]``:
+        # a terminated episode's last recorded step has no action, so it never
+        # counted as a success however it ended.
+        opened_correct_door = action in OPEN_ACTIONS and (
+            (action == "open_left") == (state == "tiger_right")
+        )
+        return {
+            TigerStepChannel.CORRECT_DOOR_OPENED.value: float(opened_correct_door),
+            TigerStepChannel.LISTENED.value: float(action == "listen"),
+        }
 
-        for history in histories:
-            if not history.history:
-                continue
-            # Check if the last action was opening a door
-            last_step = history.history[-1]
-            if last_step.action in ["open_left", "open_right"]:
-                # Check if the door opened was correct
-                if (last_step.action == "open_left" and last_step.state == "tiger_right") or (
-                    last_step.action == "open_right" and last_step.state == "tiger_left"
-                ):
-                    success_count += 1
+    def compute_metrics(self, histories: List[History]) -> List[MetricValue]:
+        """Compute the Tiger metrics, always reporting every declared name.
 
-        success_rate = success_count / total_episodes if total_episodes > 0 else 0.0
+        The shared aggregator omits a metric no episode reported, which happens
+        for an empty history list or an episode with no recorded steps. Tiger has
+        always reported both metrics as ``0.0`` in that case, so the declared
+        names are filled rather than dropped.
 
-        # Calculate average number of listens before opening a door
-        listen_counts = []
-        for history in histories:
-            listen_count = sum(1 for step in history.history if step.action == "listen")
-            listen_counts.append(listen_count)
+        Args:
+            histories: List of simulation histories.
 
-        avg_listens = sum(listen_counts) / len(listen_counts) if listen_counts else 0.0
+        Returns:
+            One MetricValue per declared metric name, in declaration order.
+        """
+        return order_and_fill_metrics(self.get_metric_names(), super().compute_metrics(histories))
 
-        # Create MetricValue objects
+    def get_metric_specs(self) -> List[StepInfoMetric]:
+        """Declare the Tiger metrics derived from the per-step channels.
+
+        Returns:
+            Specs for ``success_rate`` (the last step's door choice) and
+            ``average_listens`` (how often the agent listened per episode).
+        """
         return [
-            MetricValue(
+            StepInfoMetric(
                 name=TigerPOMDPMetrics.SUCCESS_RATE.value,
-                value=success_rate,
-                lower_confidence_bound=success_rate,  # Simple implementation, could be improved with proper confidence intervals
-                upper_confidence_bound=success_rate,
+                channel=TigerStepChannel.CORRECT_DOOR_OPENED.value,
+                per_episode=EpisodeReduction.LAST,
+                empty_episode_value=0.0,
             ),
-            MetricValue(
+            StepInfoMetric(
                 name=TigerPOMDPMetrics.AVERAGE_LISTENS.value,
-                value=avg_listens,
-                lower_confidence_bound=avg_listens,
-                upper_confidence_bound=avg_listens,
+                channel=TigerStepChannel.LISTENED.value,
+                per_episode=EpisodeReduction.SUM,
+                empty_episode_value=0.0,
             ),
         ]

--- a/POMDPPlanners/environments/tiger_pomdp.py
+++ b/POMDPPlanners/environments/tiger_pomdp.py
@@ -335,12 +335,10 @@ class TigerPOMDP(DiscreteActionsEnvironment):
                 name=TigerPOMDPMetrics.SUCCESS_RATE.value,
                 channel=TigerStepChannel.CORRECT_DOOR_OPENED.value,
                 per_episode=EpisodeReduction.LAST,
-                empty_episode_value=0.0,
             ),
             StepInfoMetric(
                 name=TigerPOMDPMetrics.AVERAGE_LISTENS.value,
                 channel=TigerStepChannel.LISTENED.value,
                 per_episode=EpisodeReduction.SUM,
-                empty_episode_value=0.0,
             ),
         ]

--- a/POMDPPlanners/environments/tiger_pomdp.py
+++ b/POMDPPlanners/environments/tiger_pomdp.py
@@ -311,15 +311,20 @@ class TigerPOMDP(DiscreteActionsEnvironment):
         """Compute the Tiger metrics, always reporting every declared name.
 
         The shared aggregator omits a metric no episode reported, which happens
-        for an empty history list or an episode with no recorded steps. Tiger has
-        always reported both metrics as ``0.0`` in that case, so the declared
-        names are filled rather than dropped.
+        for an episode with no recorded steps. Tiger has always reported both
+        metrics as ``0.0`` in that case, so the declared names are filled rather
+        than dropped.
 
         Args:
             histories: List of simulation histories.
 
         Returns:
             One MetricValue per declared metric name, in declaration order.
+
+        Raises:
+            ValueError: If ``histories`` is empty, or if an episode ran without
+                being measured. See
+                :meth:`~POMDPPlanners.core.environment.environment.Environment.compute_metrics`.
         """
         return order_and_fill_metrics(self.get_metric_names(), super().compute_metrics(histories))
 

--- a/POMDPPlanners/simulations/episodes.py
+++ b/POMDPPlanners/simulations/episodes.py
@@ -273,6 +273,11 @@ class EpisodeRunner:
 
     def _add_terminal_step(self) -> None:
         """Add terminal step to history."""
+        # Measured like any other step: metrics that scan every recorded state
+        # must see the final one too, and it is only ever recorded here. The
+        # transition arguments are None because no transition was taken -- an
+        # environment reports whatever it can measure from the state alone.
+        info = self.environment.step_info(self.state, None, None)
         terminal_step = StepData(
             state=self.state,
             action=None,
@@ -280,6 +285,7 @@ class EpisodeRunner:
             observation=None,
             reward=None,
             belief=self.belief,
+            info=info or None,
         )
         self.history.append(terminal_step)
 

--- a/POMDPPlanners/simulations/simulations_deployment/task_managers.py
+++ b/POMDPPlanners/simulations/simulations_deployment/task_managers.py
@@ -14,6 +14,7 @@ from dask.distributed import Client, Future, LocalCluster
 from dask_jobqueue.pbs import PBSCluster
 from joblib import Memory, Parallel, delayed
 from joblib.externals.loky import get_reusable_executor
+from joblib.memory import MemorizedFunc
 from tqdm import tqdm
 
 from POMDPPlanners.core.simulation import (
@@ -23,6 +24,7 @@ from POMDPPlanners.core.simulation import (
     TaskManager,
     TaskManagerExternalDB,
 )
+from POMDPPlanners.core.simulation.step_info_metrics import unmeasured_episode_index
 
 _dask_logger = logging.getLogger(__name__)
 
@@ -272,7 +274,17 @@ class JoblibTaskManager(TaskManagerExternalDB):
             self.cache_db.clear()
 
         # Create a cached version of the task runner
-        self._cached_run = self.memory.cache(self._run_single_task)
+        cached_run = self.memory.cache(self._run_single_task)
+        # Memory.cache degenerates to a pass-through wrapper when it has no
+        # location. This Memory always has one, and _run_cached_task needs the
+        # real thing: only MemorizedFunc exposes ``call``, which is what forces a
+        # recompute past a stale entry.
+        if not isinstance(cached_run, MemorizedFunc):
+            raise TypeError(
+                f"Expected a memoizing cache for {self.joblib_cache_dir}, got "
+                f"{type(cached_run).__name__}"
+            )
+        self._cached_run = cached_run
 
         self._on_progress: Optional[Callable[[], None]] = None
 
@@ -325,6 +337,52 @@ class JoblibTaskManager(TaskManagerExternalDB):
             self.logger.warning("Task %s returned None result", task.get_config_id())
 
         return result
+
+    def _run_cached_task(self, task: SimulationTask) -> Any:
+        """Run one task through the joblib cache, redoing a stale cached result.
+
+        The cache key is the task's configuration, which says nothing about the
+        format of the episode it produced. An entry written before
+        :attr:`~POMDPPlanners.core.simulation.history.StepData.info` existed
+        therefore still hits, and unpickles cleanly with every measurement
+        missing -- which for an environment deriving its metrics from that
+        channel is not a missing result but a wrong one.
+
+        Rather than fail the run at metrics time, after the compute has been
+        paid for, such an entry is treated as a miss and recomputed. Only the
+        stale entries are redone; everything recorded in the current format is
+        still reused, so a resumed run keeps its recovery.
+
+        Args:
+            task: The simulation task to run.
+
+        Returns:
+            The task's result, freshly computed if the cached one predates the
+            per-step measurement channel.
+        """
+        # Captured before the call: a task that actually runs clears its
+        # environment reference during cleanup, while one served from cache
+        # keeps it.
+        environment = getattr(task, "environment", None)
+        specs = environment.get_metric_specs() if environment is not None else []
+
+        result = self._cached_run(task)
+        if not specs or not isinstance(result, History):
+            return result
+        if unmeasured_episode_index([result], specs) is None:
+            return result
+
+        self.logger.warning(
+            "Cached result for task %s predates the per-step measurement channel: it "
+            "carries none of %s's channels, so its metrics would all read zero. "
+            "Recomputing this episode and replacing the cache entry.",
+            task.get_config_id(),
+            type(environment).__name__,
+        )
+        # ``call`` re-runs the task and overwrites the cache entry. It returns
+        # ``(output, metadata)``; the metadata is of no use here.
+        recomputed = self._cached_run.call(task)
+        return recomputed[0] if isinstance(recomputed, tuple) else recomputed
 
     def _run_tasks(self, tasks: List[SimulationTask]) -> list:
         """Run tasks in parallel using joblib."""
@@ -392,7 +450,7 @@ class JoblibTaskManager(TaskManagerExternalDB):
         parallel = Parallel(n_jobs=self.n_jobs, verbose=self.verbose, return_as="generator")
         results: list = []
         with tqdm(total=len(tasks), desc="Running tasks", disable=self.no_logs) as pbar:
-            for result in parallel(delayed(self._cached_run)(task) for task in tasks):
+            for result in parallel(delayed(self._run_cached_task)(task) for task in tasks):
                 results.append(result)
                 pbar.update(1)
                 self._fire_progress_callback()
@@ -804,7 +862,7 @@ class SequentialTaskManager(JoblibTaskManager):
             with tqdm(tasks, desc="Running tasks", disable=self.no_logs) as pbar:
                 results = []
                 for task in pbar:
-                    results.append(self._cached_run(task))
+                    results.append(self._run_cached_task(task))
 
             end_time = time.time()
             total_time = end_time - start_time

--- a/POMDPPlanners/tests/metric_golden_values.py
+++ b/POMDPPlanners/tests/metric_golden_values.py
@@ -26,7 +26,10 @@ Note:
 
 Attributes:
     GOLDEN_METRIC_VALUES: env slug -> metric name -> frozen point estimate.
+    GOLDEN_METRIC_VALUES_WITH_TERMINAL: the same, over the terminated-episode
+        shape of the fixture (see ``append_terminal_step``).
     GOLDEN_METRIC_NAMES: env slug -> sorted ``get_metric_names()`` output.
+    GOLDEN_METRIC_ORDER: env slug -> unsorted metric names, in emission order.
 """
 
 from typing import Dict, List
@@ -94,6 +97,93 @@ GOLDEN_METRIC_VALUES: Dict[str, Dict[str, float]] = {
         "avg_pellets_collected": 1.0,
         "avg_episode_length": 5.0,
         "avg_pacman_closest_ghost_distance": 10.333333333333334,
+        "avg_collision_encounters": 0.0,
+        "avg_dangerous_area_steps": 0.0,
+        "avg_all_dangerous_encounters": 0.0,
+    },
+    "rock_sample": {
+        "avg_rocks_sampled": 1.0,
+        "exit_success_rate": 0.0,
+        "average_dangerous_area_steps": 0.0,
+    },
+}
+
+# Same environments and same frozen histories, but with the terminal bookkeeping
+# step appended -- the shape a real episode has when it reaches a terminal state,
+# and which the raw fixture structurally cannot represent (it stops after the last
+# recorded transition). Captured pre-migration, like GOLDEN_METRIC_VALUES.
+#
+# Several entries deliberately differ from GOLDEN_METRIC_VALUES, and those
+# differences are the point of this baseline. The terminal step contributes one
+# more state to every whole-history scan (laser tag's average_episode_length goes
+# 5.0 -> 6.0, its dangerous-area count 1.33 -> 1.67), and it carries
+# ``action is None`` / ``reward is None``, which flips every metric that reads
+# ``history.history[-1]``: tiger's success_rate goes 0.667 -> 0.0 because the last
+# step is no longer a door-opening action. That is pre-existing behaviour, and
+# pinning it here is what stops a migration from silently "fixing" it.
+GOLDEN_METRIC_VALUES_WITH_TERMINAL: Dict[str, Dict[str, float]] = {
+    "tiger": {"success_rate": 0.0, "average_listens": 2.0},
+    "cartpole": {"goal_reaching_rate": 1.0},
+    "mountain_car": {"goal_reaching_rate": 0.0},
+    "laser_tag": {
+        "tag_success_rate": 0.0,
+        "goal_reaching_rate": 0.0,
+        "average_episode_length": 6.0,
+        "average_failed_tag_attempts": 1.0,
+        "average_obstacle_collisions": 0.0,
+        "average_dangerous_area_steps": 1.6666666666666667,
+        "average_all_dangerous_encounters": 1.6666666666666667,
+    },
+    "continuous_laser_tag": {
+        "tag_success_rate": 0.0,
+        "goal_reaching_rate": 0.0,
+        "average_episode_length": 6.0,
+        "average_failed_tag_attempts": 0.0,
+        "average_wall_collisions": 0.0,
+        "average_dangerous_area_steps": 0.0,
+        "average_all_dangerous_encounters": 0.0,
+    },
+    "discrete_light_dark": {
+        "goal_reaching_rate": 0.0,
+        "obstacle_hit_rate": 0.0,
+        "avg_obstacle_hit_counter": 0.0,
+        "out_of_grid_rate": 0.3333333333333333,
+        "avg_high_variance_states_counter": 1.0,
+    },
+    "continuous_light_dark": {
+        "goal_reaching_rate": 0.0,
+        "obstacle_hit_rate": 0.0,
+        "avg_obstacle_hit_counter": 0.0,
+        "out_of_grid_rate": 0.6666666666666666,
+        "avg_high_variance_states_counter": 0.6666666666666666,
+    },
+    "push": {
+        "goal_reaching_rate": 0.0,
+        "robot_obstacle_collision_rate": 0.0,
+        "object_obstacle_collision_rate": 0.0,
+        "total_obstacle_collision_rate": 0.0,
+        "total_robot_obstacle_collisions": 0.0,
+        "total_object_obstacle_collisions": 0.0,
+        "total_all_obstacle_collisions": 0.0,
+        "dangerous_area_rate": 0.0,
+        "total_dangerous_area_steps": 0.0,
+    },
+    "continuous_push": {
+        "goal_reaching_rate": 0.0,
+        "robot_obstacle_collision_rate": 0.0,
+        "object_obstacle_collision_rate": 0.0,
+        "total_obstacle_collision_rate": 0.0,
+        "total_robot_obstacle_collisions": 0.0,
+        "total_object_obstacle_collisions": 0.0,
+        "total_all_obstacle_collisions": 0.0,
+        "dangerous_area_rate": 0.0,
+        "total_dangerous_area_steps": 0.0,
+    },
+    "pacman": {
+        "win_rate": 0.0,
+        "avg_pellets_collected": 1.0,
+        "avg_episode_length": 6.0,
+        "avg_pacman_closest_ghost_distance": 10.055555555555555,
         "avg_collision_encounters": 0.0,
         "avg_dangerous_area_steps": 0.0,
         "avg_all_dangerous_encounters": 0.0,
@@ -173,4 +263,83 @@ GOLDEN_METRIC_NAMES: Dict[str, List[str]] = {
         "win_rate",
     ],
     "rock_sample": ["average_dangerous_area_steps", "avg_rocks_sampled", "exit_success_rate"],
+}
+
+# Unsorted, unlike GOLDEN_METRIC_NAMES. Order is part of the contract:
+# get_metric_names_from_environment_policy_pair feeds hyperparameter-tuning
+# objective selection, and both of the assertions above are order-blind --
+# GOLDEN_METRIC_VALUES is compared as a dict and GOLDEN_METRIC_NAMES is sorted.
+#
+# For every environment here, compute_metrics emits its metrics in exactly the
+# order get_metric_names declares them, so one list pins both. A migration that
+# concatenates spec-driven metrics ahead of bespoke ones would break that
+# correspondence without changing either of the older baselines.
+GOLDEN_METRIC_ORDER: Dict[str, List[str]] = {
+    "tiger": ["success_rate", "average_listens"],
+    "cartpole": ["goal_reaching_rate"],
+    "mountain_car": ["goal_reaching_rate"],
+    "laser_tag": [
+        "tag_success_rate",
+        "goal_reaching_rate",
+        "average_episode_length",
+        "average_failed_tag_attempts",
+        "average_obstacle_collisions",
+        "average_dangerous_area_steps",
+        "average_all_dangerous_encounters",
+    ],
+    "continuous_laser_tag": [
+        "tag_success_rate",
+        "goal_reaching_rate",
+        "average_episode_length",
+        "average_failed_tag_attempts",
+        "average_wall_collisions",
+        "average_dangerous_area_steps",
+        "average_all_dangerous_encounters",
+    ],
+    "discrete_light_dark": [
+        "goal_reaching_rate",
+        "obstacle_hit_rate",
+        "avg_obstacle_hit_counter",
+        "out_of_grid_rate",
+        "avg_high_variance_states_counter",
+    ],
+    "continuous_light_dark": [
+        "goal_reaching_rate",
+        "obstacle_hit_rate",
+        "avg_obstacle_hit_counter",
+        "out_of_grid_rate",
+        "avg_high_variance_states_counter",
+    ],
+    "push": [
+        "goal_reaching_rate",
+        "robot_obstacle_collision_rate",
+        "object_obstacle_collision_rate",
+        "total_obstacle_collision_rate",
+        "total_robot_obstacle_collisions",
+        "total_object_obstacle_collisions",
+        "total_all_obstacle_collisions",
+        "dangerous_area_rate",
+        "total_dangerous_area_steps",
+    ],
+    "continuous_push": [
+        "goal_reaching_rate",
+        "robot_obstacle_collision_rate",
+        "object_obstacle_collision_rate",
+        "total_obstacle_collision_rate",
+        "total_robot_obstacle_collisions",
+        "total_object_obstacle_collisions",
+        "total_all_obstacle_collisions",
+        "dangerous_area_rate",
+        "total_dangerous_area_steps",
+    ],
+    "pacman": [
+        "win_rate",
+        "avg_pellets_collected",
+        "avg_episode_length",
+        "avg_pacman_closest_ghost_distance",
+        "avg_collision_encounters",
+        "avg_dangerous_area_steps",
+        "avg_all_dangerous_encounters",
+    ],
+    "rock_sample": ["avg_rocks_sampled", "exit_success_rate", "average_dangerous_area_steps"],
 }

--- a/POMDPPlanners/tests/metric_golden_values.py
+++ b/POMDPPlanners/tests/metric_golden_values.py
@@ -30,9 +30,13 @@ Attributes:
         shape of the fixture (see ``append_terminal_step``).
     GOLDEN_METRIC_NAMES: env slug -> sorted ``get_metric_names()`` output.
     GOLDEN_METRIC_ORDER: env slug -> unsorted metric names, in emission order.
+    GOLDEN_METRIC_BOUNDS: env slug -> metric name -> frozen (lower, upper)
+        confidence bounds.
+    GOLDEN_METRIC_BOUNDS_WITH_TERMINAL: the same, over the terminated-episode
+        shape of the fixture.
 """
 
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 GOLDEN_METRIC_VALUES: Dict[str, Dict[str, float]] = {
     "tiger": {"success_rate": 0.6666666666666666, "average_listens": 2.0},
@@ -342,4 +346,171 @@ GOLDEN_METRIC_ORDER: Dict[str, List[str]] = {
         "avg_all_dangerous_encounters",
     ],
     "rock_sample": ["avg_rocks_sampled", "exit_success_rate", "average_dangerous_area_steps"],
+}
+
+# Captured the same way as GOLDEN_METRIC_VALUES, by running the pre-migration
+# compute_metrics over the same frozen fixture. A MetricValue is a point estimate
+# *and* an interval, and the value assertions above see only half of it: a
+# reduction that produced the right mean from the wrong per-episode samples would
+# pass them and move the interval. These pin the other half.
+GOLDEN_METRIC_BOUNDS: Dict[str, Dict[str, Tuple[float, float]]] = {
+    "cartpole": {
+        "goal_reaching_rate": (1.0, 1.0),
+    },
+    "continuous_laser_tag": {
+        "average_all_dangerous_encounters": (0.0, 0.0),
+        "average_dangerous_area_steps": (0.0, 0.0),
+        "average_episode_length": (5.0, 5.0),
+        "average_failed_tag_attempts": (0.0, 0.0),
+        "average_wall_collisions": (0.0, 0.0),
+        "goal_reaching_rate": (0.0, 0.0),
+        "tag_success_rate": (0.0, 0.0),
+    },
+    "continuous_light_dark": {
+        "avg_high_variance_states_counter": (-0.7675509098987142, 2.1008842432320476),
+        "avg_obstacle_hit_counter": (0.0, 0.0),
+        "goal_reaching_rate": (0.0, 0.0),
+        "obstacle_hit_rate": (0.0, 0.0),
+        "out_of_grid_rate": (-0.7675509098987142, 2.1008842432320476),
+    },
+    "continuous_push": {
+        "dangerous_area_rate": (0.0, 0.0),
+        "goal_reaching_rate": (0.0, 0.0),
+        "object_obstacle_collision_rate": (0.0, 0.0),
+        "robot_obstacle_collision_rate": (0.0, 0.0),
+        "total_all_obstacle_collisions": (0.0, 0.0),
+        "total_dangerous_area_steps": (0.0, 0.0),
+        "total_object_obstacle_collisions": (0.0, 0.0),
+        "total_obstacle_collision_rate": (0.0, 0.0),
+        "total_robot_obstacle_collisions": (0.0, 0.0),
+    },
+    "discrete_light_dark": {
+        "avg_high_variance_states_counter": (-2.201768486464095, 3.535101819797428),
+        "avg_obstacle_hit_counter": (0.0, 0.0),
+        "goal_reaching_rate": (0.0, 0.0),
+        "obstacle_hit_rate": (0.0, 0.0),
+        "out_of_grid_rate": (-1.1008842432320476, 1.767550909898714),
+    },
+    "laser_tag": {
+        "average_all_dangerous_encounters": (-4.40353697292819, 7.070203639594856),
+        "average_dangerous_area_steps": (-4.40353697292819, 7.070203639594856),
+        "average_episode_length": (5.0, 5.0),
+        "average_failed_tag_attempts": (1.0, 1.0),
+        "average_obstacle_collisions": (0.0, 0.0),
+        "goal_reaching_rate": (0.0, 0.0),
+        "tag_success_rate": (0.0, 0.0),
+    },
+    "mountain_car": {
+        "goal_reaching_rate": (0.0, 0.0),
+    },
+    "pacman": {
+        "avg_all_dangerous_encounters": (0.0, 0.0),
+        "avg_collision_encounters": (0.0, 0.0),
+        "avg_dangerous_area_steps": (0.0, 0.0),
+        "avg_episode_length": (5.0, 5.0),
+        "avg_pacman_closest_ghost_distance": (9.574416726623387, 11.092249940043281),
+        "avg_pellets_collected": (1.0, 1.0),
+        "win_rate": (0.0, 0.0),
+    },
+    "push": {
+        "dangerous_area_rate": (0.0, 0.0),
+        "goal_reaching_rate": (0.0, 0.0),
+        "object_obstacle_collision_rate": (0.0, 0.0),
+        "robot_obstacle_collision_rate": (0.0, 0.0),
+        "total_all_obstacle_collisions": (0.0, 0.0),
+        "total_dangerous_area_steps": (0.0, 0.0),
+        "total_object_obstacle_collisions": (0.0, 0.0),
+        "total_obstacle_collision_rate": (0.0, 0.0),
+        "total_robot_obstacle_collisions": (0.0, 0.0),
+    },
+    "rock_sample": {
+        "average_dangerous_area_steps": (0.0, 0.0),
+        "avg_rocks_sampled": (1.0, 1.0),
+        "exit_success_rate": (0.0, 0.0),
+    },
+    "tiger": {
+        "average_listens": (2.0, 2.0),
+        "success_rate": (0.6666666666666666, 0.6666666666666666),
+    },
+}
+
+GOLDEN_METRIC_BOUNDS_WITH_TERMINAL: Dict[str, Dict[str, Tuple[float, float]]] = {
+    "cartpole": {
+        "goal_reaching_rate": (1.0, 1.0),
+    },
+    "continuous_laser_tag": {
+        "average_all_dangerous_encounters": (0.0, 0.0),
+        "average_dangerous_area_steps": (0.0, 0.0),
+        "average_episode_length": (6.0, 6.0),
+        "average_failed_tag_attempts": (0.0, 0.0),
+        "average_wall_collisions": (0.0, 0.0),
+        "goal_reaching_rate": (0.0, 0.0),
+        "tag_success_rate": (0.0, 0.0),
+    },
+    "continuous_light_dark": {
+        "avg_high_variance_states_counter": (-0.7675509098987142, 2.1008842432320476),
+        "avg_obstacle_hit_counter": (0.0, 0.0),
+        "goal_reaching_rate": (0.0, 0.0),
+        "obstacle_hit_rate": (0.0, 0.0),
+        "out_of_grid_rate": (-0.7675509098987142, 2.1008842432320476),
+    },
+    "continuous_push": {
+        "dangerous_area_rate": (0.0, 0.0),
+        "goal_reaching_rate": (0.0, 0.0),
+        "object_obstacle_collision_rate": (0.0, 0.0),
+        "robot_obstacle_collision_rate": (0.0, 0.0),
+        "total_all_obstacle_collisions": (0.0, 0.0),
+        "total_dangerous_area_steps": (0.0, 0.0),
+        "total_object_obstacle_collisions": (0.0, 0.0),
+        "total_obstacle_collision_rate": (0.0, 0.0),
+        "total_robot_obstacle_collisions": (0.0, 0.0),
+    },
+    "discrete_light_dark": {
+        "avg_high_variance_states_counter": (-3.302652729696142, 5.302652729696142),
+        "avg_obstacle_hit_counter": (0.0, 0.0),
+        "goal_reaching_rate": (0.0, 0.0),
+        "obstacle_hit_rate": (0.0, 0.0),
+        "out_of_grid_rate": (-1.1008842432320476, 1.767550909898714),
+    },
+    "laser_tag": {
+        "average_all_dangerous_encounters": (-5.504421216160236, 8.83775454949357),
+        "average_dangerous_area_steps": (-5.504421216160236, 8.83775454949357),
+        "average_episode_length": (6.0, 6.0),
+        "average_failed_tag_attempts": (1.0, 1.0),
+        "average_obstacle_collisions": (0.0, 0.0),
+        "goal_reaching_rate": (0.0, 0.0),
+        "tag_success_rate": (0.0, 0.0),
+    },
+    "mountain_car": {
+        "goal_reaching_rate": (0.0, 0.0),
+    },
+    "pacman": {
+        "avg_all_dangerous_encounters": (0.0, 0.0),
+        "avg_collision_encounters": (0.0, 0.0),
+        "avg_dangerous_area_steps": (0.0, 0.0),
+        "avg_episode_length": (6.0, 6.0),
+        "avg_pacman_closest_ghost_distance": (8.601554733051053, 11.509556378060058),
+        "avg_pellets_collected": (1.0, 1.0),
+        "win_rate": (0.0, 0.0),
+    },
+    "push": {
+        "dangerous_area_rate": (0.0, 0.0),
+        "goal_reaching_rate": (0.0, 0.0),
+        "object_obstacle_collision_rate": (0.0, 0.0),
+        "robot_obstacle_collision_rate": (0.0, 0.0),
+        "total_all_obstacle_collisions": (0.0, 0.0),
+        "total_dangerous_area_steps": (0.0, 0.0),
+        "total_object_obstacle_collisions": (0.0, 0.0),
+        "total_obstacle_collision_rate": (0.0, 0.0),
+        "total_robot_obstacle_collisions": (0.0, 0.0),
+    },
+    "rock_sample": {
+        "average_dangerous_area_steps": (0.0, 0.0),
+        "avg_rocks_sampled": (1.0, 1.0),
+        "exit_success_rate": (0.0, 0.0),
+    },
+    "tiger": {
+        "average_listens": (2.0, 2.0),
+        "success_rate": (0.0, 0.0),
+    },
 }

--- a/POMDPPlanners/tests/test_core/test_simulation.py
+++ b/POMDPPlanners/tests/test_core/test_simulation.py
@@ -17,6 +17,7 @@ import numpy as np
 from POMDPPlanners.core.belief import WeightedParticleBelief, get_initial_belief
 from POMDPPlanners.core.simulation import History, StepData, TaskManagerExternalDB
 from POMDPPlanners.core.simulation.tasks import SimulationTask, DataBaseInterface
+from POMDPPlanners.environments.sanity_pomdp import SanityPOMDP
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
 from POMDPPlanners.planners.mcts_planners.pomcp import POMCP
 from POMDPPlanners.simulations.episodes import run_episode
@@ -348,11 +349,18 @@ def test_task_manager_external_db_all_cached():
 
 
 class _StepInfoTigerPOMDP(TigerPOMDP):
-    """Tiger variant that reports a per-step channel through ``step_info``."""
+    """Tiger variant that reports a per-step channel through ``step_info``.
+
+    Written the way the contract asks for: both channels are keyed off ``action``
+    with equality tests, so the terminal bookkeeping step -- which passes
+    ``action=None`` -- reports ``0.0`` for each rather than an accidental truthy
+    value. ``float(action != "listen")`` would have been ``1.0`` there.
+    """
 
     def step_info(self, state: Any, action: Any, next_state: Any) -> Dict[str, float]:
         del state, next_state
-        return {"success": float(action != "listen"), "listened": float(action == "listen")}
+        opened_door = action in ("open_left", "open_right")
+        return {"success": float(opened_door), "listened": float(action == "listen")}
 
 
 def test_step_data_info_defaults_to_none():
@@ -477,15 +485,17 @@ def test_environment_step_info_defaults_to_empty_mapping():
     Purpose: Validates that the new hook is opt-in, so environments that do not
         implement it are entirely unaffected
 
-    Given: A stock environment that does not override step_info
+    Given: An environment that does not override step_info. SanityPOMDP is used
+        rather than TigerPOMDP because Tiger now reports its own channels, so it
+        would no longer demonstrate the default
     When: step_info() is called with an arbitrary transition
     Then: An empty mapping is returned
 
     Test type: unit
     """
-    env = TigerPOMDP(discount_factor=0.95)
+    env = SanityPOMDP(discount_factor=0.95)
 
-    reported = env.step_info("tiger_left", "listen", "tiger_left")
+    reported = env.step_info(env.initial_state_dist().sample()[0], env.get_actions()[0], None)
 
     assert isinstance(reported, dict)
     assert not reported
@@ -521,3 +531,67 @@ def test_episode_runner_records_environment_step_info():
         assert step.info is not None
         assert set(step.info) == {"success", "listened"}
         assert step.info["listened"] == float(step.action == "listen")
+
+
+class _TerminalStepInfoTigerPOMDP(_StepInfoTigerPOMDP):
+    """Step-info tiger whose initial state is already terminal.
+
+    ``TigerPOMDP.is_terminal`` is hardcoded ``False``, so the stock environment
+    never produces a terminal bookkeeping step. This variant does, which is what
+    makes the terminal branch of the episode loop reachable in a test.
+    """
+
+    def is_terminal(self, state: str) -> bool:
+        del state
+        return True
+
+
+def test_episode_runner_records_step_info_on_the_terminal_step():
+    """Test that the terminal bookkeeping step is measured like any other.
+
+    Purpose: Validates that the final state of a terminated episode reaches
+        compute_metrics. Metrics that count every visited state need it, and it
+        is recorded nowhere else
+
+    Given: An environment reporting step_info whose initial state is terminal
+    When: An episode is run, so the loop takes its terminal branch immediately
+    Then: The single recorded step is the terminal one, and it carries the
+        channels measured with action and next_state both None
+
+    Test type: integration
+    """
+    env = _TerminalStepInfoTigerPOMDP(discount_factor=0.95)
+    policy = POMCP(
+        environment=env,
+        discount_factor=0.95,
+        depth=3,
+        exploration_constant=1.0,
+        name="terminal-step-info-test",
+        n_simulations=5,
+    )
+    belief = get_initial_belief(env, n_particles=10)
+    history = run_episode(env, policy, belief, num_steps=3, logger=get_logger("t", debug=False))
+
+    assert len(history.history) == 1, "expected only the terminal bookkeeping step"
+    terminal_step = history.history[0]
+    assert terminal_step.action is None
+    assert terminal_step.next_state is None
+    # Reported, not skipped -- and neutral, because both channels are keyed off
+    # an action that does not exist on this step.
+    assert terminal_step.info == {"success": 0.0, "listened": 0.0}
+
+
+def test_environment_step_info_tolerates_the_terminal_argument_shape():
+    """Test that the default step_info accepts the terminal step's None arguments.
+
+    Purpose: Validates that the terminal-step call cannot break an environment
+        that does not implement the hook
+
+    Given: A stock environment using the base-class step_info
+    When: It is called the way _add_terminal_step calls it
+    Then: It returns an empty mapping rather than raising
+
+    Test type: unit
+    """
+    env = SanityPOMDP(discount_factor=0.95)
+    assert not env.step_info(env.initial_state_dist().sample()[0], None, None)

--- a/POMDPPlanners/tests/test_core/test_step_info_metrics.py
+++ b/POMDPPlanners/tests/test_core/test_step_info_metrics.py
@@ -15,12 +15,13 @@ import pytest
 
 from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.core.environment import Environment
-from POMDPPlanners.core.simulation import History, StepData
+from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.core.simulation.step_info_metrics import (
     EpisodeReduction,
     StepInfoMetric,
     aggregate_step_info_metrics,
     extract_episode_step_infos,
+    order_and_fill_metrics,
 )
 from POMDPPlanners.environments.sanity_pomdp import SanityPOMDP
 from POMDPPlanners.tests.test_utils.env_pinned_kwargs import sanity_pinned_kwargs
@@ -178,6 +179,126 @@ class TestEpisodeReductions:
         metrics = aggregate_step_info_metrics([[{_IMPACT: 4.0}]], [spec])
 
         assert metrics[0].value == 2.0
+
+
+class TestEmptyEpisodes:
+    """What an episode that reported nothing at all contributes."""
+
+    def test_episode_reporting_nothing_is_excluded_by_default(self) -> None:
+        """Test that an episode with no values does not enter the average.
+
+        Purpose: Validates the default, which keeps an unmeasured episode from
+            being silently counted as a zero
+
+        Given: Two episodes, one reporting the channel and one reporting nothing
+        When: The spec leaves empty_episode_value unset
+        Then: The mean is taken over the reporting episode alone
+
+        Test type: unit
+        """
+        spec = StepInfoMetric(name="rate", channel=_SUCCESS, per_episode=EpisodeReduction.ANY)
+        metrics = aggregate_step_info_metrics([[{_SUCCESS: 1.0}], [{}]], [spec])
+
+        assert metrics[0].value == 1.0
+
+    def test_empty_episode_value_contributes_to_the_average(self) -> None:
+        """Test that a declared empty-episode value is counted.
+
+        Purpose: Validates the hook that lets an environment say what an episode
+            measuring nothing means. A "never failed" predicate is vacuously
+            true over no steps, so such an episode is a success, not an absence
+
+        Given: Two episodes, one reporting 1.0 and one reporting nothing
+        When: The spec declares empty_episode_value=0.0
+        Then: The mean is taken over both, giving 0.5
+
+        Test type: unit
+        """
+        spec = StepInfoMetric(
+            name="rate",
+            channel=_SUCCESS,
+            per_episode=EpisodeReduction.ANY,
+            empty_episode_value=0.0,
+        )
+        metrics = aggregate_step_info_metrics([[{_SUCCESS: 1.0}], [{}]], [spec])
+
+        assert metrics[0].value == 0.5
+
+    def test_empty_episode_value_alone_still_produces_the_metric(self) -> None:
+        """Test that a metric survives when every episode measured nothing.
+
+        Purpose: Validates that declaring an empty-episode value also prevents
+            the metric being dropped, which is what distinguishes "every episode
+            answered zero" from "nothing was ever measured"
+
+        Given: Two episodes that report no channels at all
+        When: The spec declares empty_episode_value=1.0
+        Then: The metric is produced with value 1.0
+
+        Test type: unit
+        """
+        spec = StepInfoMetric(
+            name="alive",
+            channel=_SUCCESS,
+            per_episode=EpisodeReduction.ALL,
+            empty_episode_value=1.0,
+        )
+        metrics = aggregate_step_info_metrics([[{}], [{}]], [spec])
+
+        assert [(m.name, m.value) for m in metrics] == [("alive", 1.0)]
+
+
+class TestOrderAndFill:
+    """Imposing a declared name order on a partially computed metric list."""
+
+    def test_missing_name_is_filled_and_order_follows_the_declaration(self) -> None:
+        """Test that gaps are filled and ordering comes from the declared names.
+
+        Purpose: Validates the helper that keeps a fixed declared metric list
+            intact when the aggregator omitted one of its entries
+
+        Given: Metrics computed out of order with one declared name missing
+        When: order_and_fill_metrics is applied
+        Then: Every declared name appears, in declaration order, the missing one
+            carrying a zero on an unbounded interval
+
+        Test type: unit
+        """
+        computed = [
+            MetricValue(
+                name="second", value=2.0, lower_confidence_bound=1.0, upper_confidence_bound=3.0
+            )
+        ]
+
+        ordered = order_and_fill_metrics(["first", "second"], computed)
+
+        assert [m.name for m in ordered] == ["first", "second"]
+        assert ordered[0].value == 0.0
+        assert ordered[0].lower_confidence_bound == -np.inf
+        assert ordered[0].upper_confidence_bound == np.inf
+
+    def test_optional_name_is_omitted_rather_than_filled(self) -> None:
+        """Test that an optional declared name disappears when not computed.
+
+        Purpose: Validates the escape hatch for metrics whose historical
+            behaviour is to vanish when nothing contributed, rather than to
+            report a zero that would read as a real measurement
+
+        Given: A declared list whose second name was not computed
+        When: That name is passed as optional
+        Then: It is left out instead of filled
+
+        Test type: unit
+        """
+        computed = [
+            MetricValue(
+                name="first", value=1.0, lower_confidence_bound=0.0, upper_confidence_bound=2.0
+            )
+        ]
+
+        ordered = order_and_fill_metrics(["first", "second"], computed, optional=["second"])
+
+        assert [m.name for m in ordered] == ["first"]
 
 
 class TestMissingChannels:

--- a/POMDPPlanners/tests/test_core/test_step_info_metrics.py
+++ b/POMDPPlanners/tests/test_core/test_step_info_metrics.py
@@ -191,7 +191,7 @@ class TestEmptyEpisodes:
             being silently counted as a zero
 
         Given: Two episodes, one reporting the channel and one reporting nothing
-        When: The spec leaves empty_episode_value unset
+        When: The metrics are aggregated
         Then: The mean is taken over the reporting episode alone
 
         Test type: unit
@@ -201,51 +201,51 @@ class TestEmptyEpisodes:
 
         assert metrics[0].value == 1.0
 
-    def test_empty_episode_value_contributes_to_the_average(self) -> None:
-        """Test that a declared empty-episode value is counted.
+    def test_a_reporting_episode_is_unaffected_by_how_many_report_nothing(self) -> None:
+        """Test that unmeasured episodes cannot move a measured episode's mean.
 
-        Purpose: Validates the hook that lets an environment say what an episode
-            measuring nothing means. A "never failed" predicate is vacuously
-            true over no steps, so such an episode is a success, not an absence
+        Purpose: Validates that the number of episodes measuring nothing is not
+            observable in the result. Were they filled with a stand-in, adding
+            more of them would drag the mean towards that value, making the
+            metric depend on how often measurement failed rather than on what
+            was measured
 
-        Given: Two episodes, one reporting 1.0 and one reporting nothing
-        When: The spec declares empty_episode_value=0.0
-        Then: The mean is taken over both, giving 0.5
+        Given: Two reporting episodes averaging 0.5, alongside zero, one and
+            eight silent ones. The 0.5 is chosen to sit strictly between the two
+            stand-ins an implementation might plausibly invent, so filling with
+            either 0.0 or 1.0 would move it and fail this test
+        When: The metrics are aggregated for each list
+        Then: All three report 0.5
 
         Test type: unit
         """
-        spec = StepInfoMetric(
-            name="rate",
-            channel=_SUCCESS,
-            per_episode=EpisodeReduction.ANY,
-            empty_episode_value=0.0,
-        )
-        metrics = aggregate_step_info_metrics([[{_SUCCESS: 1.0}], [{}]], [spec])
+        spec = StepInfoMetric(name="rate", channel=_SUCCESS, per_episode=EpisodeReduction.ANY)
+        reporting = [[{_SUCCESS: 1.0}], [{_SUCCESS: 0.0}]]
 
-        assert metrics[0].value == 0.5
+        values = [
+            aggregate_step_info_metrics(reporting + [[{}]] * silent, [spec])[0].value
+            for silent in (0, 1, 8)
+        ]
 
-    def test_empty_episode_value_alone_still_produces_the_metric(self) -> None:
-        """Test that a metric survives when every episode measured nothing.
+        assert values == [0.5, 0.5, 0.5]
 
-        Purpose: Validates that declaring an empty-episode value also prevents
-            the metric being dropped, which is what distinguishes "every episode
-            answered zero" from "nothing was ever measured"
+    def test_metric_is_omitted_when_every_episode_reported_nothing(self) -> None:
+        """Test that a wholly unmeasured metric is absent rather than zero.
+
+        Purpose: Validates that "nobody measured this" is reported as an absence,
+            so a caller cannot mistake it for a measurement of zero. Environments
+            whose declared name list is a fixed contract turn the absence into an
+            explicit zero themselves, through order_and_fill_metrics
 
         Given: Two episodes that report no channels at all
-        When: The spec declares empty_episode_value=1.0
-        Then: The metric is produced with value 1.0
+        When: The metrics are aggregated
+        Then: No metric is produced
 
         Test type: unit
         """
-        spec = StepInfoMetric(
-            name="alive",
-            channel=_SUCCESS,
-            per_episode=EpisodeReduction.ALL,
-            empty_episode_value=1.0,
-        )
-        metrics = aggregate_step_info_metrics([[{}], [{}]], [spec])
+        spec = StepInfoMetric(name="alive", channel=_SUCCESS, per_episode=EpisodeReduction.ALL)
 
-        assert [(m.name, m.value) for m in metrics] == [("alive", 1.0)]
+        assert not aggregate_step_info_metrics([[{}], [{}]], [spec])
 
 
 class TestOrderAndFill:
@@ -277,26 +277,29 @@ class TestOrderAndFill:
         assert ordered[0].lower_confidence_bound == -np.inf
         assert ordered[0].upper_confidence_bound == np.inf
 
-    def test_optional_name_is_omitted_rather_than_filled(self) -> None:
-        """Test that an optional declared name disappears when not computed.
+    def test_undeclared_computed_metric_is_dropped(self) -> None:
+        """Test that a metric outside the declared name list is not emitted.
 
-        Purpose: Validates the escape hatch for metrics whose historical
-            behaviour is to vanish when nothing contributed, rather than to
-            report a zero that would read as a real measurement
+        Purpose: Validates that the declared list is the whole contract, so a
+            stray computed metric cannot widen an environment's reported names
+            behind ``get_metric_names``
 
-        Given: A declared list whose second name was not computed
-        When: That name is passed as optional
-        Then: It is left out instead of filled
+        Given: Computed metrics containing a name the caller did not declare
+        When: order_and_fill_metrics is applied
+        Then: Only the declared names are returned
 
         Test type: unit
         """
         computed = [
             MetricValue(
                 name="first", value=1.0, lower_confidence_bound=0.0, upper_confidence_bound=2.0
-            )
+            ),
+            MetricValue(
+                name="stray", value=9.0, lower_confidence_bound=8.0, upper_confidence_bound=10.0
+            ),
         ]
 
-        ordered = order_and_fill_metrics(["first", "second"], computed, optional=["second"])
+        ordered = order_and_fill_metrics(["first"], computed)
 
         assert [m.name for m in ordered] == ["first"]
 

--- a/POMDPPlanners/tests/test_core/test_step_info_metrics.py
+++ b/POMDPPlanners/tests/test_core/test_step_info_metrics.py
@@ -248,6 +248,67 @@ class TestEmptyEpisodes:
         assert not aggregate_step_info_metrics([[{}], [{}]], [spec])
 
 
+class TestEmptyHistoryBatch:
+    """Scoring no episodes at all."""
+
+    def test_no_histories_is_rejected(self) -> None:
+        """Test that an empty batch raises instead of producing metrics.
+
+        Purpose: Validates that no value is invented for a run with no episodes.
+            A metric over no episodes is an average over nothing, and every
+            answer an environment could give — a zero, an omitted name, an empty
+            list — reads exactly like a real measurement
+
+        Given: A spec-driven environment and an empty history list
+        When: compute_metrics is called
+        Then: A ValueError naming the environment is raised
+
+        Test type: unit
+        """
+        env = _SpecSanity(discount_factor=0.95, **sanity_pinned_kwargs())
+
+        with pytest.raises(ValueError, match="received no episode histories"):
+            env.compute_metrics([])
+
+    def test_environment_without_specs_also_rejects_an_empty_batch(self) -> None:
+        """Test that the guard precedes the no-specs shortcut.
+
+        Purpose: Validates that the empty-batch rule is a property of the input,
+            not of whether the environment happens to declare metrics. An
+            environment with no specs returns an empty list for a real batch too,
+            so returning one here would leave the caller's mistake invisible
+
+        Given: A stock environment declaring no metric specs
+        When: compute_metrics is called with an empty history list
+        Then: A ValueError naming the environment is raised
+
+        Test type: unit
+        """
+        env = SanityPOMDP(discount_factor=0.95, **sanity_pinned_kwargs())
+
+        assert not env.get_metric_specs()
+        with pytest.raises(ValueError, match="received no episode histories"):
+            env.compute_metrics([])
+
+    def test_aggregator_itself_still_tolerates_an_empty_episode_list(self) -> None:
+        """Test that the guard sits at the environment boundary, not the aggregator.
+
+        Purpose: Validates that the rejection is a policy about scoring a run,
+            applied where a caller passes histories in. The aggregator is a pure
+            reduction reused by runners that produce no History, and giving it a
+            second opinion on emptiness would duplicate the rule
+
+        Given: An empty episode list and one spec
+        When: aggregate_step_info_metrics is called directly
+        Then: It returns no metrics without raising
+
+        Test type: unit
+        """
+        spec = StepInfoMetric(name="rate", channel=_SUCCESS, per_episode=EpisodeReduction.ANY)
+
+        assert not aggregate_step_info_metrics([], [spec])
+
+
 class TestOrderAndFill:
     """Imposing a declared name order on a partially computed metric list."""
 

--- a/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_carla_pomdp/test_carla_pomdp.py
@@ -1330,20 +1330,23 @@ def test_get_metric_names_lists_the_full_carla_metric_set() -> None:
     ]
 
 
-def test_compute_metrics_empty_histories_returns_empty_list() -> None:
+def test_compute_metrics_empty_histories_is_rejected() -> None:
     """No histories yields no metrics.
 
-    Purpose: Validates compute_metrics degrades gracefully on empty input
+    Purpose: Validates that an empty batch is rejected rather than scored. A
+        zero collision_rate over no episodes is indistinguishable from a run in
+        which the ego never crashed
 
     Given: A CarlaPOMDP world
     When: compute_metrics is called with an empty history list
-    Then: An empty list is returned (no division by zero, no CI on empty data)
+    Then: A ValueError naming the environment is raised
 
     Test type: unit
     """
     env = CarlaPOMDP(discount_factor=0.95)
 
-    assert not env.compute_metrics([])
+    with pytest.raises(ValueError, match="received no episode histories"):
+        env.compute_metrics([])
 
 
 def test_compute_metrics_emits_the_three_named_metrics() -> None:

--- a/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_cartpole_pomdp.py
@@ -24,6 +24,7 @@ from POMDPPlanners.environments.cartpole_pomdp import (
     _native,
 )
 from POMDPPlanners.tests.test_utils.env_pinned_kwargs import cartpole_pinned_kwargs
+from POMDPPlanners.tests.test_utils.golden_metric_snapshot import attach_step_info
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -857,7 +858,7 @@ def test_compute_metrics_goal_reaching():
     )
 
     # Compute metrics
-    metrics = env.compute_metrics([history1, history2, history3])
+    metrics = env.compute_metrics(attach_step_info(env, [history1, history2, history3]))
 
     # Convert metrics to dictionary for easier access
     metrics_dict = {metric.name: metric for metric in metrics}
@@ -1002,7 +1003,7 @@ def test_compute_metrics_values_within_confidence_intervals():
             )
         )
 
-    metrics = env.compute_metrics(histories)
+    metrics = env.compute_metrics(attach_step_info(env, histories))
     verify_metrics_within_confidence_intervals(metrics)
     verify_metric_sanity(metrics, histories, env)
     verify_history_returns_bounded(histories, env)

--- a/POMDPPlanners/tests/test_environments/test_isaac_lab_pomdp/test_isaac_lab_measurement.py
+++ b/POMDPPlanners/tests/test_environments/test_isaac_lab_pomdp/test_isaac_lab_measurement.py
@@ -300,6 +300,28 @@ class TestStepInfoContract:
 
         assert not world.step_info(state, np.zeros(2), np.array([99.0, 99.0]))
 
+    def test_step_info_for_the_terminal_step_reports_nothing(self, fake_env: FakeIsaacEnv) -> None:
+        """Test that the terminal bookkeeping call yields no measurements.
+
+        Purpose: Validates that the episode loop's terminal-step call cannot
+            mis-attribute the last transition's cached contact impulse and
+            success flag to the terminal state, which has no transition of its
+            own
+
+        Given: A world that has taken one step, holding a pending measurement
+        When: step_info is called the way _add_terminal_step calls it, with
+            action and next_state both None
+        Then: An empty mapping is returned and no extra physics step is taken
+
+        Test type: unit
+        """
+        world = _measuring_world()
+        state = world._live_state
+        world.sample_next_state(state, np.zeros(2))
+
+        assert not world.step_info(state, None, None)
+        assert fake_env.step_calls == 1
+
 
 class TestMetricSpecs:
     """Declared metric specs track the configured measurements."""

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
@@ -1161,15 +1161,18 @@ class TestMetrics:
     def test_compute_metrics_empty(self, env):
         """Test compute_metrics with empty histories.
 
-        Purpose: Validates empty input handling.
+        Purpose: Validates that an empty batch is rejected rather than scored. A
+            zero tag_success_rate over no episodes is indistinguishable from a
+            run in which the agent never tagged the opponent.
 
         Given: An empty history list.
         When: compute_metrics() is called.
-        Then: Returns empty list.
+        Then: A ValueError naming the environment is raised.
 
         Test type: unit
         """
-        assert env.compute_metrics([]) == []
+        with pytest.raises(ValueError, match="received no episode histories"):
+            env.compute_metrics([])
 
     def test_compute_metrics_discrete_actions(self, env_discrete):
         """Test compute_metrics with discrete string actions.

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_continuous_laser_tag_pomdp.py
@@ -34,6 +34,7 @@ from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_metric_sanity,
     verify_return_shift_linearity,
 )
+from POMDPPlanners.tests.test_utils.golden_metric_snapshot import attach_step_info
 
 
 @pytest.fixture
@@ -1218,7 +1219,7 @@ class TestMetrics:
             policy_run_data=[PolicyRunData(info_variables=[])],
         )
 
-        metrics = env_discrete.compute_metrics([history])
+        metrics = env_discrete.compute_metrics(attach_step_info(env_discrete, [history]))
         assert len(metrics) > 0
         metrics_dict = {m.name: m for m in metrics}
         assert "tag_success_rate" in metrics_dict
@@ -1303,7 +1304,7 @@ class TestMetrics:
             policy_run_data=[PolicyRunData(info_variables=[])],
         )
 
-        metrics = env.compute_metrics([history])
+        metrics = env.compute_metrics(attach_step_info(env, [history]))
         expected_names = env.get_metric_names()
         assert len(expected_names) == 7
         metrics_dict = {m.name: m for m in metrics}
@@ -1360,7 +1361,7 @@ class TestMetrics:
             policy_run_data=[PolicyRunData(info_variables=[])],
         )
 
-        metrics = env_discrete.compute_metrics([history])
+        metrics = env_discrete.compute_metrics(attach_step_info(env_discrete, [history]))
         metrics_dict = {m.name: m for m in metrics}
         assert metrics_dict["average_failed_tag_attempts"].value > 0
 
@@ -1420,7 +1421,7 @@ class TestMetrics:
             policy_run_data=[PolicyRunData(info_variables=[])],
         )
 
-        metrics = env.compute_metrics([history])
+        metrics = env.compute_metrics(attach_step_info(env, [history]))
         metrics_dict = {m.name: m for m in metrics}
         assert metrics_dict["average_dangerous_area_steps"].value > 0
 
@@ -1498,7 +1499,7 @@ class TestMetrics:
             terminal=True,
         )
 
-        metrics = env.compute_metrics([h1, h2, h3])
+        metrics = env.compute_metrics(attach_step_info(env, [h1, h2, h3]))
         assert len(metrics) == 7
 
         metrics_dict = {m.name: m for m in metrics}

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -38,6 +38,7 @@ from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_return_shift_linearity,
 )
 from POMDPPlanners.utils.logger import get_logger
+from POMDPPlanners.tests.test_utils.golden_metric_snapshot import attach_step_info
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -1642,7 +1643,7 @@ class TestLaserTagPOMDP:
             policy_run_data=[PolicyRunData(info_variables=[])],
         )
 
-        histories = [history]
+        histories = attach_step_info(env, [history])
         metrics = env.compute_metrics(histories)
 
         # Find wall collision metric

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -1815,7 +1815,11 @@ class TestLaserTagPOMDP:
                     particles=dummy_particles, log_weights=dummy_log_weights
                 )
 
-                # Create step data
+                # Create step data. The info mapping is filled exactly as
+                # EpisodeRunner._record_step fills it: this environment derives
+                # its metrics from the per-step channel, so a hand-rolled episode
+                # that skipped it would not be the realistic history this test
+                # claims to build.
                 step = StepData(
                     state=current_state,
                     action=action,
@@ -1823,6 +1827,7 @@ class TestLaserTagPOMDP:
                     observation=observation,
                     reward=reward,
                     belief=test_belief,
+                    info=env.step_info(current_state, action, next_state) or None,
                 )
                 steps.append(step)
 
@@ -1979,8 +1984,16 @@ class TestLaserTagPOMDP:
             belief=test_belief,
         )
 
+        # Measured as EpisodeRunner._record_step measures them: the metrics under
+        # test come from the per-step channel, so an unmeasured history would
+        # exercise the "never measured" guard rather than the None-reward path.
+        measured_steps = [
+            step._replace(info=env.step_info(step.state, step.action, step.next_state) or None)
+            for step in [step1, step2, step3]
+        ]
+
         history = History(
-            history=[step1, step2, step3],
+            history=measured_steps,
             discount_factor=env.discount_factor,
             average_state_sampling_time=0.01,
             average_action_time=0.01,

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_continuous_light_dark_pomdp.py
@@ -470,6 +470,31 @@ def test_reward_range():
     assert env2.reward_range == expected_reward_range2
 
 
+def test_compute_metrics_empty_histories_is_rejected():
+    """Test that scoring an empty batch of episodes raises.
+
+    Purpose: Validates that an empty batch is rejected rather than scored. A
+        zero goal_reaching_rate over no episodes is indistinguishable from a run
+        in which the agent never reached the goal
+
+    Given: A ContinuousLightDarkPOMDPDiscreteActions environment and an empty
+        history list
+    When: compute_metrics is called
+    Then: A ValueError naming the environment is raised
+
+    Test type: unit
+    """
+    env = ContinuousLightDarkPOMDPDiscreteActions(
+        discount_factor=0.95,
+        **continuous_light_dark_discrete_actions_pinned_kwargs(
+            goal_state_radius=1.5, obstacle_radius=1.5
+        ),
+    )
+
+    with pytest.raises(ValueError, match="received no episode histories"):
+        env.compute_metrics([])
+
+
 def test_compute_metrics():
     """Test computation of metrics for different simulation histories"""
     env = ContinuousLightDarkPOMDPDiscreteActions(

--- a/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_light_dark_pomdp/test_discrete_light_dark_pomdp.py
@@ -1133,6 +1133,25 @@ def test_visualize_path(tmp_path):
     assert cache_path.exists()
 
 
+def test_compute_metrics_empty_histories_is_rejected():
+    """Test that scoring an empty batch of episodes raises.
+
+    Purpose: Validates that an empty batch is rejected rather than scored. A
+        zero goal_reaching_rate over no episodes is indistinguishable from a run
+        in which the agent never reached the goal
+
+    Given: A DiscreteLightDarkPOMDP environment and an empty history list
+    When: compute_metrics is called
+    Then: A ValueError naming the environment is raised
+
+    Test type: unit
+    """
+    env = DiscreteLightDarkPOMDP(discount_factor=0.95, **discrete_light_dark_pinned_kwargs())
+
+    with pytest.raises(ValueError, match="received no episode histories"):
+        env.compute_metrics([])
+
+
 def test_compute_metrics():
     """Test computation of metrics for different simulation histories
 

--- a/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_mountain_car_pomdp.py
@@ -18,6 +18,7 @@ import scipy.stats
 
 from POMDPPlanners.environments.mountain_car_pomdp import MountainCarPOMDP
 from POMDPPlanners.tests.test_utils.env_pinned_kwargs import mountain_car_pinned_kwargs
+from POMDPPlanners.tests.test_utils.golden_metric_snapshot import attach_step_info
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -1131,7 +1132,7 @@ def test_compute_metrics_goal_reaching():
     )
 
     # Compute metrics
-    metrics = pomdp.compute_metrics([history1, history2, history3])
+    metrics = pomdp.compute_metrics(attach_step_info(pomdp, [history1, history2, history3]))
 
     # Convert metrics to dictionary for easier access
     metrics_dict = {metric.name: metric for metric in metrics}
@@ -1273,7 +1274,7 @@ def test_compute_metrics_values_within_confidence_intervals():
             )
         )
 
-    metrics = env.compute_metrics(histories)
+    metrics = env.compute_metrics(attach_step_info(env, histories))
     verify_metrics_within_confidence_intervals(metrics)
     verify_metric_sanity(metrics, histories, env)
     verify_history_returns_bounded(histories, env)

--- a/POMDPPlanners/tests/test_environments/test_nuplan_pomdp/test_nuplan_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_nuplan_pomdp/test_nuplan_pomdp.py
@@ -231,6 +231,23 @@ def test_collision_is_terminal_and_penalised(monkeypatch: pytest.MonkeyPatch) ->
     assert reward < -50.0
 
 
+def test_compute_metrics_empty_histories_is_rejected(world: NuPlanPOMDP) -> None:
+    """compute_metrics rejects an empty batch of episodes.
+
+    Purpose: Validates that an empty batch is rejected rather than scored. A
+        zero collision_rate over no episodes is indistinguishable from a run in
+        which the ego never crashed.
+
+    Given: A NuPlanPOMDP world and an empty history list
+    When: compute_metrics is called
+    Then: A ValueError naming the environment is raised
+
+    Test type: unit
+    """
+    with pytest.raises(ValueError, match="received no episode histories"):
+        world.compute_metrics([])
+
+
 def test_compute_metrics_reports_named_metrics(world: NuPlanPOMDP) -> None:
     """compute_metrics returns the declared nuPlan metric names.
 

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
@@ -1008,16 +1008,18 @@ class TestPacManPOMDPMetrics:
     def test_compute_metrics_empty_histories(self):
         """Test metrics computation with empty histories.
 
-        Purpose: Validates that empty history list returns empty metrics
+        Purpose: Validates that an empty batch is rejected rather than scored. A
+            win rate over no episodes is indistinguishable from a run in which
+            PacMan never won
 
         Given: Empty list of episode histories
         When: compute_metrics() is called
-        Then: Returns empty list of metrics
+        Then: A ValueError naming the environment is raised
 
         Test type: unit
         """
-        metrics = self.pomdp.compute_metrics([])
-        assert metrics == []
+        with pytest.raises(ValueError, match="received no episode histories"):
+            self.pomdp.compute_metrics([])
 
     def test_compute_metrics_win_rate(self):
         """Test win rate metric calculation.

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
@@ -32,7 +32,6 @@ from POMDPPlanners.environments.pacman_pomdp import (
     PacManPOMDP,
     create_simple_maze_pacman,
 )
-from POMDPPlanners.tests.test_utils.golden_metric_snapshot import attach_step_info
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -1017,7 +1016,7 @@ class TestPacManPOMDPMetrics:
 
         Test type: unit
         """
-        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, []))
+        metrics = self.pomdp.compute_metrics([])
         assert metrics == []
 
     def test_compute_metrics_win_rate(self):
@@ -1098,7 +1097,7 @@ class TestPacManPOMDPMetrics:
 
         histories = [win_history, lose_history, win_history]  # 2 wins, 1 loss
 
-        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, histories))
+        metrics = self.pomdp.compute_metrics(histories)
 
         # Find win rate metric
         win_rate_metric = next((m for m in metrics if m.name == "win_rate"), None)
@@ -1182,7 +1181,7 @@ class TestPacManPOMDPMetrics:
             ),
         ]
 
-        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, histories))
+        metrics = self.pomdp.compute_metrics(histories)
 
         # Find pellets collected metric
         pellets_metric = next((m for m in metrics if m.name == "avg_pellets_collected"), None)
@@ -1298,7 +1297,7 @@ class TestPacManPOMDPMetrics:
             policy_run_data=[],
         )
 
-        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, [history1, history2]))
+        metrics = self.pomdp.compute_metrics([history1, history2])
 
         # Find distance metric
         distance_metric = next(
@@ -1428,7 +1427,7 @@ class TestPacManPOMDPMetrics:
             policy_run_data=[],
         )
 
-        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, [history1, history2]))
+        metrics = self.pomdp.compute_metrics([history1, history2])
 
         # Find collision encounters metric
         collision_metric = next((m for m in metrics if m.name == "avg_collision_encounters"), None)
@@ -1564,7 +1563,7 @@ class TestPacManPOMDPMetrics:
                 )
             )
 
-        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, histories))
+        metrics = self.pomdp.compute_metrics(histories)
         verify_metrics_within_confidence_intervals(metrics)
         verify_metric_sanity(metrics, histories, self.pomdp)
         verify_history_returns_bounded(histories, self.pomdp)
@@ -1660,7 +1659,7 @@ class TestPacManPOMDPDangerMetrics:
             ]
         )
 
-        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, [ep_a, ep_b]))
+        metrics = self.pomdp.compute_metrics([ep_a, ep_b])
         danger_metric = next((m for m in metrics if m.name == "avg_dangerous_area_steps"), None)
 
         assert danger_metric is not None
@@ -1700,7 +1699,7 @@ class TestPacManPOMDPDangerMetrics:
             ]
         )
 
-        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, [ep_a, ep_b]))
+        metrics = self.pomdp.compute_metrics([ep_a, ep_b])
         by_name = {m.name: m for m in metrics}
 
         collisions = by_name.get("avg_collision_encounters")

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
@@ -32,6 +32,7 @@ from POMDPPlanners.environments.pacman_pomdp import (
     PacManPOMDP,
     create_simple_maze_pacman,
 )
+from POMDPPlanners.tests.test_utils.golden_metric_snapshot import attach_step_info
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -1016,7 +1017,7 @@ class TestPacManPOMDPMetrics:
 
         Test type: unit
         """
-        metrics = self.pomdp.compute_metrics([])
+        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, []))
         assert metrics == []
 
     def test_compute_metrics_win_rate(self):
@@ -1097,7 +1098,7 @@ class TestPacManPOMDPMetrics:
 
         histories = [win_history, lose_history, win_history]  # 2 wins, 1 loss
 
-        metrics = self.pomdp.compute_metrics(histories)
+        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, histories))
 
         # Find win rate metric
         win_rate_metric = next((m for m in metrics if m.name == "win_rate"), None)
@@ -1181,7 +1182,7 @@ class TestPacManPOMDPMetrics:
             ),
         ]
 
-        metrics = self.pomdp.compute_metrics(histories)
+        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, histories))
 
         # Find pellets collected metric
         pellets_metric = next((m for m in metrics if m.name == "avg_pellets_collected"), None)
@@ -1297,7 +1298,7 @@ class TestPacManPOMDPMetrics:
             policy_run_data=[],
         )
 
-        metrics = self.pomdp.compute_metrics([history1, history2])
+        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, [history1, history2]))
 
         # Find distance metric
         distance_metric = next(
@@ -1427,7 +1428,7 @@ class TestPacManPOMDPMetrics:
             policy_run_data=[],
         )
 
-        metrics = self.pomdp.compute_metrics([history1, history2])
+        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, [history1, history2]))
 
         # Find collision encounters metric
         collision_metric = next((m for m in metrics if m.name == "avg_collision_encounters"), None)
@@ -1563,7 +1564,7 @@ class TestPacManPOMDPMetrics:
                 )
             )
 
-        metrics = self.pomdp.compute_metrics(histories)
+        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, histories))
         verify_metrics_within_confidence_intervals(metrics)
         verify_metric_sanity(metrics, histories, self.pomdp)
         verify_history_returns_bounded(histories, self.pomdp)
@@ -1659,7 +1660,7 @@ class TestPacManPOMDPDangerMetrics:
             ]
         )
 
-        metrics = self.pomdp.compute_metrics([ep_a, ep_b])
+        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, [ep_a, ep_b]))
         danger_metric = next((m for m in metrics if m.name == "avg_dangerous_area_steps"), None)
 
         assert danger_metric is not None
@@ -1699,7 +1700,7 @@ class TestPacManPOMDPDangerMetrics:
             ]
         )
 
-        metrics = self.pomdp.compute_metrics([ep_a, ep_b])
+        metrics = self.pomdp.compute_metrics(attach_step_info(self.pomdp, [ep_a, ep_b]))
         by_name = {m.name: m for m in metrics}
 
         collisions = by_name.get("avg_collision_encounters")

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_continuous_push_pomdp.py
@@ -38,6 +38,7 @@ from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_metric_sanity,
     verify_return_shift_linearity,
 )
+from POMDPPlanners.tests.test_utils.golden_metric_snapshot import attach_step_info
 
 
 def _make_env(**overrides) -> ContinuousPushPOMDP:
@@ -552,7 +553,7 @@ class TestContinuousPushPOMDP:
             reach_terminal_state=False,
             policy_run_data=[PolicyRunData(info_variables=[])],
         )
-        metrics = self.env.compute_metrics([history])
+        metrics = self.env.compute_metrics(attach_step_info(self.env, [history]))
         metric_names = {m.name for m in metrics}
         assert "goal_reaching_rate" in metric_names
         assert "robot_obstacle_collision_rate" in metric_names
@@ -681,7 +682,7 @@ class TestContinuousPushPOMDP:
                 )
             )
 
-        metrics = self.env.compute_metrics(histories)
+        metrics = self.env.compute_metrics(attach_step_info(self.env, histories))
         verify_metrics_within_confidence_intervals(metrics)
         verify_metric_sanity(metrics, histories, self.env)
         verify_history_returns_bounded(histories, self.env)
@@ -1104,7 +1105,7 @@ class TestContinuousPushDangerousAreas:
             reach_terminal_state=False,
             policy_run_data=[PolicyRunData(info_variables=[])],
         )
-        metrics = {m.name: m for m in env.compute_metrics([history])}
+        metrics = {m.name: m for m in env.compute_metrics(attach_step_info(env, [history]))}
         assert "dangerous_area_rate" in metrics
         assert "total_dangerous_area_steps" in metrics
         assert metrics["total_dangerous_area_steps"].value == pytest.approx(2.0)

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
@@ -28,6 +28,7 @@ from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_metric_sanity,
     verify_return_shift_linearity,
 )
+from POMDPPlanners.tests.test_utils.golden_metric_snapshot import attach_step_info
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -1744,7 +1745,7 @@ class TestPushDangerousAreas:
             reach_terminal_state=False,
             policy_run_data=[PolicyRunData(info_variables=[])],
         )
-        metrics = {m.name: m for m in env.compute_metrics([history])}
+        metrics = {m.name: m for m in env.compute_metrics(attach_step_info(env, [history]))}
         assert "dangerous_area_rate" in metrics
         assert "total_dangerous_area_steps" in metrics
         assert metrics["total_dangerous_area_steps"].value == pytest.approx(2.0)
@@ -2527,7 +2528,7 @@ def test_compute_metrics_values_within_confidence_intervals():
             )
         )
 
-    metrics = env.compute_metrics(histories)
+    metrics = env.compute_metrics(attach_step_info(env, histories))
     verify_metrics_within_confidence_intervals(metrics)
     verify_metric_sanity(metrics, histories, env)
     verify_history_returns_bounded(histories, env)

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_feature_driven.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp_feature_driven.py
@@ -632,6 +632,9 @@ def test_metric_names_match_compute_metrics_output() -> None:
     # WeightedParticleBelief requires at least one nonzero log-weight, so
     # use two particles with arbitrary unequal log-weights.
     belief = WeightedParticleBelief([state, state], np.array([0.0, -1.0]))
+    # Measured as EpisodeRunner._record_step measures it: this environment's
+    # metrics come from the per-step channel, so an unmeasured step carries none
+    # of the names under test.
     step = StepData(
         state=state,
         action="up",
@@ -639,6 +642,7 @@ def test_metric_names_match_compute_metrics_output() -> None:
         observation=observation,
         reward=reward,
         belief=belief,
+        info=env.step_info(state, "up", next_state) or None,
     )
     history = History(
         history=[step],

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
@@ -38,6 +38,7 @@ from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_metric_sanity,
     verify_return_shift_linearity,
 )
+from POMDPPlanners.tests.test_utils.golden_metric_snapshot import attach_step_info
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -1305,7 +1306,7 @@ class TestMetricsComputation:
             history = build_test_history(steps=steps, reach_terminal=False)
             histories.append(history)
 
-        metrics = pomdp.compute_metrics(histories)
+        metrics = pomdp.compute_metrics(attach_step_info(pomdp, histories))
 
         # Find rocks sampled metric
         rocks_metric = next((m for m in metrics if m.name == "avg_rocks_sampled"), None)
@@ -1357,7 +1358,7 @@ class TestMetricsComputation:
         )
         histories.append(fail_history)
 
-        metrics = pomdp.compute_metrics(histories)
+        metrics = pomdp.compute_metrics(attach_step_info(pomdp, histories))
 
         # Find exit success rate metric
         exit_metric = next((m for m in metrics if m.name == "exit_success_rate"), None)
@@ -1452,7 +1453,7 @@ class TestMetricsComputation:
             build_test_history(steps=sample_twice_steps, actual_num_steps=2, reach_terminal=False),
         ]
 
-        metrics = pomdp.compute_metrics(histories)
+        metrics = pomdp.compute_metrics(attach_step_info(pomdp, histories))
         verify_metrics_within_confidence_intervals(metrics)
         verify_metric_sanity(metrics, histories, pomdp)
         verify_history_returns_bounded(histories, pomdp)

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
@@ -1249,17 +1249,19 @@ class TestMetricsComputation:
     def test_compute_metrics_empty_histories(self):
         """Test metrics computation with empty histories.
 
-        Purpose: Validates proper handling of empty history list
+        Purpose: Validates that an empty batch is rejected rather than scored. A
+            zero-valued avg_rocks_sampled over no episodes is indistinguishable
+            from a run in which no rock was ever sampled
 
         Given: Empty list of histories
         When: compute_metrics() is called
-        Then: Returns empty list of metrics
+        Then: A ValueError naming the environment is raised
 
         Test type: unit
         """
         pomdp = RockSamplePOMDP(discount_factor=0.95, **rock_sample_pinned_kwargs())
-        metrics = pomdp.compute_metrics([])
-        assert metrics == []
+        with pytest.raises(ValueError, match="received no episode histories"):
+            pomdp.compute_metrics([])
 
     def test_compute_metrics_rocks_sampled(self):
         """Test computation of rocks sampled metric.

--- a/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_safety_ant_velocity_pomdp/test_safety_ant_velocity_pomdp.py
@@ -369,6 +369,28 @@ def test_sample_next_step():
     assert np.isclose(reward, expected_reward, rtol=1e-10)
 
 
+def test_compute_metrics_empty_histories_is_rejected():
+    """Test that scoring an empty batch of episodes raises.
+
+    Purpose: Validates that an empty batch is rejected rather than scored. A
+        zero safety_violation_rate over no episodes is indistinguishable from a
+        run in which the ant never exceeded the velocity threshold
+
+    Given: A SafeAntVelocityPOMDP environment and an empty history list
+    When: compute_metrics is called
+    Then: A ValueError naming the environment is raised
+
+    Test type: unit
+    """
+    env = SafeAntVelocityPOMDP(
+        discount_factor=0.95,
+        **safety_ant_velocity_pinned_kwargs(safe_velocity_threshold=2.0),
+    )
+
+    with pytest.raises(ValueError, match="received no episode histories"):
+        env.compute_metrics([])
+
+
 def test_compute_metrics():
     """Test safety metrics computation from simulation histories.
 

--- a/POMDPPlanners/tests/test_environments/test_sanity_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_sanity_pomdp.py
@@ -724,16 +724,17 @@ class TestSanityPOMDPMetrics:
     def test_compute_metrics_empty_histories(self, sanity_pomdp):
         """Test metrics computation with empty histories.
 
-        Purpose: Validates that SanityPOMDP compute_metrics handles empty history lists correctly
+        Purpose: Validates that an empty batch is rejected rather than scored,
+            even for an environment that declares no metrics of its own
 
         Given: A SanityPOMDP environment and empty history list []
         When: compute_metrics method is called with empty histories
-        Then: Returns empty list [], confirming that no metrics are computed for empty input
+        Then: A ValueError naming the environment is raised
 
         Test type: unit
         """
-        metrics = sanity_pomdp.compute_metrics([])
-        assert metrics == []
+        with pytest.raises(ValueError, match="received no episode histories"):
+            sanity_pomdp.compute_metrics([])
 
     def test_compute_metrics_with_histories(self, sanity_pomdp):
         """Test metrics computation with sample histories.

--- a/POMDPPlanners/tests/test_environments/test_step_info_migration.py
+++ b/POMDPPlanners/tests/test_environments/test_step_info_migration.py
@@ -174,7 +174,7 @@ class TestDegenerateHistoryShapes:
     """Inputs the frozen fixture and a live episode cannot produce."""
 
     @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
-    @pytest.mark.parametrize("shape", ["no_histories", "one_empty", "two_empty", "empty_plus_real"])
+    @pytest.mark.parametrize("shape", ["one_empty", "two_empty", "empty_plus_real"])
     def test_degenerate_shapes_do_not_raise_or_invent_names(
         self, slug: str, shape: str, frozen_histories: Dict[str, List[History]]
     ) -> None:
@@ -186,8 +186,8 @@ class TestDegenerateHistoryShapes:
             well-formed result whose names are a subsequence of the declared
             ones, never an invented or reordered name
 
-        Given: A migrated environment and a degenerate history list -- none, one
-            or two episodes with no steps, or a stepless episode beside a real one
+        Given: A migrated environment and a degenerate history list -- one or two
+            episodes with no steps, or a stepless episode beside a real one
         When: compute_metrics is called
         Then: It returns without raising, and every produced name is declared,
             in declared order
@@ -196,7 +196,6 @@ class TestDegenerateHistoryShapes:
         """
         environment = build_registry()[slug]()
         shapes = {
-            "no_histories": [],
             "one_empty": [_empty_history()],
             "two_empty": [_empty_history(), _empty_history()],
             "empty_plus_real": [_empty_history(), frozen_histories[slug][0]],
@@ -215,6 +214,26 @@ class TestDegenerateHistoryShapes:
         assert all(
             name in remaining for name in produced
         ), f"{slug}/{shape}: produced {produced}, not a subsequence of {declared}"
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_no_histories_at_all_is_rejected(self, slug: str) -> None:
+        """Test that scoring an empty batch of episodes raises.
+
+        Purpose: Validates that no metric is invented for a run with no
+            episodes. A metric over no episodes is an average over nothing, and
+            every value an environment could report for it -- a zero, an omitted
+            name, an empty list -- reads exactly like a real measurement
+
+        Given: A migrated environment and an empty history list
+        When: compute_metrics is called
+        Then: A ValueError naming the environment is raised
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+
+        with pytest.raises(ValueError, match="received no episode histories"):
+            environment.compute_metrics([])
 
     @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
     def test_a_stepless_episode_does_not_shift_a_real_one(

--- a/POMDPPlanners/tests/test_environments/test_step_info_migration.py
+++ b/POMDPPlanners/tests/test_environments/test_step_info_migration.py
@@ -1,0 +1,410 @@
+# SPDX-License-Identifier: MIT
+
+"""Contract tests for environments that report metrics through ``step_info``.
+
+The golden snapshot in :mod:`POMDPPlanners.tests.test_metric_golden_snapshot`
+pins *what* each migrated environment computes. These tests pin the properties
+that make that computation trustworthy, and which a frozen value comparison
+cannot see:
+
+- a declared spec whose channel is never emitted yields a metric the aggregator
+  silently drops, so declared and produced names must be checked directly;
+- ``step_info`` runs inside the episode loop, so it must be pure and must not
+  consume randomness, or it would shift every later transition;
+- it is called once per terminated episode with ``action`` and ``next_state``
+  both ``None``, which must not raise and must not invent a measurement;
+- its values ride back to the parent process inside a pickled ``History``.
+"""
+
+import pickle
+from typing import Dict, List
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.environment import Environment
+from POMDPPlanners.core.simulation import History
+from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_pomdp import IsaacLabPOMDP
+from POMDPPlanners.tests.test_utils.golden_metric_snapshot import (
+    append_terminal_step,
+    attach_step_info,
+    build_registry,
+    load_snapshot_histories,
+)
+
+# The environments this suite covers: those that declare per-step metric specs.
+_SPEC_DRIVEN_SLUGS = sorted(
+    slug for slug, factory in build_registry().items() if factory().get_metric_specs()
+)
+
+
+@pytest.fixture(name="frozen_histories", scope="module")
+def _frozen_histories() -> Dict[str, List[History]]:
+    """Load the committed history fixture once for the whole module."""
+    return load_snapshot_histories()
+
+
+def _measured_steps(environment: Environment, histories: List[History]) -> List[Dict[str, float]]:
+    return [
+        step.info or {}
+        for history in attach_step_info(environment, histories)
+        for step in history.history
+    ]
+
+
+# PushPOMDP pairs its per-episode collision counts against the full history list
+# while excluding zero-step episodes from the counts, so a stepless episode beside
+# a real one divides by zero. That defect predates this migration and was carried
+# over verbatim rather than quietly fixed, so these tests expect it.
+_ZERO_STEP_DIVIDES_BY_ZERO = {"push"}
+
+
+def _empty_history() -> History:
+    """A history with no recorded steps, which the episode loop cannot produce."""
+    return History(
+        history=[],
+        discount_factor=0.95,
+        average_state_sampling_time=0.0,
+        average_action_time=0.0,
+        average_observation_time=0.0,
+        average_belief_update_time=0.0,
+        average_reward_time=0.0,
+        actual_num_steps=0,
+        reach_terminal_state=False,
+        policy_run_data=[],
+    )
+
+
+class TestDeclaredChannelsAreReported:
+    """Every declared spec must correspond to a channel the environment emits."""
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_every_declared_spec_channel_is_emitted(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that no spec declares a channel step_info never reports.
+
+        Purpose: Validates the invariant the shared aggregator cannot enforce --
+            it omits a metric whose channel no episode reported, so a typo in a
+            channel name would silently delete a metric rather than fail
+
+        Given: A migrated environment and the frozen histories
+        When: step_info is replayed over every step and the emitted channel names
+            are collected
+        Then: Every channel named by a declared spec was emitted
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        emitted = set()
+        for step_info in _measured_steps(environment, frozen_histories[slug]):
+            emitted.update(step_info)
+
+        declared = {spec.channel for spec in environment.get_metric_specs()}
+        assert declared <= emitted, (
+            f"{slug}: specs declare channels that step_info never emits: "
+            f"{sorted(declared - emitted)}. Such a metric is dropped silently."
+        )
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_declared_names_equal_produced_names(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that compute_metrics produces exactly the declared metric names.
+
+        Purpose: Validates the contract that tuning objectives and saved runs
+            depend on -- a metric that is declared but not produced breaks a
+            lookup by name
+
+        Given: A migrated environment and the measured frozen histories
+        When: compute_metrics and get_metric_names are compared
+        Then: They list the same names in the same order
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        measured = attach_step_info(environment, frozen_histories[slug])
+        produced = [metric.name for metric in environment.compute_metrics(measured)]
+
+        assert produced == list(environment.get_metric_names())
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_degenerate_history_never_invents_or_reorders_a_name(self, slug: str) -> None:
+        """Test that a stepless episode yields declared names in declared order.
+
+        Purpose: Validates the contract on the degenerate input. An episode with
+            no recorded steps reports no channels, so each metric either falls
+            back to the value its environment historically reported or is omitted
+            -- but the result must never contain a name that was not declared,
+            and must never reorder the ones it does contain
+
+        Given: A migrated environment and one history containing no steps
+        When: compute_metrics is called
+        Then: The produced names are a subsequence of the declared names
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        empty_history = attach_step_info(environment, [_empty_history()])
+        produced = [metric.name for metric in environment.compute_metrics(empty_history)]
+        declared = list(environment.get_metric_names())
+
+        remaining = iter(declared)
+        assert all(name in remaining for name in produced), (
+            f"{slug}: a zero-step episode produced {produced}, which is not a "
+            f"subsequence of the declared names {declared}"
+        )
+
+
+class TestDegenerateHistoryShapes:
+    """Inputs the frozen fixture and a live episode cannot produce."""
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    @pytest.mark.parametrize("shape", ["no_histories", "one_empty", "two_empty", "empty_plus_real"])
+    def test_degenerate_shapes_do_not_raise_or_invent_names(
+        self, slug: str, shape: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that degenerate history shapes stay well-formed.
+
+        Purpose: Validates the edge of the contract. Several pre-migration
+            implementations raised ValueError from confidence_interval on an
+            empty list here; the shared aggregator must instead return a
+            well-formed result whose names are a subsequence of the declared
+            ones, never an invented or reordered name
+
+        Given: A migrated environment and a degenerate history list -- none, one
+            or two episodes with no steps, or a stepless episode beside a real one
+        When: compute_metrics is called
+        Then: It returns without raising, and every produced name is declared,
+            in declared order
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        shapes = {
+            "no_histories": [],
+            "one_empty": [_empty_history()],
+            "two_empty": [_empty_history(), _empty_history()],
+            "empty_plus_real": [_empty_history(), frozen_histories[slug][0]],
+        }
+        measured = attach_step_info(environment, list(shapes[shape]))
+
+        if slug in _ZERO_STEP_DIVIDES_BY_ZERO and shape == "empty_plus_real":
+            with pytest.raises(ZeroDivisionError):
+                environment.compute_metrics(measured)
+            return
+
+        produced = [metric.name for metric in environment.compute_metrics(measured)]
+        declared = list(environment.get_metric_names())
+
+        remaining = iter(declared)
+        assert all(
+            name in remaining for name in produced
+        ), f"{slug}/{shape}: produced {produced}, not a subsequence of {declared}"
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_a_stepless_episode_does_not_shift_a_real_one(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that a stepless episode contributes rather than disappearing.
+
+        Purpose: Validates ``empty_episode_value``. An episode that reported no
+            channels is excluded from a metric's average by default, but the
+            pre-migration implementations appended a value for it, so excluding
+            it would change the mean. This checks the declared value is actually
+            being contributed
+
+        Given: One real episode, and the same episode paired with a stepless one
+        When: compute_metrics is run on both lists
+        Then: Any metric declaring an empty-episode contribution moves, because
+            the stepless episode entered its average
+
+        Test type: unit
+        """
+        if slug in _ZERO_STEP_DIVIDES_BY_ZERO:
+            pytest.skip(f"{slug} raises on a stepless episode, preserved from before the migration")
+        environment = build_registry()[slug]()
+        real = frozen_histories[slug][:1]
+        contributing = {
+            spec.name: spec.empty_episode_value
+            for spec in environment.get_metric_specs()
+            if spec.empty_episode_value is not None
+        }
+        if not contributing:
+            pytest.skip(f"{slug} declares no empty-episode contributions")
+
+        alone = {
+            m.name: m.value
+            for m in environment.compute_metrics(attach_step_info(environment, list(real)))
+        }
+        with_empty = {
+            m.name: m.value
+            for m in environment.compute_metrics(
+                attach_step_info(environment, [_empty_history()] + list(real))
+            )
+        }
+
+        for name, empty_value in contributing.items():
+            if name not in alone:
+                continue
+            expected = (alone[name] + empty_value) / 2
+            assert with_empty[name] == pytest.approx(expected), (
+                f"{slug}.{name}: a stepless episode contributing {empty_value} should move "
+                f"the mean from {alone[name]} to {expected}, got {with_empty[name]}"
+            )
+
+
+class TestStepInfoContract:
+    """Purity, terminal-step tolerance and transportability of step_info."""
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_step_info_is_pure(self, slug: str, frozen_histories: Dict[str, List[History]]) -> None:
+        """Test that repeated calls with the same transition agree.
+
+        Purpose: Validates that step_info is a function of its arguments. An
+            implementation that consumed randomness or mutated state would both
+            report unstable metrics and shift the seeded transition stream for
+            every later step of the episode
+
+        Given: A migrated environment and the frozen histories
+        When: step_info is called twice for each recorded transition
+        Then: The two mappings are equal
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        for history in frozen_histories[slug]:
+            for step in history.history:
+                first = environment.step_info(step.state, step.action, step.next_state)
+                second = environment.step_info(step.state, step.action, step.next_state)
+                assert first == second, f"{slug}: step_info is not a pure function"
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_step_info_consumes_no_randomness(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that measuring a step leaves the global RNG untouched.
+
+        Purpose: Validates the invariant that makes the hook safe to call from
+            inside the episode loop. A single np.random draw here would advance
+            the stream and silently change every subsequent transition and
+            observation, breaking seeded reproducibility far beyond metrics
+
+        Given: A migrated environment and a seeded global RNG
+        When: step_info is called for every recorded transition
+        Then: The RNG state is byte-identical to before
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        np.random.seed(4242)
+        before = np.random.get_state(legacy=True)
+
+        for history in frozen_histories[slug]:
+            for step in history.history:
+                environment.step_info(step.state, step.action, step.next_state)
+
+        after = np.random.get_state(legacy=True)
+        assert isinstance(before, tuple) and isinstance(after, tuple)
+        # The Mersenne Twister key is an ndarray, so the tuples cannot be
+        # compared directly; the position counter is what a stray draw moves.
+        assert np.array_equal(before[1], after[1]), f"{slug}: step_info advanced the global RNG"
+        assert before[2:] == after[2:], f"{slug}: step_info advanced the global RNG"
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_terminal_step_reports_no_transition_channel(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that the terminal bookkeeping call is tolerated and neutral.
+
+        Purpose: Validates the terminal-step contract. That step records the
+            final state and has no action or successor, so a transition-derived
+            channel must report a neutral value there rather than raising or
+            inventing a measurement
+
+        Given: A migrated environment and the final state of each frozen episode
+        When: step_info is called the way _add_terminal_step calls it
+        Then: It returns a mapping, and every channel it also reports for a real
+            transition is present, so no metric loses the final state
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        for history in frozen_histories[slug]:
+            final_state = history.history[-1].next_state
+            terminal_info = environment.step_info(final_state, None, None)
+            assert isinstance(terminal_info, dict)
+
+    def test_isaac_lab_step_info_tolerates_the_terminal_call(self) -> None:
+        """Test that a live-simulator environment survives the terminal call.
+
+        Purpose: Validates that the terminal-step call added to the episode loop
+            cannot mis-attribute a cached measurement, for the one shipped
+            environment that serves values from a live simulator rather than
+            computing them from the arguments
+
+        Given: An IsaacLabPOMDP instance that has taken no step
+        When: step_info is called with action and next_state both None
+        Then: An empty mapping is returned rather than an exception
+
+        Test type: unit
+        """
+        world = IsaacLabPOMDP.__new__(IsaacLabPOMDP)
+        world._pending = None  # pylint: disable=protected-access
+        assert not IsaacLabPOMDP.step_info(world, np.zeros(2), None, None)
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_reported_values_survive_pickling(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that every reported value is a plain picklable scalar.
+
+        Purpose: Validates the transport requirement. The measurements ride back
+            to the parent process inside a pickled History under every
+            multiprocess task manager, so a numpy scalar or an unpicklable object
+            here would fail far from its cause
+
+        Given: A migrated environment and the frozen histories
+        When: Each reported mapping is round-tripped through pickle
+        Then: It compares equal, and every value is a float
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        for step_info in _measured_steps(environment, frozen_histories[slug]):
+            assert pickle.loads(pickle.dumps(step_info)) == step_info
+            for channel, value in step_info.items():
+                assert isinstance(
+                    value, float
+                ), f"{slug}.{channel} reported {type(value).__name__}, not a plain float"
+
+
+class TestTerminalStepIsCounted:
+    """The terminal bookkeeping step must reach the metrics."""
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_terminal_step_contributes_measurements(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that the terminal step carries measurements of the final state.
+
+        Purpose: Validates the reason the episode loop measures the terminal step
+            at all. Metrics that count every visited state need the final one,
+            and it is recorded on no other step
+
+        Given: A migrated environment and the terminated-episode shape of the
+            frozen histories
+        When: step_info is replayed over them
+        Then: The appended terminal step carries a non-empty mapping
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        extended = append_terminal_step(frozen_histories[slug])
+        for history in attach_step_info(environment, extended):
+            terminal_step = history.history[-1]
+            assert terminal_step.action is None
+            assert terminal_step.info, (
+                f"{slug}: the terminal step carries no measurements, so any metric "
+                f"counting every visited state silently loses the final state"
+            )

--- a/POMDPPlanners/tests/test_environments/test_step_info_migration.py
+++ b/POMDPPlanners/tests/test_environments/test_step_info_migration.py
@@ -16,14 +16,16 @@ cannot see:
 - its values ride back to the parent process inside a pickled ``History``.
 """
 
+import dataclasses
 import pickle
+import random
 from typing import Dict, List
 
 import numpy as np
 import pytest
 
 from POMDPPlanners.core.environment import Environment
-from POMDPPlanners.core.simulation import History
+from POMDPPlanners.core.simulation import History, StepData
 from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_pomdp import IsaacLabPOMDP
 from POMDPPlanners.tests.test_utils.golden_metric_snapshot import (
     append_terminal_step,
@@ -57,6 +59,18 @@ def _measured_steps(environment: Environment, histories: List[History]) -> List[
 # a real one divides by zero. That defect predates this migration and was carried
 # over verbatim rather than quietly fixed, so these tests expect it.
 _ZERO_STEP_DIVIDES_BY_ZERO = {"push"}
+
+# Channels that describe the *transition* rather than the state, per environment.
+# The terminal bookkeeping step took no action and produced no successor, so
+# these must read as zero there or a SUM would count an event that never
+# happened. Listed explicitly rather than derived: which channels are
+# transition-derived is a property of the measurement, not something the spec or
+# the mapping's shape reveals.
+_TRANSITION_DERIVED_CHANNELS = {
+    "tiger": ("correct_door_opened", "listened"),
+    "laser_tag": ("obstacle_collision",),
+    "rock_sample": ("sampled_rock",),
+}
 
 
 def _empty_history() -> History:
@@ -133,10 +147,10 @@ class TestDeclaredChannelsAreReported:
         """Test that a stepless episode yields declared names in declared order.
 
         Purpose: Validates the contract on the degenerate input. An episode with
-            no recorded steps reports no channels, so each metric either falls
-            back to the value its environment historically reported or is omitted
-            -- but the result must never contain a name that was not declared,
-            and must never reorder the ones it does contain
+            no recorded steps reports no channels, so each metric is either
+            omitted by the aggregator or filled by the environment's declared
+            name list -- but the result must never contain a name that was not
+            declared, and must never reorder the ones it does contain
 
         Given: A migrated environment and one history containing no steps
         When: compute_metrics is called
@@ -206,18 +220,17 @@ class TestDegenerateHistoryShapes:
     def test_a_stepless_episode_does_not_shift_a_real_one(
         self, slug: str, frozen_histories: Dict[str, List[History]]
     ) -> None:
-        """Test that a stepless episode contributes rather than disappearing.
+        """Test that a stepless episode leaves a real episode's metrics alone.
 
-        Purpose: Validates ``empty_episode_value``. An episode that reported no
-            channels is excluded from a metric's average by default, but the
-            pre-migration implementations appended a value for it, so excluding
-            it would change the mean. This checks the declared value is actually
-            being contributed
+        Purpose: Validates that an episode reporting no channel at all is
+            dropped from a spec's average rather than contributing a stand-in
+            value. What an unmeasured episode would have measured is not knowable
+            from the metric's declaration, so inventing a number for it would
+            move the mean on the strength of a guess
 
         Given: One real episode, and the same episode paired with a stepless one
         When: compute_metrics is run on both lists
-        Then: Any metric declaring an empty-episode contribution moves, because
-            the stepless episode entered its average
+        Then: Every spec-derived metric reports the same value in both
 
         Test type: unit
         """
@@ -225,13 +238,10 @@ class TestDegenerateHistoryShapes:
             pytest.skip(f"{slug} raises on a stepless episode, preserved from before the migration")
         environment = build_registry()[slug]()
         real = frozen_histories[slug][:1]
-        contributing = {
-            spec.name: spec.empty_episode_value
-            for spec in environment.get_metric_specs()
-            if spec.empty_episode_value is not None
-        }
-        if not contributing:
-            pytest.skip(f"{slug} declares no empty-episode contributions")
+        # Only the spec-derived names. An environment keeping bespoke metrics
+        # divides them by the episode count itself, so a stepless episode does
+        # move those -- that is their pre-existing behaviour, not this one's.
+        spec_driven = {spec.name for spec in environment.get_metric_specs()}
 
         alone = {
             m.name: m.value
@@ -244,13 +254,13 @@ class TestDegenerateHistoryShapes:
             )
         }
 
-        for name, empty_value in contributing.items():
-            if name not in alone:
-                continue
-            expected = (alone[name] + empty_value) / 2
-            assert with_empty[name] == pytest.approx(expected), (
-                f"{slug}.{name}: a stepless episode contributing {empty_value} should move "
-                f"the mean from {alone[name]} to {expected}, got {with_empty[name]}"
+        compared = spec_driven & set(alone)
+        assert compared, f"{slug}: no spec-derived metric was produced, nothing would be asserted"
+
+        for name in compared:
+            assert with_empty[name] == pytest.approx(alone[name]), (
+                f"{slug}.{name}: a stepless episode must not shift the mean, but it "
+                f"moved from {alone[name]} to {with_empty[name]}"
             )
 
 
@@ -290,21 +300,27 @@ class TestStepInfoContract:
             the stream and silently change every subsequent transition and
             observation, breaking seeded reproducibility far beyond metrics
 
-        Given: A migrated environment and a seeded global RNG
+        Given: A migrated environment and seeded numpy and stdlib RNGs
         When: step_info is called for every recorded transition
-        Then: The RNG state is byte-identical to before
+        Then: Both RNG states are byte-identical to before
 
         Test type: unit
         """
         environment = build_registry()[slug]()
         np.random.seed(4242)
+        random.seed(4242)
         before = np.random.get_state(legacy=True)
+        # Covered separately from numpy: an implementation reaching for
+        # ``random.random()`` would leave the numpy stream untouched and still
+        # break reproducibility for anything seeded through the stdlib.
+        before_stdlib = random.getstate()
 
         for history in frozen_histories[slug]:
             for step in history.history:
                 environment.step_info(step.state, step.action, step.next_state)
 
         after = np.random.get_state(legacy=True)
+        assert random.getstate() == before_stdlib, f"{slug}: step_info advanced the stdlib RNG"
         assert isinstance(before, tuple) and isinstance(after, tuple)
         # The Mersenne Twister key is an ndarray, so the tuples cannot be
         # compared directly; the position counter is what a stray draw moves.
@@ -324,16 +340,32 @@ class TestStepInfoContract:
 
         Given: A migrated environment and the final state of each frozen episode
         When: step_info is called the way _add_terminal_step calls it
-        Then: It returns a mapping, and every channel it also reports for a real
-            transition is present, so no metric loses the final state
+        Then: Every channel reported for a real transition is reported here too,
+            so no metric loses the final state, and every transition-derived
+            channel reports its neutral value, so none gains a phantom event
 
         Test type: unit
         """
         environment = build_registry()[slug]()
+        transition_channels = set()
+        for step_info in _measured_steps(environment, frozen_histories[slug]):
+            transition_channels.update(step_info)
+
         for history in frozen_histories[slug]:
             final_state = history.history[-1].next_state
             terminal_info = environment.step_info(final_state, None, None)
-            assert isinstance(terminal_info, dict)
+
+            missing = transition_channels - set(terminal_info)
+            assert not missing, (
+                f"{slug}: the terminal step drops channels {sorted(missing)}. A SUM "
+                "or MEAN over them would then exclude the final state."
+            )
+            for channel in _TRANSITION_DERIVED_CHANNELS.get(slug, ()):
+                assert terminal_info[channel] == 0.0, (
+                    f"{slug}: the terminal step reports {channel}="
+                    f"{terminal_info[channel]}, inventing an event for a step where "
+                    "no action was taken and no transition happened."
+                )
 
     def test_isaac_lab_step_info_tolerates_the_terminal_call(self) -> None:
         """Test that a live-simulator environment survives the terminal call.
@@ -408,3 +440,148 @@ class TestTerminalStepIsCounted:
                 f"{slug}: the terminal step carries no measurements, so any metric "
                 f"counting every visited state silently loses the final state"
             )
+
+
+class TestUnmeasuredHistoriesAreRejected:
+    """Histories carrying no measurements must fail loudly, not score as zero."""
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_unmeasured_histories_raise_instead_of_reporting_zeros(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that histories with no per-step info are refused.
+
+        Purpose: Validates the guard on the most dangerous failure mode of
+            deriving metrics from a per-step channel. A history recorded before
+            the channel existed, or by a runner that never calls step_info,
+            carries no measurements at all -- and an absent channel reads as a
+            rate of 0.0, which is indistinguishable from a planner that always
+            failed
+
+        Given: A migrated environment and the frozen histories exactly as
+            recorded, with no info attached
+        When: compute_metrics is called on them
+        Then: A ValueError naming the environment is raised, rather than a full
+            set of zero-valued metrics
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+
+        with pytest.raises(ValueError, match="per-step measurement channel"):
+            environment.compute_metrics(frozen_histories[slug])
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_stepless_episodes_are_not_mistaken_for_unmeasured_ones(self, slug: str) -> None:
+        """Test that an episode with no recorded steps still scores.
+
+        Purpose: Validates that the guard keys on "steps were recorded and none
+            carries a measurement", not on "no measurement is present". An
+            episode with no steps legitimately measured nothing, and every
+            migrated environment has always scored it
+
+        Given: A migrated environment and a history with no recorded steps
+        When: compute_metrics is called on it
+        Then: It returns without raising
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+
+        assert isinstance(environment.compute_metrics([_empty_history()]), list)
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_one_measured_episode_does_not_vouch_for_an_unmeasured_one(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that a measured episode beside an unmeasured one still raises.
+
+        Purpose: Validates that the guard is per episode rather than over the
+            batch. A partially warm cache produces exactly this mix, and an
+            unmeasured episode that slipped through would not raise and not
+            report -- it would silently drop out of every average, shifting each
+            metric toward whichever episodes happened to be re-run
+
+        Given: A migrated environment, one measured episode and one identical
+            but unmeasured episode
+        When: compute_metrics is called on both together
+        Then: A ValueError is raised, naming the unmeasured episode's position
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        measured = attach_step_info(environment, frozen_histories[slug])[0]
+        unmeasured = frozen_histories[slug][0]
+
+        with pytest.raises(ValueError, match="episode 1"):
+            environment.compute_metrics([measured, unmeasured])
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_unrelated_info_does_not_vouch_for_a_declared_channel(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that bookkeeping in info does not satisfy the guard.
+
+        Purpose: Validates that the guard keys on the declared channels rather
+            than on info being non-empty. A future runner stamping unrelated
+            per-step bookkeeping into the same mapping would otherwise vouch for
+            measurements that were never taken
+
+        Given: A migrated environment and histories whose steps carry an info
+            mapping containing only a channel no spec declares
+        When: compute_metrics is called on them
+        Then: A ValueError is still raised
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        decoys = [
+            dataclasses.replace(
+                history,
+                history=[
+                    step._replace(info={"unrelated_bookkeeping": 1.0}) for step in history.history
+                ],
+            )
+            for history in frozen_histories[slug]
+        ]
+
+        with pytest.raises(ValueError, match="per-step measurement channel"):
+            environment.compute_metrics(decoys)
+
+    @pytest.mark.parametrize("slug", _SPEC_DRIVEN_SLUGS)
+    def test_terminal_only_episode_is_exempt(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that an episode of only a terminal step is not rejected.
+
+        Purpose: Validates the exemption the guard needs for an environment
+            serving values cached during its own step. A live simulator has
+            nothing to report for the terminal bookkeeping call, so an episode
+            consisting solely of that step legitimately carries no measurement
+            and must not be mistaken for an uninstrumented one
+
+        Given: A migrated environment and a history whose only step is a
+            terminal bookkeeping step carrying no info
+        When: compute_metrics is called on it
+        Then: It returns without raising
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        final_state = frozen_histories[slug][0].history[-1].next_state
+        terminal_only = dataclasses.replace(
+            _empty_history(),
+            history=[
+                StepData(
+                    state=final_state,
+                    action=None,
+                    next_state=None,
+                    observation=None,
+                    reward=None,
+                    belief=frozen_histories[slug][0].history[-1].belief,
+                    info=None,
+                )
+            ],
+        )
+
+        assert isinstance(environment.compute_metrics([terminal_only]), list)

--- a/POMDPPlanners/tests/test_environments/test_tiger_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_tiger_pomdp.py
@@ -19,6 +19,7 @@ from POMDPPlanners.tests.test_utils.metric_invariants_utils import (
     verify_metric_sanity,
     verify_return_shift_linearity,
 )
+from POMDPPlanners.tests.test_utils.golden_metric_snapshot import attach_step_info
 
 np.random.seed(42)
 random.seed(42)
@@ -446,7 +447,7 @@ class TestTigerPOMDPMetrics:
             )
 
         # Compute metrics for the perfect agent
-        metrics = tiger_pomdp.compute_metrics(histories)
+        metrics = tiger_pomdp.compute_metrics(attach_step_info(tiger_pomdp, histories))
 
         # Should have 100% success rate
         success_metric = next(m for m in metrics if m.name == "success_rate")
@@ -506,7 +507,7 @@ class TestTigerPOMDPMetrics:
             )
 
         # Compute metrics for the failing agent
-        metrics = tiger_pomdp.compute_metrics(histories)
+        metrics = tiger_pomdp.compute_metrics(attach_step_info(tiger_pomdp, histories))
 
         # Should have 0% success rate
         success_metric = next(m for m in metrics if m.name == "success_rate")
@@ -565,7 +566,7 @@ class TestTigerPOMDPMetrics:
             )
 
         # Compute metrics for the mixed performance agent
-        metrics = tiger_pomdp.compute_metrics(histories)
+        metrics = tiger_pomdp.compute_metrics(attach_step_info(tiger_pomdp, histories))
 
         # Should have 50% success rate
         success_metric = next(m for m in metrics if m.name == "success_rate")
@@ -621,7 +622,7 @@ class TestTigerPOMDPMetrics:
             reach_terminal_state=False,
             policy_run_data=[],
         )
-        metrics = tiger_pomdp.compute_metrics([empty_history])
+        metrics = tiger_pomdp.compute_metrics(attach_step_info(tiger_pomdp, [empty_history]))
 
         success_metric = next(m for m in metrics if m.name == "success_rate")
         listens_metric = next(m for m in metrics if m.name == "average_listens")
@@ -691,7 +692,7 @@ def test_metrics_confidence_intervals(tiger_pomdp):
         )
 
     # Compute metrics
-    metrics = tiger_pomdp.compute_metrics(histories)
+    metrics = tiger_pomdp.compute_metrics(attach_step_info(tiger_pomdp, histories))
 
     # Use generic confidence interval verification
     verify_metrics_within_confidence_intervals(metrics)

--- a/POMDPPlanners/tests/test_environments/test_tiger_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_tiger_pomdp.py
@@ -579,23 +579,18 @@ class TestTigerPOMDPMetrics:
     def test_compute_metrics_empty_histories(self, tiger_pomdp: TigerPOMDP):
         """Test metrics with empty history list.
 
-        Purpose: Validates that TigerPOMDP compute_metrics handles empty history lists correctly
+        Purpose: Validates that an empty batch is rejected rather than scored. A
+            zero success rate over no episodes is indistinguishable from a run in
+            which the agent never opened the correct door
 
         Given: A TigerPOMDP environment and empty history list []
         When: compute_metrics is called with empty histories
-        Then: Returns 0% success rate and 0 listens, confirming proper handling of empty input
+        Then: A ValueError naming the environment is raised
 
         Test type: unit
         """
-        metrics = tiger_pomdp.compute_metrics([])
-
-        # Should have 0% success rate
-        success_metric = next(m for m in metrics if m.name == "success_rate")
-        assert success_metric.value == 0.0
-
-        # Should have 0 listens
-        listens_metric = next(m for m in metrics if m.name == "average_listens")
-        assert listens_metric.value == 0.0
+        with pytest.raises(ValueError, match="received no episode histories"):
+            tiger_pomdp.compute_metrics([])
 
     def test_compute_metrics_history_with_zero_steps(self, tiger_pomdp: TigerPOMDP):
         """Regression: compute_metrics must not IndexError when an episode has zero steps.

--- a/POMDPPlanners/tests/test_metric_consistency_utils.py
+++ b/POMDPPlanners/tests/test_metric_consistency_utils.py
@@ -12,6 +12,7 @@ from POMDPPlanners.core.belief import Belief
 from POMDPPlanners.core.environment import Environment
 from POMDPPlanners.core.policy import Policy
 from POMDPPlanners.core.simulation import History
+from POMDPPlanners.tests.test_utils.golden_metric_snapshot import attach_step_info
 
 
 def verify_environment_metric_consistency(
@@ -53,8 +54,13 @@ def verify_environment_metric_consistency(
     # Get declared metric names
     declared_names = set(environment.get_metric_names())
 
-    # Get actual metric names from compute_metrics()
-    actual_metrics = environment.compute_metrics(histories)
+    # Get actual metric names from compute_metrics(). The histories are measured
+    # first: an environment reporting through the per-step channel derives its
+    # metrics from StepData.info, which hand-built histories do not carry, so
+    # without this the comparison would be vacuous -- every declared name would
+    # look missing.
+    measured = attach_step_info(environment, histories)
+    actual_metrics = environment.compute_metrics(measured)
     actual_names = set(metric.name for metric in actual_metrics)
 
     # Verify exact match

--- a/POMDPPlanners/tests/test_metric_golden_snapshot.py
+++ b/POMDPPlanners/tests/test_metric_golden_snapshot.py
@@ -19,10 +19,14 @@ import pytest
 from POMDPPlanners.core.simulation import History, StepData
 from POMDPPlanners.tests.metric_golden_values import (
     GOLDEN_METRIC_NAMES,
+    GOLDEN_METRIC_ORDER,
     GOLDEN_METRIC_VALUES,
+    GOLDEN_METRIC_VALUES_WITH_TERMINAL,
 )
 from POMDPPlanners.tests.test_utils.golden_metric_snapshot import (
+    append_terminal_step,
     build_registry,
+    compute_metric_order,
     compute_metric_snapshot,
     load_snapshot_histories,
 )
@@ -69,6 +73,64 @@ class TestMetricGoldenSnapshot:
             ), f"{slug}.{name} changed: {expected_value} -> {actual[name]}"
 
     @pytest.mark.parametrize("slug", _ENV_SLUGS)
+    def test_metric_values_match_frozen_baseline_with_terminal_step(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that metric values are unchanged on the terminated-episode shape.
+
+        Purpose: Validates that the final state of a terminated episode is still
+            counted exactly as before, which the raw fixture cannot show because
+            it carries no terminal bookkeeping step
+
+        Given: The frozen histories extended with a terminal bookkeeping step,
+            and the pre-change golden values for that shape
+        When: compute_metrics() is run for the environment against them
+        Then: Every metric name is present and every value matches the baseline
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        actual = compute_metric_snapshot(environment, append_terminal_step(frozen_histories[slug]))
+        expected = GOLDEN_METRIC_VALUES_WITH_TERMINAL[slug]
+
+        assert set(actual) == set(expected), (
+            f"{slug}: produced metric names drifted from the terminal-shape baseline. "
+            f"Added={sorted(set(actual) - set(expected))}, "
+            f"removed={sorted(set(expected) - set(actual))}"
+        )
+        for name, expected_value in expected.items():
+            assert math.isclose(
+                actual[name], expected_value, rel_tol=1e-9, abs_tol=1e-12
+            ), f"{slug}.{name} changed on the terminal shape: {expected_value} -> {actual[name]}"
+
+    @pytest.mark.parametrize("slug", _ENV_SLUGS)
+    def test_metric_order_matches_frozen_baseline(
+        self, slug: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that produced and declared metric orders are unchanged.
+
+        Purpose: Validates that no environment reordered its metrics. Both other
+            value/name assertions are order-blind -- one compares a dict, the
+            other sorts -- so a reordering would otherwise pass unnoticed while
+            silently changing positional consumers such as tuning objectives
+
+        Given: An environment from the registry and its frozen order baseline
+        When: compute_metrics() and get_metric_names() are called
+        Then: Both emit exactly the baseline names in exactly the baseline order
+
+        Test type: unit
+        """
+        environment = build_registry()[slug]()
+        expected = GOLDEN_METRIC_ORDER[slug]
+
+        assert (
+            compute_metric_order(environment, frozen_histories[slug]) == expected
+        ), f"{slug}: compute_metrics() changed the order it emits metrics in."
+        assert (
+            list(environment.get_metric_names()) == expected
+        ), f"{slug}: get_metric_names() changed the order it declares metrics in."
+
+    @pytest.mark.parametrize("slug", _ENV_SLUGS)
     def test_metric_names_match_frozen_baseline(self, slug: str) -> None:
         """Test that each environment's declared metric names are unchanged.
 
@@ -99,7 +161,13 @@ class TestMetricGoldenSnapshot:
 
         Test type: unit
         """
-        assert set(build_registry()) == set(GOLDEN_METRIC_VALUES) == set(GOLDEN_METRIC_NAMES)
+        assert (
+            set(build_registry())
+            == set(GOLDEN_METRIC_VALUES)
+            == set(GOLDEN_METRIC_VALUES_WITH_TERMINAL)
+            == set(GOLDEN_METRIC_NAMES)
+            == set(GOLDEN_METRIC_ORDER)
+        )
 
     def test_frozen_history_fixture_is_well_formed(
         self, frozen_histories: Dict[str, List[History]]

--- a/POMDPPlanners/tests/test_metric_golden_snapshot.py
+++ b/POMDPPlanners/tests/test_metric_golden_snapshot.py
@@ -18,6 +18,8 @@ import pytest
 
 from POMDPPlanners.core.simulation import History, StepData
 from POMDPPlanners.tests.metric_golden_values import (
+    GOLDEN_METRIC_BOUNDS,
+    GOLDEN_METRIC_BOUNDS_WITH_TERMINAL,
     GOLDEN_METRIC_NAMES,
     GOLDEN_METRIC_ORDER,
     GOLDEN_METRIC_VALUES,
@@ -26,12 +28,20 @@ from POMDPPlanners.tests.metric_golden_values import (
 from POMDPPlanners.tests.test_utils.golden_metric_snapshot import (
     append_terminal_step,
     build_registry,
+    compute_metric_bounds,
     compute_metric_order,
     compute_metric_snapshot,
     load_snapshot_histories,
 )
 
 _ENV_SLUGS = sorted(build_registry())
+
+# The one bound this migration deliberately moved. Tiger reported
+# ``lower == upper == value`` -- a placeholder its own source comment called out
+# -- and now gets a real 95% t-interval from the shared aggregator. Listed here
+# rather than baked into the baseline so the exception stays visible: every other
+# environment, metric and shape is asserted unchanged.
+_DELIBERATELY_CHANGED_BOUNDS = {("tiger", "success_rate")}
 
 
 @pytest.fixture(name="frozen_histories", scope="module")
@@ -102,6 +112,46 @@ class TestMetricGoldenSnapshot:
             assert math.isclose(
                 actual[name], expected_value, rel_tol=1e-9, abs_tol=1e-12
             ), f"{slug}.{name} changed on the terminal shape: {expected_value} -> {actual[name]}"
+
+    @pytest.mark.parametrize("slug", _ENV_SLUGS)
+    @pytest.mark.parametrize("shape", ["plain", "terminal"])
+    def test_confidence_bounds_match_frozen_baseline(
+        self, slug: str, shape: str, frozen_histories: Dict[str, List[History]]
+    ) -> None:
+        """Test that each environment's confidence bounds are unchanged.
+
+        Purpose: Validates the half of every MetricValue the value assertions
+            cannot see. A declared reduction that yields the right mean from the
+            wrong per-episode samples passes those and moves the interval, which
+            is precisely the failure mode a per-episode reduction can introduce
+
+        Given: The frozen histories, in both the plain and terminated-episode
+            shapes, and the pre-change bounds baseline for that shape
+        When: compute_metrics() is run for the environment against them
+        Then: Every metric's (lower, upper) pair matches the baseline, except
+            the bounds this migration deliberately changed
+
+        Test type: unit
+        """
+        histories = frozen_histories[slug]
+        expected = GOLDEN_METRIC_BOUNDS[slug]
+        if shape == "terminal":
+            histories = append_terminal_step(histories)
+            expected = GOLDEN_METRIC_BOUNDS_WITH_TERMINAL[slug]
+
+        actual = compute_metric_bounds(build_registry()[slug](), histories)
+
+        for name, (expected_lower, expected_upper) in expected.items():
+            if (slug, name) in _DELIBERATELY_CHANGED_BOUNDS:
+                continue
+            assert name in actual, f"{slug}.{name} disappeared on the {shape} shape."
+            actual_lower, actual_upper = actual[name]
+            assert math.isclose(
+                actual_lower, expected_lower, rel_tol=1e-9, abs_tol=1e-12
+            ) and math.isclose(actual_upper, expected_upper, rel_tol=1e-9, abs_tol=1e-12), (
+                f"{slug}.{name} confidence bounds changed on the {shape} shape: "
+                f"({expected_lower}, {expected_upper}) -> ({actual_lower}, {actual_upper})"
+            )
 
     @pytest.mark.parametrize("slug", _ENV_SLUGS)
     def test_metric_order_matches_frozen_baseline(

--- a/POMDPPlanners/tests/test_simulations/test_simulation_statistics.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulation_statistics.py
@@ -9,6 +9,7 @@ from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.core.policy import PolicyInfoVariable, PolicyRunData
 from POMDPPlanners.core.simulation import History, MetricValue, StepData
 from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+from POMDPPlanners.tests.test_utils.golden_metric_snapshot import attach_step_info
 from POMDPPlanners.planners.mcts_planners.pomcp import POMCP
 from POMDPPlanners.planners.sparse_sampling_planners.sparse_sampling import (
     SparseSamplingDiscreteActionsPlanner,
@@ -33,6 +34,13 @@ def create_test_history(rewards: List[float], discount_factor: float = 0.95) -> 
             resampling=False,
         )
 
+    # Measured as EpisodeRunner._record_step measures it. TigerPOMDP derives its
+    # environment metrics from the per-step channel, so a history built without
+    # info is not a stand-in for a recorded one -- it is an unmeasured history,
+    # which compute_metrics rejects rather than scoring as zero.
+    environment = TigerPOMDP(discount_factor=discount_factor)
+    step_info = environment.step_info("tiger_left", "listen", "tiger_left") or None
+
     steps = [
         StepData(
             state="tiger_left",
@@ -41,6 +49,7 @@ def create_test_history(rewards: List[float], discount_factor: float = 0.95) -> 
             observation="hear_left",
             reward=r,
             belief=create_test_belief("tiger_left"),
+            info=step_info,
         )
         for r in rewards
     ]
@@ -350,9 +359,14 @@ def test_compute_statistics_environment_policy_pair():
         ),
     ]
 
-    # Compute statistics
+    # Compute statistics. The histories are measured first, exactly as the
+    # episode runner measures a recorded one: TigerPOMDP's metrics come from the
+    # per-step channel, which a hand-built history carries nothing in.
     statistics = compute_statistics_environment_policy_pair(
-        env=environment, histories=histories, alpha=0.1, confidence_interval_level=0.95
+        env=environment,
+        histories=attach_step_info(environment, histories),
+        alpha=0.1,
+        confidence_interval_level=0.95,
     )
 
     # Verify statistics
@@ -513,10 +527,11 @@ def test_compute_statistics_environments_policies_comparison():
         ),
     ]
 
-    # Create histories dictionary
+    # Create histories dictionary, measured as the episode runner measures a
+    # recorded history: TigerPOMDP's metrics come from the per-step channel.
     histories = {
-        "TigerPOMDP_1": {"Policy1": history1},
-        "TigerPOMDP_2": {"Policy2": history2},
+        "TigerPOMDP_1": {"Policy1": attach_step_info(env1, history1)},
+        "TigerPOMDP_2": {"Policy2": attach_step_info(env2, history2)},
     }
 
     # Compute statistics

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/test_watcher.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_run_progress/test_watcher.py
@@ -131,7 +131,7 @@ def test_main_is_idempotent_across_calls(populated_db, db_path):
     assert mock_urlopen.call_count == 1
 
 
-def test_main_no_webhook_logs_and_returns_zero(populated_db, db_path, caplog):
+def test_main_no_webhook_logs_and_returns_zero(populated_db, db_path, caplog, monkeypatch):
     """Verify the watcher logs (does not crash) when no webhook is configured.
 
     Purpose: Validates the "configured for stall detection but no webhook"
@@ -145,6 +145,10 @@ def test_main_no_webhook_logs_and_returns_zero(populated_db, db_path, caplog):
     Test type: integration
     """
     del populated_db
+    # Cleared explicitly: this is the only test here that depends on *no*
+    # webhook being configured, so an exported SLACK_WEBHOOK_URL in the
+    # developer's shell would otherwise be picked up and the watcher would post.
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
 
     with patch("urllib.request.urlopen") as mock_urlopen:
         with caplog.at_level("WARNING", logger="run_progress.watcher"):

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_task_managers.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_task_managers.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 
 # pylint: disable=protected-access  # Tests need to access protected members
+import dataclasses
+import logging
 import shutil
 import tempfile
 import threading
@@ -9,6 +11,7 @@ import warnings
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import joblib
 import numpy as np
 import pytest
 from dask.distributed import LocalCluster
@@ -3026,3 +3029,185 @@ def test_joblib_task_manager_log_cache_statistics_precision(cache_db):
 #         assert manager.memory == "1GB"
 #         assert manager.walltime == "00:10:00"
 #         assert isinstance(manager, DaskTaskManager)
+
+
+class _WarningCollector(logging.Handler):
+    """Collect warnings from the task manager's logger.
+
+    The project's loggers set ``propagate = False``, so pytest's ``caplog`` sees
+    nothing. Attaching a handler directly is also the only option that keeps the
+    task manager picklable: joblib hashes ``self`` to build the cache key, and a
+    mock anywhere in that object graph makes the hash fail.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(logging.WARNING)
+        self.messages: list = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(record.getMessage())
+
+
+def _tiger_episode_task(environment, temp_cache_dir):
+    """Build an EpisodeSimulationTask whose cache key repeats across calls.
+
+    The policy is constructed fresh each time on purpose: running an episode
+    mutates the planner, and joblib keys on the pickled task, so a reused policy
+    instance would hash differently the second time and miss the cache.
+    """
+    return EpisodeSimulationTask(
+        environment=environment,
+        policy=SparsePFT(
+            environment=environment,
+            discount_factor=0.95,
+            depth=3,
+            c_ucb=1.0,
+            beta_ucb=0.5,
+            belief_child_num=4,
+            n_simulations=2,
+        ),
+        initial_belief=create_test_belief(),
+        num_steps=2,
+        episode_id=0,
+        seed=7,
+        discount_factor=0.95,
+        cache_dir=temp_cache_dir,
+        console_output=False,
+    )
+
+
+def test_stale_cached_episode_is_recomputed_with_a_warning(cache_db, environment, temp_cache_dir):
+    """Test that a cached episode predating the measurement channel is redone.
+
+    Purpose: Validates the run-recovery path. The joblib cache key is the task
+        configuration, which says nothing about the format of the episode it
+        produced, so an entry written before StepData.info existed still hits and
+        unpickles cleanly with every measurement missing. Scoring it would report
+        every metric as zero, and refusing it would fail a resumed run at metrics
+        time, so it must be treated as a miss and recomputed
+
+    Given: A JoblibTaskManager whose cached entry for a task has been rewritten
+        to carry no per-step info, as a pre-channel run would have left it
+    When: The same task configuration is run through the cache again
+    Then: The stale entry is recomputed into a measured history, and a warning
+        names the task and says why it was redone
+
+    Test type: integration
+    """
+    collector = _WarningCollector()
+    logging.getLogger("task_manager").addHandler(collector)
+    try:
+        with JoblibTaskManager(
+            cache_db=cache_db, n_jobs=1, cache_dir=temp_cache_dir, no_logs=True
+        ) as task_manager:
+            first = task_manager._run_cached_task(_tiger_episode_task(environment, temp_cache_dir))
+            assert isinstance(first, History)
+            assert any(
+                step.info for step in first.history
+            ), "the fresh run recorded no measurements"
+
+            # Rewrite the cache entry the way a pre-channel run would have left it.
+            cached_outputs = list(Path(task_manager.joblib_cache_dir).rglob("output.pkl"))
+            assert cached_outputs, "the first run populated no joblib cache entry"
+            stale = dataclasses.replace(
+                first, history=[step._replace(info=None) for step in first.history]
+            )
+            for path in cached_outputs:
+                joblib.dump(stale, path)
+
+            replayed = task_manager._cached_run(_tiger_episode_task(environment, temp_cache_dir))
+            assert isinstance(replayed, History)
+            assert not any(
+                step.info for step in replayed.history
+            ), "the cache entry was not actually poisoned, so the rest proves nothing"
+
+            second = task_manager._run_cached_task(_tiger_episode_task(environment, temp_cache_dir))
+    finally:
+        logging.getLogger("task_manager").removeHandler(collector)
+
+    assert any(
+        step.info for step in second.history
+    ), "the stale cache entry was returned instead of being recomputed"
+    assert any("predates the per-step measurement channel" in m for m in collector.messages)
+
+
+def test_measured_cached_episode_is_reused_without_recomputing(
+    cache_db, environment, temp_cache_dir
+):
+    """Test that a well-formed cached episode is still served from the cache.
+
+    Purpose: Validates that the stale-entry check costs nothing in the normal
+        case. Recovery is the whole point of the cache, so an entry recorded in
+        the current format must still be reused rather than quietly redone
+
+    Given: A JoblibTaskManager that has already cached a measured episode
+    When: The same task configuration is run through the cache again
+    Then: The call is reported as cached, the same measurements come back, and
+        no recomputation warning is emitted
+
+    Test type: integration
+    """
+    collector = _WarningCollector()
+    logging.getLogger("task_manager").addHandler(collector)
+    try:
+        with JoblibTaskManager(
+            cache_db=cache_db, n_jobs=1, cache_dir=temp_cache_dir, no_logs=True
+        ) as task_manager:
+            first = task_manager._run_cached_task(_tiger_episode_task(environment, temp_cache_dir))
+
+            repeat = _tiger_episode_task(environment, temp_cache_dir)
+            assert task_manager._cached_run.check_call_in_cache(repeat)
+            second = task_manager._run_cached_task(repeat)
+    finally:
+        logging.getLogger("task_manager").removeHandler(collector)
+
+    assert [step.info for step in second.history] == [step.info for step in first.history]
+    assert not any("predates the per-step measurement channel" in m for m in collector.messages)
+
+
+def test_stale_cache_db_entry_is_rerun_with_a_warning(cache_db, environment, temp_cache_dir):
+    """Test that a stale result in the cache DB is rerun rather than returned.
+
+    Purpose: Validates the primary recovery path. run_tasks consults the cache
+        database before a task ever reaches the executor, so an entry written
+        before StepData.info existed would otherwise be handed straight back and
+        scored as a full set of zeros -- the joblib layer never sees it
+
+    Given: A cache database primed with an episode carrying no per-step info,
+        under the config id of a task that has not been run
+    When: run_tasks is called for that task
+    Then: The task is rerun into a measured history, the cache entry is
+        replaced, and a warning names the task and says why
+
+    Test type: integration
+    """
+    task = _tiger_episode_task(environment, temp_cache_dir)
+    task_id = task.get_config_id()
+
+    collector = _WarningCollector()
+    logging.getLogger("task_manager").addHandler(collector)
+    try:
+        with JoblibTaskManager(
+            cache_db=cache_db, n_jobs=1, cache_dir=temp_cache_dir, no_logs=True
+        ) as task_manager:
+            measured = task_manager._run_cached_task(
+                _tiger_episode_task(environment, temp_cache_dir)
+            )
+            assert isinstance(measured, History)
+            stale = dataclasses.replace(
+                measured, history=[step._replace(info=None) for step in measured.history]
+            )
+            cache_db.set(task_id, stale)
+
+            results, identifiers = task_manager.run_tasks([task], [task_id])
+    finally:
+        logging.getLogger("task_manager").removeHandler(collector)
+
+    assert identifiers == [task_id]
+    assert any(
+        step.info for step in results[0].history
+    ), "the stale cache entry was returned instead of being rerun"
+    assert any("predates the per-step measurement channel" in m for m in collector.messages)
+    assert any(
+        step.info for step in cache_db.get(task_id).history
+    ), "the cache kept the stale entry"

--- a/POMDPPlanners/tests/test_utils/golden_metric_snapshot.py
+++ b/POMDPPlanners/tests/test_utils/golden_metric_snapshot.py
@@ -350,12 +350,39 @@ def compute_metric_snapshot(environment: Environment, histories: List[History]) 
             the per-step channel sees the same input it would in a real run.
 
     Returns:
-        Mapping from metric name to point estimate. Confidence bounds are
-        deliberately excluded: with three episodes several are infinite, which
-        makes them useless as a stable baseline.
+        Mapping from metric name to point estimate. The confidence bounds are
+        pinned separately by :func:`compute_metric_bounds`.
     """
     metrics = environment.compute_metrics(attach_step_info(environment, histories))
     return {metric.name: float(metric.value) for metric in metrics}
+
+
+def compute_metric_bounds(
+    environment: Environment, histories: List[History]
+) -> Dict[str, Tuple[float, float]]:
+    """Compute one environment's confidence bounds as a name -> (lower, upper) mapping.
+
+    A ``MetricValue`` is a point estimate *and* an interval, and
+    :func:`compute_metric_snapshot` pins only the former. That is not merely
+    incomplete: a reduction that produced the right mean from the wrong
+    per-episode samples — the exact failure mode this migration risks, since it
+    replaces bespoke per-episode accumulation with declared reductions — leaves
+    the mean intact and moves the interval.
+
+    Args:
+        environment: The environment to snapshot.
+        histories: The frozen histories to feed it, measured through
+            :func:`attach_step_info` first, exactly as in
+            :func:`compute_metric_snapshot`.
+
+    Returns:
+        Mapping from metric name to its ``(lower, upper)`` confidence bounds.
+    """
+    metrics = environment.compute_metrics(attach_step_info(environment, histories))
+    return {
+        metric.name: (float(metric.lower_confidence_bound), float(metric.upper_confidence_bound))
+        for metric in metrics
+    }
 
 
 def compute_metric_order(environment: Environment, histories: List[History]) -> List[str]:

--- a/POMDPPlanners/tests/test_utils/golden_metric_snapshot.py
+++ b/POMDPPlanners/tests/test_utils/golden_metric_snapshot.py
@@ -32,14 +32,20 @@ Functions:
     build_snapshot_histories: Roll out fresh histories (fixture generation only).
     generate_snapshot_histories_fixture: Write the pickled history fixture.
     load_snapshot_histories: Load the pickled histories for one environment.
+    attach_step_info: Replay an environment's step_info over pre-built histories.
+    append_terminal_step: Derive the terminated-episode shape of a history list.
     compute_metric_snapshot: Reduce one environment's metrics to name -> value.
+    compute_metric_order: Collect one environment's produced metric names, in order.
     compute_all_metric_snapshots: Snapshot every environment from the fixture.
+    compute_all_metric_snapshots_with_terminal: Snapshot the terminated-episode shape.
+    compute_all_metric_orders: Collect produced and declared name orders per environment.
     compute_all_metric_names: Collect every environment's declared metric names.
 """
 
+import dataclasses
 import pickle
 from pathlib import Path
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Tuple
 
 import numpy as np
 from numba import njit
@@ -243,19 +249,132 @@ def load_snapshot_histories(fixture_path: Path = FIXTURE_PATH) -> Dict[str, List
         return pickle.load(handle)
 
 
+def attach_step_info(environment: Environment, histories: List[History]) -> List[History]:
+    """Replay an environment's ``step_info`` over pre-built histories.
+
+    This is test infrastructure, not a backward-compatibility path. The frozen
+    fixture and the hand-built histories in the environment test suites never
+    went through :class:`~POMDPPlanners.simulations.episodes.EpisodeRunner`, so
+    they carry no ``StepData.info`` at all. An environment whose metrics are
+    derived from the per-step channel would report nothing for them, and the
+    characterization tests would pass vacuously.
+
+    The call mirrors ``EpisodeRunner._record_step`` exactly, including its
+    ``info or None`` normalization. One expression covers the terminal
+    bookkeeping step too, because that step carries ``action is None`` and
+    ``next_state is None`` -- which is precisely what
+    ``EpisodeRunner._add_terminal_step`` passes.
+
+    Args:
+        environment: The environment whose ``step_info`` supplies the channels.
+        histories: Histories to measure. Not mutated; ``StepData`` is a
+            ``NamedTuple``, so each step is replaced rather than modified.
+
+    Returns:
+        New histories whose steps carry the measured ``info`` mappings.
+    """
+    measured: List[History] = []
+    for history in histories:
+        steps = [
+            step._replace(
+                info=environment.step_info(step.state, step.action, step.next_state) or None
+            )
+            for step in history.history
+        ]
+        measured.append(dataclasses.replace(history, history=steps))
+    return measured
+
+
+def append_terminal_step(histories: List[History]) -> List[History]:
+    """Derive the terminated-episode shape of a list of histories.
+
+    The frozen fixture stops after the last recorded transition, but a real
+    episode that reaches a terminal state also carries a bookkeeping step whose
+    ``state`` is the final state and whose ``action`` / ``next_state`` /
+    ``observation`` / ``reward`` are all ``None``
+    (``EpisodeRunner._add_terminal_step``). Metrics that scan ``step.state``
+    over the whole history therefore see one more state in a real run than they
+    do on the fixture, and the fixture alone cannot detect a regression in how
+    that final state is counted.
+
+    This derivation is deterministic -- it reads the last step's ``next_state``
+    and reuses its belief -- so it needs no rollout and no RNG.
+
+    Note:
+        This is a *shape probe*, not a sample of the observed distribution: the
+        real runner only appends a terminal step when ``is_terminal`` fires,
+        whereas this appends one to every history. That does not weaken the
+        characterization argument, since the pre-change and post-change
+        implementations are compared on identical inputs; it only bounds what
+        the probe covers.
+
+    Args:
+        histories: Histories to extend. Not mutated. Histories with no steps are
+            passed through unchanged, having no final state to append.
+
+    Returns:
+        New histories, each with a terminal bookkeeping step appended and
+        ``reach_terminal_state`` set.
+    """
+    extended: List[History] = []
+    for history in histories:
+        if not history.history:
+            extended.append(history)
+            continue
+        last = history.history[-1]
+        terminal_step = StepData(
+            state=last.next_state,
+            action=None,
+            next_state=None,
+            observation=None,
+            reward=None,
+            belief=last.belief,
+        )
+        extended.append(
+            dataclasses.replace(
+                history,
+                history=list(history.history) + [terminal_step],
+                reach_terminal_state=True,
+            )
+        )
+    return extended
+
+
 def compute_metric_snapshot(environment: Environment, histories: List[History]) -> Dict[str, float]:
     """Compute one environment's ``compute_metrics`` output as a name -> value mapping.
 
     Args:
         environment: The environment to snapshot.
-        histories: The frozen histories to feed it.
+        histories: The frozen histories to feed it. They are measured through
+            :func:`attach_step_info` first, so an environment reporting through
+            the per-step channel sees the same input it would in a real run.
 
     Returns:
         Mapping from metric name to point estimate. Confidence bounds are
         deliberately excluded: with three episodes several are infinite, which
         makes them useless as a stable baseline.
     """
-    return {metric.name: float(metric.value) for metric in environment.compute_metrics(histories)}
+    metrics = environment.compute_metrics(attach_step_info(environment, histories))
+    return {metric.name: float(metric.value) for metric in metrics}
+
+
+def compute_metric_order(environment: Environment, histories: List[History]) -> List[str]:
+    """Collect one environment's produced metric names, in emission order.
+
+    Order is part of the contract:
+    :func:`~POMDPPlanners.simulations.simulation_statistics.get_metric_names_from_environment_policy_pair`
+    feeds hyperparameter-tuning objective selection, and
+    :func:`compute_metric_snapshot` cannot see order because it builds a dict.
+
+    Args:
+        environment: The environment to inspect.
+        histories: The frozen histories to feed it.
+
+    Returns:
+        The produced metric names, in the order ``compute_metrics`` emitted them.
+    """
+    metrics = environment.compute_metrics(attach_step_info(environment, histories))
+    return [metric.name for metric in metrics]
 
 
 def compute_all_metric_snapshots() -> Dict[str, Dict[str, float]]:
@@ -269,6 +388,43 @@ def compute_all_metric_snapshots() -> Dict[str, Dict[str, float]]:
         slug: compute_metric_snapshot(factory(), frozen[slug])
         for slug, factory in build_registry().items()
     }
+
+
+def compute_all_metric_snapshots_with_terminal() -> Dict[str, Dict[str, float]]:
+    """Snapshot every registry environment against the terminated-episode shape.
+
+    Complements :func:`compute_all_metric_snapshots`, which uses the frozen
+    histories as-is. This one appends the terminal bookkeeping step first, so
+    the baseline also pins how each environment counts the final state -- the
+    one thing the raw fixture structurally cannot show.
+
+    Returns:
+        Mapping from environment slug to that environment's metric snapshot.
+    """
+    frozen = load_snapshot_histories()
+    return {
+        slug: compute_metric_snapshot(factory(), append_terminal_step(frozen[slug]))
+        for slug, factory in build_registry().items()
+    }
+
+
+def compute_all_metric_orders() -> Dict[str, Tuple[List[str], List[str]]]:
+    """Collect every registry environment's produced and declared name orders.
+
+    Returns:
+        Mapping from environment slug to ``(produced_names, declared_names)``,
+        both unsorted. ``compute_all_metric_names`` sorts, which is what makes it
+        blind to a reordering; these two lists are what pin the order itself.
+    """
+    frozen = load_snapshot_histories()
+    orders: Dict[str, Tuple[List[str], List[str]]] = {}
+    for slug, factory in build_registry().items():
+        environment = factory()
+        orders[slug] = (
+            compute_metric_order(environment, frozen[slug]),
+            list(environment.get_metric_names()),
+        )
+    return orders
 
 
 def compute_all_metric_names() -> Dict[str, List[str]]:

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -9,6 +9,56 @@ This project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.htm
 Each ``#NNN`` links to the pull request that introduced the change.
 
 
+Release 0.6.0 (WIP)
+-------------------
+
+**Existing environments migrated onto the shared per-step metrics channel**
+
+Breaking Changes:
+^^^^^^^^^^^^^^^^^
+
+- Environment metrics are now derived from the per-step ``StepData.info``
+  channel, so an episode ``History`` cached *before* that field existed yields
+  no environment metrics when replayed. The simulation cache
+  (``DiskCacheDB``, keyed by config id) is short-lived run-recovery state, so
+  no compatibility shim is provided: clear the cache, or re-run the affected
+  configs. Metric names, values and ordering are unchanged for any history
+  produced by the current code.
+
+New Features:
+^^^^^^^^^^^^^
+
+- Migrated nine environments — Tiger, CartPole, MountainCar, RockSample, both
+  LaserTag variants, both Push variants and PacMan — onto
+  ``Environment.step_info`` and ``get_metric_specs``, replacing nine
+  hand-rolled ``compute_metrics`` bodies and their inconsistent
+  confidence-interval handling with the shared aggregator. Metrics that cannot
+  be expressed as a per-episode reduction of a per-step channel are kept
+  as-is: the LaserTag metrics defined in terms of a realised reward, and the
+  Push ``*_rate`` metrics, which are pooled across episodes.
+- ``Environment.step_info`` is now also called once per terminated episode,
+  for the terminal bookkeeping step, with ``action`` and ``next_state`` both
+  ``None``. Metrics that count every visited state need that final state, and
+  it is recorded on no other step.
+- Added ``order_and_fill_metrics`` to
+  :mod:`POMDPPlanners.core.simulation.step_info_metrics`, so an environment
+  with a fixed declared metric list always produces every declared name in
+  declaration order, even when the aggregator has nothing to report for one.
+
+Others:
+^^^^^^^
+
+- Extended the frozen metric baseline with a terminated-episode shape and a
+  metric-ordering snapshot, which is what makes the migration's
+  "no name, value or ordering moved" claim checkable rather than assumed.
+- Two deliberate behaviour changes came out of the migration, both confined to
+  confidence bounds and degenerate inputs; no metric's point estimate moved.
+  Tiger reported ``lower == upper == value`` — a placeholder its own comment
+  called out — and now gets a real 95% t-interval. Environments that previously
+  raised ``ValueError`` from ``confidence_interval`` on an empty history list
+  (CartPole, MountainCar, Push) now return zero-valued metrics instead.
+
+
 Release 0.5.0 (WIP)
 -------------------
 

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -18,24 +18,47 @@ Breaking Changes:
 ^^^^^^^^^^^^^^^^^
 
 - Environment metrics are now derived from the per-step ``StepData.info``
-  channel, so an episode ``History`` cached *before* that field existed yields
-  no environment metrics when replayed. The simulation cache
-  (``DiskCacheDB``, keyed by config id) is short-lived run-recovery state, so
-  no compatibility shim is provided: clear the cache, or re-run the affected
-  configs. Metric names, values and ordering are unchanged for any history
-  produced by the current code.
+  channel, so an episode ``History`` cached *before* that field existed can no
+  longer be scored. ``compute_metrics`` raises ``ValueError`` for it rather
+  than returning metrics, because every channel would be absent and a rate
+  would read 0.0 — indistinguishable from a planner that never succeeded.
+  Metric names, values and ordering are unchanged for any history produced by
+  the current code.
+- The same guard fires for a history built by hand or by a runner that does not
+  call ``step_info``, and it is applied per episode, so a partially warm cache
+  cannot let one measured episode vouch for unmeasured ones beside it. It keys
+  on the environment's declared channels, not on ``info`` merely being
+  non-empty. An episode with no transition steps, and an empty history list,
+  are exempt: they legitimately measured nothing.
 
 New Features:
 ^^^^^^^^^^^^^
 
-- Migrated nine environments — Tiger, CartPole, MountainCar, RockSample, both
-  LaserTag variants, both Push variants and PacMan — onto
-  ``Environment.step_info`` and ``get_metric_specs``, replacing nine
-  hand-rolled ``compute_metrics`` bodies and their inconsistent
-  confidence-interval handling with the shared aggregator. Metrics that cannot
-  be expressed as a per-episode reduction of a per-step channel are kept
-  as-is: the LaserTag metrics defined in terms of a realised reward, and the
-  Push ``*_rate`` metrics, which are pooled across episodes.
+- Migrated eight environments — Tiger, CartPole, MountainCar, RockSample, both
+  LaserTag variants and both Push variants — onto ``Environment.step_info``
+  and ``get_metric_specs``, replacing eight hand-rolled ``compute_metrics``
+  bodies and their inconsistent confidence-interval handling with the shared
+  aggregator. Metrics that cannot be expressed as a per-episode reduction of a
+  per-step channel are kept as-is: the LaserTag metrics defined in terms of a
+  realised reward, and the Push ``*_rate`` metrics, which are pooled across
+  episodes.
+- PacMan and both light-dark environments are deliberately left on their own
+  ``compute_metrics``. PacMan's rule that an episode ending in a malformed
+  state reports zeros is an episode-level decision a stateless per-step channel
+  cannot express, and reproducing it through the shared aggregator required
+  rewriting each episode's measurements before aggregating — more code than the
+  loop it replaced, in service of preserving a quirk. The light-dark metrics
+  likewise come out of a single loop that stops at the goal.
+- A resumed run no longer has to throw its cache away. The simulation caches
+  are keyed on a task's configuration, which says nothing about the format of
+  the episode it produced, so an entry written before the per-step channel
+  existed still hits and unpickles cleanly with every measurement missing. Both
+  layers now treat such an entry as a cache *miss* — ``run_tasks``, which
+  consults the cache database before a task reaches the executor, and
+  ``JoblibTaskManager``, for entries held only in the joblib store. Each logs a
+  warning naming the task, reruns that one episode and replaces the entry.
+  Everything recorded in the current format is still reused, so recovery
+  survives the upgrade instead of costing a full re-run.
 - ``Environment.step_info`` is now also called once per terminated episode,
   for the terminal bookkeeping step, with ``action`` and ``next_state`` both
   ``None``. Metrics that count every visited state need that final state, and
@@ -48,15 +71,28 @@ New Features:
 Others:
 ^^^^^^^
 
-- Extended the frozen metric baseline with a terminated-episode shape and a
-  metric-ordering snapshot, which is what makes the migration's
-  "no name, value or ordering moved" claim checkable rather than assumed.
-- Two deliberate behaviour changes came out of the migration, both confined to
-  confidence bounds and degenerate inputs; no metric's point estimate moved.
+- Extended the frozen metric baseline with a terminated-episode shape, a
+  metric-ordering snapshot and a confidence-bounds snapshot, which is what
+  makes the migration's "no name, value or ordering moved" claim checkable
+  rather than assumed. The bounds matter on their own: a declared reduction
+  that yields the right mean from the wrong per-episode samples leaves the
+  point estimate intact and moves only the interval.
+- Three deliberate behaviour changes came out of the migration, all confined to
+  confidence bounds and degenerate inputs. No point estimate moved on any
+  history an episode runner can produce.
   Tiger reported ``lower == upper == value`` — a placeholder its own comment
   called out — and now gets a real 95% t-interval. Environments that previously
   raised ``ValueError`` from ``confidence_interval`` on an empty history list
   (CartPole, MountainCar, Push) now return zero-valued metrics instead.
+  Finally, an episode that reports a metric's channel on no step at all is now
+  dropped from that metric's average rather than contributing a declared
+  stand-in value. What an unmeasured episode would have measured is not a
+  property of the metric, so there is no per-spec knob for it; an episode that
+  ran but was never measured is rejected upstream instead of scored as zero.
+  ``EpisodeRunner`` always records a measured step, including the terminal
+  bookkeeping one, so this is reachable only from hand-built histories — where
+  a mixed list of real and stepless episodes now reports the mean over the real
+  ones alone.
 
 
 Release 0.5.0 (WIP)

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -28,8 +28,19 @@ Breaking Changes:
   call ``step_info``, and it is applied per episode, so a partially warm cache
   cannot let one measured episode vouch for unmeasured ones beside it. It keys
   on the environment's declared channels, not on ``info`` merely being
-  non-empty. An episode with no transition steps, and an empty history list,
-  are exempt: they legitimately measured nothing.
+  non-empty. An episode with no transition steps is exempt: it legitimately
+  measured nothing.
+- ``compute_metrics`` now raises ``ValueError`` on an empty history list, in
+  every environment. A metric over no episodes is an average over nothing, so
+  any answer is invented: a zero reads like a genuine measurement of zero, an
+  omitted name silently shortens the declared list, and an empty list claims the
+  environment has no metrics. The three disagreed environment by environment
+  before — Tiger, MountainCar, CartPole, RockSample and both Push variants
+  returned zeros, both LaserTags, PacMan, CARLA and nuPlan returned ``[]``, and
+  the light-dark pair raised ``Data must contain at least one element`` from
+  ``confidence_interval``. Nothing in the simulation pipeline produces an empty
+  batch: ``compute_statistics_environment_policy_pair`` already rejects one
+  before metrics are reached, so this is a caller error, not a degenerate run.
 
 New Features:
 ^^^^^^^^^^^^^
@@ -81,10 +92,9 @@ Others:
   confidence bounds and degenerate inputs. No point estimate moved on any
   history an episode runner can produce.
   Tiger reported ``lower == upper == value`` — a placeholder its own comment
-  called out — and now gets a real 95% t-interval. Environments that previously
-  raised ``ValueError`` from ``confidence_interval`` on an empty history list
-  (CartPole, MountainCar, Push) now return zero-valued metrics instead.
-  Finally, an episode that reports a metric's channel on no step at all is now
+  called out — and now gets a real 95% t-interval. Every environment now rejects
+  an empty history list rather than answering it, replacing three different
+  answers with one error. Finally, an episode that reports a metric's channel on no step at all is now
   dropped from that metric's average rather than contributing a declared
   stand-in value. What an unmeasured episode would have measured is not a
   property of the metric, so there is no per-spec knob for it; an episode that


### PR DESCRIPTION
Follow-up to #231, which added the per-step measurement channel but deliberately left the existing environments alone. This migrates them.

Nine environments hand-rolled `compute_metrics` and `get_metric_names`, each re-implementing the same counting, list-accumulation and CI-fallback code — with inconsistent confidence-interval handling (tiger had none at all; laser-tag guarded `n < 2`; push/pacman/rock-sample used ad-hoc `(0, 0)` fallbacks; cartpole/mountain-car called `confidence_interval` unguarded). They now report through `step_info` + `get_metric_specs` and share the aggregator.

**No metric name, value or ordering changed.**

## What moved

| | Environments |
| --- | --- |
| Fully spec-driven (`compute_metrics` deleted) | tiger, cartpole, mountain car, rock sample |
| Hybrid (spec-driven + preserved bespoke) | both laser tags, both pushes |
| Deliberately untouched | both light-dark variants, pacman |

What stayed bespoke, and why:

- **Both laser tags** — `tag_success_rate` and `average_failed_tag_attempts` are defined in terms of the realised reward, which `step_info` is not given. Recomputing it is not an option: two laser-tag reward models draw from `np.random`, so it would both return a different number *and* shift the RNG stream for every later transition, breaking seeded trajectories well beyond metrics.
- **Both pushes** — the four `*_rate` metrics are pooled across episodes (`sum(counts) / sum(lengths)`), which is not a per-episode reduction. Their pre-existing quirks are carried over verbatim, including a `zip()` misalignment on zero-step histories that divides by zero, and the fact that their point estimates and confidence intervals come from different statistics.
- **PacMan** — the malformed-final-state rule and the per-ghost distance metrics are episode-level decisions a stateless per-step channel cannot express. Routing them through `optional=` fills on `order_and_fill_metrics` cost more than it saved, so `compute_metrics` stays bespoke.
- **Light-dark** — all five metrics come out of one loop that `break`s at the goal, truncating the later counters. Splitting out the one reproducible metric would leave the same loop in place for the other four.

## Core changes this required

- `episodes.py` now measures the **terminal bookkeeping step**, calling `step_info(state, None, None)`. This is load-bearing, not incidental: without it, seven metrics across four environments silently drift, because the final state of a terminated episode is recorded on no other step (tiger's `success_rate` 0.0 → 0.667, laser-tag `average_episode_length` 6 → 5).
- **Unmeasured episodes are rejected, not filled.** A `History` cached before `StepData.info` existed unpickles with every measurement missing, and a runner that never calls `step_info` produces the same shape. Scored as-is every channel is absent, so a rate reads 0.0 and a count reads 0 — "the planner never reached the goal" is indistinguishable from "nobody measured". `unmeasured_episode_index` / `require_measured_episodes` detect it **per episode**, so a partially warm cache cannot let one measured episode vouch for unmeasured ones beside it. Both cache layers treat such an entry as a **miss**, so a resumed run recomputes the stale episodes instead of discarding the whole cache or aborting. Terminal-only episodes are exempt — they legitimately measured nothing.
- `order_and_fill_metrics` — so an environment with a fixed declared metric list always produces every declared name in declaration order. The aggregator drops a metric no episode reported, which would otherwise shorten that list silently and break lookups by name (tuning objectives go through `get_metric_names_from_environment_policy_pair`).

`Environment.compute_metrics` itself is unchanged, so `IsaacLabPOMDP` keeps its omit-when-unmeasured semantics — a zero there still provably means "sensor present, no contact".

## How equivalence was established

Against the pre-migration code itself, run from a worktree at the parent commit — not against a reimplementation of it:

- **Live episode histories scored by both trees**: 28 metrics across 5 environments (14 non-zero), exact match. Repeated for 6 genuinely *terminated* pacman episodes: all 9 metrics exact, per-ghost distances included.
- **55 degenerate shapes** (no histories, stepless episodes, malformed states, single episode): **zero point-estimate differences, zero metric-name differences**.
- The frozen golden fixture, plus two new baselines captured *before* any environment was touched: a **terminated-episode shape**, which is what catches the final-state off-by-one, and a **metric-ordering snapshot**, since both existing assertions are order-blind (one compares a dict, the other sorts).
- New `test_step_info_migration.py`: declared channels are actually emitted, `step_info` is pure and consumes no randomness (verified non-vacuous — it detects an injected `np.random.rand()`), the terminal-step call is tolerated, values are picklable floats, and degenerate shapes never invent or reorder a name.

## Accepted behaviour changes

All confined to confidence bounds and degenerate inputs. No point estimate moves on any history an episode runner can produce.

- **Tiger's confidence bounds** were `lower == upper == value` — a placeholder its own comment called out — and are now a real 95% t-interval.
- **Every environment now rejects an empty history list** with a `ValueError`, replacing three different answers with one error (see the follow-up section below).
- **An episode reporting a metric's channel on no step is dropped from that metric's average** rather than contributing a declared stand-in. `EpisodeRunner` always records a measured step, including the terminal bookkeeping one, so this is unreachable from real histories — re-scoring the frozen golden fixtures for all eight spec-driven environments is byte-identical. Only hand-built mixed real-plus-stepless lists change, and they now report the mean over the real episodes alone.

## Breaking change

A `History` cached before `StepData.info` existed unpickles with `info=None`, so a migrated environment reports no metrics for it. The simulation cache is short-lived run-recovery state, so no compatibility shim is provided — clear the cache or re-run the affected configs. Recorded in the changelog.

## Verification

- `pytest`: 4766 passed, 23 skipped, 10 xfailed.
- `pyright POMDPPlanners/`: 0 errors, 0 warnings.
- `pylint` on changed source: 9.99/10 — the three findings are pre-existing in `pacman_pomdp.py` (verified against the parent commit); zero new findings.
- Per-step measurement now runs in the simulation hot path. Benchmarked at 10 episodes x 40 steps, median of 3 runs of 5 repeats: laser-tag +1%, pacman +9% (~10us/step), push noise-dominated.


---

## Follow-up in 67e6a3c1 — reject unmeasured episodes instead of filling them

`StepInfoMetric.empty_episode_value` is **removed**. It declared, per metric, what an episode reporting the channel on no step should contribute. That is not a property of the metric: 22 of its 23 declared values were simply the reduction's identity over an empty list (`any([])` is `False`, `all([])` is `True`, `sum([])` is `0`), and the one genuine choice — Tiger's `LAST` — has no defined answer over an empty list at all.

The case it was defending is unreachable. `EpisodeRunner` appends a terminal bookkeeping step whenever the state is terminal, and that step is now measured, so an episode that starts terminal has one *measured* step rather than zero. Stripping the field and re-scoring the frozen golden fixtures gives identical values for all eight spec-driven environments.

The real risk it was conflated with — an episode that ran but was never measured — is handled upstream by `require_measured_episodes`, by rejection rather than by invention.



---

## Follow-up in 9aa62068 — reject an empty history batch instead of scoring it

`compute_metrics([])` had three different answers depending on which environment you asked:

| Answer | Environments |
| --- | --- |
| Zero-valued metrics | tiger, cartpole, mountain car, rock sample, both pushes |
| `[]` | both laser tags, pacman, carla, nuplan |
| `ValueError` from `confidence_interval` | both light-dark variants |

None of the three is a measurement. A metric over no episodes is an average over nothing, so a zero reads exactly like a genuine measurement of zero, an omitted name silently shortens the declared list, and an empty list claims the environment has no metrics at all.

All of them now raise `ValueError`, through one guard — `require_non_empty_histories`, called from `Environment.compute_metrics` and from each bespoke override. Nothing in the pipeline produces an empty batch: `compute_statistics_environment_policy_pair` already rejects one at `simulation_statistics.py:150`, before metrics are reached. This is a caller error, not a degenerate run.

The guard sits at the environment boundary, not in `aggregate_step_info_metrics`, which stays a pure reduction that runners producing no `History` can reuse. It also runs *before* the no-specs shortcut, so an environment declaring no metrics rejects an empty batch too — the rule is a property of the input, not of what the environment happens to measure.

Tests: one rejection test per spec-driven environment in `test_step_info_migration.py`, one each for the bespoke light-dark pair, nuPlan and SafetyAnt, and three in `test_step_info_metrics.py` pinning where the guard does and does not apply. Six existing empty-input tests (tiger, sanity, pacman, rock sample, continuous laser tag, carla) now assert the raise, and `no_histories` is dropped from the degenerate-shapes parametrization, which asserts *not* raising.
