### PR TITLE
feat(racetrack): let the planner anticipate corners

### DIFF
--- a/POMDPPlanners/environments/racetrack_pomdp/__init__.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/__init__.py
@@ -17,7 +17,11 @@ package, constructing the model, or running the belief never loads the simulator
 
 Classes:
     RacetrackPOMDP: Forward-only adapter exposing a racetrack session as a world.
-    RacetrackModelPOMDP: Planner-side generative model over the racetrack schema.
+    RacetrackModelPOMDP: Abstract planner-side model; concrete models differ only in
+        where curvature comes from.
+    KnownTrackModel: Planner knows the circuit and looks curvature up by arclength.
+    ObservedTrackModel: Planner estimates curvature from the road it can see.
+    TrackGeometry: Piecewise-constant curvature of a lap, indexed by arclength.
     RacetrackVectorizedModel: Batched torch counterpart of that model, for VOPP.
     TrackedAgentsBelief: Particle belief that stamps grid-tracked agents onto particles.
     OccupancyVelocityTracker: Turns consecutive occupancy grids into cluster velocities.
@@ -28,7 +32,13 @@ Classes:
 """
 
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_belief import TrackedAgentsBelief
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_known_track_model import (
+    KnownTrackModel,
+)
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp import RacetrackModelPOMDP
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_observed_track_model import (
+    ObservedTrackModel,
+)
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_occupancy_tracker import (
     OccupancyVelocityTracker,
     TrackedCluster,
@@ -47,6 +57,11 @@ from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     build_racetrack_config,
     racetrack_reward,
 )
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import (
+    TrackGeometry,
+    build_track_geometry,
+    geometry_from_world,
+)
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_vectorized_model import (
     RacetrackVectorizedModel,
 )
@@ -56,15 +71,20 @@ __all__ = [
     "DEFAULT_ACTION_PRESETS",
     "DEFAULT_MAX_TRACKED_AGENTS",
     "EGO_STATE_WIDTH",
+    "KnownTrackModel",
     "ObservationMode",
+    "ObservedTrackModel",
     "OccupancyVelocityTracker",
     "RacetrackMetric",
     "RacetrackModelPOMDP",
     "RacetrackPOMDP",
     "RacetrackStepChannel",
     "RacetrackVectorizedModel",
+    "TrackGeometry",
     "TrackedAgentsBelief",
     "TrackedCluster",
     "build_racetrack_config",
+    "build_track_geometry",
+    "geometry_from_world",
     "racetrack_reward",
 ]

--- a/POMDPPlanners/environments/racetrack_pomdp/__init__.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/__init__.py
@@ -18,6 +18,7 @@ package, constructing the model, or running the belief never loads the simulator
 Classes:
     RacetrackPOMDP: Forward-only adapter exposing a racetrack session as a world.
     RacetrackModelPOMDP: Planner-side generative model over the racetrack schema.
+    RacetrackVectorizedModel: Batched torch counterpart of that model, for VOPP.
     TrackedAgentsBelief: Particle belief that stamps grid-tracked agents onto particles.
     OccupancyVelocityTracker: Turns consecutive occupancy grids into cluster velocities.
     TrackedCluster: One tracked occupancy cluster with its relative velocity.
@@ -46,6 +47,9 @@ from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     build_racetrack_config,
     racetrack_reward,
 )
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_vectorized_model import (
+    RacetrackVectorizedModel,
+)
 
 __all__ = [
     "AGENT_SLOT_WIDTH",
@@ -58,6 +62,7 @@ __all__ = [
     "RacetrackModelPOMDP",
     "RacetrackPOMDP",
     "RacetrackStepChannel",
+    "RacetrackVectorizedModel",
     "TrackedAgentsBelief",
     "TrackedCluster",
     "build_racetrack_config",

--- a/POMDPPlanners/environments/racetrack_pomdp/racetrack_known_track_model.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/racetrack_known_track_model.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT
+
+"""Planner-side racetrack model for a planner that knows the circuit.
+
+This is the easy half of the pair. The track is a fixed, closed loop of straights and
+constant-radius arcs, so if the planner is allowed to know it, the curvature under a
+particle is a table lookup on the particle's own arclength — exact, cheap, and valid as far
+ahead as the rollout cares to go. See
+:mod:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry` for the table
+and how it is walked out of the lane graph.
+
+Knowing the circuit is a real assumption, not a free win: it is the "map-based planner"
+baseline. Its counterpart,
+:class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_observed_track_model.ObservedTrackModel`,
+has to read the road out of the observation instead, and the gap between the two is what a
+map is worth on this problem.
+
+Classes:
+    KnownTrackModel: Generative racetrack model whose curvature comes from a track map.
+"""
+
+from typing import Any
+
+import numpy as np
+
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp import RacetrackModelPOMDP
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import EGO_ARCLENGTH_M
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import TrackGeometry
+
+
+class KnownTrackModel(RacetrackModelPOMDP):
+    """Generative racetrack model that looks its curvature up in a track map.
+
+    Every substep indexes :attr:`track_geometry` with the particle's own arclength slot,
+    which the base class advances by the along-track rate as it integrates. A rollout
+    therefore drives *through* a corner rather than past it: the curvature the Frenet update
+    sees changes exactly where the road changes.
+
+    Attributes:
+        track_geometry: Piecewise-constant curvature of the lap, indexed by arclength.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(42)  # For reproducible results
+        >>>
+        >>> from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import (
+        ...     TrackGeometry,
+        ... )
+        >>>
+        >>> # A lap of one 10 m straight followed by one 10 m left-hand arc
+        >>> geometry = TrackGeometry(
+        ...     segment_starts=np.array([0.0, 10.0]),
+        ...     segment_curvatures=np.array([0.0, 0.05]),
+        ...     total_length_m=20.0,
+        ... )
+        >>> env = KnownTrackModel(discount_factor=0.95, track_geometry=geometry)
+        >>>
+        >>> # Propagate a state cruising straight at the speed limit
+        >>> state = np.zeros(env.state_width)
+        >>> state[3] = 10.0  # speed, m/s
+        >>> next_state = env.sample_next_state(state, action=13)  # coast, straight ahead
+        >>> bool(next_state[0] > state[0])  # the ego moved forward
+        True
+        >>> bool(next_state[6] > 0.0)  # and its arclength advanced with it
+        True
+
+    Note:
+        The map is built for one lane. Parallel lanes on the same segment have different
+        radii, so a model that ever learns to change lanes would need a per-lane profile.
+    """
+
+    def __init__(
+        self,
+        discount_factor: float,
+        track_geometry: TrackGeometry,
+        **model_kwargs: Any,
+    ) -> None:
+        """Initialize a racetrack model over a known circuit.
+
+        Args:
+            discount_factor: Discount factor for future rewards (0 < d <= 1).
+            track_geometry: Curvature profile of the lap the ego is driving. Build one with
+                :func:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry.build_track_geometry`
+                or
+                :func:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry.geometry_from_world`.
+            **model_kwargs: Every other argument of
+                :class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp.RacetrackModelPOMDP`
+                — observation mode, step rates, action presets, noise scales and the reward
+                weights — forwarded unchanged.
+        """
+        self.track_geometry = track_geometry
+        super().__init__(discount_factor=discount_factor, **model_kwargs)
+
+    def _curvature_for(self, ego: np.ndarray) -> np.ndarray:
+        return np.asarray(
+            self.track_geometry.curvature_at(ego[:, EGO_ARCLENGTH_M]), dtype=float
+        ).reshape(len(ego))
+
+    # The base class's all-ones on-road layer and zero on-road likelihood are kept
+    # deliberately, and the two halves of that have different reasons.
+    #
+    # Dropping the *likelihood* term is free. The layer would be a function of the
+    # particle's arclength only, and arclength carries no process noise, so every particle
+    # in a belief reports the same road; the term adds one constant to every log-weight and
+    # vanishes at normalisation, at a cost of 144 cells of arithmetic per particle per step.
+    #
+    # Leaving the *sampled* layer at all ones is a genuine inaccuracy, not a free one: an
+    # observation this model draws in a rollout claims the whole window is drivable, which
+    # in a corner is false. It is tolerated because nothing downstream of this model reads
+    # that layer -- the belief's tracker works off the presence layer, and unlike
+    # ObservedTrackModel this model never feeds its own samples back through an estimator.
+    # If a consumer of the on-road layer ever appears, override _render_on_road_layer here;
+    # the map makes it straightforward, and ObservedTrackModel already shows the rasteriser.
+
+
+__all__ = ["KnownTrackModel"]

--- a/POMDPPlanners/environments/racetrack_pomdp/racetrack_model_pomdp.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/racetrack_model_pomdp.py
@@ -13,9 +13,19 @@ The transition reproduces highway-env's kinematic bicycle **exactly** for the eg
 ``arctan(tan(delta)/2)`` slip angle, the same ``LENGTH / 2`` wheelbase term, the same update
 order, integrated over ``substeps`` sub-intervals of ``dt / substeps`` so the model takes
 the same number of physics steps per decision as the simulator. The Frenet pair
-``(lat, ang)`` is integrated alongside it against the state's own ``curvature``, held fixed
-over the planning horizon — the racetrack is straights and constant-radius arcs, so that is
-exact within a lane segment and wrong only where the lane changes underneath the ego.
+``(lat, ang)`` is integrated alongside it against the curvature of the road under the ego.
+
+**Where the road bends is the subclass's job.** This class is abstract for exactly one
+reason: it does not know the track. Every substep asks :meth:`RacetrackModelPOMDP._curvature_for`
+what the curvature is under each particle, and the two shipped subclasses answer it from
+two different places —
+:class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_known_track_model.KnownTrackModel`
+looks the circuit up by arclength, and
+:class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_observed_track_model.ObservedTrackModel`
+reads it out of the observation's on-road layer. Curvature is deliberately *not* a state
+slot: it is a property of the road, so freezing it in the state would encode a prediction
+rather than a fact, and a rollout reusing one frozen value drives straight through every
+corner.
 
 **The model error is deliberate and lives in the other vehicles.** Agent slots are
 propagated as constant-velocity drift in the ego body frame, while the world drives them
@@ -32,9 +42,10 @@ Note:
     model heading with a world heading modulo ``2 * pi`` rather than by subtraction.
 
 Classes:
-    RacetrackModelPOMDP: Generative model paired with the forward-only racetrack world.
+    RacetrackModelPOMDP: Abstract generative model paired with the forward-only world.
 """
 
+from abc import abstractmethod
 from collections.abc import Hashable
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
@@ -57,7 +68,7 @@ from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     DEFAULT_MAX_TRACKED_AGENTS,
     DEFAULT_SPEED_LIMIT,
     EGO_ANG,
-    EGO_CURVATURE,
+    EGO_ARCLENGTH_M,
     EGO_HEADING,
     EGO_LAT,
     EGO_SPEED,
@@ -77,11 +88,12 @@ from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     state_agent_rows,
 )
 
-# Process noise is applied to the first six ego entries only. Curvature is the seventh and
-# is excluded on purpose: it is a property of the lane the ego occupies, not a state the
-# vehicle diffuses through, and the dynamics hold it fixed over the horizon. Jittering it
-# would scatter particles onto imaginary lanes of wildly different radius.
-_EGO_NOISE_WIDTH = EGO_CURVATURE
+# Process noise is applied to the first six ego entries only. Arclength is the seventh and
+# is excluded on purpose: it is not an independent coordinate but the running integral of
+# the ego's own along-track motion, already noisy through the speed it is integrated from.
+# Jittering it on top would teleport a particle down the track and, worse, re-index the
+# curvature profile a known-track model reads with it.
+_EGO_NOISE_WIDTH = EGO_ARCLENGTH_M
 
 # The ego sits in the middle cell of the occupancy grid, at (6, 6) for the shipped 12x12.
 _GRID_CENTRE = GRID_CELLS // 2
@@ -94,7 +106,7 @@ _MIN_FRENET_DENOMINATOR = 1e-3
 # -inf log-likelihood, which would annihilate an otherwise good particle.
 _FLIP_PROB_EPS = 1e-12
 
-_OCCUPANCY_KEY = "occupancy"
+OCCUPANCY_KEY = "occupancy"
 _EGO_KEY = "ego"
 _AGENTS_KEY = "agents"
 
@@ -133,13 +145,18 @@ def _gaussian_log_prob(deviation: np.ndarray, std: float) -> float:
 
 
 class RacetrackModelPOMDP(DiscreteActionsEnvironment):
-    """Generative racetrack model: the planner's beliefs about the forward-only world.
+    """Abstract generative racetrack model: the planner's beliefs about the world.
 
     Reproduces the world's ego dynamics exactly and its other vehicles only crudely (see the
     module docstring). The observation follows whichever arm of the matched pair the world is
     running, selected by ``observation_mode``; :meth:`encode_observation` is the single seam
     where the world's raw reading enters, and every other observation method works in the
     encoded space.
+
+    Subclasses supply :meth:`_curvature_for`, the one thing this class does not know: where
+    the road bends. They may also override :meth:`_render_on_road_layer` and
+    :meth:`_on_road_log_prob` if their curvature source lets them predict the observation's
+    on-road layer; the defaults here decline to, and say why.
 
     Attributes:
         observation_mode: Which arm of the matched pair this model scores.
@@ -152,25 +169,11 @@ class RacetrackModelPOMDP(DiscreteActionsEnvironment):
         collision_distance: Range (m) at or below which a present agent slot is a collision.
         lane_half_width: Lateral offset (m) beyond which the ego has left the lane.
 
-    Example:
-        >>> import numpy as np
-        >>> np.random.seed(42)  # For reproducible results
-        >>>
-        >>> # Initialize the planner-side model
-        >>> env = RacetrackModelPOMDP(discount_factor=0.95)
-        >>>
-        >>> # The action set indexes the shared control presets
-        >>> len(env.get_actions())
-        9
-        >>>
-        >>> # Propagate a state cruising straight at the speed limit
-        >>> state = np.zeros(env.state_width)
-        >>> state[3] = 10.0  # speed, m/s
-        >>> next_state = env.sample_next_state(state, action=4)  # coast, straight ahead
-        >>> next_state.shape == (env.state_width,)
-        True
-        >>> bool(next_state[0] > state[0])  # the ego moved forward
-        True
+    Note:
+        This is an abstract base class and cannot be instantiated directly. Use
+        :class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_known_track_model.KnownTrackModel`
+        or
+        :class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_observed_track_model.ObservedTrackModel`.
     """
 
     def __init__(
@@ -271,7 +274,7 @@ class RacetrackModelPOMDP(DiscreteActionsEnvironment):
 
         super().__init__(
             discount_factor=discount_factor,
-            name=name if name is not None else f"RacetrackModelPOMDP-{observation_mode.value}",
+            name=name if name is not None else f"{type(self).__name__}-{observation_mode.value}",
             space_info=SpaceInfo(
                 action_space=SpaceType.DISCRETE,
                 observation_space=SpaceType.CONTINUOUS,
@@ -295,6 +298,27 @@ class RacetrackModelPOMDP(DiscreteActionsEnvironment):
         return int(action)
 
     # ── Transition (highway-env's kinematic bicycle, reproduced) ─────────
+    @abstractmethod
+    def _curvature_for(self, ego: np.ndarray) -> np.ndarray:
+        """Signed curvature in 1/m for each row of the ego block, shape ``(B,)``.
+
+        Called once per integration substep with the ego block ``(B, EGO_STATE_WIDTH)`` as
+        it stands *at the start of that substep*, so a subclass indexing by arclength sees
+        the arclength the ego has actually reached rather than the one it started the
+        decision at.
+
+        Args:
+            ego: The ego block of the particle batch, shape ``(B, EGO_STATE_WIDTH)``.
+
+        Returns:
+            Signed curvature in 1/m per row, positive in the same sense as
+            :class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry.TrackGeometry`.
+
+        Note:
+            Subclasses must implement this. It is the only thing separating a model that
+            knows the circuit from one that has to read the road out of its observations.
+        """
+
     def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
         """Propagate ``state`` one decision forward under ``action``, with process noise.
 
@@ -331,7 +355,7 @@ class RacetrackModelPOMDP(DiscreteActionsEnvironment):
     def transition_log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
         """Log-density of each candidate successor under the noisy propagation.
 
-        The density covers the first six ego entries only. Curvature and every agent slot
+        The density covers the first six ego entries only. Arclength and every agent slot
         are *deterministic* functions of ``(state, action)`` — no noise is added to them — so
         including them would contribute a constant at best and an infinite mismatch penalty
         at worst.
@@ -404,7 +428,7 @@ class RacetrackModelPOMDP(DiscreteActionsEnvironment):
         heading = ego[:, EGO_HEADING].copy()
         lateral = ego[:, EGO_LAT].copy()
         angle = ego[:, EGO_ANG].copy()
-        curvature = ego[:, EGO_CURVATURE]
+        curvature = self._curvature_for(ego)
 
         yaw_rate = speed * np.sin(slip) / (self.vehicle_length / 2.0)
         # The Frenet rates use the *velocity* direction, ``ang + slip``, not the heading:
@@ -423,6 +447,10 @@ class RacetrackModelPOMDP(DiscreteActionsEnvironment):
         ego[:, EGO_LAT] = lateral + speed * np.sin(drift) * step
         ego[:, EGO_ANG] = _wrap_to_pi_array(angle + (yaw_rate - curvature * along_rate) * step)
         ego[:, EGO_SPEED] = speed + acceleration * step
+        # Advanced by the *along-track* rate, not by ``speed * step``: the two differ once
+        # the ego is yawed relative to the lane or offset from its centreline on an arc,
+        # and it is the along-track one that indexes the curvature profile correctly.
+        ego[:, EGO_ARCLENGTH_M] = ego[:, EGO_ARCLENGTH_M] + along_rate * step
 
         self._drift_agents(agents, -yaw_rate * step, step)
 
@@ -531,7 +559,7 @@ class RacetrackModelPOMDP(DiscreteActionsEnvironment):
             rel_vy]}``, with absent rows left at zero.
         """
         if self.observation_mode is ObservationMode.POMDP:
-            return {_OCCUPANCY_KEY: np.asarray(observation, dtype=np.float32)}
+            return {OCCUPANCY_KEY: np.asarray(observation, dtype=np.float32)}
         return self._encode_kinematics(np.asarray(observation, dtype=float))
 
     def _encode_kinematics(self, rows: np.ndarray) -> Dict[str, np.ndarray]:
