### PR TITLE
Fix CVaR return confidence intervals

### DIFF
--- a/POMDPPlanners/simulations/simulation_statistics.py
+++ b/POMDPPlanners/simulations/simulation_statistics.py
@@ -32,6 +32,15 @@ class StandardMetrics(Enum):
     AVERAGE_REACH_TERMINAL_STATE = "average_reach_terminal_state"
 
 
+def _standard_metric_names(env: Environment) -> List[str]:
+    """Return standard metrics supported by the environment metadata."""
+    return [
+        metric.value
+        for metric in StandardMetrics
+        if metric is not StandardMetrics.RETURN_CVAR or env.reward_range is not None
+    ]
+
+
 def _cvar_return_bounds(
     env: Environment,
 ) -> Tuple[Optional[float], Optional[float]]:
@@ -202,18 +211,26 @@ def compute_statistics_environment_policy_pair(  # pylint: disable=too-many-stat
 
     average_return = sum(return_samples) / len(return_samples)
 
-    return_cvar = -cvar_estimator(-np.array(return_samples), alpha)
     return_value_at_risk = np.percentile(return_samples, alpha * 100)
 
-    neg_lower, neg_upper = _cvar_return_bounds(env)
-    neg_ci = cvar_confidence_interval(
-        data=list(-np.array(return_samples)),
-        alpha=alpha,
-        delta=1 - confidence_interval_level,
-        dist_lower_bound=neg_lower,
-        dist_upper_bound=neg_upper,
-    )
-    cvar_return_confidence_interval = (-neg_ci[1], -neg_ci[0])
+    cvar_return_metric = None
+    if env.reward_range is not None:
+        return_cvar = -cvar_estimator(-np.array(return_samples), alpha)
+        neg_lower, neg_upper = _cvar_return_bounds(env)
+        neg_ci = cvar_confidence_interval(
+            data=list(-np.array(return_samples)),
+            alpha=alpha,
+            delta=1 - confidence_interval_level,
+            dist_lower_bound=neg_lower,
+            dist_upper_bound=neg_upper,
+        )
+        cvar_return_confidence_interval = (-neg_ci[1], -neg_ci[0])
+        cvar_return_metric = MetricValue(
+            name=StandardMetrics.RETURN_CVAR.value,
+            value=float(return_cvar),
+            lower_confidence_bound=cvar_return_confidence_interval[0],
+            upper_confidence_bound=cvar_return_confidence_interval[1],
+        )
     return_value_at_risk_confidence_interval = quantile_confidence_interval(
         data=return_samples, alpha=alpha, conf_level=confidence_interval_level
     )
@@ -267,12 +284,7 @@ def compute_statistics_environment_policy_pair(  # pylint: disable=too-many-stat
                 lower_confidence_bound=average_return_confidence_interval[0],
                 upper_confidence_bound=average_return_confidence_interval[1],
             ),
-            MetricValue(
-                name=StandardMetrics.RETURN_CVAR.value,
-                value=float(return_cvar),
-                lower_confidence_bound=cvar_return_confidence_interval[0],
-                upper_confidence_bound=cvar_return_confidence_interval[1],
-            ),
+            *([cvar_return_metric] if cvar_return_metric is not None else []),
             MetricValue(
                 name=StandardMetrics.RETURN_VALUE_AT_RISK.value,
                 value=float(return_value_at_risk),
@@ -548,8 +560,8 @@ def get_metric_names_from_environment_policy_pair(
     # Policy-specific metrics (second, prefixed with "policy_info_")
     policy_metrics = [f"policy_info_{name}" for name in policy_class.get_info_variable_names()]
 
-    # Standard metrics (last, always available)
-    standard_metrics = [metric.value for metric in StandardMetrics]
+    # Standard metrics (last, conditional on required environment metadata)
+    standard_metrics = _standard_metric_names(environment)
 
     return env_metrics + policy_metrics + standard_metrics
 
@@ -601,8 +613,8 @@ def get_available_optimization_metrics(
         >>> "policy_info_min_actions_visit_count" in available_metrics
         True
     """
-    # Standard metrics (always available)
-    standard = [metric.value for metric in StandardMetrics]
+    # Standard metrics (conditional on required environment metadata)
+    standard = _standard_metric_names(environment)
 
     # Environment-specific metrics
     env_metrics = environment.get_metric_names()

--- a/POMDPPlanners/tests/test_core/test_hyper_parameter_tuning.py
+++ b/POMDPPlanners/tests/test_core/test_hyper_parameter_tuning.py
@@ -1103,6 +1103,7 @@ class TestOptimizedPolicyResultValidation:
                     discount_factor=0.95,
                     name="mock_env",
                     space_info=SpaceInfo(SpaceType.DISCRETE, SpaceType.DISCRETE),
+                    reward_range=(-1.0, 1.0),
                 )
 
             @property

--- a/POMDPPlanners/tests/test_simulations/test_simulation_statistics.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulation_statistics.py
@@ -4,6 +4,7 @@ import random
 from typing import List
 
 import numpy as np
+import pytest
 
 from POMDPPlanners.core.belief import WeightedParticleBelief
 from POMDPPlanners.core.policy import PolicyInfoVariable, PolicyRunData
@@ -18,6 +19,7 @@ from POMDPPlanners.simulations.simulation_statistics import (
     StandardMetrics,
     compute_statistics_environment_policy_pair,
     compute_statistics_environments_policies_comparison,
+    get_available_optimization_metrics,
     get_metric_names_from_environment_policy_pair,
 )
 
@@ -844,3 +846,48 @@ def test_metric_estimates_within_confidence_intervals():
             f"Metric '{metric.name}': value {metric.value} not within CI "
             f"[{metric.lower_confidence_bound}, {metric.upper_confidence_bound}]"
         )
+
+
+def test_cvar_return_rejects_samples_outside_declared_reward_range():
+    """CVaR concentration bounds must not use an invalid return support."""
+    histories = [create_test_history([-100.0], discount_factor=0.0) for _ in range(10)]
+    environment = TigerPOMDP(discount_factor=0.0)
+    environment.reward_range = (-1.0, 1.0)
+
+    with pytest.raises(ValueError, match="outside the distribution support"):
+        compute_statistics_environment_policy_pair(
+            env=environment,
+            histories=histories,
+            alpha=0.1,
+            confidence_interval_level=0.95,
+        )
+
+
+def test_cvar_metric_omitted_without_reward_range():
+    """CVaR is unavailable when the environment has no known reward support."""
+    environment = TigerPOMDP(discount_factor=0.95)
+    environment.reward_range = None
+    histories = [create_test_history([float(i)]) for i in range(1, 11)]
+
+    metrics = compute_statistics_environment_policy_pair(
+        env=environment,
+        histories=histories,
+        alpha=0.1,
+        confidence_interval_level=0.95,
+    )
+    assert StandardMetrics.RETURN_CVAR.value not in {metric.name for metric in metrics}
+
+    dataframe = compute_statistics_environments_policies_comparison(
+        histories={environment.name: {"test_policy": histories}},
+        environments=[environment],
+        alpha=0.1,
+        confidence_interval_level=0.95,
+    )
+    assert not any(column.startswith("return_cvar") for column in dataframe.columns)
+
+    assert StandardMetrics.RETURN_CVAR.value not in get_metric_names_from_environment_policy_pair(
+        environment, POMCP
+    )
+    assert StandardMetrics.RETURN_CVAR.value not in get_available_optimization_metrics(
+        environment, POMCP
+    )

--- a/POMDPPlanners/utils/statistics_utils.py
+++ b/POMDPPlanners/utils/statistics_utils.py
@@ -216,7 +216,7 @@ def cvar_confidence_interval(
     dist_upper_bound: Optional[float] = None,
 ):
     """
-    Calculate the confidence interval for the CVaR of a dataset using the t-distribution.
+    Calculate finite-sample CVaR concentration bounds using the Thomas method.
 
     Args:
         data: Array of values
@@ -231,29 +231,55 @@ def cvar_confidence_interval(
         tuple: (lower_bound, upper_bound) of the confidence interval
 
     Raises:
-        ValueError: If data contains NaN values or has insufficient samples
+        ValueError: If parameters, data, support, or computed bounds are invalid
     """
 
-    if not 0 <= alpha <= 1:
-        raise ValueError("confidence must be between 0 and 1")
-    if len(data) == 0:
-        raise ValueError("Input vector must not be empty")
+    if not 0 < alpha <= 1:
+        raise ValueError("alpha must be between 0 (exclusive) and 1")
+    if not 0 < delta < 1:
+        raise ValueError("delta must be between 0 and 1 (exclusive)")
 
-    # For single data point, return the value as both bounds
-    if len(data) == 1:
-        cvar_value = cvar_estimator(data, alpha)
+    data_arr = np.asarray(data, dtype=float)
+    if data_arr.size == 0:
+        raise ValueError("Input vector must not be empty")
+    if not np.all(np.isfinite(data_arr)):
+        raise ValueError("Input vector must contain only finite values")
+
+    effective_lower = (
+        float(dist_lower_bound) if dist_lower_bound is not None else float(np.min(data_arr))
+    )
+    effective_upper = (
+        float(dist_upper_bound) if dist_upper_bound is not None else float(np.max(data_arr))
+    )
+    if not np.isfinite(effective_lower) or not np.isfinite(effective_upper):
+        raise ValueError("Distribution support bounds must be finite")
+    if effective_lower > effective_upper:
+        raise ValueError("Distribution lower bound must not exceed upper bound")
+
+    sample_lower = float(np.min(data_arr))
+    sample_upper = float(np.max(data_arr))
+    if sample_lower < effective_lower or sample_upper > effective_upper:
+        raise ValueError(
+            "Data contains values outside the distribution support: "
+            f"observed [{sample_lower}, {sample_upper}], "
+            f"support [{effective_lower}, {effective_upper}]"
+        )
+
+    # For a single data point, the CVaR is known exactly.
+    if data_arr.size == 1:
+        cvar_value = cvar_estimator(data_arr, alpha)
         return (cvar_value, cvar_value)
 
-    data_arr = np.asarray(data)
-    effective_lower = dist_lower_bound if dist_lower_bound is not None else float(np.min(data_arr))
-    effective_upper = dist_upper_bound if dist_upper_bound is not None else float(np.max(data_arr))
-
     lower_bound = cvar_probabilistic_lower_bound_thomas(
-        vec=data, alpha=alpha, delta=delta / 2, dist_lower_bound=effective_lower
+        vec=data_arr, alpha=alpha, delta=delta / 2, dist_lower_bound=effective_lower
     )
     upper_bound = cvar_probabilistic_upper_bound_thomas(
-        vec=data, alpha=alpha, delta=delta / 2, dist_upper_bound=effective_upper
+        vec=data_arr, alpha=alpha, delta=delta / 2, dist_upper_bound=effective_upper
     )
+    if not np.isfinite(lower_bound) or not np.isfinite(upper_bound):
+        raise ValueError("CVaR confidence bounds must be finite")
+    if lower_bound > upper_bound:
+        raise ValueError(f"CVaR confidence bounds are reversed: [{lower_bound}, {upper_bound}]")
     return lower_bound, upper_bound
 
 


### PR DESCRIPTION
## Summary

- validate CVaR concentration-bound parameters, samples, declared support, and computed interval ordering
- reject observed returns outside the environment-derived reward support instead of emitting crossed intervals
- omit the `return_cvar` metric and its CI columns when an environment has no `reward_range`
- keep metric discovery and optimization metric lists consistent with the generated statistics
- add regression coverage for invalid support and missing reward ranges

## Before / after

- Before: ten returns of `-100` with declared `reward_range=(-1, 1)` produced the crossed interval `[-1, -100]`.
- After: the same input raises a descriptive `ValueError` identifying observed `[100, 100]` versus cost support `[-1, 1]`.
- Valid in-support input remains unchanged: point estimate `0.8333333333333334`, interval `[0, 1]` before and after.
- Environments with `reward_range=None` no longer expose `return_cvar` in metric results, DataFrame columns, or optimization metric discovery.

## Verification

- `49 passed` across simulation-statistics and statistics-utility tests
- Black passed
- Pylint: 10.00/10
- Pyright: 0 errors, 0 warnings
- commit and push hooks passed