@@ -573,10 +601,9 @@ class RacetrackModelPOMDP(DiscreteActionsEnvironment):
         """Log-density of each observation given ``next_state``.
 
         In POMDP mode this is an independent Bernoulli over the 144 presence cells of the
-        grid :meth:`sample_observation` would have rasterised. **The on-road layer is
-        excluded**: it is a function of track geometry, which this model's state does not
-        carry, so it is identical across every particle and can only add a constant — a term
-        that cannot discriminate has no business in a weight.
+        grid :meth:`sample_observation` would have rasterised, plus whatever
+        :meth:`_on_road_log_prob` contributes for the second layer — nothing at all, unless
+        the subclass can predict the road.
 
         In MDP mode it is a diagonal Gaussian over the ego row and the *present* agent slots;
         absent slots contribute nothing, because a slot that holds no vehicle carries no
@@ -603,7 +630,13 @@ class RacetrackModelPOMDP(DiscreteActionsEnvironment):
         candidates = [observations] if isinstance(observations, dict) else list(observations)
         if self.observation_mode is ObservationMode.POMDP:
             grid = self._render_presence_grid(next_state)
-            return np.array([self._grid_log_prob(grid, obs) for obs in candidates], dtype=float)
+            return np.array(
+                [
+                    self._grid_log_prob(grid, obs) + self._on_road_log_prob(next_state, obs)
+                    for obs in candidates
+                ],
+                dtype=float,
+            )
         clean = self._clean_kinematics(next_state)
         return np.array([self._kinematics_log_prob(clean, obs) for obs in candidates], dtype=float)
 
@@ -617,8 +650,31 @@ class RacetrackModelPOMDP(DiscreteActionsEnvironment):
         flips = np.random.random(grid.shape) < self.cell_flip_prob
         occupancy = np.zeros((2, GRID_CELLS, GRID_CELLS), dtype=np.float32)
         occupancy[PRESENCE_LAYER] = np.logical_xor(grid, flips)
-        occupancy[ON_ROAD_LAYER] = 1.0
-        return {_OCCUPANCY_KEY: occupancy}
+        occupancy[ON_ROAD_LAYER] = self._render_on_road_layer(state)
+        return {OCCUPANCY_KEY: occupancy}
+
+    def _render_on_road_layer(self, state: Any) -> np.ndarray:
+        """The on-road layer this model predicts for ``state``; all-ones by default.
+
+        All-ones is the honest answer for a model with no picture of the road: it says
+        "drivable everywhere I can see", which is what the shipped racetrack shows on a
+        straight anyway. A subclass that carries a road model should override this so that
+        the observations it *samples* are the same shape as the ones it *reads* — otherwise
+        it feeds itself an all-clear corridor on the approach to every corner.
+        """
+        del state
+        return np.ones((GRID_CELLS, GRID_CELLS), dtype=np.float32)
+
+    def _on_road_log_prob(self, state: Any, observation: Any) -> float:
+        """Contribution of the on-road layer to the likelihood; zero by default.
+
+        Zero, and not a Bernoulli over the layer, because the default
+        :meth:`_render_on_road_layer` does not depend on ``state``: a term identical across
+        every particle shifts all the log-weights alike and vanishes at normalisation, so it
+        buys nothing but 144 cells of arithmetic per particle per step.
+        """
+        del state, observation
+        return 0.0
 
     def _draw_kinematics(self, state: Any) -> Dict[str, np.ndarray]:
         clean = self._clean_kinematics(state)
@@ -660,9 +716,13 @@ class RacetrackModelPOMDP(DiscreteActionsEnvironment):
         return grid
 
     def _grid_log_prob(self, grid: np.ndarray, observation: Any) -> float:
-        observed = np.asarray(observation[_OCCUPANCY_KEY], dtype=float)[PRESENCE_LAYER] > 0.5
+        observed = np.asarray(observation[OCCUPANCY_KEY], dtype=float)[PRESENCE_LAYER] > 0.5
+        return self._bernoulli_cell_log_prob(grid, observed)
+
+    def _bernoulli_cell_log_prob(self, predicted: np.ndarray, observed: np.ndarray) -> float:
+        """Independent per-cell flip model over two boolean grids of the same shape."""
         flip_prob = float(np.clip(self.cell_flip_prob, _FLIP_PROB_EPS, 1.0 - _FLIP_PROB_EPS))
-        agreements = int(np.count_nonzero(observed == grid))
+        agreements = int(np.count_nonzero(observed == predicted))
         disagreements = observed.size - agreements
         return agreements * float(np.log1p(-flip_prob)) + disagreements * float(np.log(flip_prob))
 

--- a/POMDPPlanners/environments/racetrack_pomdp/racetrack_observed_track_model.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/racetrack_observed_track_model.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: MIT
+
+"""Planner-side racetrack model for a planner with no map of the circuit.
+
+This is the hard half of the pair. Where
+:class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_known_track_model.KnownTrackModel`
+looks the curvature up by arclength, this model has to *see* it: the only thing it knows
+about the road is the on-road layer of the occupancy observation, a 12x12 window of 3 m
+cells over +/-18 m, aligned to the ego's own axes.
+
+**The layer leads the state.** At a step where the arclength still sits on a straight, the
+on-road cells already show the drivable corridor bending — the road ahead is in the window
+before the ego reaches it. That is the whole reason this model can corner at all.
+
+**The estimate is one number per step, shared by every particle.** It is computed once in
+:meth:`ObservedTrackModel.encode_observation`, the model's single raw-observation seam, and
+handed to every row of every rollout until the next observation arrives. That is a real
+approximation and not a bookkeeping detail: within one planning step the belief cannot
+disagree about where the road goes, so curvature uncertainty is absent from the search.
+
+**Beyond 18 m the estimate is simply held.** The rollout keeps using the last measured
+curvature for the rest of the horizon, so a bend that starts just past the window edge is
+invisible. At the shipped rates a rollout covers roughly 12 m, comfortably inside the
+window, but this is a true consequence of seeing 18 m rather than a shortcut worth fixing
+in the estimator.
+
+**How well this reads the road depends on how well the car is being driven, and the variable
+that decides it is lane-relative yaw.** Measured against the live circuit deep inside one
+arc, a thousand poses per band::
+
+    |ang| <= 0.15 rad    1.06x true curvature
+    0.15 - 0.25          0.97x
+    0.25 - 0.35          0.88x
+    0.35 - 0.50          0.84x
+
+A lane-keeper holds a mean ``|ang|`` of 0.089 and gets bends back at 0.78x over a lap.
+Every figure here scores against the curvature at the ego's arclength. Scoring instead
+against the lane object the ego happens to occupy reads about 0.05 lower, because a
+wandering car crosses onto the parallel lane, which on an arc has a different radius — a
+difference in the yardstick, not in the model.
+
+Those bands are what the fit gives *without* the textbook ``/(1 + b^2)^{3/2}`` slope term,
+which :meth:`ObservedTrackModel._fit_curvature` deliberately omits. With it the same bands
+read 1.05x, 0.91x, 0.77x and 0.65x — the correction bit hardest at exactly the yaw angles
+where the estimate matters most. Removing it buys a great deal at high yaw and almost
+nothing at low: over a lane-keeper lap the ratio moves only 0.76x to 0.78x, because a car
+that is driving well spends 83% of its steps under 0.15 rad where the term was inert. It
+earns its place by helping a car that is already in trouble, not by improving the average.
+
+So there is a loop here worth naming: a weak estimate under-steers, under-steering yaws the
+car away from the lane, and a yawed car reads the road worse still. Quote an accuracy for
+this model without saying how the car was driven and the number means nothing.
+
+Classes:
+    ObservedTrackModel: Generative racetrack model that reads curvature off the observation.
+"""
+
+from typing import Any, Dict, Tuple
+
+import numpy as np
+
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp import (
+    OCCUPANCY_KEY,
+    RacetrackModelPOMDP,
+)
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
+    EGO_ANG,
+    EGO_LAT,
+    GRID_CELLS,
+    GRID_HALF_EXTENT_M,
+    GRID_STEP_M,
+    ON_ROAD_LAYER,
+    ObservationMode,
+)
+
+# The ego sits in the middle cell of the occupancy grid, at (6, 6) for the shipped 12x12.
+_GRID_CENTRE = GRID_CELLS // 2
+
+# Offset from a cell index to the metre coordinate of that cell's centre.
+_CELL_CENTRE_OFFSET_M = GRID_HALF_EXTENT_M - 0.5 * GRID_STEP_M
+
+# A quadratic needs three points; below that the fit is not determined.
+_MIN_FIT_POINTS = 3
+
+# Arclength step used when rasterising the predicted lane centreline. Half a metre is a
+# sixth of a cell, fine enough that the marked cells are the ones the curve really crosses.
+LANE_SAMPLE_STEP_M = 0.5
+
+# How far along the predicted centreline to walk when rasterising it. Curvature and yaw both
+# stretch arclength relative to the grid's along-track axis, so a window's worth of cells
+# needs more than a window's worth of centreline.
+LANE_SAMPLE_REACH_M = 1.5 * GRID_HALF_EXTENT_M
+
+
+def _cell_centres_m(indices: Any) -> np.ndarray:
+    """Metre coordinate of the centre of each grid cell index, along either axis."""
+    return np.asarray(indices, dtype=float) * GRID_STEP_M - _CELL_CENTRE_OFFSET_M
+
+
+def _cell_indices(metres: np.ndarray) -> np.ndarray:
+    """Grid cell index containing each metre coordinate, along either axis."""
+    return np.floor((np.asarray(metres, dtype=float) + GRID_HALF_EXTENT_M) / GRID_STEP_M).astype(
+        int
+    )
+
+
+class ObservedTrackModel(RacetrackModelPOMDP):
+    """Generative racetrack model that reads its curvature out of the on-road layer.
+
+    Every decision, :meth:`encode_observation` fits the drivable corridor visible in the
+    observation and stores one signed curvature; the rollout that follows integrates the
+    Frenet pair against it. Unlike its known-track counterpart this model also *renders*
+    the on-road layer, from that same curvature plus the particle's own lane offset and
+    lane-relative angle, and scores it — the layer it reads has to be a layer it can also
+    produce, or the observations it samples in a rollout would show an all-clear corridor
+    on the approach to every corner.
+
+    Attributes:
+        curvature_window_m: Half-extent, along and across, of the cells the fit uses.
+        curvature_estimate: Signed curvature in 1/m from the most recent observation; zero
+            before any observation has been encoded.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(42)  # For reproducible results
+        >>>
+        >>> env = ObservedTrackModel(discount_factor=0.95)
+        >>>
+        >>> # Before any observation arrives the road is assumed straight
+        >>> env.curvature_estimate
+        0.0
+        >>>
+        >>> # A straight-ahead corridor keeps it there
+        >>> observation = np.zeros((2, 12, 12), dtype=np.float32)
+        >>> observation[1, :, 6] = 1.0
+        >>> _ = env.encode_observation(observation)
+        >>> abs(env.curvature_estimate) < 1e-9
+        True
+        >>>
+        >>> # Propagate a state cruising straight at the speed limit
+        >>> state = np.zeros(env.state_width)
+        >>> state[3] = 10.0  # speed, m/s
+        >>> next_state = env.sample_next_state(state, action=13)  # coast, straight ahead
+        >>> bool(next_state[0] > state[0])  # the ego moved forward
+        True
+
+    Note:
+        POMDP mode only. The MDP arm's observation is a table of vehicle kinematics with no
+        road in it at all, so this model has nothing to read and would silently drive
+        straight through every corner; the constructor refuses instead.
+    """
+
+    def __init__(
+        self,
+        discount_factor: float,
+        curvature_window_m: float = 12.0,
+        **model_kwargs: Any,
+    ) -> None:
+        """Initialize a racetrack model that infers the road from its observations.
+
+        Args:
+            discount_factor: Discount factor for future rewards (0 < d <= 1).
+            curvature_window_m: Cells further than this from the ego, along or across, are
+                dropped before fitting. Defaults to 12.0 m, which was swept against the
+                shipped circuit: the full 18 m window lets an unrelated part of the loop
+                passing nearby into the fit, and roughly doubles the error.
+            **model_kwargs: Every other argument of
+                :class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp.RacetrackModelPOMDP`,
+                forwarded unchanged.
+
+        Raises:
+            ValueError: If ``curvature_window_m`` is not positive, or if the model is asked
+                for the MDP observation arm, whose observation carries no road.
+        """
+        if curvature_window_m <= 0.0:
+            raise ValueError(f"curvature_window_m must be positive, got {curvature_window_m}.")
+        self.curvature_window_m = float(curvature_window_m)
+        self._curvature_estimate = 0.0
+        super().__init__(discount_factor=discount_factor, **model_kwargs)
+        if self.observation_mode is not ObservationMode.POMDP:
+            raise ValueError(
+                "ObservedTrackModel needs the POMDP occupancy observation: its whole premise "
+                "is reading the road out of the on-road layer, and the MDP arm's kinematics "
+                "table has no road in it. Use KnownTrackModel for the MDP arm."
+            )
+
+    @property
+    def curvature_estimate(self) -> float:
+        """Signed curvature in 1/m inferred from the most recent observation."""
+        return self._curvature_estimate
+
+    # ── Curvature from the on-road layer ─────────────────────────────────
+    def encode_observation(self, observation: Any) -> Dict[str, np.ndarray]:
+        """Encode the raw reading and refresh the model's curvature estimate.
+
+        Extends the base encoder with the one side effect this model is built around:
+        the on-road layer of the incoming grid is fitted and the result cached for the
+        rollouts that follow. Encoding an observation therefore *changes the transition
+        model*, which is unusual and deliberate — it is how a planner with no map learns
+        where the road goes.
+
+        Args:
+            observation: The raw ``(2, 12, 12)`` occupancy grid emitted by the world.
+
+        Returns:
+            ``{"occupancy": (2, 12, 12) float32}``, as the base class does.
+        """
+        encoded = super().encode_observation(observation)
+        self._curvature_estimate = self._fit_curvature(encoded[OCCUPANCY_KEY][ON_ROAD_LAYER])
+        return encoded
+
+    def _curvature_for(self, ego: np.ndarray) -> np.ndarray:
+        return np.full(len(ego), self._curvature_estimate, dtype=float)
+
+    def _fit_curvature(self, layer: np.ndarray) -> float:
+        """Signed curvature of the corridor visible in one on-road layer, in 1/m.
+
+        The fit is a plain quadratic ``across = a * along^2 + b * along + c`` through the
+        corridor centres, read as ``2a``.
+
+        The slope term of the textbook curvature formula, ``/(1 + b^2)^{3/2}``, is
+        deliberately absent. It divides out a corridor slope on the understanding that the
+        slope means the road runs obliquely across the window — but the dominant source of
+        ``b`` here is the ego's own yaw tilting the whole corridor, so the correction fires
+        when the road is doing nothing. It suppressed the estimate hardest exactly when the
+        car was most turned away from the lane, which is when it most needs to be told the
+        road bends. See the module docstring for the per-yaw-band measurements.
+
+        Before restoring it, know that two independent harnesses found the same monotonic
+        decline with yaw: a hand-placed sweep holding everything but yaw fixed deep inside
+        one arc, and a driven-episode sweep whose poses were never chosen at all. They
+        disagree on the absolute ratios, because they sample different parts of the track
+        and the driven one carries lateral offset and boundary effects the placed one
+        excludes, but they agree on the trend and on its direction. One harness showing this
+        would be worth doubting; two built on different principles is why it was safe to act
+        on. An earlier seven-point version of the placed sweep read as noise and was
+        dismissed — single estimates here have a standard deviation near 0.25, so any
+        re-test needs hundreds of samples per band, not a handful.
+        """
+        along, across = self._corridor_centres(np.asarray(layer, dtype=float) > 0.5)
+        if len(along) < _MIN_FIT_POINTS:
+            return 0.0
+        quadratic = float(np.polyfit(along, across, 2)[0])
+        return 2.0 * quadratic
+
+    def _corridor_centres(self, on_road: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """Mean across-track position of the on-road cells in each along-track row, in metres.
+
+        Rows with no on-road cell are skipped rather than filled: an empty row means the
+        window ran off the end of what the sensor can see, and inventing a centre for it
+        would bend the fit toward whatever value was invented.
+
+        The gate is counted in whole cells out from the ego's *cell*, not from the ego. At
+        the shipped 3 m resolution that rounds ``curvature_window_m`` down to a multiple of
+        3 and shifts the window half a cell forward and to one side, because the ego sits at
+        the corner of its cell rather than the middle of it. A quadratic fitted over a
+        shifted window still recovers the same curvature, so this costs nothing on a
+        constant-radius arc; it only matters where the curvature changes inside the window,
+        and there it is the window's 12 m reach that decides the answer, not its half-cell
+        offset.
+        """
+        window = int(np.floor(self.curvature_window_m / GRID_STEP_M))
+        low, high = _GRID_CENTRE - window, _GRID_CENTRE + window
+        along, across = [], []
+        for row in range(max(low, 0), min(high + 1, GRID_CELLS)):
+            columns = np.nonzero(on_road[row])[0]
+            columns = columns[(columns >= low) & (columns <= high)]
+            if columns.size == 0:
+                continue
+            along.append(_cell_centres_m(row))
+            across.append(_cell_centres_m(columns.mean()))
+        return np.asarray(along, dtype=float), np.asarray(across, dtype=float)
+
+    # ── Predicting the on-road layer back ────────────────────────────────
+    def _render_on_road_layer(self, state: Any) -> np.ndarray:
+        """Rasterise the ego's own lane centreline under the current curvature estimate.
+
+        One lane, not the whole road: the model has no idea how many lanes the circuit has
+        or which side they sit on, so it draws the only piece of road it can locate — the
+        centreline it is measuring its own offset from. The world's layer additionally shows
+        neighbouring lanes, which shows up in :meth:`_on_road_log_prob` as a fixed
+        disagreement on those cells rather than as anything that separates particles.
+        """
+        array = np.asarray(state, dtype=float)
+        lateral, angle = float(array[EGO_LAT]), float(array[EGO_ANG])
+        arclength = np.arange(
+            -LANE_SAMPLE_REACH_M, LANE_SAMPLE_REACH_M + LANE_SAMPLE_STEP_M, LANE_SAMPLE_STEP_M
+        )
+        # Centreline in the lane frame relative to the ego, then rotated into the body
+        # frame by the ego's lane-relative angle. The lane's own lateral axis is the body
+        # frame's across-track axis when the two are aligned, which is why a centreline the
+        # ego sits ``lateral`` metres from appears at ``-lateral`` across-track.
+        lane_across = 0.5 * self._curvature_estimate * arclength**2 - lateral
+        cos_a, sin_a = float(np.cos(angle)), float(np.sin(angle))
+        body_along = cos_a * arclength + sin_a * lane_across
+        body_across = -sin_a * arclength + cos_a * lane_across
+
+        layer = np.zeros((GRID_CELLS, GRID_CELLS), dtype=np.float32)
+        rows, columns = _cell_indices(body_along), _cell_indices(body_across)
+        inside = (rows >= 0) & (rows < GRID_CELLS) & (columns >= 0) & (columns < GRID_CELLS)
+        layer[rows[inside], columns[inside]] = 1.0
+        return layer
+
+    def _on_road_log_prob(self, state: Any, observation: Any) -> float:
+        observed = np.asarray(observation[OCCUPANCY_KEY], dtype=float)[ON_ROAD_LAYER] > 0.5
+        return self._bernoulli_cell_log_prob(self._render_on_road_layer(state) > 0.5, observed)
+
+
+__all__ = ["ObservedTrackModel"]

--- a/POMDPPlanners/environments/racetrack_pomdp/racetrack_pomdp.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/racetrack_pomdp.py
@@ -74,6 +74,9 @@ import numpy as np
 from POMDPPlanners.core.distributions import Distribution
 from POMDPPlanners.core.environment import Environment, SpaceInfo, SpaceType
 from POMDPPlanners.core.simulation.step_info_metrics import EpisodeReduction, StepInfoMetric
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import (
+    lane_curvature,
+)
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     AGENT_PRESENT,
     AGENT_REL_X,
@@ -131,22 +134,6 @@ class RacetrackMetric(Enum):
     NEAR_MISS_RATE = "near_miss_rate"
 
 
-def lane_curvature(lane: Any) -> float:
-    """Signed curvature of a highway-env lane, in 1/m.
-
-    Args:
-        lane: A highway-env lane object.
-
-    Returns:
-        ``0.0`` for a straight lane, otherwise ``direction / radius`` where ``direction``
-        is ``+1`` clockwise and ``-1`` counter-clockwise.
-    """
-    radius = getattr(lane, "radius", None)
-    if radius is None or float(radius) == 0.0:
-        return 0.0
-    return float(getattr(lane, "direction", 1.0)) / float(radius)
-
-
 class _RacetrackSession:
     """Live highway-env session: the only object in this package touching the backend."""
 
@@ -171,6 +158,7 @@ class _RacetrackSession:
         # unwrapped racetrack env.
         self._env: Any = gymnasium.make(env_id, config=config, render_mode=render_mode)
         self._max_tracked_agents = max_tracked_agents
+        self._lane_offsets: Dict[Any, float] = {}
 
     def render_frame(self) -> Optional[np.ndarray]:
         """Return the current bird's-eye frame, or None if not rendering."""
@@ -208,11 +196,39 @@ class _RacetrackSession:
                 float(vehicle.speed),
                 float(offset[1]),
                 float(offset[2]),
-                lane_curvature(vehicle.lane),
+                self._arclength_of(vehicle),
             ],
             dtype=float,
         )
         return np.concatenate([ego, self._read_agent_slots(vehicle)])
+
+    def _arclength_of(self, vehicle: Any) -> float:
+        """Distance travelled along the track centreline, in metres.
+
+        ``lane_offset`` is measured within the current lane, so it restarts at every
+        segment boundary. Adding the lap offset of that lane makes it monotonic around the
+        lap, which is what the planner's model indexes its curvature profile with.
+        """
+        lane_index = vehicle.lane_index
+        if lane_index not in self._lane_offsets:
+            self._lane_offsets = self._build_lane_offsets(lane_index)
+        local = float(np.asarray(vehicle.lane_offset, dtype=float)[0])
+        return self._lane_offsets.get(lane_index, 0.0) + local
+
+    def _build_lane_offsets(self, lane_index: Any) -> Dict[Any, float]:
+        """Cumulative lap offset of every lane reachable by following ``next_lane``."""
+        network = self._env.unwrapped.road.network
+        offsets: Dict[Any, float] = {}
+        total = 0.0
+        current = lane_index
+        for _ in range(64):
+            if current in offsets:
+                break
+            lane = network.get_lane(current)
+            offsets[current] = total
+            total += float(lane.length)
+            current = network.next_lane(current, position=lane.position(lane.length, 0))
+        return offsets
 
     def _read_agent_slots(self, ego: Any) -> np.ndarray:
         rows = np.zeros((self._max_tracked_agents, AGENT_SLOT_WIDTH), dtype=float)

--- a/POMDPPlanners/environments/racetrack_pomdp/racetrack_schema.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/racetrack_schema.py
@@ -26,14 +26,22 @@ flag is a dynamics key applied identically to both arms, so the matched pair is 
 **State layout** (identical in the world and in the model, on purpose — a wider world
 state is what makes CARLA's agent-slot reshape unsafe against a world vector)::
 
-    [x, y, heading, speed, lat, ang, curvature] + max_tracked_agents * [present, rel_x, rel_y, rel_vx, rel_vy]
+    [x, y, heading, speed, lat, ang, s] + max_tracked_agents * [present, rel_x, rel_y, rel_vx, rel_vy]
 
 The ego block is world-frame position in metres, heading in radians, scalar speed in m/s,
 then the Frenet terms: signed lateral offset from the lane centreline in metres, the angle
-between the heading and the lane direction in radians, and the signed curvature of the
-current lane in 1/m. Agent slots are in the ego body frame — ``rel_x`` forward, ``rel_y``
-left — and hold **relative** velocity, because that is exactly what differencing two
-ego-aligned occupancy grids can measure.
+between the heading and the lane direction in radians, and the distance travelled along the
+track centreline in metres.
+
+The last slot is deliberately the car's **arclength**, not the road's curvature. Curvature is
+a property of the road, so freezing it in the state encodes a prediction about the future
+rather than a fact about the present, and a rollout that reuses it drives straight through
+every corner. Where the road bends is the transition model's business: see
+:mod:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry`.
+
+Agent slots are in the ego body frame — ``rel_x`` forward, ``rel_y`` left — and hold
+**relative** velocity, because that is exactly what differencing two ego-aligned
+occupancy grids can measure.
 
 Classes:
     ObservationMode: Which observation the world emits; dynamics are unaffected.
@@ -55,7 +63,7 @@ EGO_HEADING = 2
 EGO_SPEED = 3
 EGO_LAT = 4
 EGO_ANG = 5
-EGO_CURVATURE = 6
+EGO_ARCLENGTH_M = 6
 
 AGENT_PRESENT = 0
 AGENT_REL_X = 1
@@ -78,19 +86,21 @@ ON_ROAD_LAYER = 1
 MAX_ACCELERATION_MPS2 = 5.0
 MAX_STEERING_RAD = np.pi / 4
 
-# A 3x3 grid of (acceleration, steering) commands, both normalised to [-1, 1].
+# Every acceleration crossed with every steering angle, both normalised to [-1, 1].
 # The planner selects an index into this tuple, so the world and the model share
 # one action vocabulary by construction rather than by convention.
-DEFAULT_ACTION_PRESETS: Tuple[Tuple[float, float], ...] = (
-    (1.0, -1.0),
-    (1.0, 0.0),
-    (1.0, 1.0),
-    (0.0, -1.0),
-    (0.0, 0.0),
-    (0.0, 1.0),
-    (-1.0, -1.0),
-    (-1.0, 0.0),
-    (-1.0, 1.0),
+# Steering is sampled finely near zero and coarsely at the extremes. Full lock is
+# pi/4 = 45 degrees, which on this track is a spin rather than a correction: sweeping
+# constant steering through the first bend, -1.0 survives 5 steps while -0.05 survives
+# 29. A bang-bang set of {-1, 0, +1} simply does not contain the manoeuvre the track
+# needs, so no amount of planning can select it.
+STEERING_PRESETS: Tuple[float, ...] = (-1.0, -0.25, -0.1, -0.05, 0.0, 0.05, 0.1, 0.25, 1.0)
+ACCELERATION_PRESETS: Tuple[float, ...] = (1.0, 0.0, -1.0)
+
+DEFAULT_ACTION_PRESETS: Tuple[Tuple[float, float], ...] = tuple(
+    (acceleration, steering)
+    for acceleration in ACCELERATION_PRESETS
+    for steering in STEERING_PRESETS
 )
 
 # ── Simulator defaults (racetrack-v0, verified against highway-env 1.12.1) ──

--- a/POMDPPlanners/environments/racetrack_pomdp/racetrack_track_geometry.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/racetrack_track_geometry.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: MIT
+
+"""Curvature of the racetrack as a function of distance along it.
+
+The planner's model needs to know where the road bends. Putting that in the *state* would
+be wrong: curvature is a property of the road, so a state slot holding it encodes a
+prediction about the future rather than a fact about the present, and a rollout that
+reuses one frozen value drives straight through every corner. Where the road bends belongs
+to the transition model, and this is how the transition model holds it.
+
+The circuit is exactly representable, which makes this cheap and precise rather than an
+approximation. Walking ``racetrack-v0``'s lane graph gives nine segments over 381.9 m, and
+every one is either a straight (curvature ``0``) or a circular arc (curvature
+``±1/radius``). So the curvature profile is **piecewise constant** — three short arrays,
+no polyline sampling and no numerical differentiation of a fitted spline.
+
+Only :func:`build_track_geometry` touches ``highway_env``, and it is called once when a
+model is constructed. :class:`TrackGeometry` itself is plain NumPy, so a model carrying one
+still pickles for Ray or Dask and still constructs on a machine with no simulator
+installed.
+
+Classes:
+    TrackGeometry: Piecewise-constant curvature indexed by arclength along the track.
+"""
+
+from dataclasses import dataclass
+from typing import Any, List, Tuple
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class TrackGeometry:
+    """Signed curvature of a closed track, as a function of distance along it.
+
+    Attributes:
+        segment_starts: Cumulative arclength in metres at the start of each segment,
+            ascending, beginning at ``0.0``.
+        segment_curvatures: Signed curvature of each segment in 1/m; ``0.0`` on a
+            straight, ``±1/radius`` on an arc.
+        total_length_m: Length of one lap in metres.
+
+    Example:
+        A square-ish loop of one straight and one arc::
+
+            >>> import numpy as np
+            >>> geometry = TrackGeometry(
+            ...     segment_starts=np.array([0.0, 10.0]),
+            ...     segment_curvatures=np.array([0.0, 0.05]),
+            ...     total_length_m=20.0,
+            ... )
+            >>> float(geometry.curvature_at(4.0))
+            0.0
+            >>> float(geometry.curvature_at(12.0))
+            0.05
+            >>> float(geometry.curvature_at(24.0))  # wraps around the lap
+            0.0
+    """
+
+    segment_starts: np.ndarray
+    segment_curvatures: np.ndarray
+    total_length_m: float
+
+    def curvature_at(self, arclength_m: Any) -> np.ndarray:
+        """Signed curvature at one or many distances along the track.
+
+        Args:
+            arclength_m: Distance along the centreline in metres. Scalar or array; values
+                outside one lap wrap around, so a rollout may run past the finish line.
+
+        Returns:
+            Curvature in 1/m, shaped like the input.
+        """
+        distance = np.mod(np.asarray(arclength_m, dtype=float), self.total_length_m)
+        index = np.searchsorted(self.segment_starts, distance, side="right") - 1
+        return self.segment_curvatures[np.clip(index, 0, len(self.segment_curvatures) - 1)]
+
+
+def lane_curvature(lane: Any) -> float:
+    """Signed curvature of a highway-env lane, in 1/m.
+
+    Args:
+        lane: A highway-env lane object.
+
+    Returns:
+        ``0.0`` for a straight lane, otherwise ``direction / radius`` where ``direction``
+        is ``+1`` clockwise and ``-1`` counter-clockwise.
+    """
+    radius = getattr(lane, "radius", None)
+    if radius is None or float(radius) == 0.0:
+        return 0.0
+    return float(getattr(lane, "direction", 1.0)) / float(radius)
+
+
+def build_track_geometry(
+    road_network: Any, lane_index: Any, max_segments: int = 64
+) -> TrackGeometry:
+    """Walk a closed lane loop and record its curvature against distance.
+
+    Follows ``next_lane`` from ``lane_index`` until the walk returns to where it started,
+    accumulating each segment's length and curvature.
+
+    Args:
+        road_network: A highway-env ``RoadNetwork``.
+        lane_index: The lane to start from, normally the ego's current lane.
+        max_segments: Guard against a network that never closes. Defaults to 64.
+
+    Returns:
+        The curvature profile of that lap.
+
+    Raises:
+        ValueError: If the walk does not return to its starting lane, which means the lane
+            sequence is not a closed loop and arclength would not wrap correctly.
+
+    Note:
+        Built for one lane. Parallel lanes on the same segment have different radii, so a
+        lane change invalidates the profile. The planner's model does not represent lane
+        changes, so this is consistent today, but it is a trap if that ever changes.
+    """
+    starts: List[float] = []
+    curvatures: List[float] = []
+    total = 0.0
+    current = lane_index
+    for _ in range(max_segments):
+        lane = road_network.get_lane(current)
+        starts.append(total)
+        curvatures.append(lane_curvature(lane))
+        total += float(lane.length)
+        current = road_network.next_lane(current, position=lane.position(lane.length, 0))
+        if current == lane_index:
+            return TrackGeometry(
+                segment_starts=np.asarray(starts, dtype=float),
+                segment_curvatures=np.asarray(curvatures, dtype=float),
+                total_length_m=total,
+            )
+    raise ValueError(
+        f"Lane walk from {lane_index} did not close into a loop within {max_segments} "
+        "segments; arclength cannot wrap on an open lane sequence."
+    )
+
+
+def geometry_from_world(world: Any) -> Tuple[TrackGeometry, Any]:
+    """Build the curvature profile of the lane the world's ego currently occupies.
+
+    Args:
+        world: A live :class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_pomdp.RacetrackPOMDP`
+            that has been reset at least once.
+
+    Returns:
+        The geometry and the lane index it was built for.
+    """
+    # pylint: disable=protected-access  # The session is the world's only backend handle.
+    unwrapped = world._get_session()._env.unwrapped
+    lane_index = unwrapped.vehicle.lane_index
+    return build_track_geometry(unwrapped.road.network, lane_index), lane_index
+
+
+__all__ = [
+    "TrackGeometry",
+    "build_track_geometry",
+    "geometry_from_world",
+    "lane_curvature",
+]

--- a/POMDPPlanners/environments/racetrack_pomdp/racetrack_vectorized_model.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/racetrack_vectorized_model.py
@@ -14,6 +14,23 @@ Every dynamics, reward and perception parameter is read off a live ``RacetrackMo
 instance, so the scalar model stays the single source of truth for configuration; only the
 numeric kernels are duplicated here, and the parity test pins the two together.
 
+**One torch model, two curvature sources.** The scalar side is abstract in exactly one
+place — :meth:`RacetrackModelPOMDP._curvature_for`, which answers where the road bends under
+each particle — and its two subclasses answer it from a track map and from the observation
+respectively. That difference is a single lookup, so it is a *parameter* here rather than a
+second module: :class:`RacetrackVectorizedModel` takes a curvature source, resolves the
+right one off the scalar model it is built from, and is otherwise one implementation. Two
+torch files differing in one line would drift.
+
+The map lookup is written in torch — a ``searchsorted`` over the segment starts — rather
+than by calling
+:meth:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry.TrackGeometry.curvature_at`
+and converting. That method is NumPy, so reusing it would mean a device round-trip *per
+substep*, which on CUDA is a synchronisation in the middle of the hot loop and defeats the
+point of batching. The profile is three short arrays of constants, so mirroring the lookup
+costs four lines and no accuracy: both sides take ``searchsorted(..., right) - 1`` on the
+same floored modulo.
+
 **Tensor layouts.** The state is the schema's own vector, ``EGO_STATE_WIDTH + K *
 AGENT_SLOT_WIDTH`` wide, and its column indices come from
 :mod:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_schema` rather than from
@@ -29,21 +46,35 @@ the protocol trades in ``[N, do]`` tensors rather than dictionaries:
 Note:
     The scalar model's deliberate approximations carry over unchanged, because reproducing
     it is the point: agent slots drift at constant velocity while the world drives them
-    with IDM, collisions use a centre-distance circle rather than an oriented rectangle,
-    and the lane curvature is held fixed over the horizon.
+    with IDM, and collisions use a centre-distance circle rather than an oriented rectangle.
+
+The on-road layer is parameterised the same way and dispatched on the same signal, because
+it is the same question asked twice: a model that reads the road out of its observations is
+exactly the model that has to predict the road back in order to score them, while a model
+holding a map gains nothing by rendering a layer every particle would agree on.
 
 Classes:
     RacetrackVectorizedModel: Batched torch counterpart of ``RacetrackModelPOMDP``.
 """
 
 import math
-from typing import Optional, Tuple
+import numbers
+from typing import Callable, Optional, Protocol, Tuple
 
 import numpy as np
 import torch
 from torch import Tensor
 
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp import RacetrackModelPOMDP
+
+# Imported from the mapless model rather than copied, deliberately. The torch rasteriser has
+# to sample the predicted centreline at exactly the points the scalar one does, or the two
+# layers disagree on the cells at either end of the sweep -- a difference the parity test
+# would catch, but only after someone had already shipped two definitions of the same road.
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_observed_track_model import (
+    LANE_SAMPLE_REACH_M,
+    LANE_SAMPLE_STEP_M,
+)
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     AGENT_PRESENT,
     AGENT_REL_VX,
@@ -51,7 +82,7 @@ from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     AGENT_REL_Y,
     AGENT_SLOT_WIDTH,
     EGO_ANG,
-    EGO_CURVATURE,
+    EGO_ARCLENGTH_M,
     EGO_HEADING,
     EGO_LAT,
     EGO_SPEED,
@@ -67,11 +98,40 @@ from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     PRESENCE_LAYER,
     ObservationMode,
 )
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import TrackGeometry
+
+# Given the ego block at the start of a substep, ``[N, EGO_STATE_WIDTH]``, return the signed
+# curvature in 1/m under each row, ``[N]``. The torch counterpart of the scalar model's
+# ``_curvature_for``, and the one thing that differs between a planner with a map and one
+# without.
+CurvatureSource = Callable[[Tensor], Tensor]
+
+# The public attribute a mapless scalar model exposes its per-step estimate on. Read by name
+# rather than by class, so a model does not have to be one of the two shipped ones.
+_CURVATURE_ESTIMATE_ATTR = "curvature_estimate"
+
+
+class RoadLayer(Protocol):
+    """What the model predicts the observation's on-road layer looks like, and its weight.
+
+    The second thing the scalar side leaves to its subclass. A model with a map does not
+    bother predicting the road; a model that reads the road out of its observations has to,
+    because that is what it scores them against.
+    """
+
+    def render(self, states: Tensor) -> Tensor:
+        """Predicted on-road layer per row, ``[N, 144]``, in the model's floating dtype."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    def log_probs(self, states: Tensor, observations: Tensor) -> Tensor:
+        """Contribution of the on-road layer to each row's log-likelihood, ``[N]``."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
 
 # Mirrors the scalar model: process noise touches the first six ego entries only, stopping
-# short of curvature, which is a property of the lane rather than a state the vehicle
-# diffuses through.
-_EGO_NOISE_WIDTH = EGO_CURVATURE
+# short of arclength. Arclength is integrated from the along-track rate, so jittering it
+# would teleport a particle to a different part of the circuit rather than blur its pose.
+_EGO_NOISE_WIDTH = EGO_ARCLENGTH_M
 
 # The ego sits in the middle cell of the occupancy grid, at (6, 6) for the shipped 12x12.
 _GRID_CENTRE = GRID_CELLS // 2
@@ -116,6 +176,228 @@ def _rotate(vectors: Tensor, angles: Tensor) -> Tensor:
     )
 
 
+class TrackMapCurvature:
+    """Torch mirror of ``TrackGeometry.curvature_at``: a table lookup by arclength.
+
+    Holds the profile as device tensors so the whole substep loop stays on one device. The
+    NumPy original is not called here on purpose — see the module docstring — but the two
+    agree by construction: the same floored modulo, the same ``searchsorted(..., right) - 1``
+    and the same clamp, so a rollout on the map cannot diverge between the two models.
+
+    Attributes:
+        total_length_m: Length of one lap in metres, the modulus the arclength wraps on.
+    """
+
+    def __init__(self, geometry: TrackGeometry, device: torch.device, dtype: torch.dtype) -> None:
+        """Move a curvature profile onto a device.
+
+        Args:
+            geometry: The lap's piecewise-constant curvature profile.
+            device: Device the lookup's tensors live on.
+            dtype: Floating dtype of the returned curvature.
+        """
+        # The starts are held in the *model's* dtype, matching the arclength they are
+        # compared against, and that is deliberate. In a float32 model the arclength itself
+        # is already rounded -- a boundary like 372.2208 m is off by up to 1.1e-5 m before
+        # the lookup sees it -- so holding the starts in float64 cannot recover the
+        # intended segment, and measurably makes it worse: on the shipped circuit's nine
+        # boundaries, float32 starts agree with NumPy on all nine and float64 starts on
+        # five. Matching dtypes is what makes a boundary compare equal.
+        self._starts = torch.as_tensor(
+            np.asarray(geometry.segment_starts, dtype=np.float64), dtype=dtype, device=device
+        )
+        self._curvatures = torch.as_tensor(
+            np.asarray(geometry.segment_curvatures, dtype=np.float64), dtype=dtype, device=device
+        )
+        self.total_length_m = float(geometry.total_length_m)
+
+    def __call__(self, ego: Tensor) -> Tensor:
+        distance = torch.remainder(ego[:, EGO_ARCLENGTH_M], self.total_length_m)
+        index = torch.searchsorted(self._starts, distance.contiguous(), right=True) - 1
+        return self._curvatures[index.clamp_(0, self._curvatures.shape[0] - 1)]
+
+
+class ObservedCurvature:
+    """A single estimated curvature, refreshed each real step and shared by every row.
+
+    The counterpart of :class:`TrackMapCurvature` for a planner with no map, which estimates
+    one curvature per step from what it can see and has nothing better to assume further
+    ahead. The value is read through a callable rather than copied in, because the estimate
+    is replaced on every real step while this model is built once: caching it would freeze
+    the planner on the corner it happened to start in.
+    """
+
+    def __init__(self, read_curvature: Callable[[], float]) -> None:
+        """Wrap a live per-step curvature estimate.
+
+        Args:
+            read_curvature: Zero-argument callable returning the current estimate in 1/m.
+        """
+        self._read_curvature = read_curvature
+
+    def __call__(self, ego: Tensor) -> Tensor:
+        return torch.full_like(ego[:, EGO_ARCLENGTH_M], float(self._read_curvature()))
+
+
+class AllRoadLayer:
+    """The base model's on-road layer: drivable everywhere, and worth nothing in a weight.
+
+    All-ones is the honest answer for a model with no picture of the road, and because it
+    does not depend on the state it is identical across every particle — so its likelihood
+    term shifts all the log-weights alike and vanishes at normalisation. Returning zero is
+    not a shortcut; it is the same number, without 144 cells of arithmetic per particle.
+    """
+
+    def __init__(self, dtype: torch.dtype, device: torch.device) -> None:
+        """Record the tensor kind the rendered layers should come back as."""
+        self._dtype = dtype
+        self._device = device
+
+    def render(self, states: Tensor) -> Tensor:
+        return torch.ones(states.shape[0], _GRID_CELL_COUNT, dtype=self._dtype, device=self._device)
+
+    def log_probs(self, states: Tensor, observations: Tensor) -> Tensor:
+        del observations
+        return torch.zeros(states.shape[0], dtype=self._dtype, device=self._device)
+
+
+class LaneCorridorLayer:
+    """The mapless model's on-road layer: its own lane centreline, drawn from one estimate.
+
+    One lane, not the whole road — the model has no idea how many lanes the circuit has, so
+    it draws the only piece of road it can locate, the centreline it measures its own offset
+    from. Unlike :class:`AllRoadLayer` this *does* depend on the state, through the ego's
+    lateral offset and lane-relative angle, so it separates particles and its likelihood has
+    to be scored rather than dropped.
+    """
+
+    def __init__(
+        self,
+        read_curvature: Callable[[], float],
+        cell_flip_prob: float,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> None:
+        """Build the corridor rasteriser.
+
+        Args:
+            read_curvature: Zero-argument callable returning the current estimate in 1/m.
+            cell_flip_prob: Per-cell probability that an on-road bit is read wrong.
+            dtype: Floating dtype of the rendered layers.
+            device: Device the rendered layers live on.
+        """
+        self._read_curvature = read_curvature
+        self._flip_prob = cell_flip_prob
+        self._dtype = dtype
+        self._device = device
+        # Built in NumPy with the scalar model's own arange arguments, then moved once. The
+        # sample points have to land on exactly the same cells as the scalar rasteriser's,
+        # and re-deriving the sequence in torch risks a different final element.
+        self._arclength = torch.as_tensor(
+            np.arange(
+                -LANE_SAMPLE_REACH_M,
+                LANE_SAMPLE_REACH_M + LANE_SAMPLE_STEP_M,
+                LANE_SAMPLE_STEP_M,
+            ),
+            dtype=dtype,
+            device=device,
+        )
+
+    def render(self, states: Tensor) -> Tensor:
+        lateral = states[:, EGO_LAT][:, None]
+        angle = states[:, EGO_ANG][:, None]
+        curvature = float(self._read_curvature())
+        # Centreline in the lane frame relative to the ego, then rotated into the body frame
+        # by the ego's lane-relative angle. A centreline the ego sits ``lateral`` metres from
+        # appears at ``-lateral`` across-track.
+        lane_across = 0.5 * curvature * self._arclength**2 - lateral
+        cos_a, sin_a = torch.cos(angle), torch.sin(angle)
+        body_along = cos_a * self._arclength + sin_a * lane_across
+        body_across = -sin_a * self._arclength + cos_a * lane_across
+        return self._scatter_cells(body_along, body_across)
+
+    def log_probs(self, states: Tensor, observations: Tensor) -> Tensor:
+        start = ON_ROAD_LAYER * _GRID_CELL_COUNT
+        observed = observations[:, start : start + _GRID_CELL_COUNT] > 0.5
+        return _bernoulli_cell_log_probs(
+            self.render(states) > 0.5, observed, self._flip_prob, self._dtype
+        )
+
+    def _scatter_cells(self, body_along: Tensor, body_across: Tensor) -> Tensor:
+        """Mark the cell each sample point falls in, dropping the ones off the window."""
+        rows = torch.floor((body_along + GRID_HALF_EXTENT_M) / GRID_STEP_M)
+        columns = torch.floor((body_across + GRID_HALF_EXTENT_M) / GRID_STEP_M)
+        inside = (rows >= 0.0) & (rows < GRID_CELLS) & (columns >= 0.0) & (columns < GRID_CELLS)
+        cell = (rows * GRID_CELLS + columns).to(torch.int64)
+        # One column wider than the grid, used as a bin for the sample points that fall
+        # outside it. Unlike the presence grid there is no always-set cell to redirect them
+        # onto, so the extra column is sliced off at the end instead.
+        sink = torch.full_like(cell, _GRID_CELL_COUNT)
+        flat = torch.zeros(
+            body_along.shape[0], _GRID_CELL_COUNT + 1, dtype=self._dtype, device=self._device
+        )
+        flat.scatter_(1, torch.where(inside, cell, sink), 1.0)
+        return flat[:, :_GRID_CELL_COUNT]
+
+
+def _bernoulli_cell_log_probs(
+    predicted: Tensor, observed: Tensor, flip_prob: float, dtype: torch.dtype
+) -> Tensor:
+    """Independent per-cell flip model over two boolean ``[N, cells]`` grids."""
+    agreements = (observed == predicted).sum(dim=1).to(dtype)
+    disagreements = float(predicted.shape[1]) - agreements
+    return agreements * math.log1p(-flip_prob) + disagreements * math.log(flip_prob)
+
+
+def _resolve_curvature_source(
+    env: RacetrackModelPOMDP, device: torch.device, dtype: torch.dtype
+) -> CurvatureSource:
+    """Pick the torch curvature lookup matching the scalar model's own ``_curvature_for``.
+
+    Dispatches on what the model exposes rather than on its class, so a third subclass with
+    a track map or a per-step estimate works without editing this module. Anything else is
+    rejected rather than defaulted to zero curvature: a silent straight-line model would
+    still run, still look plausible, and drive through every corner.
+    """
+    geometry = getattr(env, "track_geometry", None)
+    if isinstance(geometry, TrackGeometry):
+        return TrackMapCurvature(geometry, device, dtype)
+    if _has_curvature_estimate(env):
+        return ObservedCurvature(lambda: float(getattr(env, _CURVATURE_ESTIMATE_ATTR)))
+    raise ValueError(
+        f"Cannot infer a curvature source from {type(env).__name__}: it exposes neither a "
+        f"'track_geometry' nor a '{_CURVATURE_ESTIMATE_ATTR}'. Pass curvature_source= "
+        f"explicitly. Defaulting to zero curvature would give a model that runs, looks "
+        f"plausible, and drives straight through every corner."
+    )
+
+
+def _resolve_road_layer(
+    env: RacetrackModelPOMDP, device: torch.device, dtype: torch.dtype
+) -> RoadLayer:
+    """Pick the on-road layer matching the scalar model's ``_render_on_road_layer``.
+
+    Dispatched on the same signal as the curvature, and for the same reason: a model that
+    reads the road out of its observations is exactly the model that has to predict the road
+    back to score them, while a model holding a map gains nothing by rendering a layer every
+    particle would agree on.
+    """
+    if _has_curvature_estimate(env):
+        return LaneCorridorLayer(
+            lambda: float(getattr(env, _CURVATURE_ESTIMATE_ATTR)),
+            float(np.clip(env.cell_flip_prob, _FLIP_PROB_EPS, 1.0 - _FLIP_PROB_EPS)),
+            dtype,
+            device,
+        )
+    return AllRoadLayer(dtype, device)
+
+
+def _has_curvature_estimate(env: RacetrackModelPOMDP) -> bool:
+    # numbers.Real rather than float, so an estimate held as a NumPy scalar -- the natural
+    # thing to fall out of a fit over the on-road layer -- is recognised too.
+    return isinstance(getattr(env, _CURVATURE_ESTIMATE_ATTR, None), numbers.Real)
+
+
 def _hash_weights(count: int) -> np.ndarray:
     """Fixed pseudo-random odd int64 weights, one per observation entry.
 
@@ -145,26 +427,41 @@ class RacetrackVectorizedModel:
         num_actions: Number of discrete control presets.
         state_dim: Width of the state vectors (``EGO_STATE_WIDTH + K * AGENT_SLOT_WIDTH``).
         observation_dim: Width of the flattened observation vectors.
+        curvature_source: Where each substep's curvature comes from — a track map, a live
+            per-step estimate, or whatever the caller supplied.
+        road_layer: What the model predicts the observation's on-road layer looks like, and
+            what that prediction is worth in a weight.
 
     Example:
+        >>> import numpy as np
         >>> import torch
-        >>> from POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp import (
-        ...     RacetrackModelPOMDP,
+        >>> from POMDPPlanners.environments.racetrack_pomdp.racetrack_known_track_model import (
+        ...     KnownTrackModel,
+        ... )
+        >>> from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import (
+        ...     TrackGeometry,
         ... )
         >>> from POMDPPlanners.environments.racetrack_pomdp.racetrack_vectorized_model import (
         ...     RacetrackVectorizedModel,
         ... )
         >>> torch.manual_seed(0)  # doctest: +ELLIPSIS
         <torch._C.Generator object at ...>
-        >>> env = RacetrackModelPOMDP(discount_factor=0.95)
+        >>> geometry = TrackGeometry(  # a 10 m straight into a 10 m left-hand arc
+        ...     segment_starts=np.array([0.0, 10.0]),
+        ...     segment_curvatures=np.array([0.0, 0.05]),
+        ...     total_length_m=20.0,
+        ... )
+        >>> env = KnownTrackModel(discount_factor=0.95, track_geometry=geometry)
         >>> model = RacetrackVectorizedModel(env, device=torch.device("cpu"))
         >>> states = torch.zeros(3, model.state_dim)
         >>> states[:, 3] = 10.0  # speed, m/s
-        >>> actions = torch.full((3,), 4, dtype=torch.int64)  # coast, straight ahead
+        >>> actions = torch.full((3,), 13, dtype=torch.int64)  # coast, straight ahead
         >>> next_states = model.sample_next_states(states, actions)
         >>> rewards = model.rewards(states, actions, next_states)
         >>> tuple(next_states.shape), tuple(rewards.shape)
         ((3, 27), (3,))
+        >>> bool(next_states[0, 6] > 0.0)  # the arclength advanced along the track
+        True
     """
 
     def __init__(
@@ -174,6 +471,8 @@ class RacetrackVectorizedModel:
         device: Optional[torch.device] = None,
         dtype: torch.dtype = torch.float32,
         observation_resolution: float = 1.0,
+        curvature_source: Optional[CurvatureSource] = None,
+        road_layer: Optional[RoadLayer] = None,
     ) -> None:
         """Build the model from a live scalar racetrack model.
 
@@ -185,9 +484,17 @@ class RacetrackVectorizedModel:
             observation_resolution: Grid spacing used to quantize observations into integer
                 tree keys. Defaults to 1.0, which leaves the POMDP arm's already-binary
                 occupancy cells untouched and bins the MDP arm's metres.
+            curvature_source: Torch counterpart of the scalar model's ``_curvature_for``,
+                mapping an ego block to a per-row curvature. Defaults to None, which reads
+                a track map or a live per-step estimate off ``env``.
+            road_layer: Torch counterpart of the scalar model's ``_render_on_road_layer``
+                and ``_on_road_log_prob``. Defaults to None, which picks the corridor
+                render for a mapless model and the all-ones layer for every other.
 
         Raises:
-            ValueError: If ``observation_resolution`` is not positive.
+            ValueError: If ``observation_resolution`` is not positive, or if
+                ``curvature_source`` is omitted and ``env`` exposes neither a track map nor
+                a per-step curvature estimate.
         """
         if observation_resolution <= 0.0:
             raise ValueError(
@@ -200,6 +507,14 @@ class RacetrackVectorizedModel:
         self._num_agents = int(env.max_tracked_agents)
         self.state_dim = EGO_STATE_WIDTH + self._num_agents * AGENT_SLOT_WIDTH
         self.observation_dim = self._observation_width()
+        self.curvature_source: CurvatureSource = (
+            curvature_source
+            if curvature_source is not None
+            else _resolve_curvature_source(env, self.device, dtype)
+        )
+        self.road_layer: RoadLayer = (
+            road_layer if road_layer is not None else _resolve_road_layer(env, self.device, dtype)
+        )
         self._read_action_table(env)
         self._read_dynamics_params(env)
         self._read_reward_params(env)
@@ -303,7 +618,10 @@ class RacetrackVectorizedModel:
         """One explicit-Euler sub-interval, mirroring the scalar model's update order."""
         speed, heading = ego[:, EGO_SPEED], ego[:, EGO_HEADING]
         lateral, angle = ego[:, EGO_LAT], ego[:, EGO_ANG]
-        curvature = ego[:, EGO_CURVATURE]
+        # Read at the *start* of the substep, as the scalar model does, so a particle that
+        # crosses into a corner mid-decision picks the new curvature up on the next
+        # sub-interval rather than a whole decision late.
+        curvature = self.curvature_source(ego)
 
         yaw_rate = speed * torch.sin(slip) / self._wheelbase
         # The Frenet rates use the velocity direction ``ang + slip``, not the heading, so
@@ -312,8 +630,8 @@ class RacetrackVectorizedModel:
         denominator = torch.clamp_min(1.0 - curvature * lateral, _MIN_FRENET_DENOMINATOR)
         along_rate = speed * torch.cos(drift) / denominator
 
-        # Cloned rather than empty: curvature is carried over untouched, and a widened ego
-        # block would inherit its old value rather than uninitialised memory.
+        # Cloned rather than empty: a widened ego block would then carry its old values
+        # over rather than uninitialised memory.
         updated = ego.clone()
         updated[:, EGO_X] = ego[:, EGO_X] + speed * torch.cos(heading + slip) * self._step
         updated[:, EGO_Y] = ego[:, EGO_Y] + speed * torch.sin(heading + slip) * self._step
@@ -321,6 +639,10 @@ class RacetrackVectorizedModel:
         updated[:, EGO_LAT] = lateral + speed * torch.sin(drift) * self._step
         updated[:, EGO_ANG] = _wrap_to_pi(angle + (yaw_rate - curvature * along_rate) * self._step)
         updated[:, EGO_SPEED] = speed + acceleration * self._step
+        # Advanced by the along-track rate, not by ``speed * step``: the two differ once the
+        # ego is yawed relative to the lane or offset from its centreline on an arc, and it
+        # is the along-track one that indexes the curvature profile correctly.
+        updated[:, EGO_ARCLENGTH_M] = ego[:, EGO_ARCLENGTH_M] + along_rate * self._step
         return updated, self._drift_agents(agents, -yaw_rate * self._step)
 
     def _drift_agents(self, agents: Tensor, rotation: Tensor) -> Tensor:
@@ -449,18 +771,16 @@ class RacetrackVectorizedModel:
             device=self.device,
         )
         occupancy[:, PRESENCE_LAYER] = torch.logical_xor(grid, flips).to(self.dtype)
-        occupancy[:, ON_ROAD_LAYER] = 1.0
+        # The on-road layer is drawn without flip noise, as the scalar model draws it.
+        occupancy[:, ON_ROAD_LAYER] = self.road_layer.render(next_states)
         return occupancy.reshape(next_states.shape[0], -1)
 
     def _occupancy_log_probs(self, next_states: Tensor, observations: Tensor) -> Tensor:
         grid = self._render_presence_grid(next_states)
         start = PRESENCE_LAYER * _GRID_CELL_COUNT
         observed = observations[:, start : start + _GRID_CELL_COUNT] > 0.5
-        agreements = (observed == grid).sum(dim=1).to(self.dtype)
-        disagreements = float(_GRID_CELL_COUNT) - agreements
-        return agreements * math.log1p(-self._cell_flip_prob) + disagreements * math.log(
-            self._cell_flip_prob
-        )
+        presence = _bernoulli_cell_log_probs(grid, observed, self._cell_flip_prob, self.dtype)
+        return presence + self.road_layer.log_probs(next_states, observations)
 
     def _render_presence_grid(self, states: Tensor) -> Tensor:
         """Rasterise the presence layer as a flat ``[N, 144]`` boolean grid.
@@ -595,4 +915,12 @@ def _gaussian_log_prob(square_error: Tensor, count: Tensor, std: float) -> Tenso
     return -0.5 * square_error / variance - 0.5 * count * math.log(2.0 * math.pi * variance)
 
 
-__all__ = ["RacetrackVectorizedModel"]
+__all__ = [
+    "AllRoadLayer",
+    "CurvatureSource",
+    "LaneCorridorLayer",
+    "ObservedCurvature",
+    "RacetrackVectorizedModel",
+    "RoadLayer",
+    "TrackMapCurvature",
+]

--- a/POMDPPlanners/environments/racetrack_pomdp/racetrack_vectorized_model.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/racetrack_vectorized_model.py
@@ -1,0 +1,598 @@
+# SPDX-License-Identifier: MIT
+
+"""Torch, on-device vectorized generative model for the racetrack POMDP.
+
+This module provides :class:`RacetrackVectorizedModel`, a fully batched implementation of
+:class:`~POMDPPlanners.core.environment.vectorized_generative_model.VectorizedGenerativeModel`
+for :class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp.RacetrackModelPOMDP`.
+It re-expresses that model's kinematic-bicycle transition, Frenet integration, agent-slot
+drift, highway-env reward, collision terminal check and both observation arms as torch
+tensor kernels, so a vectorized planner (VOPP) can run tens of thousands of parallel
+simulations without a per-row Python loop or a host/device sync.
+
+Every dynamics, reward and perception parameter is read off a live ``RacetrackModelPOMDP``
+instance, so the scalar model stays the single source of truth for configuration; only the
+numeric kernels are duplicated here, and the parity test pins the two together.
+
+**Tensor layouts.** The state is the schema's own vector, ``EGO_STATE_WIDTH + K *
+AGENT_SLOT_WIDTH`` wide, and its column indices come from
+:mod:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_schema` rather than from
+literals here. The observation is the scalar model's encoded observation *flattened*, since
+the protocol trades in ``[N, do]`` tensors rather than dictionaries:
+
+* POMDP mode: the ``(2, 12, 12)`` occupancy grid in C order, so ``do = 288`` and
+  ``obs.reshape(2, 12, 12)`` recovers the array the scalar model's ``"occupancy"`` key
+  holds. The presence layer occupies the first 144 entries.
+* MDP mode: ``[x, y, vx, vy]`` followed by ``K`` agent slots, so ``do = 4 + 5 * K``, which
+  is the scalar model's ``"ego"`` and ``"agents"`` arrays concatenated.
+
+Note:
+    The scalar model's deliberate approximations carry over unchanged, because reproducing
+    it is the point: agent slots drift at constant velocity while the world drives them
+    with IDM, collisions use a centre-distance circle rather than an oriented rectangle,
+    and the lane curvature is held fixed over the horizon.
+
+Classes:
+    RacetrackVectorizedModel: Batched torch counterpart of ``RacetrackModelPOMDP``.
+"""
+
+import math
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp import RacetrackModelPOMDP
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
+    AGENT_PRESENT,
+    AGENT_REL_VX,
+    AGENT_REL_X,
+    AGENT_REL_Y,
+    AGENT_SLOT_WIDTH,
+    EGO_ANG,
+    EGO_CURVATURE,
+    EGO_HEADING,
+    EGO_LAT,
+    EGO_SPEED,
+    EGO_STATE_WIDTH,
+    EGO_X,
+    EGO_Y,
+    GRID_CELLS,
+    GRID_HALF_EXTENT_M,
+    GRID_STEP_M,
+    MAX_ACCELERATION_MPS2,
+    MAX_STEERING_RAD,
+    ON_ROAD_LAYER,
+    PRESENCE_LAYER,
+    ObservationMode,
+)
+
+# Mirrors the scalar model: process noise touches the first six ego entries only, stopping
+# short of curvature, which is a property of the lane rather than a state the vehicle
+# diffuses through.
+_EGO_NOISE_WIDTH = EGO_CURVATURE
+
+# The ego sits in the middle cell of the occupancy grid, at (6, 6) for the shipped 12x12.
+_GRID_CENTRE = GRID_CELLS // 2
+_GRID_CELL_COUNT = GRID_CELLS * GRID_CELLS
+_GRID_CENTRE_INDEX = _GRID_CENTRE * GRID_CELLS + _GRID_CENTRE
+
+# The shipped occupancy observation carries two feature layers: presence and on_road.
+_OCCUPANCY_LAYERS = 2
+
+# The MDP arm's ego row is [x, y, vx, vy].
+_EGO_OBS_WIDTH = 4
+
+# Floor for the Frenet denominator ``1 - curvature * lat``, which vanishes at the centre of
+# curvature and would otherwise divide by zero on a tight arc.
+_MIN_FRENET_DENOMINATOR = 1e-3
+
+# Keeps a flip probability of exactly 0 or 1 from turning a single mismatched cell into a
+# -inf log-likelihood, which would annihilate an otherwise good particle.
+_FLIP_PROB_EPS = 1e-12
+
+# Seeds the observation-hash weights. Fixed so belief-tree keys are reproducible across
+# processes; the particular value carries no meaning.
+_HASH_SEED = 20260809
+
+
+def _wrap_to_pi(angles: Tensor) -> Tensor:
+    """Wrap angles in radians to ``[-pi, pi)``, elementwise."""
+    return (angles + math.pi) % (2.0 * math.pi) - math.pi
+
+
+def _rotate(vectors: Tensor, angles: Tensor) -> Tensor:
+    """Rotate ``[N, K, 2]`` vectors counter-clockwise by a per-row angle ``[N]``."""
+    cos_a = torch.cos(angles)[:, None]
+    sin_a = torch.sin(angles)[:, None]
+    x_component, y_component = vectors[..., 0], vectors[..., 1]
+    return torch.stack(
+        [
+            cos_a * x_component - sin_a * y_component,
+            sin_a * x_component + cos_a * y_component,
+        ],
+        dim=-1,
+    )
+
+
+def _hash_weights(count: int) -> np.ndarray:
+    """Fixed pseudo-random odd int64 weights, one per observation entry.
+
+    Not the first ``count`` primes, which is the obvious choice and the wrong one here: the
+    POMDP arm's observation is a 288-entry *binary* vector, and a prime-weighted sum of a
+    handful of small primes lands in a range of a few thousand, so two genuinely different
+    occupancy grids collide onto one belief-tree node routinely. Weights spread over 48 bits
+    push the collision rate down to the point where it stops mattering, and a fixed seed
+    keeps the keys reproducible across processes.
+    """
+    generator = np.random.default_rng(_HASH_SEED)
+    return generator.integers(1, 2**48, size=count, dtype=np.int64) | 1
+
+
+class RacetrackVectorizedModel:
+    """Fully vectorized torch generative model for the racetrack POMDP.
+
+    Batches the transition, observation, reward, terminal and observation-likelihood
+    kernels over a leading particle dimension and keeps every tensor on one device. Actions
+    are integer indices into the scalar model's ``(acceleration, steering)`` preset table,
+    which is the same vocabulary the world uses.
+
+    Attributes:
+        device: Device every tensor argument and return value lives on.
+        dtype: Floating dtype used for state, observation and reward tensors.
+        observation_mode: Which arm of the matched pair this model observes in.
+        num_actions: Number of discrete control presets.
+        state_dim: Width of the state vectors (``EGO_STATE_WIDTH + K * AGENT_SLOT_WIDTH``).
+        observation_dim: Width of the flattened observation vectors.
+
+    Example:
+        >>> import torch
+        >>> from POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp import (
+        ...     RacetrackModelPOMDP,
+        ... )
+        >>> from POMDPPlanners.environments.racetrack_pomdp.racetrack_vectorized_model import (
+        ...     RacetrackVectorizedModel,
+        ... )
+        >>> torch.manual_seed(0)  # doctest: +ELLIPSIS
+        <torch._C.Generator object at ...>
+        >>> env = RacetrackModelPOMDP(discount_factor=0.95)
+        >>> model = RacetrackVectorizedModel(env, device=torch.device("cpu"))
+        >>> states = torch.zeros(3, model.state_dim)
+        >>> states[:, 3] = 10.0  # speed, m/s
+        >>> actions = torch.full((3,), 4, dtype=torch.int64)  # coast, straight ahead
+        >>> next_states = model.sample_next_states(states, actions)
+        >>> rewards = model.rewards(states, actions, next_states)
+        >>> tuple(next_states.shape), tuple(rewards.shape)
+        ((3, 27), (3,))
+    """
+
+    def __init__(
+        self,
+        env: RacetrackModelPOMDP,
+        *,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+        observation_resolution: float = 1.0,
+    ) -> None:
+        """Build the model from a live scalar racetrack model.
+
+        Args:
+            env: The scalar model whose parameters and presets are mirrored. Every
+                dynamics, reward and perception constant is read from it.
+            device: Target device; defaults to CPU.
+            dtype: Floating dtype for real-valued tensors.
+            observation_resolution: Grid spacing used to quantize observations into integer
+                tree keys. Defaults to 1.0, which leaves the POMDP arm's already-binary
+                occupancy cells untouched and bins the MDP arm's metres.
+
+        Raises:
+            ValueError: If ``observation_resolution`` is not positive.
+        """
+        if observation_resolution <= 0.0:
+            raise ValueError(
+                f"observation_resolution must be positive, got {observation_resolution}."
+            )
+        self.device = torch.empty(0, device=device).device
+        self.dtype = dtype
+        self.observation_mode = env.observation_mode
+        self._obs_resolution = float(observation_resolution)
+        self._num_agents = int(env.max_tracked_agents)
+        self.state_dim = EGO_STATE_WIDTH + self._num_agents * AGENT_SLOT_WIDTH
+        self.observation_dim = self._observation_width()
+        self._read_action_table(env)
+        self._read_dynamics_params(env)
+        self._read_reward_params(env)
+        self._read_perception_params(env)
+        self._obs_hash = torch.as_tensor(
+            _hash_weights(self.observation_dim), dtype=torch.int64, device=self.device
+        )
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers
+    # ------------------------------------------------------------------ #
+
+    def _observation_width(self) -> int:
+        if self.observation_mode is ObservationMode.POMDP:
+            return _OCCUPANCY_LAYERS * _GRID_CELL_COUNT
+        return _EGO_OBS_WIDTH + self._num_agents * AGENT_SLOT_WIDTH
+
+    def _read_action_table(self, env: RacetrackModelPOMDP) -> None:
+        """Precompute the per-action slip, acceleration and control effort in float64.
+
+        Deriving these in numpy and casting once keeps them bit-identical to the scalar
+        model's own ``arctan(0.5 * tan(delta))``, rather than re-deriving them in whatever
+        dtype the caller asked for.
+        """
+        presets = np.asarray(env.action_presets, dtype=np.float64)
+        self.num_actions = int(presets.shape[0])
+        self._slip = self._to_tensor(np.arctan(0.5 * np.tan(presets[:, 1] * MAX_STEERING_RAD)))
+        self._acceleration = self._to_tensor(presets[:, 0] * MAX_ACCELERATION_MPS2)
+        self._effort = self._to_tensor(np.linalg.norm(presets, axis=1))
+
+    def _read_dynamics_params(self, env: RacetrackModelPOMDP) -> None:
+        self._substeps = int(env.substeps)
+        self._step = float(env.dt) / self._substeps
+        self._wheelbase = float(env.vehicle_length) / 2.0
+        self._lane_half_width = float(env.lane_half_width)
+        self._collision_distance = float(env.collision_distance)
+        self._process_noise_std = float(env.process_noise_std)
+
+    def _read_reward_params(self, env: RacetrackModelPOMDP) -> None:
+        self._collision_reward = float(env.collision_reward)
+        self._lane_centering_cost = float(env.lane_centering_cost)
+        self._lane_centering_reward = float(env.lane_centering_reward)
+        self._action_reward = float(env.action_reward)
+
+    def _read_perception_params(self, env: RacetrackModelPOMDP) -> None:
+        self._cell_flip_prob = float(
+            np.clip(env.cell_flip_prob, _FLIP_PROB_EPS, 1.0 - _FLIP_PROB_EPS)
+        )
+        self._ego_pose_std = float(env.ego_pose_std)
+        self._agent_pose_std = float(env.agent_pose_std)
+        self._agent_velocity_std = float(env.agent_velocity_std)
+
+    def _to_tensor(self, array: np.ndarray) -> Tensor:
+        return torch.as_tensor(np.asarray(array), dtype=self.dtype, device=self.device)
+
+    def _agent_rows(self, states: Tensor) -> Tensor:
+        return states[:, EGO_STATE_WIDTH:].reshape(
+            states.shape[0], self._num_agents, AGENT_SLOT_WIDTH
+        )
+
+    # ------------------------------------------------------------------ #
+    # Transition
+    # ------------------------------------------------------------------ #
+
+    def sample_next_states(self, states: Tensor, actions: Tensor) -> Tensor:
+        """Propagate one decision forward per row, with the scalar model's process noise.
+
+        Args:
+            states: ``[N, state_dim]`` current states.
+            actions: ``[N]`` integer indices into the control presets.
+
+        Returns:
+            ``[N, state_dim]`` sampled next states.
+        """
+        return self._perturb(self.propagate(states, actions))
+
+    def propagate(self, states: Tensor, actions: Tensor) -> Tensor:
+        """Return the noise-free propagation of each row, the transition's mean.
+
+        Exposed because it is the deterministic kernel a parity test can compare exactly
+        and a planner may want when it is predicting rather than sampling.
+
+        Args:
+            states: ``[N, state_dim]`` current states.
+            actions: ``[N]`` integer indices into the control presets.
+
+        Returns:
+            ``[N, state_dim]`` propagated states, with no process noise added.
+        """
+        slip = self._slip[actions]
+        acceleration = self._acceleration[actions]
+        ego = states[:, :EGO_STATE_WIDTH].clone()
+        agents = self._agent_rows(states).clone()
+        for _ in range(self._substeps):
+            ego, agents = self._integrate_substep(ego, agents, slip, acceleration)
+        return torch.cat([ego, agents.reshape(states.shape[0], -1)], dim=1)
+
+    def _integrate_substep(
+        self, ego: Tensor, agents: Tensor, slip: Tensor, acceleration: Tensor
+    ) -> Tuple[Tensor, Tensor]:
+        """One explicit-Euler sub-interval, mirroring the scalar model's update order."""
+        speed, heading = ego[:, EGO_SPEED], ego[:, EGO_HEADING]
+        lateral, angle = ego[:, EGO_LAT], ego[:, EGO_ANG]
+        curvature = ego[:, EGO_CURVATURE]
+
+        yaw_rate = speed * torch.sin(slip) / self._wheelbase
+        # The Frenet rates use the velocity direction ``ang + slip``, not the heading, so
+        # the lane offset tracks the world-frame update the two lines above already make.
+        drift = angle + slip
+        denominator = torch.clamp_min(1.0 - curvature * lateral, _MIN_FRENET_DENOMINATOR)
+        along_rate = speed * torch.cos(drift) / denominator
+
+        # Cloned rather than empty: curvature is carried over untouched, and a widened ego
+        # block would inherit its old value rather than uninitialised memory.
+        updated = ego.clone()
+        updated[:, EGO_X] = ego[:, EGO_X] + speed * torch.cos(heading + slip) * self._step
+        updated[:, EGO_Y] = ego[:, EGO_Y] + speed * torch.sin(heading + slip) * self._step
+        updated[:, EGO_HEADING] = _wrap_to_pi(heading + yaw_rate * self._step)
+        updated[:, EGO_LAT] = lateral + speed * torch.sin(drift) * self._step
+        updated[:, EGO_ANG] = _wrap_to_pi(angle + (yaw_rate - curvature * along_rate) * self._step)
+        updated[:, EGO_SPEED] = speed + acceleration * self._step
+        return updated, self._drift_agents(agents, -yaw_rate * self._step)
+
+    def _drift_agents(self, agents: Tensor, rotation: Tensor) -> Tensor:
+        """Carry constant-velocity agent slots through one sub-interval of ego motion."""
+        positions = agents[..., AGENT_REL_X : AGENT_REL_X + 2]
+        velocities = agents[..., AGENT_REL_VX : AGENT_REL_VX + 2]
+        drifted = positions + velocities * self._step
+        moved = agents.clone()
+        # Absent slots are all-zero and stay all-zero: rotating the origin is the origin.
+        moved[..., AGENT_REL_X : AGENT_REL_X + 2] = _rotate(drifted, rotation)
+        moved[..., AGENT_REL_VX : AGENT_REL_VX + 2] = _rotate(velocities, rotation)
+        return moved
+
+    def _perturb(self, states: Tensor) -> Tensor:
+        if self._process_noise_std <= 0.0:
+            return states
+        noise = torch.randn(states.shape[0], _EGO_NOISE_WIDTH, dtype=self.dtype, device=self.device)
+        perturbed = states.clone()
+        perturbed[:, :_EGO_NOISE_WIDTH] += noise * self._process_noise_std
+        return perturbed
+
+    # ------------------------------------------------------------------ #
+    # Reward and termination
+    # ------------------------------------------------------------------ #
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        """Score each transition with highway-env's racetrack reward.
+
+        Args:
+            states: ``[N, state_dim]`` states the steps were taken from; unused, because the
+                reward reads the realised successor only.
+            actions: ``[N]`` integer indices into the control presets.
+            next_states: ``[N, state_dim]`` realised successors.
+
+        Returns:
+            ``[N]`` immediate rewards, zero wherever the ego has left the lane.
+        """
+        del states  # The reward scores the resulting state, as the world does.
+        lateral = next_states[:, EGO_LAT]
+        centering = self._lane_centering_reward / (1.0 + self._lane_centering_cost * lateral**2)
+        crashed = self._collision_mask(next_states).to(self.dtype)
+        raw = (
+            centering
+            + self._action_reward * self._effort[actions]
+            + self._collision_reward * crashed
+        )
+        # The upstream normalisation maps from [collision_reward, 1] using the literal 1,
+        # not lane_centering_reward, and does not clip. Both quirks are reproduced.
+        scaled = (raw - self._collision_reward) / (1.0 - self._collision_reward)
+        on_road = (lateral.abs() <= self._lane_half_width).to(self.dtype)
+        return scaled * on_road
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        """Flag rows where the ego has left the lane or is inside a tracked agent.
+
+        Args:
+            states: ``[N, state_dim]`` states to test.
+
+        Returns:
+            ``[N]`` boolean tensor, ``True`` where the state is terminal.
+        """
+        off_lane = states[:, EGO_LAT].abs() > self._lane_half_width
+        return off_lane | self._collision_mask(states)
+
+    def _collision_mask(self, states: Tensor) -> Tensor:
+        rows = self._agent_rows(states)
+        present = rows[..., AGENT_PRESENT] > 0.5
+        # sqrt of the summed squares, not torch.hypot: this has to agree with numpy's
+        # ``linalg.norm`` to the last bit, or a slot sitting exactly on the collision
+        # radius flips the terminal flag between the two implementations.
+        ranges = torch.sqrt(rows[..., AGENT_REL_X] ** 2 + rows[..., AGENT_REL_Y] ** 2)
+        return (present & (ranges <= self._collision_distance)).any(dim=1)
+
+    # ------------------------------------------------------------------ #
+    # Observation
+    # ------------------------------------------------------------------ #
+
+    def sample_observations(self, next_states: Tensor, actions: Tensor) -> Tensor:
+        """Draw one observation per row in this model's observation mode.
+
+        Args:
+            next_states: ``[N, state_dim]`` post-transition states.
+            actions: ``[N]`` action indices; unused, the observation depends on the state.
+
+        Returns:
+            ``[N, observation_dim]`` sampled observations, flattened as described in the
+            module docstring.
+        """
+        del actions  # The observation depends on the state alone.
+        if self.observation_mode is ObservationMode.POMDP:
+            return self._sample_occupancy(next_states)
+        return self._sample_kinematics(next_states)
+
+    def observation_log_probs(
+        self, next_states: Tensor, actions: Tensor, observations: Tensor
+    ) -> Tensor:
+        """Score each observation against its row's state.
+
+        In POMDP mode this is an independent Bernoulli over the 144 presence cells; the
+        on-road layer is excluded because it is identical across every particle and a term
+        that cannot discriminate has no business in a weight. In MDP mode it is a diagonal
+        Gaussian over the ego row and the *present* agent slots, with presence read from the
+        state rather than from the observation.
+
+        Args:
+            next_states: ``[N, state_dim]`` post-transition states.
+            actions: ``[N]`` action indices; unused, the observation depends on the state.
+            observations: ``[N, observation_dim]`` observations to score.
+
+        Returns:
+            ``[N]`` log-likelihoods.
+        """
+        del actions  # The observation depends on the state alone.
+        if self.observation_mode is ObservationMode.POMDP:
+            return self._occupancy_log_probs(next_states, observations)
+        return self._kinematics_log_probs(next_states, observations)
+
+    def _sample_occupancy(self, next_states: Tensor) -> Tensor:
+        grid = self._render_presence_grid(next_states)
+        flips = torch.rand(grid.shape, dtype=self.dtype, device=self.device) < self._cell_flip_prob
+        occupancy = torch.zeros(
+            next_states.shape[0],
+            _OCCUPANCY_LAYERS,
+            _GRID_CELL_COUNT,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        occupancy[:, PRESENCE_LAYER] = torch.logical_xor(grid, flips).to(self.dtype)
+        occupancy[:, ON_ROAD_LAYER] = 1.0
+        return occupancy.reshape(next_states.shape[0], -1)
+
+    def _occupancy_log_probs(self, next_states: Tensor, observations: Tensor) -> Tensor:
+        grid = self._render_presence_grid(next_states)
+        start = PRESENCE_LAYER * _GRID_CELL_COUNT
+        observed = observations[:, start : start + _GRID_CELL_COUNT] > 0.5
+        agreements = (observed == grid).sum(dim=1).to(self.dtype)
+        disagreements = float(_GRID_CELL_COUNT) - agreements
+        return agreements * math.log1p(-self._cell_flip_prob) + disagreements * math.log(
+            self._cell_flip_prob
+        )
+
+    def _render_presence_grid(self, states: Tensor) -> Tensor:
+        """Rasterise the presence layer as a flat ``[N, 144]`` boolean grid.
+
+        Axis 0 of the grid is along-track and axis 1 across-track, matching highway-env
+        1.12.1, and the ego is always written into the centre cell. A vehicle marks exactly
+        one cell, not a footprint.
+        """
+        rows = self._agent_rows(states)
+        along = torch.floor((rows[..., AGENT_REL_X] + GRID_HALF_EXTENT_M) / GRID_STEP_M)
+        across = torch.floor((rows[..., AGENT_REL_Y] + GRID_HALF_EXTENT_M) / GRID_STEP_M)
+        inside = (
+            (rows[..., AGENT_PRESENT] > 0.5)
+            & (along >= 0.0)
+            & (along < GRID_CELLS)
+            & (across >= 0.0)
+            & (across < GRID_CELLS)
+        )
+        cell = (along * GRID_CELLS + across).to(torch.int64)
+        # Out-of-window slots are redirected onto the ego's own centre cell, which is
+        # already set: writing there is a no-op, which is what "do not mark" means here.
+        index = torch.where(inside, cell, torch.full_like(cell, _GRID_CENTRE_INDEX))
+        flat = torch.zeros(states.shape[0], _GRID_CELL_COUNT, dtype=self.dtype, device=self.device)
+        flat[:, _GRID_CENTRE_INDEX] = 1.0
+        flat.scatter_(1, index, 1.0)
+        return flat > 0.5
+
+    def _clean_kinematics(self, states: Tensor) -> Tuple[Tensor, Tensor]:
+        """The noise-free MDP reading: the ego row and the state's own agent slots."""
+        speed, heading = states[:, EGO_SPEED], states[:, EGO_HEADING]
+        ego = torch.stack(
+            [
+                states[:, EGO_X],
+                states[:, EGO_Y],
+                speed * torch.cos(heading),
+                speed * torch.sin(heading),
+            ],
+            dim=1,
+        )
+        return ego, self._agent_rows(states)
+
+    def _sample_kinematics(self, next_states: Tensor) -> Tensor:
+        clean_ego, agents = self._clean_kinematics(next_states)
+        batch = next_states.shape[0]
+        ego = (
+            clean_ego
+            + torch.randn(batch, _EGO_OBS_WIDTH, dtype=self.dtype, device=self.device)
+            * self._ego_pose_std
+        )
+        present = (agents[..., AGENT_PRESENT] > 0.5)[..., None]
+        shape = (batch, self._num_agents, 2)
+        pose_noise = torch.randn(shape, dtype=self.dtype, device=self.device)
+        velocity_noise = torch.randn(shape, dtype=self.dtype, device=self.device)
+        observed = agents.clone()
+        observed[..., AGENT_REL_X : AGENT_REL_X + 2] += torch.where(
+            present, pose_noise * self._agent_pose_std, torch.zeros_like(pose_noise)
+        )
+        observed[..., AGENT_REL_VX : AGENT_REL_VX + 2] += torch.where(
+            present, velocity_noise * self._agent_velocity_std, torch.zeros_like(velocity_noise)
+        )
+        return torch.cat([ego, observed.reshape(batch, -1)], dim=1)
+
+    def _kinematics_log_probs(self, next_states: Tensor, observations: Tensor) -> Tensor:
+        clean_ego, agents = self._clean_kinematics(next_states)
+        observed = observations[:, _EGO_OBS_WIDTH:].reshape(
+            next_states.shape[0], self._num_agents, AGENT_SLOT_WIDTH
+        )
+        present = agents[..., AGENT_PRESENT] > 0.5
+        count = present.sum(dim=1).to(self.dtype)
+        positions = slice(AGENT_REL_X, AGENT_REL_X + 2)
+        velocities = slice(AGENT_REL_VX, AGENT_REL_VX + 2)
+        return (
+            _gaussian_log_prob(
+                ((observations[:, :_EGO_OBS_WIDTH] - clean_ego) ** 2).sum(dim=1),
+                torch.full_like(count, float(_EGO_OBS_WIDTH)),
+                self._ego_pose_std,
+            )
+            + _gaussian_log_prob(
+                self._masked_square_error(observed, agents, positions, present),
+                2.0 * count,
+                self._agent_pose_std,
+            )
+            + _gaussian_log_prob(
+                self._masked_square_error(observed, agents, velocities, present),
+                2.0 * count,
+                self._agent_velocity_std,
+            )
+        )
+
+    @staticmethod
+    def _masked_square_error(
+        observed: Tensor, agents: Tensor, columns: slice, present: Tensor
+    ) -> Tensor:
+        """Squared error over a slot's columns, summed over the *present* slots only."""
+        deviation = observed[..., columns] - agents[..., columns]
+        per_slot = (deviation**2).sum(dim=-1)
+        return torch.where(present, per_slot, torch.zeros_like(per_slot)).sum(dim=1)
+
+    # ------------------------------------------------------------------ #
+    # Tree keys
+    # ------------------------------------------------------------------ #
+
+    def action_keys(self, actions: Tensor) -> Tensor:
+        """Return the belief-tree key of each action index.
+
+        Args:
+            actions: ``[N]`` integer action indices.
+
+        Returns:
+            ``[N]`` int64 keys; the index is already a dense key.
+        """
+        return actions.to(torch.int64)
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        """Hash observations into integer belief-tree keys.
+
+        Args:
+            observations: ``[N, observation_dim]`` observations.
+
+        Returns:
+            ``[N]`` int64 keys: a weighted sum of the quantized entries, wrapping mod 2**64
+            on the rare row large enough to overflow. In POMDP mode the entries are already
+            binary, so the quantization is the identity and only the hashing is lossy.
+        """
+        quantized = torch.floor(observations / self._obs_resolution).to(torch.int64)
+        return (quantized * self._obs_hash).sum(dim=1)
+
+
+def _gaussian_log_prob(square_error: Tensor, count: Tensor, std: float) -> Tensor:
+    """Diagonal-Gaussian log-density from a summed squared error and a per-row term count."""
+    variance = std**2
+    return -0.5 * square_error / variance - 0.5 * count * math.log(2.0 * math.pi * variance)
+
+
+__all__ = ["RacetrackVectorizedModel"]

--- a/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_episode.py
+++ b/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_episode.py
@@ -23,6 +23,7 @@ from POMDPPlanners.core.belief import Belief, WeightedParticleBelief
 from POMDPPlanners.core.environment import SpaceType
 from POMDPPlanners.core.policy import Policy, PolicyRunData, PolicySpaceInfo
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_belief import TrackedAgentsBelief
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_known_track_model import KnownTrackModel
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp import RacetrackModelPOMDP
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_pomdp import (
     RacetrackMetric,
@@ -33,10 +34,12 @@ from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     AGENT_REL_VX,
     AGENT_REL_X,
     AGENT_SLOT_WIDTH,
+    DEFAULT_ACTION_PRESETS,
     EGO_STATE_WIDTH,
     ObservationMode,
     state_agent_rows,
 )
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import geometry_from_world
 from POMDPPlanners.simulations.episodes import run_episode
 
 pytest.importorskip("highway_env")
@@ -56,7 +59,22 @@ _POSITION_MATCH_TOLERANCE_M = 6.0
 # places an opponent itself.
 _OPPONENT_GAP_M = 10.0
 _OPPONENT_SPEED_MPS = 4.0
-_COAST_ONLY = 4
+
+
+def _preset(acceleration: float, steering: float) -> int:
+    """Index of a control preset, looked up rather than written as a literal.
+
+    The shipped table is a 3-by-9 grid of accelerations by steering angles, so every index
+    moves whenever the steering resolution changes. Naming the command keeps these tests
+    testing what they say they test.
+    """
+    return DEFAULT_ACTION_PRESETS.index((acceleration, steering))
+
+
+_COAST_ONLY = _preset(0.0, 0.0)
+# Coast, accelerate, coast, brake -- all straight ahead, so the ego stays on the lane long
+# enough for the episode to record something.
+_STRAIGHT_CYCLE = [_COAST_ONLY, _preset(1.0, 0.0), _COAST_ONLY, _preset(-1.0, 0.0)]
 
 
 class _FixedCyclePolicy(Policy):
@@ -221,15 +239,22 @@ def _build_triple(
         max_tracked_agents=_MAX_TRACKED_AGENTS,
         seed=seed,
     )
-    model = RacetrackModelPOMDP(
+    # Reset before the map is walked, and walk it from the world's own starting lane. The
+    # world writes arclength as an offset from that lane, so a map built from any other
+    # starting point would put its corners in the wrong place relative to the state the
+    # belief is seeded with -- consistent-looking numbers, silently misaligned track.
+    world.initial_state_dist().sample()
+    track_geometry, _ = geometry_from_world(world)
+    model = KnownTrackModel(
         discount_factor=0.95,
+        track_geometry=track_geometry,
         observation_mode=mode,
         max_tracked_agents=_MAX_TRACKED_AGENTS,
     )
     policy = _FixedCyclePolicy(
         environment=model,
         discount_factor=0.95,
-        actions=list(actions) if actions is not None else [4, 1, 4, 7],
+        actions=list(actions) if actions is not None else list(_STRAIGHT_CYCLE),
     )
     return world, model, policy
 

--- a/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_known_track_model.py
+++ b/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_known_track_model.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the racetrack model that plans with a map of the circuit.
+
+The base class's dynamics are covered in ``test_racetrack_model_pomdp``; what is left here
+is the one thing this subclass adds — curvature by arclength lookup — and the consequence
+that makes it worth having: a rollout that reaches a bend starts behaving like a bend.
+
+The last test is the load-bearing one. A model with a frozen curvature slot passes a
+straight-line tracking test perfectly and still cannot corner, so tracking the simulator on
+a straight proves nothing at all about the change this class exists to make.
+"""
+
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_known_track_model import KnownTrackModel
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp import RacetrackModelPOMDP
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_observed_track_model import (
+    ObservedTrackModel,
+)
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
+    EGO_ANG,
+    EGO_ARCLENGTH_M,
+    EGO_LAT,
+    EGO_SPEED,
+    GRID_CELLS,
+    ON_ROAD_LAYER,
+    STEERING_PRESETS,
+)
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import TrackGeometry
+
+COAST_STRAIGHT = 13
+# The coasting row of the preset table; add a steering index to select a command.
+COAST_ROW_BASE = 1 * len(STEERING_PRESETS)
+
+
+def _two_segment_geometry() -> TrackGeometry:
+    """A 100 m lap: 20 m of straight, then a left-hand arc for the rest."""
+    return TrackGeometry(
+        segment_starts=np.array([0.0, 20.0]),
+        segment_curvatures=np.array([0.0, -0.05]),
+        total_length_m=100.0,
+    )
+
+
+def _model(**overrides: Any) -> KnownTrackModel:
+    settings: Dict[str, Any] = {
+        "discount_factor": 0.95,
+        "process_noise_std": 0.0,
+        "track_geometry": _two_segment_geometry(),
+    }
+    settings.update(overrides)
+    return KnownTrackModel(**settings)
+
+
+def _cruising_state(model: KnownTrackModel, arclength: float) -> np.ndarray:
+    state = np.zeros(model.state_width, dtype=float)
+    state[EGO_SPEED] = 10.0
+    state[EGO_ARCLENGTH_M] = arclength
+    return state
+
+
+def test_curvature_is_read_from_the_map_at_each_particles_own_arclength():
+    """Test that the curvature hook indexes the map per particle, not per model.
+
+    Purpose: Particles in a belief sit at different points on the track, so a hook that
+        returned one curvature for the whole batch would put every particle on the same
+        piece of road and quietly destroy the spread the filter is maintaining
+
+    Given: A two-segment map, straight until 20 m and curving after it, and an ego block of
+        three rows at arclengths 5, 25 and 95 metres
+    When: The curvature hook is called on that block
+    Then: It returns the straight's zero for the first row and the arc's curvature for the
+        other two, matching the map's own lookup exactly
+
+    Test type: unit
+    """
+    # pylint: disable=protected-access
+    model = _model()
+    ego = np.zeros((3, 7), dtype=float)
+    ego[:, EGO_ARCLENGTH_M] = [5.0, 25.0, 95.0]
+
+    curvature = model._curvature_for(ego)
+
+    assert curvature.shape == (3,)
+    np.testing.assert_allclose(curvature, [0.0, -0.05, -0.05], atol=1e-12)
+
+
+def test_a_rollout_starts_bending_when_it_reaches_the_bend():
+    """Test that the curvature a rollout integrates changes underneath it.
+
+    Purpose: This is the whole point of indexing by arclength. A model holding one frozen
+        curvature for the horizon predicts that coasting straight keeps the ego on the
+        centreline forever, which is exactly the prediction that lets a planner drive into
+        a wall
+
+    Given: A two-segment map with the bend at 20 m, and a coasting state 6 m short of it
+    When: Twelve decisions of coast-straight are propagated
+    Then: The lane-relative angle and lateral offset stay at zero while the ego is on the
+        straight, and both grow away from it once it crosses into the arc. The signs follow
+        the map's own convention: a negative curvature turns the lane away from a
+        straight-driving ego, so its lane-relative angle and offset both go positive
+
+    Test type: unit
+    """
+    model = _model()
+    state = _cruising_state(model, arclength=14.0)
+    offsets: List[Tuple[float, float]] = []
+    for _ in range(12):
+        state = model.sample_next_state(state, COAST_STRAIGHT)
+        offsets.append((float(state[EGO_ARCLENGTH_M]), float(state[EGO_LAT])))
+
+    on_straight = [lateral for arclength, lateral in offsets if arclength <= 20.0]
+    in_bend = [lateral for arclength, lateral in offsets if arclength > 22.0]
+
+    assert on_straight, "the rollout should spend at least one step on the straight"
+    assert all(abs(lateral) < 1e-12 for lateral in on_straight)
+    assert in_bend[-1] > 1.0
+    assert float(state[EGO_ANG]) > 0.3
+
+
+def test_the_on_road_layer_is_neither_rendered_nor_scored():
+    """Test that this model leaves the observation's on-road layer alone.
+
+    Purpose: With a known track the layer is a function of arclength, which carries no
+        process noise, so every particle in a belief would predict the same road. A
+        likelihood term identical across particles shifts all the log-weights alike and
+        vanishes at normalisation; paying 144 cells of arithmetic per particle per step for
+        it would be pure cost
+
+    Given: A POMDP-mode model and two observations that differ *only* in the on-road layer
+    When: Observations are sampled, and both candidates are scored
+    Then: The sampled layer is all ones, and the two candidates score identically
+
+    Test type: unit
+    """
+    model = _model()
+    state = _cruising_state(model, arclength=5.0)
+
+    drawn = np.asarray(model.sample_observation(state, COAST_STRAIGHT)["occupancy"])
+    all_road = np.zeros((2, GRID_CELLS, GRID_CELLS), dtype=np.float32)
+    all_road[ON_ROAD_LAYER] = 1.0
+    no_road = all_road.copy()
+    no_road[ON_ROAD_LAYER] = 0.0
+    scores = model.observation_log_probability(
+        state, COAST_STRAIGHT, [{"occupancy": all_road}, {"occupancy": no_road}]
+    )
+
+    np.testing.assert_allclose(drawn[ON_ROAD_LAYER], 1.0)
+    assert scores[0] == pytest.approx(scores[1], abs=1e-12)
+
+
+def _steer_toward_the_centreline(state: np.ndarray) -> int:
+    """A crude lane-keeping controller, so a corner can be driven rather than crashed into."""
+    target = -0.35 * float(state[EGO_LAT]) - 1.2 * float(state[EGO_ANG])
+    return COAST_ROW_BASE + int(np.argmin([abs(preset - target) for preset in STEERING_PRESETS]))
+
+
+def _drive_through_the_first_corner(model: RacetrackModelPOMDP, steps: int) -> float:
+    """Largest lane-offset disagreement between ``model`` and the live world over ``steps``."""
+    # Imported here so this module still imports where highway-env is absent.
+    from POMDPPlanners.environments.racetrack_pomdp.racetrack_pomdp import (  # pylint: disable=import-outside-toplevel
+        RacetrackPOMDP,
+    )
+
+    world = RacetrackPOMDP(discount_factor=0.95, seed=0, other_vehicles=0)
+    truth = np.asarray(world.initial_state_dist().sample()[0], dtype=float)
+    predicted = truth.copy()
+    worst = 0.0
+    for _ in range(steps):
+        action = _steer_toward_the_centreline(truth)
+        predicted = model.sample_next_state(predicted, action)
+        truth = np.asarray(world.sample_next_state(truth, action), dtype=float)
+        worst = max(worst, abs(float(predicted[EGO_LAT]) - float(truth[EGO_LAT])))
+    return worst
+
+
+def test_the_map_model_tracks_the_live_simulator_through_a_corner(monkeypatch):
+    """Test that the predicted lane offset follows the simulator's around a bend.
+
+    Purpose: A straight-line tracking test is passed perfectly by a model that cannot
+        corner at all, so it certifies nothing. This drives the ego from its spawn on the
+        first straight into the first bend of ``racetrack-v0`` and compares the whole way
+
+    Given: A live world seeded at 0, a noise-free model carrying that world's own track map,
+        and a crude lane-keeping controller driving both from the world's true state
+    When: 35 decisions are applied, enough to spend roughly 20 of them inside the bend
+    Then: The worst lane-offset disagreement stays under 0.5 m, and a model that holds
+        curvature at zero — which is what the old frozen-curvature state slot amounted to —
+        is at least twice as wrong over the same drive
+
+    Test type: integration
+    """
+    pytest.importorskip("highway_env")
+    monkeypatch.setenv("SDL_VIDEODRIVER", "offscreen")
+    # Imported here so this module still imports where highway-env is absent.
+    from POMDPPlanners.environments.racetrack_pomdp.racetrack_pomdp import (  # pylint: disable=import-outside-toplevel
+        RacetrackPOMDP,
+    )
+    from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import (  # pylint: disable=import-outside-toplevel
+        geometry_from_world,
+    )
+
+    probe = RacetrackPOMDP(discount_factor=0.95, seed=0, other_vehicles=0)
+    probe.initial_state_dist().sample()
+    geometry, _ = geometry_from_world(probe)
+
+    mapped = _drive_through_the_first_corner(
+        KnownTrackModel(discount_factor=0.95, process_noise_std=0.0, track_geometry=geometry), 35
+    )
+    # ObservedTrackModel that is never shown an observation holds curvature at zero, which
+    # is exactly the behaviour of the model this refactor replaced.
+    flat = _drive_through_the_first_corner(
+        ObservedTrackModel(discount_factor=0.95, process_noise_std=0.0), 35
+    )
+
+    assert mapped < 0.5
+    assert flat > 2.0 * mapped

--- a/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_model_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_model_pomdp.py
@@ -1,11 +1,20 @@
 # SPDX-License-Identifier: MIT
 
-"""Tests for the planner-side racetrack generative model.
+"""Tests for the abstract planner-side racetrack generative model.
 
-Every test but the last is pure NumPy and never touches highway-env: the model exists so a
-planner can run without the simulator, and a test suite that needed the simulator to check
-the model would not be checking that. The last test is the exception on purpose — it is the
-only thing that can show the reproduced bicycle really tracks the one the world integrates.
+The class under test cannot be instantiated — it is abstract precisely because it does not
+know where the road bends — so everything here is exercised through the thinnest concrete
+subclass available, a
+:class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_known_track_model.KnownTrackModel`
+over a one-segment map. What is being checked is the *base* behaviour: the bicycle
+integration, the Frenet coupling, the densities, the rasteriser and the arclength slot.
+Behaviour specific to either subclass lives in its own file.
+
+Every test but the last two is pure NumPy and never touches highway-env: the model exists so
+a planner can run without the simulator, and a test suite that needed the simulator to check
+the model would not be checking that. The last two are the exception on purpose — they are
+the only things that can show the reproduced bicycle really tracks the one the world
+integrates.
 """
 
 from typing import Any, Dict
@@ -13,6 +22,7 @@ from typing import Any, Dict
 import numpy as np
 import pytest
 
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_known_track_model import KnownTrackModel
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp import RacetrackModelPOMDP
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     AGENT_PRESENT,
@@ -23,7 +33,7 @@ from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     AGENT_SLOT_WIDTH,
     DEFAULT_ACTION_PRESETS,
     EGO_ANG,
-    EGO_CURVATURE,
+    EGO_ARCLENGTH_M,
     EGO_HEADING,
     EGO_LAT,
     EGO_SPEED,
@@ -36,21 +46,41 @@ from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     ON_ROAD_LAYER,
     PRESENCE_LAYER,
     ObservationMode,
+    racetrack_reward,
 )
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import TrackGeometry
 
-# Indices into DEFAULT_ACTION_PRESETS, named so the tests read as driving commands.
-COAST_STRAIGHT = 4
-ACCELERATE_STRAIGHT = 1
-COAST_FULL_LEFT = 5
+# Indices into DEFAULT_ACTION_PRESETS, named so the tests read as driving commands. The
+# table is the 3 accelerations crossed with the 9 steering angles, acceleration major.
+COAST_STRAIGHT = 13
+ACCELERATE_STRAIGHT = 4
+COAST_FULL_LEFT = 17
 
 DT = 0.2
 
+# A map with one segment and no bends, so the base class's dynamics are exercised without
+# a subclass's curvature source doing anything interesting.
+_STRAIGHT_LAP_M = 1000.0
 
-def _model(**overrides: Any) -> RacetrackModelPOMDP:
-    """Build a model with deterministic dynamics unless a test asks for noise."""
-    settings: Dict[str, Any] = {"discount_factor": 0.95, "process_noise_std": 0.0}
+
+def _flat_geometry(curvature: float = 0.0) -> TrackGeometry:
+    """A single-segment lap of constant curvature."""
+    return TrackGeometry(
+        segment_starts=np.array([0.0]),
+        segment_curvatures=np.array([curvature]),
+        total_length_m=_STRAIGHT_LAP_M,
+    )
+
+
+def _model(**overrides: Any) -> KnownTrackModel:
+    """Build a model with deterministic dynamics on a straight map, unless asked otherwise."""
+    settings: Dict[str, Any] = {
+        "discount_factor": 0.95,
+        "process_noise_std": 0.0,
+        "track_geometry": _flat_geometry(),
+    }
     settings.update(overrides)
-    return RacetrackModelPOMDP(**settings)
+    return KnownTrackModel(**settings)
 
 
 def _ego_state(
@@ -60,7 +90,7 @@ def _ego_state(
     heading: float = 0.0,
     lateral: float = 0.0,
     angle: float = 0.0,
-    curvature: float = 0.0,
+    arclength: float = 0.0,
 ) -> np.ndarray:
     """A state with the given ego block and every agent slot empty."""
     state = np.zeros(model.state_width, dtype=float)
@@ -68,7 +98,7 @@ def _ego_state(
     state[EGO_HEADING] = heading
     state[EGO_LAT] = lateral
     state[EGO_ANG] = angle
-    state[EGO_CURVATURE] = curvature
+    state[EGO_ARCLENGTH_M] = arclength
     return state
 
 
@@ -99,15 +129,33 @@ def _occupancy(grid: np.ndarray) -> dict:
     return {"occupancy": occupancy}
 
 
+def test_the_base_model_cannot_be_instantiated_without_a_curvature_source():
+    """Test that the base class is abstract on the one method that matters.
+
+    Purpose: The base class deliberately does not know the track. Leaving it concrete with
+        a zero-curvature default would let a caller build a model that silently drives
+        straight through every corner, which is the exact bug the split exists to prevent
+
+    Given: The abstract RacetrackModelPOMDP class
+    When: It is constructed directly with otherwise valid arguments
+    Then: TypeError names the unimplemented curvature hook
+
+    Test type: unit
+    """
+    # pylint: disable=abstract-class-instantiated
+    with pytest.raises(TypeError, match="_curvature_for"):
+        RacetrackModelPOMDP(discount_factor=0.95)  # type: ignore[abstract]
+
+
 def test_actions_index_the_presets_and_hash_action_round_trips():
     """Test that the discrete action set enumerates the shared control presets.
 
     Purpose: Validates that the planner's action vocabulary is exactly the indices into
         the preset table the world also indexes, and that hashing an action is reversible
 
-    Given: A model built with the default nine-entry preset grid
+    Given: A model built with the default 27-entry preset grid
     When: get_actions() is enumerated and each action is hashed
-    Then: The actions are 0..8 in order and each hash equals the action itself
+    Then: The actions are 0..26 in order and each hash equals the action itself
 
     Test type: unit
     """
@@ -193,22 +241,57 @@ def test_non_zero_curvature_bends_the_lane_relative_angle():
         the ego does not, so the heading-versus-lane angle must drift negative on a
         left-curving lane
 
-    Given: Two identical coasting states differing only in curvature, 0.0 and 0.05 1/m
+    Given: Two identical coasting states, propagated by two models whose maps differ only
+        in curvature, 0.0 and 0.05 1/m
     When: Each is propagated one decision with no steering
     Then: The straight lane leaves the angle at zero while the curved lane makes it
         negative, at roughly -curvature * speed * dt
 
     Test type: unit
     """
-    model = _model()
     curvature = 0.05
+    flat = _model()
+    curved_model = _model(track_geometry=_flat_geometry(curvature))
 
-    straight = model.sample_next_state(_ego_state(model), COAST_STRAIGHT)
-    curved = model.sample_next_state(_ego_state(model, curvature=curvature), COAST_STRAIGHT)
+    straight = flat.sample_next_state(_ego_state(flat), COAST_STRAIGHT)
+    curved = curved_model.sample_next_state(_ego_state(curved_model), COAST_STRAIGHT)
 
     assert straight[EGO_ANG] == pytest.approx(0.0, abs=1e-12)
     assert curved[EGO_ANG] < 0.0
     assert curved[EGO_ANG] == pytest.approx(-curvature * 10.0 * DT, rel=0.05)
+
+
+def test_arclength_advances_monotonically_and_its_lookup_wraps_at_the_lap_seam():
+    """Test the arclength slot the curvature hook is indexed by.
+
+    Purpose: The slot replaced a frozen curvature value, and the whole point is that it
+        moves: a rollout has to walk along the track for a lookup by arclength to ever see
+        a different segment. It also has to survive crossing the finish line, which a
+        planning horizon on the last segment routinely does
+
+    Given: A one-segment 1000 m map, and a state seeded 4 m short of the lap seam
+    When: Ten coasting decisions are propagated from each of arclength 0 and 996
+    Then: The slot strictly increases on every step, advances by speed * dt per step on a
+        straight, and the map's own lookup wraps a past-the-seam arclength back onto the
+        first segment rather than clamping to the last
+
+    Test type: unit
+    """
+    model = _model()
+    state = _ego_state(model)
+    history = [float(state[EGO_ARCLENGTH_M])]
+    for _ in range(10):
+        state = model.sample_next_state(state, COAST_STRAIGHT)
+        history.append(float(state[EGO_ARCLENGTH_M]))
+
+    assert all(later > earlier for earlier, later in zip(history, history[1:]))
+    assert history[-1] == pytest.approx(10 * 10.0 * DT, abs=1e-9)
+
+    past_seam = _ego_state(model, arclength=_STRAIGHT_LAP_M - 4.0)
+    for _ in range(10):
+        past_seam = model.sample_next_state(past_seam, COAST_STRAIGHT)
+    assert past_seam[EGO_ARCLENGTH_M] > _STRAIGHT_LAP_M
+    assert float(model.track_geometry.curvature_at(past_seam[EGO_ARCLENGTH_M])) == 0.0
 
 
 def test_sample_next_state_batch_matches_a_seeded_loop_over_sample_next_state():
@@ -239,6 +322,29 @@ def test_sample_next_state_batch_matches_a_seeded_loop_over_sample_next_state():
 
     assert batched.shape == (5, model.state_width)
     np.testing.assert_array_equal(batched, looped)
+
+
+def test_process_noise_leaves_the_arclength_slot_alone():
+    """Test that the transition's noise stops short of the arclength slot.
+
+    Purpose: Arclength is not an independent coordinate but the integral of the ego's own
+        motion, and a known-track model indexes its curvature profile with it. Jittering it
+        would scatter particles onto different parts of the circuit for no modelling reason
+
+    Given: A noisy model and one particle propagated many times from the same state
+    When: The successors' arclength slots are compared
+    Then: Every draw carries exactly the same arclength, while the ego position does vary
+
+    Test type: unit
+    """
+    model = _model(process_noise_std=0.1)
+    state = _ego_state(model, arclength=25.0)
+
+    draws = model.sample_next_state(state, COAST_STRAIGHT, n_samples=32)
+
+    assert len(np.unique(draws[:, EGO_ARCLENGTH_M])) == 1
+    assert draws[0, EGO_ARCLENGTH_M] == pytest.approx(25.0 + 10.0 * DT, abs=1e-9)
+    assert len(np.unique(draws[:, EGO_X])) > 1
 
 
 def test_transition_log_probability_is_finite_and_peaks_at_the_deterministic_successor():
@@ -286,6 +392,41 @@ def test_transition_log_probability_rejects_a_noise_free_model():
 
     with pytest.raises(ValueError, match="point mass"):
         model.transition_log_probability(state, COAST_STRAIGHT, [state])
+
+
+def test_reward_matches_the_shared_racetrack_reward_on_the_resulting_state():
+    """Test that the model scores a transition with the world's own reward function.
+
+    Purpose: The world and the planner call one reward function so the planner cannot be
+        optimising a different objective; that only holds if the model feeds it the same
+        arguments the world does — the *resulting* lateral offset and the applied command
+
+    Given: A coasting state and its deterministic successor
+    When: reward is called with the successor and, separately, with the successor left out
+    Then: Both equal racetrack_reward evaluated on the successor's lateral offset with this
+        model's own weights, and the off-road case scores exactly zero
+
+    Test type: unit
+    """
+    model = _model()
+    state = _ego_state(model, lateral=0.4)
+    successor = model.sample_next_state(state, COAST_FULL_LEFT)
+    expected = racetrack_reward(
+        float(successor[EGO_LAT]),
+        model.action_presets[COAST_FULL_LEFT],
+        False,
+        True,
+        collision_reward=model.collision_reward,
+        lane_centering_cost=model.lane_centering_cost,
+        lane_centering_reward=model.lane_centering_reward,
+        action_reward=model.action_reward,
+    )
+
+    assert model.reward(state, COAST_FULL_LEFT, successor) == pytest.approx(expected, abs=1e-12)
+    assert model.reward(state, COAST_FULL_LEFT) == pytest.approx(expected, abs=1e-12)
+
+    off_road = _ego_state(model, lateral=model.lane_half_width + 1.0)
+    assert model.reward(off_road, COAST_STRAIGHT, off_road) == pytest.approx(0.0, abs=1e-12)
 
 
 def test_is_terminal_fires_off_road_and_on_a_near_agent_but_not_in_the_clear():
@@ -369,6 +510,31 @@ def test_pomdp_observation_log_probability_prefers_the_matching_grid():
     assert log_probs[0] > log_probs[1]
 
 
+def test_pomdp_sample_observation_returns_the_two_layer_grid_the_world_emits():
+    """Test the shape and layer count of a sampled occupancy observation.
+
+    Purpose: The belief and the vectorized model both reshape this array by position, so a
+        model that emitted a single layer, or the layers transposed, would be caught only
+        far downstream
+
+    Given: A POMDP-mode model and a state with one agent ahead
+    When: Three observations are drawn
+    Then: Each is a dict holding one (2, 12, 12) array whose presence layer is binary
+
+    Test type: unit
+    """
+    model = _model(observation_mode=ObservationMode.POMDP)
+    state = _place_agent(_ego_state(model), slot=0, rel_x=9.0, rel_y=-3.0)
+
+    draws = model.sample_observation(state, COAST_STRAIGHT, n_samples=3)
+
+    assert len(draws) == 3
+    for draw in draws:
+        grid = np.asarray(draw["occupancy"])
+        assert grid.shape == (2, GRID_CELLS, GRID_CELLS)
+        assert set(np.unique(grid[PRESENCE_LAYER])).issubset({0.0, 1.0})
+
+
 def test_mdp_encode_observation_rotates_absolute_rows_into_the_ego_body_frame():
     """Test that the MDP encoder converts absolute vehicle rows to ego-relative ones.
 
@@ -403,10 +569,13 @@ def _track_live_world(action: int, steps: int = 10) -> tuple:
     from POMDPPlanners.environments.racetrack_pomdp.racetrack_pomdp import (  # pylint: disable=import-outside-toplevel
         RacetrackPOMDP,
     )
+    from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import (  # pylint: disable=import-outside-toplevel
+        geometry_from_world,
+    )
 
     world = RacetrackPOMDP(discount_factor=0.95, seed=0, other_vehicles=0)
-    model = _model()
     truth = np.asarray(world.initial_state_dist().sample()[0], dtype=float)
+    model = _model(track_geometry=geometry_from_world(world)[0])
     predicted = truth.copy()
     for _ in range(steps):
         predicted = model.sample_next_state(predicted, action)
@@ -422,19 +591,26 @@ def test_model_tracks_the_live_simulator_over_ten_coasting_steps(monkeypatch):
         and comparing the ego pose is what rules that out
 
     Given: A live racetrack world seeded at 0 with no extra opponents, and a noise-free
-        model started from the world's true state
+        model started from the world's true state and carrying the world's own track map
     When: Ten coast-straight decisions are applied to both, the model propagating from its
         own prediction rather than being re-synchronised
-    Then: The predicted (x, y, heading, lateral offset) stays within 1e-6 of the
+    Then: The predicted (x, y, heading, lateral offset, arclength) stays within 1e-6 of the
         simulator's. The tolerance is tight on purpose: the ego update is reproduced term
         for term, so the only expected difference is float accumulation over thirty
         substeps — the measured error at this seed is in fact exactly zero, and anything
         near 1e-6 would already be a real disagreement rather than drift
 
+    Note:
+        The arclength comparison is only valid because ten steps from the spawn point do
+        not reach the lap seam. The world derives arclength from lane offsets, so it wraps
+        into ``[0, lap)``; the model integrates it and leaves it unbounded, exactly as
+        ``curvature_at`` expects. Extend this drive past a full lap and the two must be
+        compared modulo the lap length, the same caveat heading already carries
+
     Test type: integration
     """
     pytest.importorskip("highway_env")
-    monkeypatch.setenv("SDL_VIDEODRIVER", "dummy")
+    monkeypatch.setenv("SDL_VIDEODRIVER", "offscreen")
 
     predicted, truth = _track_live_world(COAST_STRAIGHT)
 
@@ -442,6 +618,7 @@ def test_model_tracks_the_live_simulator_over_ten_coasting_steps(monkeypatch):
     assert abs(predicted[EGO_Y] - truth[EGO_Y]) < 1e-6
     assert abs(predicted[EGO_HEADING] - truth[EGO_HEADING]) < 1e-6
     assert abs(predicted[EGO_LAT] - truth[EGO_LAT]) < 1e-6
+    assert abs(predicted[EGO_ARCLENGTH_M] - truth[EGO_ARCLENGTH_M]) < 1e-6
 
 
 def test_model_tracks_the_live_simulator_through_a_full_lock_arc(monkeypatch):
@@ -455,15 +632,12 @@ def test_model_tracks_the_live_simulator_through_a_full_lock_arc(monkeypatch):
     Given: The same seeded world and noise-free model
     When: Ten full-lock left decisions are applied to both
     Then: Position, heading and lateral offset all match to 1e-6. Heading is compared
-        modulo 2*pi because the model wraps to [-pi, pi) and highway-env does not; the
-        lateral check holds while the ego stays over one lane segment, which this 2 s arc
-        does — a manoeuvre that crossed to the neighbouring lane would jump by a lane width,
-        and that is a limit of the fixed-curvature model, not a defect in the integration
+        modulo 2*pi because the model wraps to [-pi, pi) and highway-env does not
 
     Test type: integration
     """
     pytest.importorskip("highway_env")
-    monkeypatch.setenv("SDL_VIDEODRIVER", "dummy")
+    monkeypatch.setenv("SDL_VIDEODRIVER", "offscreen")
 
     predicted, truth = _track_live_world(COAST_FULL_LEFT)
 

--- a/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_observed_track_model.py
+++ b/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_observed_track_model.py
@@ -1,0 +1,398 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the racetrack model that reads the road out of its observations.
+
+Two kinds of test live here and they are not interchangeable. The pure-NumPy ones build a
+corridor with :meth:`ObservedTrackModel._render_on_road_layer` and check the estimator
+recovers it — useful, but self-consistent by construction, so they cannot tell you the sign
+convention is right. The sign and the rough magnitude are pinned against a *live* circuit
+and its :class:`TrackGeometry` profile instead, which is the only comparison that could
+catch an across-track axis pointing the other way.
+"""
+
+from typing import Any, Dict
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_observed_track_model import (
+    ObservedTrackModel,
+)
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
+    EGO_ANG,
+    EGO_ARCLENGTH_M,
+    EGO_LAT,
+    EGO_SPEED,
+    GRID_CELLS,
+    ON_ROAD_LAYER,
+    PRESENCE_LAYER,
+    ObservationMode,
+)
+
+COAST_STRAIGHT = 13
+
+# The bends on the shipped racetrack run from 1/30 to 1/15 per metre, so a synthetic
+# corridor at 0.05 is a representative one.
+_SYNTHETIC_CURVATURE = 0.05
+
+
+def _model(**overrides: Any) -> ObservedTrackModel:
+    settings: Dict[str, Any] = {"discount_factor": 0.95, "process_noise_std": 0.0}
+    settings.update(overrides)
+    return ObservedTrackModel(**settings)
+
+
+def _cruising_state(model: ObservedTrackModel, lateral: float = 0.0) -> np.ndarray:
+    state = np.zeros(model.state_width, dtype=float)
+    state[EGO_SPEED] = 10.0
+    state[EGO_LAT] = lateral
+    return state
+
+
+def _corridor_observation(curvature: float, lateral: float = 0.0) -> Dict[str, np.ndarray]:
+    """A raw occupancy grid whose on-road layer is one lane of the given curvature."""
+    # pylint: disable=protected-access
+    renderer = _model()
+    renderer._curvature_estimate = curvature
+    state = _cruising_state(renderer, lateral=lateral)
+    grid = np.zeros((2, GRID_CELLS, GRID_CELLS), dtype=np.float32)
+    grid[PRESENCE_LAYER, 6, 6] = 1.0
+    grid[ON_ROAD_LAYER] = renderer._render_on_road_layer(state)
+    return {"occupancy": grid}
+
+
+def test_curvature_is_zero_before_any_observation_has_been_encoded():
+    """Test the estimate a fresh model starts from.
+
+    Purpose: A model that has not yet seen the road has to assume something, and a straight
+        is the only defensible assumption. Leaving the attribute unset, or seeded from a
+        previous episode, would make the first decision of every episode depend on history
+        the model does not have
+
+    Given: A freshly constructed model
+    When: Its curvature estimate is read and a state is propagated
+    Then: The estimate is exactly zero and the rollout stays on the centreline
+
+    Test type: unit
+    """
+    model = _model()
+    state = _cruising_state(model)
+
+    for _ in range(10):
+        state = model.sample_next_state(state, COAST_STRAIGHT)
+
+    assert model.curvature_estimate == 0.0
+    assert float(state[EGO_LAT]) == pytest.approx(0.0, abs=1e-12)
+    assert float(state[EGO_ARCLENGTH_M]) == pytest.approx(20.0, abs=1e-9)
+
+
+def test_the_mdp_arm_is_refused_rather_than_silently_driving_straight():
+    """Test that a model with nothing to read is rejected at construction.
+
+    Purpose: The MDP observation is a table of vehicle kinematics with no road in it. A
+        model built against it would hold curvature at zero for the whole episode and drive
+        into the first corner, and the failure would look like a planning bug rather than a
+        configuration one
+
+    Given: A request for this model in MDP observation mode
+    When: It is constructed
+    Then: ValueError names the missing road and points at the known-track model
+
+    Test type: configuration
+    """
+    with pytest.raises(ValueError, match="on-road layer"):
+        _model(observation_mode=ObservationMode.MDP)
+
+    with pytest.raises(ValueError, match="curvature_window_m must be positive"):
+        _model(curvature_window_m=0.0)
+
+
+def test_the_estimate_recovers_a_synthetic_corridors_sign_and_ordering():
+    """Test the estimator against corridors of known curvature.
+
+    Purpose: Fixes the estimator's internal consistency — that fitting the corridor centres
+        and reading 2a off the quadratic recovers the curvature that drew them, with the
+        sign preserved rather than flipped by the across-track axis, and with a bigger bend
+        reading as a bigger number
+
+    Given: Occupancy grids whose on-road layer is a single-lane corridor drawn at 0, 0.033,
+        0.05 and 0.067 1/m, in both signs
+    When: Each is encoded
+    Then: The sign is preserved, the magnitudes come out in the same order as the drawn
+        curvatures, and a straight corridor estimates below 0.005 1/m
+
+    Note: The scale is deliberately *not* asserted here. A single lane line quantised into
+        3 m cells loses roughly a third of the amplitude, and a round trip through this
+        model's own renderer would only measure that quantisation. Scale is pinned against
+        the live circuit instead, where the corridor is two lane lines and the row mean
+        lands between cells
+
+    Test type: unit
+    """
+    model = _model()
+    magnitudes = []
+    for curvature in (0.0, 0.033, _SYNTHETIC_CURVATURE, 0.067):
+        for sign in (1.0, -1.0):
+            model.encode_observation(_corridor_observation(sign * curvature)["occupancy"])
+            if curvature > 0.0:
+                assert np.sign(model.curvature_estimate) == sign
+        magnitudes.append(abs(model.curvature_estimate))
+
+    assert magnitudes[0] < 5e-3
+    assert all(later > earlier for earlier, later in zip(magnitudes, magnitudes[1:]))
+
+
+def test_encoding_an_observation_changes_the_rollout_it_produces():
+    """Test that the estimate actually reaches the transition, not just an attribute.
+
+    Purpose: The cache is only worth anything if ``_curvature_for`` hands it to the Frenet
+        integration. A model that stored the estimate and then propagated against zero
+        would pass an estimator test and still be unable to corner
+
+    Given: One model propagated before and after being shown a curving corridor
+    When: Ten coasting decisions are propagated in each case from the same start state
+    Then: The pre-observation rollout stays on the centreline and the post-observation one
+        does not, and their lane-relative angles differ by more than 0.1 rad
+
+    Test type: unit
+    """
+    model = _model()
+    start = _cruising_state(model)
+
+    blind = start.copy()
+    for _ in range(10):
+        blind = model.sample_next_state(blind, COAST_STRAIGHT)
+
+    model.encode_observation(_corridor_observation(-_SYNTHETIC_CURVATURE)["occupancy"])
+    seeing = start.copy()
+    for _ in range(10):
+        seeing = model.sample_next_state(seeing, COAST_STRAIGHT)
+
+    assert float(blind[EGO_LAT]) == pytest.approx(0.0, abs=1e-12)
+    assert float(blind[EGO_ANG]) == pytest.approx(0.0, abs=1e-12)
+    assert abs(float(seeing[EGO_LAT])) > 1.0
+    # Checked as well as the offset: the estimate enters the dynamics through the lane-angle
+    # rate, and the offset only follows from it. A model that moved the ego sideways without
+    # turning the lane frame under it would satisfy the offset assertion alone.
+    assert abs(float(seeing[EGO_ANG]) - float(blind[EGO_ANG])) > 0.1
+
+
+def test_the_rendered_on_road_layer_moves_with_the_particles_lane_offset():
+    """Test that the predicted on-road layer is a function of the particle, not just the step.
+
+    Purpose: This is what makes the layer worth scoring at all. The curvature estimate is
+        shared by every particle in a step, so if the rendered corridor depended on nothing
+        else the likelihood term would be a constant and would vanish at normalisation. It
+        depends on the particle's own lane offset, which is exactly the quantity the layer
+        can measure
+
+    Given: A model shown a straight corridor, and two states 3 m apart laterally
+    When: The on-road layer is rendered for each
+    Then: Neither layer is all ones, the two differ, and the marked corridor sits on
+        opposite sides of the ego's centre column — a particle offset one way sees the
+        centreline offset the other
+
+    Test type: unit
+    """
+    # pylint: disable=protected-access
+    model = _model()
+    left = model._render_on_road_layer(_cruising_state(model, lateral=-3.0))
+    right = model._render_on_road_layer(_cruising_state(model, lateral=3.0))
+
+    assert not np.all(left == 1.0)
+    assert not np.array_equal(left, right)
+    assert float(np.nonzero(left[6])[0].mean()) > 6.0
+    assert float(np.nonzero(right[6])[0].mean()) < 6.0
+
+
+def test_the_on_road_likelihood_prefers_the_particle_that_is_where_the_road_says():
+    """Test that the on-road layer discriminates between particles.
+
+    Purpose: Model B is required to make this layer informative rather than decorative. If
+        two particles at different lane offsets scored identically, the extra 144 cells of
+        arithmetic would be buying nothing
+
+    Given: An observation rendered for an ego 2 m off the centreline, and three particles at
+        -2, 0 and +2 m
+    When: observation_log_probability scores each of them against it
+    Then: All three scores are finite and the matching particle scores strictly highest
+
+    Test type: unit
+    """
+    model = _model()
+    observation = _corridor_observation(0.0, lateral=2.0)
+
+    scores = np.array(
+        [
+            model.observation_log_probability(
+                _cruising_state(model, lateral=offset), COAST_STRAIGHT, [observation]
+            )[0]
+            for offset in (-2.0, 0.0, 2.0)
+        ]
+    )
+
+    assert np.all(np.isfinite(scores))
+    assert int(np.argmax(scores)) == 2
+
+
+def test_sampled_observations_carry_a_corridor_the_model_can_read_back():
+    """Test that the model's own sampled observations are ones it could have received.
+
+    Purpose: A planner that samples observations inside a rollout feeds them back through
+        the same encoder. If the sampler wrote an all-ones on-road layer, the model would
+        read its own sample as a perfectly straight road on the approach to every corner
+
+    Given: A model holding a curving estimate, and a state on the centreline
+    When: An observation is sampled and then encoded by a second, fresh model
+    Then: The sampled on-road layer is not all ones, and the fresh model recovers a
+        curvature of the same sign
+
+    Test type: unit
+    """
+    model = _model()
+    model.encode_observation(_corridor_observation(-_SYNTHETIC_CURVATURE)["occupancy"])
+    state = _cruising_state(model)
+
+    sampled = model.sample_observation(state, COAST_STRAIGHT)
+    reader = _model()
+    reader.encode_observation(sampled["occupancy"])
+
+    assert not np.all(np.asarray(sampled["occupancy"])[ON_ROAD_LAYER] == 1.0)
+    assert reader.curvature_estimate < 0.0
+
+
+def _sweep_the_live_lap(monkeypatch) -> tuple:
+    """Estimate the curvature all the way round the real circuit; return it and the truth."""
+    monkeypatch.setenv("SDL_VIDEODRIVER", "offscreen")
+    # Imported here so this module still imports where highway-env is absent.
+    from POMDPPlanners.environments.racetrack_pomdp.racetrack_pomdp import (  # pylint: disable=import-outside-toplevel
+        RacetrackPOMDP,
+    )
+    from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import (  # pylint: disable=import-outside-toplevel
+        geometry_from_world,
+    )
+
+    world = RacetrackPOMDP(discount_factor=0.95, seed=0, other_vehicles=0)
+    world.initial_state_dist().sample()
+    geometry, lane_index = geometry_from_world(world)
+    # pylint: disable=protected-access  # The session is the world's only backend handle.
+    backend = world._get_session()._env.unwrapped
+    vehicle, network = backend.vehicle, backend.road.network
+
+    lap_offsets, running, current = {}, 0.0, lane_index
+    while current not in lap_offsets:
+        lane = network.get_lane(current)
+        lap_offsets[current] = running
+        running += float(lane.length)
+        current = network.next_lane(current, position=lane.position(lane.length, 0))
+
+    model = ObservedTrackModel(discount_factor=0.95, process_noise_std=0.0)
+    truths, estimates = [], []
+    for arclength in range(int(geometry.total_length_m)):
+        for index, offset in lap_offsets.items():
+            lane = network.get_lane(index)
+            if offset <= arclength < offset + lane.length:
+                vehicle.position = lane.position(arclength - offset, 0.0)
+                vehicle.heading = lane.heading_at(arclength - offset)
+                vehicle.lane_index, vehicle.lane = index, lane
+                break
+        model.encode_observation(np.asarray(backend.observation_type.observe()))
+        truths.append(float(geometry.curvature_at(float(arclength))))
+        estimates.append(model.curvature_estimate)
+    return np.asarray(truths), np.asarray(estimates)
+
+
+def test_the_live_circuits_curvature_is_recovered_with_the_right_sign_and_scale(monkeypatch):
+    """Test the estimator against the real track's own curvature profile.
+
+    Purpose: The across-track axis of the occupancy grid could point either way, and every
+        synthetic test above would pass with the sign flipped because it draws the corridor
+        with the same convention it reads it back with. Comparing against a profile walked
+        out of highway-env's lane graph is the only check that closes that loop
+
+    Given: The ego walked round every metre of ``racetrack-v0``'s lap, on the centreline,
+        with the on-road layer read at each point
+    When: Each reading is encoded and compared with TrackGeometry's own curvature there
+    Then: The estimate agrees in sign on at least 90% of the curved metres, the mean
+        absolute error is under 0.015 1/m against bends running from 0.033 to 0.067, the
+        regression of estimate on truth has a clearly positive slope, and the straights
+        average under 0.015 1/m of spurious curvature
+
+    Note:
+        This walks the ego along the centreline, which characterises the estimator but
+        flatters it. Measured under a lane-keeper actually driving the lap, the regression
+        slope falls from 0.77 to 0.61 and bends come back at roughly three quarters of
+        their true magnitude — the ego is off-centre and yawed, and the 12 m fit window
+        spends much of every arc straddling a segment boundary. Do not read the thresholds
+        here as a claim about what a planner sees
+
+    Test type: integration
+    """
+    pytest.importorskip("highway_env")
+
+    truths, estimates = _sweep_the_live_lap(monkeypatch)
+    curved = truths != 0.0
+
+    assert np.mean(np.sign(estimates[curved]) == np.sign(truths[curved])) > 0.9
+    assert np.mean(np.abs(estimates - truths)) < 0.015
+    assert float(np.polyfit(truths, estimates, 1)[0]) > 0.6
+    assert np.mean(np.abs(estimates[~curved])) < 0.015
+
+
+def test_the_two_models_disagree_on_the_approach_to_a_corner(monkeypatch):
+    """Test that the observed-track model sees a bend before the map model reaches it.
+
+    Purpose: If the two produce the same rollout, the observation is not being read: the
+        window looks 18 m ahead while the arclength lookup only reports the road the ego is
+        already on, so on the approach to a bend they *must* differ. Identical rollouts here
+        would be the signature of a dead estimator
+
+    Given: The live world driven forward until the ego is a few metres short of the first
+        bend, its map curvature still exactly zero
+    When: The observation there is encoded by the observed-track model, and both models roll
+        the same state forward ten coasting decisions
+    Then: The map model reports zero curvature under the ego while the observed model
+        already reports a non-zero one; three steps later the map model is still exactly on
+        the centreline and the observed one has left it; and over ten steps the two
+        predictions disagree by more than 0.5 m at their widest
+
+    Test type: integration
+    """
+    pytest.importorskip("highway_env")
+    monkeypatch.setenv("SDL_VIDEODRIVER", "offscreen")
+    # Imported here so this module still imports where highway-env is absent.
+    from POMDPPlanners.environments.racetrack_pomdp.racetrack_known_track_model import (  # pylint: disable=import-outside-toplevel
+        KnownTrackModel,
+    )
+    from POMDPPlanners.environments.racetrack_pomdp.racetrack_pomdp import (  # pylint: disable=import-outside-toplevel
+        RacetrackPOMDP,
+    )
+    from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import (  # pylint: disable=import-outside-toplevel
+        geometry_from_world,
+    )
+
+    world = RacetrackPOMDP(discount_factor=0.95, seed=0, other_vehicles=0)
+    truth = np.asarray(world.initial_state_dist().sample()[0], dtype=float)
+    geometry, _ = geometry_from_world(world)
+    # The first bend begins at 58 m; coast until the ego is within 6 m of it.
+    while float(truth[EGO_ARCLENGTH_M]) < 52.0:
+        truth = np.asarray(world.sample_next_state(truth, COAST_STRAIGHT), dtype=float)
+
+    observed = ObservedTrackModel(discount_factor=0.95, process_noise_std=0.0)
+    observed.encode_observation(world.sample_observation(truth, COAST_STRAIGHT))
+    mapped = KnownTrackModel(discount_factor=0.95, process_noise_std=0.0, track_geometry=geometry)
+
+    assert float(geometry.curvature_at(float(truth[EGO_ARCLENGTH_M]))) == 0.0
+    assert abs(observed.curvature_estimate) > 0.01
+
+    from_map, from_sight = truth.copy(), truth.copy()
+    disagreements = []
+    for step in range(10):
+        from_map = mapped.sample_next_state(from_map, COAST_STRAIGHT)
+        from_sight = observed.sample_next_state(from_sight, COAST_STRAIGHT)
+        disagreements.append(abs(float(from_map[EGO_LAT]) - float(from_sight[EGO_LAT])))
+        if step == 2:
+            assert float(from_map[EGO_LAT]) == pytest.approx(0.0, abs=1e-9)
+            assert abs(float(from_sight[EGO_LAT])) > 0.2
+
+    assert max(disagreements) > 0.5

--- a/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_pomdp.py
@@ -35,13 +35,17 @@ from POMDPPlanners.environments.racetrack_pomdp.racetrack_pomdp import (
 )
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     AGENT_SLOT_WIDTH,
+    DEFAULT_ACTION_PRESETS,
     DEFAULT_MAX_TRACKED_AGENTS,
     EGO_STATE_WIDTH,
     GRID_CELLS,
     ObservationMode,
 )
 
-_COAST_STRAIGHT = 4  # Index of the (0.0, 0.0) preset in the default 3x3 action grid.
+# Index of the (0.0, 0.0) preset: coast, straight ahead. Looked up rather than written as a
+# literal, because the shipped table is a 3-by-9 grid of accelerations by steering angles
+# and every index moves whenever the steering resolution changes.
+_COAST_STRAIGHT = DEFAULT_ACTION_PRESETS.index((0.0, 0.0))
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
 

--- a/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_schema.py
+++ b/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_schema.py
@@ -19,13 +19,16 @@ import numpy as np
 import pytest
 
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
+    ACCELERATION_PRESETS,
     AGENT_SLOT_WIDTH,
+    DEFAULT_ACTION_PRESETS,
     DEFAULT_ACTION_REWARD,
     DEFAULT_COLLISION_REWARD,
     DEFAULT_MAX_TRACKED_AGENTS,
     EGO_STATE_WIDTH,
     GRID_HALF_EXTENT_M,
     GRID_STEP_M,
+    STEERING_PRESETS,
     ObservationMode,
     build_racetrack_config,
     observation_config,
@@ -216,6 +219,49 @@ def test_action_block_enables_longitudinal_control() -> None:
         assert action["type"] == "ContinuousAction"
         assert action["longitudinal"] is True
         assert action["lateral"] is True
+
+
+def test_action_presets_are_the_full_acceleration_by_steering_grid() -> None:
+    """The preset table is every acceleration crossed with every steering angle, in order.
+
+    Purpose: Validates the shape of the action vocabulary the world, the scalar model and
+        the vectorized model all index into. They share it by construction, so an index
+        that moves moves everywhere at once and nothing complains
+
+    Given: The shipped acceleration and steering preset tuples
+    When: DEFAULT_ACTION_PRESETS is inspected
+    Then: It is the full product, acceleration-major, with no duplicates
+
+    Test type: unit
+    """
+    expected = [
+        (acceleration, steering)
+        for acceleration in ACCELERATION_PRESETS
+        for steering in STEERING_PRESETS
+    ]
+    assert list(DEFAULT_ACTION_PRESETS) == expected
+    assert len(DEFAULT_ACTION_PRESETS) == len(ACCELERATION_PRESETS) * len(STEERING_PRESETS)
+    assert len(set(DEFAULT_ACTION_PRESETS)) == len(DEFAULT_ACTION_PRESETS)
+
+
+def test_steering_presets_are_fine_near_zero_and_include_the_useful_angle() -> None:
+    """Steering is sampled finely near centre, not bang-bang between the lock stops.
+
+    Purpose: Pins the reason the table is nine steering angles rather than three. Full lock
+        is pi/4, which on this track is a spin: sweeping constant steering through the first
+        bend, -1.0 survives 5 steps while -0.05 survives 29. A set of {-1, 0, +1} does not
+        contain the manoeuvre the track needs, so no amount of planning can select it
+
+    Given: The shipped steering presets
+    When: They are inspected
+    Then: They are symmetric about an exact zero, ascending, and include -0.05
+
+    Test type: unit
+    """
+    assert 0.0 in STEERING_PRESETS
+    assert -0.05 in STEERING_PRESETS
+    assert list(STEERING_PRESETS) == sorted(STEERING_PRESETS)
+    assert list(STEERING_PRESETS) == [-angle for angle in reversed(STEERING_PRESETS)]
 
 
 def test_overrides_are_applied_to_both_arms() -> None:

--- a/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_track_geometry.py
+++ b/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_track_geometry.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the racetrack's piecewise-constant curvature profile.
+
+:class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry.TrackGeometry`
+is what replaced the state's frozen curvature slot, so the lookup has to be right in the
+places a rollout actually lands: inside a segment, exactly on a boundary, and past the
+finish line where the arclength has to wrap. Those are checked against hand-built profiles
+in pure NumPy, with no simulator involved.
+
+:func:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry.build_track_geometry`
+gets two kinds of test. A synthetic lane network pins the walk and the closed-loop guard
+without highway-env; a live ``racetrack-v0`` pins the numbers that matter in practice --
+nine segments over 381.9 m, straights at exactly zero and arcs not -- because a walk that
+silently visited a different set of lanes would still look like a valid profile.
+"""
+
+from typing import Any, Optional, Sequence
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import (
+    TrackGeometry,
+    build_track_geometry,
+    lane_curvature,
+)
+
+# The real circuit, measured against highway-env 1.12.1. A walk that wandered onto the
+# parallel lane or stopped early would still produce an ascending profile, so the totals
+# are what makes the live test an assertion rather than a smoke test.
+_REAL_SEGMENT_COUNT = 9
+_REAL_STRAIGHT_COUNT = 3
+_REAL_LAP_LENGTH_M = 381.9
+
+
+@pytest.fixture(name="geometry")
+def geometry_fixture() -> TrackGeometry:
+    """A three-segment lap: a 10 m straight, a 15 m left arc, then a 15 m right arc."""
+    return TrackGeometry(
+        segment_starts=np.array([0.0, 10.0, 25.0]),
+        segment_curvatures=np.array([0.0, 0.04, -0.02]),
+        total_length_m=40.0,
+    )
+
+
+class _FakeLane:
+    """Minimal stand-in for a highway-env lane: a length and an optional arc radius."""
+
+    def __init__(self, length: float, radius: Optional[float] = None, direction: float = 1.0):
+        self.length = length
+        self.direction = direction
+        if radius is not None:
+            self.radius = radius
+
+    def position(self, longitudinal: float, lateral: float) -> np.ndarray:
+        # The walk only forwards this to ``next_lane``, which ignores it here.
+        return np.array([longitudinal, lateral], dtype=float)
+
+
+class _FakeNetwork:
+    """A chain of lanes indexed ``0, 1, 2, ...`` that either closes into a lap or does not.
+
+    ``get_lane`` takes the index modulo the chain length so an open walk keeps returning
+    real lanes instead of raising, which is what lets the closed-loop guard be the thing
+    under test rather than an incidental KeyError.
+    """
+
+    def __init__(self, lanes: Sequence[_FakeLane], closed: bool = True):
+        self._lanes = list(lanes)
+        self._closed = closed
+
+    def get_lane(self, index: Any) -> _FakeLane:
+        return self._lanes[int(index) % len(self._lanes)]
+
+    def next_lane(self, index: Any, position: Any = None) -> int:
+        del position
+        following = int(index) + 1
+        return following % len(self._lanes) if self._closed else following
+
+
+def test_curvature_lookup_lands_in_the_containing_segment(geometry: TrackGeometry) -> None:
+    """A distance inside a segment reads that segment's curvature.
+
+    Purpose: Validates the basic piecewise-constant lookup for every segment
+
+    Given: A three-segment lap of a straight, a left arc and a right arc
+    When: curvature_at is called at a point strictly inside each segment
+    Then: Each lookup returns that segment's own curvature
+
+    Test type: unit
+    """
+    assert float(geometry.curvature_at(4.0)) == 0.0
+    assert float(geometry.curvature_at(17.5)) == 0.04
+    assert float(geometry.curvature_at(31.0)) == -0.02
+
+
+def test_curvature_exactly_on_a_boundary_takes_the_following_segment(
+    geometry: TrackGeometry,
+) -> None:
+    """A distance sitting exactly on a segment start belongs to the segment it starts.
+
+    Purpose: Pins the half-open convention at the one input where the two segments meet,
+        which a searchsorted ``side`` flip would silently invert
+
+    Given: The same three-segment lap
+    When: curvature_at is called at 0.0, 10.0 and 25.0 -- each an exact segment start
+    Then: Each returns the curvature of the segment beginning there, not the one before it
+
+    Test type: unit
+    """
+    assert float(geometry.curvature_at(0.0)) == 0.0
+    assert float(geometry.curvature_at(10.0)) == 0.04
+    assert float(geometry.curvature_at(25.0)) == -0.02
+
+
+def test_arclength_beyond_the_lap_wraps_to_the_start(geometry: TrackGeometry) -> None:
+    """Driving past the finish line reads the curvature of the next lap, not the last arc.
+
+    Purpose: Validates the wrap, without which every rollout that completes a lap would be
+        pinned to the final segment's curvature for the rest of the horizon
+
+    Given: A 40 m lap
+    When: curvature_at is called at exactly 40 m, and at 52 m and 97.5 m
+    Then: Each equals the lookup at the same distance modulo the lap length
+
+    Test type: unit
+    """
+    assert float(geometry.curvature_at(40.0)) == float(geometry.curvature_at(0.0))
+    assert float(geometry.curvature_at(52.0)) == float(geometry.curvature_at(12.0))
+    assert float(geometry.curvature_at(97.5)) == float(geometry.curvature_at(17.5))
+
+
+def test_negative_arclength_wraps_backwards_from_the_end(geometry: TrackGeometry) -> None:
+    """A negative distance reads from the end of the lap, not from the first segment.
+
+    Purpose: Validates the wrap in the reverse direction, which a truncating modulo (C-style
+        remainder rather than NumPy's floored ``mod``) would get wrong by a whole lap
+
+    Given: A 40 m lap whose last segment starts at 25 m
+    When: curvature_at is called at -5 m and -32.5 m
+    Then: They read the last and the middle segment respectively, matching +35 m and +7.5 m
+
+    Test type: unit
+    """
+    assert float(geometry.curvature_at(-5.0)) == -0.02
+    assert float(geometry.curvature_at(-5.0)) == float(geometry.curvature_at(35.0))
+    assert float(geometry.curvature_at(-32.5)) == float(geometry.curvature_at(7.5))
+
+
+def test_batch_lookup_matches_scalar_lookups_one_by_one(geometry: TrackGeometry) -> None:
+    """A batch of arclengths gives exactly what a loop of scalar lookups gives.
+
+    Purpose: Validates the vectorised path the torch and NumPy models both call per substep,
+        where a broadcasting mistake would go unnoticed because the shape would still fit
+
+    Given: 500 arclengths spanning several laps in both directions, including exact
+        boundaries and exact multiples of the lap length
+    When: curvature_at is called once on the whole array and once per element
+    Then: The results are identical and the array is shaped like the input
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(0)
+    arclengths = np.concatenate(
+        [
+            rng.uniform(-200.0, 200.0, size=497),
+            np.array([0.0, 10.0, 40.0]),
+        ]
+    )
+    batch = geometry.curvature_at(arclengths)
+    expected = np.array([float(geometry.curvature_at(float(s))) for s in arclengths])
+    assert batch.shape == arclengths.shape
+    np.testing.assert_array_equal(batch, expected)
+
+
+def test_lane_curvature_is_zero_on_a_straight_and_signed_on_an_arc() -> None:
+    """Curvature is direction over radius, and zero when there is no radius at all.
+
+    Purpose: Validates the single place a highway-env lane object is read for its geometry
+
+    Given: A straight lane with no radius attribute, a degenerate lane with radius 0, and
+        two arcs of radius 25 m running in opposite directions
+    When: lane_curvature is called on each
+    Then: The straights give exactly 0.0 and the arcs give +-1/25
+
+    Test type: unit
+    """
+    assert lane_curvature(_FakeLane(length=10.0)) == 0.0
+    assert lane_curvature(_FakeLane(length=10.0, radius=0.0)) == 0.0
+    assert lane_curvature(_FakeLane(length=10.0, radius=25.0, direction=1.0)) == 0.04
+    assert lane_curvature(_FakeLane(length=10.0, radius=25.0, direction=-1.0)) == -0.04
+
+
+def test_build_track_geometry_accumulates_a_synthetic_closed_loop() -> None:
+    """Walking a closed chain records each lane's start distance and curvature in order.
+
+    Purpose: Validates the walk itself -- cumulative starts, per-lane curvature, and the lap
+        total -- without needing a simulator
+
+    Given: A four-lane loop of a 10 m straight, a 20 m left arc, a 10 m straight and a 20 m
+        right arc
+    When: build_track_geometry walks it from lane 0
+    Then: The starts are the running totals, the curvatures follow the lanes, and the total
+        length is the sum
+
+    Test type: unit
+    """
+    network = _FakeNetwork(
+        [
+            _FakeLane(length=10.0),
+            _FakeLane(length=20.0, radius=50.0, direction=1.0),
+            _FakeLane(length=10.0),
+            _FakeLane(length=20.0, radius=40.0, direction=-1.0),
+        ]
+    )
+    geometry = build_track_geometry(network, 0)
+    np.testing.assert_array_equal(geometry.segment_starts, [0.0, 10.0, 30.0, 40.0])
+    np.testing.assert_allclose(geometry.segment_curvatures, [0.0, 0.02, 0.0, -0.025])
+    assert geometry.total_length_m == 60.0
+
+
+def test_open_lane_sequence_raises_value_error() -> None:
+    """A lane chain that never returns to its start is rejected rather than truncated.
+
+    Purpose: Validates the guard that keeps arclength wrapping meaningful -- on an open
+        sequence the lap length is whatever the walk happened to stop at, so every
+        past-the-end lookup would read a curvature from the wrong part of the track
+
+    Given: A network whose next_lane always advances and never closes
+    When: build_track_geometry walks it with a small max_segments budget
+    Then: ValueError is raised naming the starting lane
+
+    Test type: unit
+    """
+    network = _FakeNetwork([_FakeLane(length=10.0)] * 3, closed=False)
+    with pytest.raises(ValueError, match="did not close into a loop"):
+        build_track_geometry(network, 0, max_segments=5)
+
+
+def _real_track_geometry() -> TrackGeometry:
+    """Profile of the lane a freshly reset ``racetrack-v0`` puts its ego on, or skip."""
+    # Importing highway_env is also what registers racetrack-v0 with gymnasium, so the
+    # skip and the registration are the same line.
+    pytest.importorskip("highway_env")
+    gymnasium = pytest.importorskip("gymnasium")
+    env = gymnasium.make("racetrack-v0")
+    try:
+        env.reset(seed=0)
+        unwrapped = env.unwrapped
+        return build_track_geometry(unwrapped.road.network, unwrapped.vehicle.lane_index)
+    finally:
+        env.close()
+
+
+def test_real_racetrack_is_a_closed_nine_segment_lap() -> None:
+    """The live circuit walks to nine segments over 381.9 m: three straights and six arcs.
+
+    Purpose: Pins the measured shape of the real track, so a walk that wandered onto the
+        parallel lane or closed early is caught -- it would still produce an ascending
+        profile and pass every structural check
+
+    Given: A freshly reset racetrack-v0 and the lane its ego starts on
+    When: build_track_geometry walks that lane's loop
+    Then: There are nine segments starting at 0.0 and ascending, the lap is 381.9 m to
+        within 0.1 m, and exactly three of them are straights at an exact zero
+
+    Test type: integration
+    """
+    geometry = _real_track_geometry()
+
+    starts = geometry.segment_starts
+    curvatures = geometry.segment_curvatures
+    assert len(starts) == _REAL_SEGMENT_COUNT
+    assert len(curvatures) == _REAL_SEGMENT_COUNT
+    assert starts[0] == 0.0
+    assert np.all(np.diff(starts) > 0.0)
+    assert starts[-1] < geometry.total_length_m
+    assert abs(geometry.total_length_m - _REAL_LAP_LENGTH_M) < 0.1
+    # Exactly zero, not almost: a straight lane has no radius at all, so anything else here
+    # means the walk read a curvature off a lane it should not have been on.
+    assert int(np.count_nonzero(curvatures == 0.0)) == _REAL_STRAIGHT_COUNT
+    assert int(np.count_nonzero(curvatures != 0.0)) == _REAL_SEGMENT_COUNT - _REAL_STRAIGHT_COUNT
+
+
+def test_real_racetrack_lookup_reaches_every_segment_of_the_lap() -> None:
+    """Sweeping the live lap reads every distinct curvature the profile records.
+
+    Purpose: Guards the lookup against an off-by-one that would clip the last segment away
+        or index past it -- the three-segment synthetic profiles are too short to expose it
+
+    Given: The live circuit's profile, 2000 points spread over four laps in both
+        directions, and a 1 m sweep of a single lap
+    When: curvature_at is evaluated on both
+    Then: Every sampled value is one of the recorded curvatures, and the sweep reaches all
+        of the distinct ones
+
+    Test type: integration
+    """
+    geometry = _real_track_geometry()
+
+    rng = np.random.default_rng(1)
+    sampled = geometry.curvature_at(rng.uniform(-2.0, 2.0, size=2000) * geometry.total_length_m)
+    assert np.all(np.isin(sampled, geometry.segment_curvatures))
+
+    swept = geometry.curvature_at(np.arange(0.0, geometry.total_length_m, 1.0))
+    np.testing.assert_array_equal(np.unique(swept), np.unique(geometry.segment_curvatures))

--- a/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_vectorized_model.py
@@ -1,0 +1,588 @@
+# SPDX-License-Identifier: MIT
+
+"""Parity tests: the torch vectorized racetrack model vs. the scalar racetrack model.
+
+These tests pin :class:`RacetrackVectorizedModel` to
+:class:`~POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp.RacetrackModelPOMDP`
+so the two implementations cannot drift apart. The deterministic kernels — the
+kinematic-bicycle transition with its Frenet pair and agent-slot drift, the highway-env
+reward, the collision terminal check, and both observation log-densities — are compared in
+float64 against the scalar model row by row, over several supported configurations. The
+scalar model is built with ``process_noise_std=0.0`` wherever the transition itself is under
+test, so the comparison is against a deterministic propagation rather than two independent
+noise draws; the noise is then checked separately by its empirical moments.
+
+The occupancy rasteriser gets a dedicated crafted-state test, because its axis order
+(along-track first, across-track second) and its always-marked centre cell were established
+empirically against highway-env 1.12.1 and are the easiest thing in the module to silently
+invert.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.core.environment.vectorized_generative_model import (
+    VectorizedGenerativeModel,
+)
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp import RacetrackModelPOMDP
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
+    AGENT_SLOT_WIDTH,
+    EGO_LAT,
+    EGO_STATE_WIDTH,
+    GRID_CELLS,
+    ObservationMode,
+)
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_vectorized_model import (
+    RacetrackVectorizedModel,
+)
+
+_TOLERANCE = 1e-9
+
+_CUSTOM_PRESETS = [(1.0, -1.0), (0.5, 0.25), (0.0, 0.0), (-1.0, 0.75)]
+
+# Every case is a supported scalar-model configuration. Noise is off so the transition
+# comparison is deterministic on both sides; the samplers are tested separately.
+_SUPPORTED_CASES: List[Dict[str, Any]] = [
+    {"discount_factor": 0.95, "process_noise_std": 0.0},
+    {
+        "discount_factor": 0.9,
+        "process_noise_std": 0.0,
+        "dt": 0.5,
+        "substeps": 7,
+        "vehicle_length": 4.2,
+        "max_tracked_agents": 2,
+        "lane_half_width": 3.5,
+        "collision_distance": 2.0,
+    },
+    {
+        "discount_factor": 0.95,
+        "process_noise_std": 0.0,
+        "action_presets": _CUSTOM_PRESETS,
+        "collision_reward": -3.0,
+        "lane_centering_cost": 1.5,
+        "lane_centering_reward": 2.0,
+        "action_reward": -0.1,
+        "cell_flip_prob": 0.2,
+    },
+]
+_CASE_IDS = ["defaults", "coarse-steps", "custom-weights"]
+
+
+@dataclass
+class _Case:
+    """A scalar model paired with the vectorized twin built from it."""
+
+    env: RacetrackModelPOMDP
+    model: RacetrackVectorizedModel
+
+
+def _build_case(**kwargs: Any) -> _Case:
+    env = RacetrackModelPOMDP(**kwargs)
+    model = RacetrackVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    return _Case(env=env, model=model)
+
+
+@pytest.fixture(params=_SUPPORTED_CASES, ids=_CASE_IDS, name="case")
+def case_fixture(request: pytest.FixtureRequest) -> _Case:
+    return _build_case(**request.param)
+
+
+@pytest.fixture(name="pomdp_case")
+def pomdp_case_fixture() -> _Case:
+    return _build_case(discount_factor=0.95, process_noise_std=0.0)
+
+
+def _tensor(array: np.ndarray) -> torch.Tensor:
+    return torch.as_tensor(np.asarray(array), dtype=torch.float64)
+
+
+def _actions(indices: np.ndarray) -> torch.Tensor:
+    return torch.as_tensor(np.asarray(indices), dtype=torch.int64)
+
+
+def _random_states(rng: np.random.Generator, env: RacetrackModelPOMDP, count: int) -> np.ndarray:
+    """Random states mixing present/absent slots, curved and straight lanes."""
+    states = np.zeros((count, env.state_width))
+    states[:, 0:2] = rng.uniform(-40.0, 40.0, size=(count, 2))
+    states[:, 2] = rng.uniform(-np.pi, np.pi, size=count)
+    states[:, 3] = rng.uniform(0.0, 15.0, size=count)
+    states[:, 4] = rng.uniform(-3.0, 3.0, size=count)
+    states[:, 5] = rng.uniform(-0.6, 0.6, size=count)
+    states[:, 6] = rng.uniform(-0.05, 0.05, size=count)
+    slots = states[:, EGO_STATE_WIDTH:].reshape(count, env.max_tracked_agents, AGENT_SLOT_WIDTH)
+    slots[..., 0] = (rng.uniform(size=slots.shape[:2]) < 0.6).astype(float)
+    slots[..., 1] = rng.uniform(-25.0, 25.0, size=slots.shape[:2])
+    slots[..., 2] = rng.uniform(-12.0, 12.0, size=slots.shape[:2])
+    slots[..., 3] = rng.uniform(-6.0, 6.0, size=slots.shape[:2])
+    slots[..., 4] = rng.uniform(-6.0, 6.0, size=slots.shape[:2])
+    return states
+
+
+def _random_action_indices(
+    rng: np.random.Generator, env: RacetrackModelPOMDP, count: int
+) -> np.ndarray:
+    return rng.integers(0, len(env.action_presets), size=count)
+
+
+def _scalar_next_states(
+    env: RacetrackModelPOMDP, states: np.ndarray, indices: np.ndarray
+) -> np.ndarray:
+    return np.stack(
+        [env.sample_next_state(states[i], int(indices[i])) for i in range(states.shape[0])]
+    )
+
+
+def _occupancy_dict(flat: torch.Tensor) -> Dict[str, np.ndarray]:
+    return {"occupancy": flat.numpy().reshape(2, GRID_CELLS, GRID_CELLS)}
+
+
+def _kinematics_dict(flat: torch.Tensor, num_agents: int) -> Dict[str, np.ndarray]:
+    array = flat.numpy()
+    return {
+        "ego": array[:4].copy(),
+        "agents": array[4:].reshape(num_agents, AGENT_SLOT_WIDTH).copy(),
+    }
+
+
+def test_model_conforms_to_protocol_across_configs(case: _Case) -> None:
+    """Every supported configuration yields a conforming vectorized model.
+
+    Purpose: Validates structural protocol conformance and the reported dimensions
+
+    Given: A vectorized model built from each supported scalar configuration
+    When: It is checked against the runtime-checkable VectorizedGenerativeModel protocol
+    Then: isinstance reports conformance and the dimensions follow the schema
+
+    Test type: unit
+    """
+    assert isinstance(case.model, VectorizedGenerativeModel)
+    assert case.model.num_actions == len(case.env.action_presets)
+    assert case.model.state_dim == case.env.state_width
+    assert case.model.observation_dim == 2 * GRID_CELLS * GRID_CELLS
+
+
+def test_transition_matches_native_exactly(case: _Case) -> None:
+    """Sampled next states equal the scalar propagation row by row.
+
+    Purpose: Validates the batched bicycle + Frenet + agent-drift transition kernel
+
+    Given: 256 random states with per-row random action indices and no process noise
+    When: sample_next_states is compared to scalar sample_next_state per row
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(1)
+    states = _random_states(rng, case.env, 256)
+    indices = _random_action_indices(rng, case.env, 256)
+    expected = _scalar_next_states(case.env, states, indices)
+    actual = case.model.sample_next_states(_tensor(states), _actions(indices)).numpy()
+    assert np.max(np.abs(expected - actual)) < _TOLERANCE
+
+
+def test_transition_matches_native_for_every_action(case: _Case) -> None:
+    """Each control preset, including full-lock steer and braking, propagates identically.
+
+    Purpose: Validates the per-action slip and acceleration table against the scalar model
+
+    Given: A fixed batch of random states replayed once under every action index
+    When: The vectorized transition is compared to the scalar one for that action
+    Then: Every action agrees to within 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(2)
+    states = _random_states(rng, case.env, 32)
+    for index in range(len(case.env.action_presets)):
+        indices = np.full(states.shape[0], index)
+        expected = _scalar_next_states(case.env, states, indices)
+        actual = case.model.sample_next_states(_tensor(states), _actions(indices)).numpy()
+        assert np.max(np.abs(expected - actual)) < _TOLERANCE, f"action {index} diverged"
+
+
+def test_transition_matches_scalar_batch_helper(pomdp_case: _Case) -> None:
+    """The scalar batch transition agrees with the vectorized kernel under one action.
+
+    Purpose: Cross-checks sample_next_state_batch, the filter's hot path, against the twin
+
+    Given: 128 random states and a single shared action index
+    When: The scalar batch propagation and the vectorized transition are compared
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: integration
+    """
+    rng = np.random.default_rng(3)
+    states = _random_states(rng, pomdp_case.env, 128)
+    expected = pomdp_case.env.sample_next_state_batch(states, 2)
+    actual = pomdp_case.model.sample_next_states(_tensor(states), _actions(np.full(128, 2))).numpy()
+    assert np.max(np.abs(expected - actual)) < _TOLERANCE
+
+
+def _reward_states(env: RacetrackModelPOMDP) -> np.ndarray:
+    """Four states spanning centred, off-centre, off-road, and crashed."""
+    states = np.zeros((4, env.state_width))
+    states[1, EGO_LAT] = 1.2
+    states[2, EGO_LAT] = env.lane_half_width + 0.5
+    states[3, EGO_STATE_WIDTH : EGO_STATE_WIDTH + AGENT_SLOT_WIDTH] = [1.0, 1.0, 0.5, 0.0, 0.0]
+    return states
+
+
+def test_reward_matches_native_exactly(case: _Case) -> None:
+    """Rewards equal the scalar racetrack reward across every branch.
+
+    Purpose: Validates the centering, effort, collision, normalisation and on-road terms
+
+    Given: Crafted next states spanning centred, off-centre, off-road and crashed, plus a
+        batch of random ones, each scored under every action preset
+    When: The vectorized reward is compared to env.reward per row
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(4)
+    next_states = np.concatenate(
+        [_reward_states(case.env), _random_states(rng, case.env, 64)], axis=0
+    )
+    states = np.zeros_like(next_states)
+    for index in range(len(case.env.action_presets)):
+        indices = np.full(next_states.shape[0], index)
+        expected = np.array(
+            [case.env.reward(states[i], index, next_states[i]) for i in range(next_states.shape[0])]
+        )
+        actual = case.model.rewards(
+            _tensor(states), _actions(indices), _tensor(next_states)
+        ).numpy()
+        assert np.max(np.abs(expected - actual)) < _TOLERANCE, f"action {index} diverged"
+
+
+def test_terminal_matches_native_exactly(case: _Case) -> None:
+    """Terminal flags equal the scalar off-lane and collision check row by row.
+
+    Purpose: Validates the batched terminal mask
+
+    Given: Crafted off-road and crashed states plus 512 random ones
+    When: terminal_mask is compared to env.is_terminal per row
+    Then: Every entry agrees, and both terminal branches are actually exercised
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(5)
+    states = np.concatenate([_reward_states(case.env), _random_states(rng, case.env, 512)], axis=0)
+    expected = np.array([case.env.is_terminal(states[i]) for i in range(states.shape[0])])
+    actual = case.model.terminal_mask(_tensor(states)).numpy()
+    assert np.array_equal(expected, actual)
+    assert bool(expected.any()) and not bool(expected.all())
+
+
+def test_occupancy_log_probs_match_native_exactly(case: _Case) -> None:
+    """Occupancy log-densities equal the scalar Bernoulli grid density row by row.
+
+    Purpose: Validates the presence-grid likelihood, including the excluded on-road layer
+
+    Given: Random next states and observations drawn from the vectorized sampler
+    When: observation_log_probs is compared to env.observation_log_probability
+    Then: The maximum absolute difference is below 1e-9 and every value is finite
+
+    Test type: unit
+    """
+    torch.manual_seed(6)
+    rng = np.random.default_rng(6)
+    next_states = _random_states(rng, case.env, 128)
+    indices = _actions(np.zeros(128, dtype=int))
+    observations = case.model.sample_observations(_tensor(next_states), indices)
+    expected = np.array(
+        [
+            case.env.observation_log_probability(
+                next_states[i], 0, _occupancy_dict(observations[i])
+            )[0]
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actual = case.model.observation_log_probs(_tensor(next_states), indices, observations).numpy()
+    assert actual.shape == (128,)
+    assert np.all(np.isfinite(actual))
+    assert np.max(np.abs(expected - actual)) < _TOLERANCE
+
+
+def test_occupancy_log_prob_prefers_the_matching_grid(pomdp_case: _Case) -> None:
+    """A grid that matches the state scores strictly above a corrupted one.
+
+    Purpose: Validates that the presence likelihood actually discriminates particles
+
+    Given: A state with one visible agent and its noise-free rendered observation
+    When: That observation is scored, then scored again with twenty cells inverted
+    Then: The matching grid scores strictly higher, and both scores are finite
+
+    Test type: unit
+    """
+    state = np.zeros((1, pomdp_case.env.state_width))
+    state[0, EGO_STATE_WIDTH : EGO_STATE_WIDTH + AGENT_SLOT_WIDTH] = [1.0, 6.0, 0.0, 0.0, 0.0]
+    clean = _build_case(discount_factor=0.95, process_noise_std=0.0, cell_flip_prob=0.0)
+    matching = clean.model.sample_observations(_tensor(state), _actions(np.zeros(1, dtype=int)))
+    mismatched = matching.clone()
+    mismatched[0, 100:120] = 1.0 - mismatched[0, 100:120]
+    indices = _actions(np.zeros(1, dtype=int))
+    scores = [
+        float(pomdp_case.model.observation_log_probs(_tensor(state), indices, grid)[0])
+        for grid in (matching, mismatched)
+    ]
+    assert all(np.isfinite(scores))
+    assert scores[0] > scores[1]
+
+
+def test_rasteriser_axis_order_places_agent_along_then_across() -> None:
+    """An agent 9 m ahead and 3 m to the right lands in cell (9, 5), not (5, 9).
+
+    Purpose: Pins the empirically established axis order and the always-marked centre cell
+
+    Given: A state with one present agent at rel_x = +9 m, rel_y = -3 m, and no cell flips
+    When: A noise-free occupancy observation is sampled and reshaped to (2, 12, 12)
+    Then: Exactly the ego centre cell (6, 6) and the cell (9, 5) are marked present
+
+    Test type: unit
+    """
+    clean = _build_case(discount_factor=0.95, process_noise_std=0.0, cell_flip_prob=0.0)
+    state = np.zeros((1, clean.env.state_width))
+    state[0, EGO_STATE_WIDTH : EGO_STATE_WIDTH + AGENT_SLOT_WIDTH] = [1.0, 9.0, -3.0, 0.0, 0.0]
+    observation = clean.model.sample_observations(_tensor(state), _actions(np.zeros(1, dtype=int)))
+    presence = observation[0].numpy().reshape(2, GRID_CELLS, GRID_CELLS)[0]
+    assert sorted(map(tuple, np.argwhere(presence > 0.5))) == [(6, 6), (9, 5)]
+
+
+def test_occupancy_sampler_flips_at_the_configured_rate(pomdp_case: _Case) -> None:
+    """The sampled presence layer disagrees with the truth at cell_flip_prob.
+
+    Purpose: Validates the Bernoulli flip sampler against the parameter it reads
+
+    Given: One fixed state observed 4000 times by the vectorized sampler
+    When: The fraction of cells differing from the noise-free grid is measured
+    Then: It is within 0.005 of the model's cell_flip_prob, and on_road stays all ones
+
+    Test type: unit
+    """
+    torch.manual_seed(7)
+    clean = _build_case(discount_factor=0.95, process_noise_std=0.0, cell_flip_prob=0.0)
+    state = np.zeros((1, pomdp_case.env.state_width))
+    state[0, EGO_STATE_WIDTH : EGO_STATE_WIDTH + AGENT_SLOT_WIDTH] = [1.0, 6.0, 3.0, 0.0, 0.0]
+    truth = clean.model.sample_observations(_tensor(state), _actions(np.zeros(1, dtype=int)))
+    batch = _tensor(np.tile(state, (4000, 1)))
+    drawn = pomdp_case.model.sample_observations(batch, _actions(np.zeros(4000, dtype=int)))
+    cells = GRID_CELLS * GRID_CELLS
+    flipped = (drawn[:, :cells] != truth[0, :cells]).to(torch.float64).mean().item()
+    assert abs(flipped - pomdp_case.env.cell_flip_prob) < 0.005
+    assert torch.all(drawn[:, cells:] == 1.0)
+
+
+def _mdp_case(**kwargs: Any) -> _Case:
+    return _build_case(
+        discount_factor=0.95,
+        process_noise_std=0.0,
+        observation_mode=ObservationMode.MDP,
+        **kwargs,
+    )
+
+
+def test_mdp_log_probs_match_native_exactly() -> None:
+    """MDP log-densities equal the scalar diagonal-Gaussian density row by row.
+
+    Purpose: Validates the MDP arm's ego and present-slot Gaussian likelihood
+
+    Given: Random next states and random observations, so present and absent slots and
+        both matching and mismatching readings all occur
+    When: observation_log_probs is compared to env.observation_log_probability
+    Then: The maximum absolute difference is below 1e-9
+
+    Test type: unit
+    """
+    case = _mdp_case()
+    assert isinstance(case.model, VectorizedGenerativeModel)
+    rng = np.random.default_rng(8)
+    next_states = _random_states(rng, case.env, 128)
+    observations = rng.uniform(-8.0, 8.0, size=(128, case.model.observation_dim))
+    expected = np.array(
+        [
+            case.env.observation_log_probability(
+                next_states[i], 0, _kinematics_dict(_tensor(observations[i]), 4)
+            )[0]
+            for i in range(next_states.shape[0])
+        ]
+    )
+    actual = case.model.observation_log_probs(
+        _tensor(next_states), _actions(np.zeros(128, dtype=int)), _tensor(observations)
+    ).numpy()
+    assert np.max(np.abs(expected - actual)) < _TOLERANCE
+
+
+def test_mdp_observation_dimension_and_sampler_moments() -> None:
+    """MDP observations have the documented width and the scalar sampler's noise scale.
+
+    Purpose: Validates the MDP observation layout and its per-channel noise standard
+        deviations against the parameters read off the scalar model
+
+    Given: One state with a single present agent, observed 20000 times
+    When: The per-column standard deviation of the observation is measured
+    Then: The width is 4 + 5K, and the ego, pose and velocity channels each match their
+        configured standard deviation to within 3%
+
+    Test type: unit
+    """
+    torch.manual_seed(9)
+    case = _mdp_case()
+    assert case.model.observation_dim == 4 + case.env.max_tracked_agents * AGENT_SLOT_WIDTH
+    state = np.zeros((1, case.env.state_width))
+    state[0, EGO_STATE_WIDTH : EGO_STATE_WIDTH + AGENT_SLOT_WIDTH] = [1.0, 8.0, 1.0, 2.0, -1.0]
+    drawn = case.model.sample_observations(
+        _tensor(np.tile(state, (20000, 1))), _actions(np.zeros(20000, dtype=int))
+    ).numpy()
+    deviations = drawn.std(axis=0)
+    assert np.max(np.abs(deviations[:4] - case.env.ego_pose_std)) < 0.03 * case.env.ego_pose_std
+    assert (
+        np.max(np.abs(deviations[5:7] - case.env.agent_pose_std)) < 0.03 * case.env.agent_pose_std
+    )
+    assert (
+        np.max(np.abs(deviations[7:9] - case.env.agent_velocity_std))
+        < 0.03 * case.env.agent_velocity_std
+    )
+    assert np.max(deviations[9:]) < _TOLERANCE  # absent slots carry no measurement
+
+
+def test_process_noise_matches_the_configured_scale() -> None:
+    """Transition noise perturbs the first six ego entries at process_noise_std.
+
+    Purpose: Validates that sample_next_states reproduces the scalar model's process noise,
+        including which entries it leaves alone
+
+    Given: One state propagated 20000 times by a model with process_noise_std = 0.3
+    When: The per-column standard deviation of the next states is measured
+    Then: The six noisy ego entries match 0.3 within 3%, while curvature and the agent
+        slots stay deterministic to floating-point precision
+
+    Test type: unit
+    """
+    torch.manual_seed(10)
+    case = _build_case(discount_factor=0.95, process_noise_std=0.3)
+    state = np.zeros((1, case.env.state_width))
+    state[0, 3] = 8.0
+    state[0, EGO_STATE_WIDTH : EGO_STATE_WIDTH + AGENT_SLOT_WIDTH] = [1.0, 12.0, 2.0, -1.0, 0.5]
+    drawn = case.model.sample_next_states(
+        _tensor(np.tile(state, (20000, 1))), _actions(np.zeros(20000, dtype=int))
+    ).numpy()
+    deviations = drawn.std(axis=0)
+    assert np.max(np.abs(deviations[:6] - 0.3)) < 0.03 * 0.3
+    # Not exactly zero: torch's elementwise kernels can differ in the last bit between the
+    # vectorised body of a batch and its remainder, even on identical inputs.
+    assert np.max(deviations[6:]) < _TOLERANCE
+
+
+def test_method_shapes_and_dtypes(case: _Case) -> None:
+    """Every generative method returns the documented shape and dtype.
+
+    Purpose: Validates the tensor contract of the whole public surface
+
+    Given: A batch of 16 random states and zero actions
+    When: Each generative and key method is invoked
+    Then: Shapes are [N, .] or [N], the terminal mask is bool and the keys are int64
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(11)
+    states = _tensor(_random_states(rng, case.env, 16))
+    indices = _actions(np.zeros(16, dtype=int))
+    next_states = case.model.sample_next_states(states, indices)
+    observations = case.model.sample_observations(next_states, indices)
+    assert next_states.shape == (16, case.model.state_dim)
+    assert next_states.dtype == torch.float64
+    assert observations.shape == (16, case.model.observation_dim)
+    assert case.model.rewards(states, indices, next_states).shape == (16,)
+    assert case.model.terminal_mask(states).dtype == torch.bool
+    assert case.model.observation_log_probs(next_states, indices, observations).shape == (16,)
+    assert case.model.action_keys(indices).dtype == torch.int64
+    assert case.model.observation_keys(observations).dtype == torch.int64
+
+
+def test_defaults_to_cpu_and_float32() -> None:
+    """A model built with no device runs on the CPU in float32.
+
+    Purpose: Validates that the model is usable on a machine with no GPU
+
+    Given: A model constructed without a device or dtype argument
+    When: A short batch is propagated, observed, scored and hashed
+    Then: Every tensor is a CPU float32 tensor and no CUDA call is made
+
+    Test type: unit
+    """
+    model = RacetrackVectorizedModel(RacetrackModelPOMDP(discount_factor=0.95))
+    assert model.device == torch.device("cpu")
+    states = torch.zeros(5, model.state_dim)
+    indices = torch.zeros(5, dtype=torch.int64)
+    next_states = model.sample_next_states(states, indices)
+    observations = model.sample_observations(next_states, indices)
+    assert next_states.dtype == torch.float32
+    assert observations.device.type == "cpu"
+    assert model.rewards(states, indices, next_states).dtype == torch.float32
+    assert model.observation_keys(observations).shape == (5,)
+
+
+def test_keys_are_deterministic_and_discriminating(case: _Case) -> None:
+    """Action and observation keys are stable and separate distinct inputs.
+
+    Purpose: Validates the integer belief-tree key mappings
+
+    Given: A fixed action vector and three observations, two of them distinct
+    When: The key methods are called twice on the same inputs
+    Then: Repeated calls agree and distinct observations receive distinct keys
+
+    Test type: unit
+    """
+    indices = torch.tensor([0, 1, 2, 3])
+    assert torch.equal(case.model.action_keys(indices), indices.to(torch.int64))
+    base = torch.zeros(3, case.model.observation_dim, dtype=torch.float64)
+    base[1, 0] = 1.0
+    base[2, 5] = 1.0
+    first = case.model.observation_keys(base)
+    assert torch.equal(first, case.model.observation_keys(base))
+    assert first[0] != first[1]
+    assert first[0] != first[2]
+    assert first[1] != first[2]
+
+
+def test_observation_keys_separate_sparse_binary_grids(pomdp_case: _Case) -> None:
+    """Two thousand distinct sparse occupancy grids hash to two thousand distinct keys.
+
+    Purpose: Guards the hash weights against the collisions a small-prime weighting causes
+        on binary vectors, where a handful of set cells sum into a range of a few thousand
+
+    Given: 2000 grids that each set a different random subset of six presence cells
+    When: They are hashed into belief-tree keys
+    Then: Every key is distinct, so no two genuinely different observations merge
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(12)
+    cells = GRID_CELLS * GRID_CELLS
+    grids = np.zeros((2000, pomdp_case.model.observation_dim))
+    for row in range(grids.shape[0]):
+        grids[row, rng.choice(cells, size=6, replace=False)] = 1.0
+    unique_grids = np.unique(grids, axis=0).shape[0]
+    keys = pomdp_case.model.observation_keys(_tensor(grids)).numpy()
+    assert len(np.unique(keys)) == unique_grids
+
+
+def test_nonpositive_observation_resolution_raises() -> None:
+    """A non-positive observation resolution is rejected at construction.
+
+    Purpose: Validates the guard on the only knob the model does not read off the env
+
+    Given: A valid scalar model and observation_resolution = 0.0
+    When: A vectorized model is constructed from it
+    Then: ValueError is raised
+
+    Test type: unit
+    """
+    env = RacetrackModelPOMDP(discount_factor=0.95)
+    with pytest.raises(ValueError, match="observation_resolution must be positive"):
+        RacetrackVectorizedModel(env, observation_resolution=0.0)

--- a/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_vectorized_model.py
@@ -16,7 +16,18 @@ The occupancy rasteriser gets a dedicated crafted-state test, because its axis o
 (along-track first, across-track second) and its always-marked centre cell were established
 empirically against highway-env 1.12.1 and are the easiest thing in the module to silently
 invert.
+
+**Curvature is the part that has to be watched.** The scalar model asks its subclass where
+the road bends once per substep, and the torch model re-implements that lookup rather than
+calling back into NumPy. So the parity tests deliberately put particles on a lap short
+enough that a rollout crosses several segment boundaries, and both arms of the lookup — a
+track map and a per-step scalar estimate — are compared against the scalar model over a
+multi-decision rollout, not just one step. A single-step comparison would agree even if the
+torch side froze the curvature at the value it started with, which is the exact bug the
+arclength slot exists to prevent.
 """
+
+# pylint: disable=too-many-lines  # One test module per source module, as the test layout requires.
 
 from dataclasses import dataclass
 from typing import Any, Dict, List
@@ -28,21 +39,48 @@ import torch
 from POMDPPlanners.core.environment.vectorized_generative_model import (
     VectorizedGenerativeModel,
 )
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_known_track_model import KnownTrackModel
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_model_pomdp import RacetrackModelPOMDP
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_observed_track_model import (
+    ObservedTrackModel,
+)
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     AGENT_SLOT_WIDTH,
+    DEFAULT_ACTION_PRESETS,
+    EGO_ARCLENGTH_M,
     EGO_LAT,
+    EGO_SPEED,
     EGO_STATE_WIDTH,
     GRID_CELLS,
+    GRID_HALF_EXTENT_M,
+    GRID_STEP_M,
+    ON_ROAD_LAYER,
     ObservationMode,
 )
+from POMDPPlanners.environments.racetrack_pomdp.racetrack_track_geometry import TrackGeometry
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_vectorized_model import (
+    ObservedCurvature,
     RacetrackVectorizedModel,
+    TrackMapCurvature,
 )
 
 _TOLERANCE = 1e-9
 
 _CUSTOM_PRESETS = [(1.0, -1.0), (0.5, 0.25), (0.0, 0.0), (-1.0, 0.75)]
+
+# Index of the (0.0, 0.0) preset: coast, straight ahead. Looked up rather than written as a
+# literal, because the shipped table is a 3-by-9 grid whose indices move whenever the
+# steering resolution changes. Only valid for cases built on the default table.
+_COAST_STRAIGHT = DEFAULT_ACTION_PRESETS.index((0.0, 0.0))
+
+# A deliberately short lap -- two straights and two arcs of opposite sign over 60 m -- so a
+# rollout of a few decisions at track speed crosses several boundaries and wraps. A profile
+# the length of the real circuit would let a frozen-curvature bug pass every test here.
+_TEST_GEOMETRY = TrackGeometry(
+    segment_starts=np.array([0.0, 12.0, 30.0, 45.0]),
+    segment_curvatures=np.array([0.0, 0.05, -0.03, 0.0]),
+    total_length_m=60.0,
+)
 
 # Every case is a supported scalar-model configuration. Noise is off so the transition
 # comparison is deterministic on both sides; the samplers are tested separately.
@@ -72,6 +110,29 @@ _SUPPORTED_CASES: List[Dict[str, Any]] = [
 _CASE_IDS = ["defaults", "coarse-steps", "custom-weights"]
 
 
+class _FixedCurvatureModel(RacetrackModelPOMDP):
+    """A scalar model whose curvature is one number, replaced from outside between steps.
+
+    Stands in for the shipped model that estimates curvature from its observations rather
+    than from a map. What the vectorized twin has to reproduce about such a model is only
+    that the estimate is read *live* — it changes every real step while the torch model is
+    built once — so a settable attribute is the whole of the contract worth testing here.
+
+    Attributes:
+        curvature_estimate: The current estimate in 1/m, shared by every particle.
+    """
+
+    def __init__(self, discount_factor: float, curvature_estimate: Any, **kwargs: Any) -> None:
+        # Stored as handed over, not coerced to float: a real estimator computes this off an
+        # array and would hand over a NumPy scalar, and whether the twin recognises that is
+        # part of what these tests check.
+        self.curvature_estimate = curvature_estimate
+        super().__init__(discount_factor=discount_factor, **kwargs)
+
+    def _curvature_for(self, ego: np.ndarray) -> np.ndarray:
+        return np.full(len(ego), float(self.curvature_estimate), dtype=float)
+
+
 @dataclass
 class _Case:
     """A scalar model paired with the vectorized twin built from it."""
@@ -81,9 +142,12 @@ class _Case:
 
 
 def _build_case(**kwargs: Any) -> _Case:
-    env = RacetrackModelPOMDP(**kwargs)
-    model = RacetrackVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
-    return _Case(env=env, model=model)
+    env = KnownTrackModel(track_geometry=_TEST_GEOMETRY, **kwargs)
+    return _Case(env=env, model=_twin(env))
+
+
+def _twin(env: RacetrackModelPOMDP) -> RacetrackVectorizedModel:
+    return RacetrackVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
 
 
 @pytest.fixture(params=_SUPPORTED_CASES, ids=_CASE_IDS, name="case")
@@ -105,14 +169,19 @@ def _actions(indices: np.ndarray) -> torch.Tensor:
 
 
 def _random_states(rng: np.random.Generator, env: RacetrackModelPOMDP, count: int) -> np.ndarray:
-    """Random states mixing present/absent slots, curved and straight lanes."""
+    """Random states mixing present/absent slots, and every segment of the test lap.
+
+    Arclengths span several laps in both directions, so the wrap and every segment of the
+    profile are exercised by an ordinary parity run rather than only by the tests that
+    target the lookup directly.
+    """
     states = np.zeros((count, env.state_width))
     states[:, 0:2] = rng.uniform(-40.0, 40.0, size=(count, 2))
     states[:, 2] = rng.uniform(-np.pi, np.pi, size=count)
     states[:, 3] = rng.uniform(0.0, 15.0, size=count)
     states[:, 4] = rng.uniform(-3.0, 3.0, size=count)
     states[:, 5] = rng.uniform(-0.6, 0.6, size=count)
-    states[:, 6] = rng.uniform(-0.05, 0.05, size=count)
+    states[:, EGO_ARCLENGTH_M] = rng.uniform(-150.0, 150.0, size=count)
     slots = states[:, EGO_STATE_WIDTH:].reshape(count, env.max_tracked_agents, AGENT_SLOT_WIDTH)
     slots[..., 0] = (rng.uniform(size=slots.shape[:2]) < 0.6).astype(float)
     slots[..., 1] = rng.uniform(-25.0, 25.0, size=slots.shape[:2])
@@ -217,9 +286,402 @@ def test_transition_matches_scalar_batch_helper(pomdp_case: _Case) -> None:
     """
     rng = np.random.default_rng(3)
     states = _random_states(rng, pomdp_case.env, 128)
-    expected = pomdp_case.env.sample_next_state_batch(states, 2)
-    actual = pomdp_case.model.sample_next_states(_tensor(states), _actions(np.full(128, 2))).numpy()
+    expected = pomdp_case.env.sample_next_state_batch(states, _COAST_STRAIGHT)
+    actual = pomdp_case.model.sample_next_states(
+        _tensor(states), _actions(np.full(128, _COAST_STRAIGHT))
+    ).numpy()
     assert np.max(np.abs(expected - actual)) < _TOLERANCE
+
+
+def _rollout_states(count: int, geometry: TrackGeometry) -> np.ndarray:
+    """Particles on the lane centreline at track speed, spread around the whole lap."""
+    states = np.zeros((count, EGO_STATE_WIDTH + 4 * AGENT_SLOT_WIDTH))
+    states[:, EGO_SPEED] = 10.0
+    states[:, EGO_ARCLENGTH_M] = np.linspace(0.0, geometry.total_length_m, count, endpoint=False)
+    return states
+
+
+def _scalar_rollout(
+    env: RacetrackModelPOMDP, states: np.ndarray, action: int, steps: int
+) -> np.ndarray:
+    current = states
+    for _ in range(steps):
+        current = env.sample_next_state_batch(current, action)
+    return current
+
+
+def _vector_rollout(
+    model: RacetrackVectorizedModel, states: np.ndarray, action: int, steps: int
+) -> np.ndarray:
+    current = _tensor(states)
+    indices = _actions(np.full(states.shape[0], action))
+    for _ in range(steps):
+        current = model.sample_next_states(current, indices)
+    return current.numpy()
+
+
+def test_map_rollout_crossing_segment_boundaries_matches_native() -> None:
+    """A multi-decision rollout over a whole lap tracks the scalar model step for step.
+
+    Purpose: This is the test the curvature change exists for. One step agrees even if the
+        torch side freezes the curvature it started with; only a rollout that drives through
+        corners can tell a live lookup from a frozen one
+
+    Given: 32 particles spread around a four-segment lap at 10 m/s, no process noise, and
+        40 coasting decisions -- enough to cross every boundary and wrap past the finish
+    When: The scalar and vectorized models are each rolled forward the same 40 steps
+    Then: The full state agrees to within 1e-9, and the run really did visit more than one
+        curvature rather than sitting on a straight the whole way
+
+    Test type: integration
+    """
+    case = _build_case(discount_factor=0.95, process_noise_std=0.0)
+    states = _rollout_states(32, _TEST_GEOMETRY)
+    steps = 40
+
+    expected = _scalar_rollout(case.env, states, _COAST_STRAIGHT, steps)
+    actual = _vector_rollout(case.model, states, _COAST_STRAIGHT, steps)
+    assert np.max(np.abs(expected - actual)) < _TOLERANCE
+
+    # The rollout is only meaningful if it moved: arclength has to have advanced past at
+    # least one boundary, and the particles must have seen more than one curvature.
+    travelled = expected[:, EGO_ARCLENGTH_M] - states[:, EGO_ARCLENGTH_M]
+    assert np.min(travelled) > _TEST_GEOMETRY.segment_starts[1]
+    assert len(np.unique(_TEST_GEOMETRY.curvature_at(expected[:, EGO_ARCLENGTH_M]))) > 1
+
+
+def test_torch_curvature_lookup_matches_the_numpy_profile() -> None:
+    """The torch table lookup returns exactly what TrackGeometry.curvature_at returns.
+
+    Purpose: The torch lookup is a deliberate re-implementation rather than a call into
+        NumPy, so the two have to be pinned together or the map silently means two
+        different things on the two sides
+
+    Given: 4000 arclengths spanning several laps in both directions, plus every exact
+        segment boundary and the lap length itself
+    When: TrackMapCurvature and TrackGeometry.curvature_at are both evaluated on them
+    Then: The results are bit-identical, boundaries included
+
+    Test type: unit
+    """
+    rng = np.random.default_rng(13)
+    arclengths = np.concatenate(
+        [
+            rng.uniform(-200.0, 200.0, size=4000),
+            _TEST_GEOMETRY.segment_starts,
+            np.array([_TEST_GEOMETRY.total_length_m, -_TEST_GEOMETRY.total_length_m]),
+        ]
+    )
+    ego = np.zeros((arclengths.size, EGO_STATE_WIDTH))
+    ego[:, EGO_ARCLENGTH_M] = arclengths
+
+    lookup = TrackMapCurvature(_TEST_GEOMETRY, torch.device("cpu"), torch.float64)
+    actual = lookup(_tensor(ego)).numpy()
+    np.testing.assert_array_equal(actual, _TEST_GEOMETRY.curvature_at(arclengths))
+
+
+def _real_profile() -> TrackGeometry:
+    """The shipped circuit's measured profile: awkward boundaries over an awkward lap."""
+    return TrackGeometry(
+        segment_starts=np.array(
+            [0.0, 58.0, 97.7062, 107.7062, 170.8872, 206.7537, 235.0379, 313.5778, 372.2208]
+        ),
+        segment_curvatures=np.array(
+            [0.0, -0.04, 0.0, -0.05, 1.0 / 15.0, 0.0, -1.0 / 30.0, -1.0 / 30.0, 2.0 / 37.0]
+        ),
+        total_length_m=381.9074033363339,
+    )
+
+
+def _float32_lookup(geometry: TrackGeometry, arclengths: np.ndarray) -> np.ndarray:
+    ego = np.zeros((arclengths.size, EGO_STATE_WIDTH))
+    ego[:, EGO_ARCLENGTH_M] = arclengths
+    lookup = TrackMapCurvature(geometry, torch.device("cpu"), torch.float32)
+    return lookup(torch.as_tensor(ego, dtype=torch.float32)).numpy()
+
+
+def test_float32_curvature_lookup_agrees_with_the_numpy_profile() -> None:
+    """In float32 the lookup still picks the segment the float64 profile picks.
+
+    Purpose: Every other parity test runs in float64, and the shipped default is float32.
+        Segment boundaries on the real circuit are awkward numbers like 372.2208 m over a
+        381.9074 m lap, so this is where the two dtypes would diverge if they were going to
+
+    Given: The measured profile of the shipped circuit, its nine exact boundaries, and
+        20000 arclengths spread over three laps in both directions
+    When: The float32 lookup is compared to TrackGeometry.curvature_at
+    Then: Every one agrees
+
+    Test type: unit
+    """
+    geometry = _real_profile()
+    rng = np.random.default_rng(17)
+    arclengths = np.concatenate(
+        [
+            geometry.segment_starts,
+            rng.uniform(-3.0, 3.0, size=20000) * geometry.total_length_m,
+        ]
+    )
+    actual = _float32_lookup(geometry, arclengths)
+    np.testing.assert_array_equal(actual, geometry.curvature_at(arclengths).astype(np.float32))
+
+
+def test_float32_boundaries_a_whole_lap_away_are_off_by_at_most_one_segment() -> None:
+    """A boundary reached after a full lap can read the neighbouring segment in float32.
+
+    Purpose: Records a real limit rather than papering over it. A float32 arclength is up to
+        1.1e-5 m from the boundary it means, so which side of that boundary it falls on is
+        not recoverable -- not by holding the profile in float64, which measurably makes it
+        worse, and not by any other lookup. What can be pinned is that the disagreement
+        stays confined to boundaries and to one segment either way
+
+    Given: The shipped profile's boundaries offset by exactly one and three laps, looked up
+        through a probe profile whose "curvatures" are the segment indices, so the two sides
+        can be compared by which segment they chose rather than by a curvature value two
+        segments happen to share
+    When: The float32 lookup is compared to the float64 profile
+    Then: Any row that disagrees is within 1e-4 m of a boundary and lands one segment away,
+        never further
+
+    Test type: unit
+    """
+    geometry = _real_profile()
+    starts, lap = geometry.segment_starts, geometry.total_length_m
+    probe = TrackGeometry(
+        segment_starts=starts,
+        segment_curvatures=np.arange(len(starts), dtype=float),
+        total_length_m=lap,
+    )
+    arclengths = np.concatenate([starts + lap, starts + 3.0 * lap, starts - lap])
+
+    chosen = _float32_lookup(probe, arclengths)
+    reference = probe.curvature_at(arclengths)
+    disagreed = np.flatnonzero(chosen != reference)
+    assert disagreed.size > 0, "the float32 limit this test documents no longer reproduces"
+
+    distance = np.mod(arclengths[disagreed], lap)
+    assert np.all(np.min(np.abs(distance[:, None] - starts[None, :]), axis=1) < 1e-4)
+    assert np.all(np.abs(chosen[disagreed] - reference[disagreed]) == 1.0)
+
+
+def test_curvature_estimate_is_read_live_and_matches_the_scalar_model() -> None:
+    """A per-step curvature estimate reaches the torch rollout the step it changes.
+
+    Purpose: Validates the other arm of the curvature source. Caching the estimate at
+        construction would leave a mapless planner frozen on whichever corner it started
+        in, and every single-step test would still pass
+
+    Given: A scalar model holding one settable curvature, its vectorized twin, and a
+        20-decision rollout run at two different curvature values
+    When: The estimate is changed on the scalar model between the two runs
+    Then: Both runs match the scalar model to 1e-9, and the two runs differ from each other
+
+    Test type: unit
+    """
+    env = _FixedCurvatureModel(discount_factor=0.95, curvature_estimate=0.0, process_noise_std=0.0)
+    model = _twin(env)
+    states = _rollout_states(8, _TEST_GEOMETRY)
+
+    outcomes = []
+    for curvature in (0.02, -0.04):
+        env.curvature_estimate = curvature
+        expected = _scalar_rollout(env, states, _COAST_STRAIGHT, 20)
+        actual = _vector_rollout(model, states, _COAST_STRAIGHT, 20)
+        assert np.max(np.abs(expected - actual)) < _TOLERANCE, f"curvature {curvature} diverged"
+        outcomes.append(actual)
+    assert np.max(np.abs(outcomes[0] - outcomes[1])) > 1e-3
+
+
+def test_a_numpy_scalar_curvature_estimate_is_recognised() -> None:
+    """An estimate held as a NumPy scalar resolves the same as a Python float.
+
+    Purpose: A curvature estimated from the on-road layer falls out of an array computation
+        as a np.float32, which is not a Python float. Rejecting it would send a working
+        model down the "cannot infer a curvature source" path for a reason that has nothing
+        to do with the model
+
+    Given: A scalar model whose curvature_estimate is a np.float32
+    When: A vectorized twin is built from it and a five-decision rollout is run
+    Then: Construction succeeds and the rollout matches the scalar model to 1e-9
+
+    Test type: unit
+    """
+    env = _FixedCurvatureModel(
+        discount_factor=0.95, curvature_estimate=np.float32(0.03), process_noise_std=0.0
+    )
+    states = _rollout_states(8, _TEST_GEOMETRY)
+    expected = _scalar_rollout(env, states, _COAST_STRAIGHT, 5)
+    actual = _vector_rollout(_twin(env), states, _COAST_STRAIGHT, 5)
+    assert np.max(np.abs(expected - actual)) < _TOLERANCE
+
+
+def _curved_on_road_observation(curvature: float) -> np.ndarray:
+    """A raw occupancy grid whose on-road corridor bends, so a fit reads a real curvature."""
+    grid = np.zeros((2, GRID_CELLS, GRID_CELLS), dtype=np.float32)
+    for row in range(GRID_CELLS):
+        along = row * GRID_STEP_M - GRID_HALF_EXTENT_M + 0.5 * GRID_STEP_M
+        across = 0.5 * curvature * along**2
+        column = int(np.floor((across + GRID_HALF_EXTENT_M) / GRID_STEP_M))
+        if 0 <= column < GRID_CELLS:
+            grid[ON_ROAD_LAYER, row, column] = 1.0
+    return grid
+
+
+def _observed_case() -> _Case:
+    """A live ObservedTrackModel that has already read one bending corridor, and its twin.
+
+    The corridor is drawn at 0.08 1/m, well beyond anything on the real circuit. It has to
+    be: the fit runs on 3 m cells over a 12 m window, so a realistic 0.04 bends the corridor
+    by less than one cell and quantises back to a straight road. What is under test here is
+    the *layer*, not the fit, and the layer needs a curvature that survives rasterisation.
+    """
+    env = ObservedTrackModel(discount_factor=0.95, process_noise_std=0.0, cell_flip_prob=0.05)
+    env.encode_observation(_curved_on_road_observation(0.08))
+    assert abs(env.curvature_estimate) > 1e-3, "the fixture failed to produce a bending road"
+    return _Case(env=env, model=_twin(env))
+
+
+def test_observed_model_on_road_layer_matches_native() -> None:
+    """The torch corridor render equals the mapless model's, cell for cell.
+
+    Purpose: The mapless model predicts the road back in order to score the road it reads,
+        so the layer is state-dependent and separates particles. A twin that kept the base
+        model's all-ones layer would still return the right shape and the wrong weights
+
+    Given: A live ObservedTrackModel that has fitted a bending corridor, and 64 random
+        states spanning the lateral offsets and lane angles the ego actually takes
+    When: Both models draw a noise-free on-road layer for each state
+    Then: The two layers are identical, and the rendered corridor is neither empty nor the
+        whole grid -- an all-ones or all-zeros layer would match trivially
+
+    Test type: unit
+    """
+    case = _observed_case()
+    rng = np.random.default_rng(14)
+    states = _random_states(rng, case.env, 64)
+
+    drawn = case.model.sample_observations(_tensor(states), _actions(np.zeros(64, dtype=int)))
+    actual = drawn.numpy().reshape(64, 2, GRID_CELLS, GRID_CELLS)[:, ON_ROAD_LAYER]
+    expected = np.stack(
+        [
+            np.asarray(case.env.sample_observation(states[i], None)["occupancy"])[ON_ROAD_LAYER]
+            for i in range(states.shape[0])
+        ]
+    )
+    np.testing.assert_array_equal(actual, expected)
+    marked = expected.reshape(64, -1).sum(axis=1)
+    assert np.all(marked > 0) and np.all(marked < GRID_CELLS * GRID_CELLS)
+
+
+def test_observed_model_observation_log_probs_match_native() -> None:
+    """Occupancy log-densities match the mapless model, on-road term included.
+
+    Purpose: Validates the full POMDP likelihood for the mapless arm -- the presence
+        Bernoulli plus the on-road Bernoulli the base model declines to score
+
+    Given: A live ObservedTrackModel with a fitted corridor, 64 random states, and
+        observations drawn from the vectorized sampler
+    When: observation_log_probs is compared to env.observation_log_probability per row
+    Then: The maximum absolute difference is below 1e-9, every value is finite, and the
+        on-road term is actually contributing rather than silently zero
+
+    Test type: unit
+    """
+    torch.manual_seed(15)
+    case = _observed_case()
+    rng = np.random.default_rng(15)
+    states = _random_states(rng, case.env, 64)
+    indices = _actions(np.zeros(64, dtype=int))
+
+    observations = case.model.sample_observations(_tensor(states), indices)
+    expected = np.array(
+        [
+            case.env.observation_log_probability(states[i], 0, _occupancy_dict(observations[i]))[0]
+            for i in range(states.shape[0])
+        ]
+    )
+    actual = case.model.observation_log_probs(_tensor(states), indices, observations).numpy()
+    assert np.all(np.isfinite(actual))
+    assert np.max(np.abs(expected - actual)) < _TOLERANCE
+
+    # The on-road term must be doing work: a zero contribution would make this test pass
+    # while the mapless arm scored its road exactly as the mapped arm does.
+    on_road = case.model.road_layer.log_probs(_tensor(states), observations).numpy()
+    assert np.all(on_road < 0.0)
+
+
+def test_a_mapped_model_keeps_the_all_ones_road_layer() -> None:
+    """A model holding a track map renders road everywhere and scores it at zero.
+
+    Purpose: Pins the other side of the dispatch. Rendering a corridor for a mapped model
+        would cost 144 cells of arithmetic per particle to add a constant every particle
+        shares, and the scalar model declines to for that reason
+
+    Given: A vectorized twin of a KnownTrackModel and 16 random states
+    When: The road layer is rendered and scored
+    Then: Every cell is on-road and every log-probability is exactly zero
+
+    Test type: unit
+    """
+    case = _build_case(discount_factor=0.95, process_noise_std=0.0)
+    rng = np.random.default_rng(16)
+    states = _tensor(_random_states(rng, case.env, 16))
+    observations = case.model.sample_observations(states, _actions(np.zeros(16, dtype=int)))
+    assert torch.all(case.model.road_layer.render(states) == 1.0)
+    assert torch.all(case.model.road_layer.log_probs(states, observations) == 0.0)
+
+
+def test_explicit_curvature_source_overrides_the_env() -> None:
+    """A caller-supplied curvature source is used in place of the one read off the model.
+
+    Purpose: Validates the escape hatch that keeps this module from needing an edit for
+        every new subclass
+
+    Given: A model carrying a track map, and a vectorized twin built with an explicit
+        constant-curvature source instead
+    When: One decision is propagated
+    Then: The result matches a scalar model whose curvature is that same constant, not the
+        one the map would have given
+
+    Test type: unit
+    """
+    mapped = KnownTrackModel(
+        discount_factor=0.95, track_geometry=_TEST_GEOMETRY, process_noise_std=0.0
+    )
+    fixed = _FixedCurvatureModel(
+        discount_factor=0.95, curvature_estimate=0.05, process_noise_std=0.0
+    )
+    overridden = RacetrackVectorizedModel(
+        mapped,
+        device=torch.device("cpu"),
+        dtype=torch.float64,
+        curvature_source=ObservedCurvature(lambda: 0.05),
+    )
+    states = _rollout_states(8, _TEST_GEOMETRY)
+    expected = _scalar_rollout(fixed, states, _COAST_STRAIGHT, 5)
+    actual = _vector_rollout(overridden, states, _COAST_STRAIGHT, 5)
+    assert np.max(np.abs(expected - actual)) < _TOLERANCE
+
+
+def test_model_without_a_curvature_source_is_rejected() -> None:
+    """A scalar model exposing neither a map nor an estimate cannot be twinned silently.
+
+    Purpose: Guards the one failure that would not look like a failure -- defaulting to zero
+        curvature gives a model that runs, scores, and drives straight through every corner
+
+    Given: A scalar model with neither a track_geometry nor an curvature_estimate
+    When: A vectorized twin is built from it with no explicit curvature source
+    Then: ValueError is raised naming both attributes and the explicit argument
+
+    Test type: unit
+    """
+
+    class _NoCurvature(RacetrackModelPOMDP):
+        def _curvature_for(self, ego: np.ndarray) -> np.ndarray:
+            return np.zeros(len(ego))
+
+    with pytest.raises(ValueError, match="Cannot infer a curvature source"):
+        RacetrackVectorizedModel(_NoCurvature(discount_factor=0.95))
 
 
 def _reward_states(env: RacetrackModelPOMDP) -> np.ndarray:
@@ -458,7 +920,7 @@ def test_process_noise_matches_the_configured_scale() -> None:
 
     Given: One state propagated 20000 times by a model with process_noise_std = 0.3
     When: The per-column standard deviation of the next states is measured
-    Then: The six noisy ego entries match 0.3 within 3%, while curvature and the agent
+    Then: The six noisy ego entries match 0.3 within 3%, while the arclength and the agent
         slots stay deterministic to floating-point precision
 
     Test type: unit
@@ -466,7 +928,7 @@ def test_process_noise_matches_the_configured_scale() -> None:
     torch.manual_seed(10)
     case = _build_case(discount_factor=0.95, process_noise_std=0.3)
     state = np.zeros((1, case.env.state_width))
-    state[0, 3] = 8.0
+    state[0, EGO_SPEED] = 8.0
     state[0, EGO_STATE_WIDTH : EGO_STATE_WIDTH + AGENT_SLOT_WIDTH] = [1.0, 12.0, 2.0, -1.0, 0.5]
     drawn = case.model.sample_next_states(
         _tensor(np.tile(state, (20000, 1))), _actions(np.zeros(20000, dtype=int))
@@ -515,7 +977,9 @@ def test_defaults_to_cpu_and_float32() -> None:
 
     Test type: unit
     """
-    model = RacetrackVectorizedModel(RacetrackModelPOMDP(discount_factor=0.95))
+    model = RacetrackVectorizedModel(
+        KnownTrackModel(discount_factor=0.95, track_geometry=_TEST_GEOMETRY)
+    )
     assert model.device == torch.device("cpu")
     states = torch.zeros(5, model.state_dim)
     indices = torch.zeros(5, dtype=torch.int64)
@@ -583,6 +1047,6 @@ def test_nonpositive_observation_resolution_raises() -> None:
 
     Test type: unit
     """
-    env = RacetrackModelPOMDP(discount_factor=0.95)
+    env = KnownTrackModel(discount_factor=0.95, track_geometry=_TEST_GEOMETRY)
     with pytest.raises(ValueError, match="observation_resolution must be positive"):
         RacetrackVectorizedModel(env, observation_resolution=0.0)


### PR DESCRIPTION
## The problem

The planner-side model could not anticipate corners, and that was measured rather than guessed.

It held the *current* lane's curvature fixed for the whole rollout, so on the straight before a bend it predicted a perfectly centred car — lateral offset 0.000 m — while the real one drifted to 1.961 m of a 2.5 m lane. It scored coasting straight at 5.298 against 0.673 for the best steering action, rating the one manoeuvre that survives the corner as the worst available.

More search did not help. 8, 11 and 14 planning iterations all gave exactly 20% survival while decision time tripled. The model was wrong, not the search.

## What changed

Seven changes, following the `carla_pomdp` pattern of several swappable planner-side models over one world.

1. **The state's last ego slot is now `s`, the car's arclength along the track**, in place of `curvature`. Same width. The state should describe the car; predicting where the road goes is the transition model's job, and freezing a road property in the state encodes a prediction rather than a fact.
2. **`racetrack_track_geometry.py`** holds exact piecewise-constant curvature by arclength. Walking the circuit's lane graph gives 9 segments over 381.9 m, each a straight or a circular arc, so the profile is three short arrays — no spline, no numerical differentiation. Only the builder touches `highway-env`; the geometry itself is plain NumPy and still pickles for Ray.
3. **`RacetrackModelPOMDP` is now abstract**, on exactly one hook: `_curvature_for`.
4. **`KnownTrackModel`** (A) looks curvature up by arclength — the planner knows the circuit.
5. **`ObservedTrackModel`** (B) estimates curvature from the observation's `on_road` layer — the planner does not. B also renders and scores that layer, which previously was written as a constant and never read, so half the observation carries information for the first time.
6. **`RacetrackVectorizedModel` takes a `curvature_source`**, so VOPP inherits whichever model it is given. Parameterised rather than forked, because the two models differ in a single lookup and two near-identical torch files drift apart.
7. **Action presets go from 9 to 27**, steering sampled finely near zero. The best constant steer through the first bend is −0.05; the old `{−1, 0, +1}` set could not express it. Sweeping constant steering through that bend, −1.0 survives 5 steps and −0.05 survives 29.

## Results

**VOPP completion: 6/30 (20%) before → 11/15 (73%) after**, with model B. Fisher exact p = 0.0009, odds ratio 11.

A 5-episode run gave 5/5 but **did not reproduce** on a rerun — VOPP's particle sampling is not seeded deterministically. The 15-episode figure is the one quoted here; the smaller one is not a result.

**B ≥ A.** The model that reads the road off the grid does at least as well as the one handed the exact circuit. That defuses the privileged-information concern that motivated building both.

**A's cornering prediction is accurate to 0.409 m** through the first bend against the live simulator, versus **25.86 m** for the frozen-curvature model it replaces.

**A 30-episode PFT-DPW comparison at a small fixed budget showed survival unchanged** — A 5/30, B 7/30, baseline 6/30, indistinguishable at n=30 — while duration rose 34% and return 31%. Stated plainly: the model fix is necessary but not sufficient at a small search budget. That table used the pre-fix B.

**A defect was found and removed after the first runs.** B's fit divided by the textbook `(1 + b²)^{3/2}` slope term, which suppressed the estimate when the ego was yawed — hardest exactly when the car most needed to know the road bends. Removing it moves the arc ratio only 0.76 → 0.78 on a well-driven car, so it helps a car recovering from a mistake rather than improving the average.

## Commits

Four, and the first is older than the rest of this work:

- `280c18e4` — the torch vectorized model itself. Written before this change and never merged on its own, so it rides along here.
- `0363afc` — the state slot and the track geometry.
- `eca8967` — the model split, with A and B.
- `efd4795` — the vectorized mirror and the downstream test updates.

## Verification

| Gate | Result |
| --- | --- |
| `black --line-length=100 --check` (21 racetrack files) | clean |
| `pyright POMDPPlanners/` | 0 errors, 0 warnings |
| `pylint` (racetrack source + tests) | 10.00/10 |
| `pytest --doctest-modules POMDPPlanners/environments/racetrack_pomdp/` | 7 passed |
| `pytest POMDPPlanners/tests/` | 5102 passed, 23 skipped, 10 xfailed |

Every changed and new file parses under `ast.parse(feature_version=(3,10))`, and none imports anything newer than 3.10 — CI runs 3.10.20 and a `tomllib` import broke this branch series once already.

One unrelated flake to be aware of: `test_laser_tag_reward_cpp_parity.py::test_cpp_matches_python_in_mean[DISTANCE_DECAYED_HAZARD_PENALTY-1.5]` failed on an earlier run of the suite and passed on the final one plus five standalone reruns. It is an unseeded 3-sigma sample-mean comparison, so it fails at roughly its stated rate. Nothing on this branch touches LaserTag.

## Known limits

- **Curvature uncertainty is absent from the search.** One estimate per step, shared by every particle, so within a planning step the belief cannot disagree about where the road goes.
- **B refuses construction in MDP mode.** That observation has no road in it, and a model that silently held curvature at zero would look like a planning bug rather than a configuration one.
- **Two model errors are untouched.** Agent slots drift at constant velocity while the world runs IDM, and collisions use a centre-distance circle where the world uses an oriented rectangle. Neither mattered here — zero collisions in every run — but both will matter in traffic.
- **`_build_lane_offsets` only populates lane-1 indices**, so a lane change would reset the arclength origin and misalign it from a map built once at reset. Not observed in a full lap of closed-loop driving, but latent.
- **Commit `0363afc` does not import on its own.** The schema rename lands there while `racetrack_model_pomdp.py` still references `EGO_CURVATURE` until the next commit. The branch tip is green; the intermediate commit is not.
