### PR TITLE
Fix reward ranges for zero-mean danger shocks

### DIFF
--- a/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
+++ b/POMDPPlanners/environments/laser_tag_pomdp/laser_tag_pomdp.py
@@ -286,11 +286,23 @@ class LaserTagPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-pub
             observation_space=SpaceType.CONTINUOUS,  # Continuous 8-dimensional laser measurements with noise
         )
 
+        danger_term_min = 0.0
+        danger_term_max = 0.0
+        if reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
+            if walls:
+                danger_term_min -= abs(dangerous_area_penalty)
+            if dangerous_areas is None or dangerous_areas:
+                danger_term_min -= abs(dangerous_area_penalty)
+                danger_term_max += abs(dangerous_area_penalty)
+
         super().__init__(
             discount_factor=discount_factor,
             name=name,
             space_info=space_info,
-            reward_range=(-tag_penalty, tag_reward),
+            reward_range=(
+                -tag_penalty + danger_term_min,
+                tag_reward + danger_term_max,
+            ),
             output_dir=output_dir,
             debug=debug,
             use_queue_logger=use_queue_logger,

--- a/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
+++ b/POMDPPlanners/environments/pacman_pomdp/pacman_pomdp.py
@@ -222,10 +222,19 @@ class PacManPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-publi
         # is configured, so disabling the feature preserves the historical
         # reward range exactly.
         _has_dangerous_areas = bool(dangerous_areas)
-        min_reward = step_penalty + ghost_collision_penalty
         if _has_dangerous_areas:
-            min_reward -= float(dangerous_area_penalty)
-        max_reward = step_penalty + pellet_reward + win_reward
+            if reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
+                danger_term_min = -abs(dangerous_area_penalty)
+                danger_term_max = abs(dangerous_area_penalty)
+            else:
+                danger_contribution = -float(dangerous_area_penalty)
+                danger_term_min = min(0.0, danger_contribution)
+                danger_term_max = max(0.0, danger_contribution)
+        else:
+            danger_term_min = 0.0
+            danger_term_max = 0.0
+        min_reward = step_penalty + ghost_collision_penalty + danger_term_min
+        max_reward = step_penalty + pellet_reward + win_reward + danger_term_max
 
         space_info = SpaceInfo(
             action_space=SpaceType.DISCRETE, observation_space=SpaceType.DISCRETE

--- a/POMDPPlanners/environments/push_pomdp/push_pomdp.py
+++ b/POMDPPlanners/environments/push_pomdp/push_pomdp.py
@@ -301,12 +301,20 @@ class PushPOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-public-
         # advertised lower bound. Maximum distance is diagonal from corner to
         # corner: sqrt(2) * (grid_size - 1).
         max_distance = np.sqrt(2) * (grid_size - 1)
+        if self.dangerous_areas:
+            if reward_model_type == RewardModelType.ZERO_MEAN_HAZARD_SHOCK:
+                danger_term_min = -abs(dangerous_area_penalty)
+                danger_term_max = abs(dangerous_area_penalty)
+            else:
+                danger_term_min = min(0.0, dangerous_area_penalty)
+                danger_term_max = max(0.0, dangerous_area_penalty)
+        else:
+            danger_term_min = 0.0
+            danger_term_max = 0.0
         min_reward = (
-            -max_distance
-            + min(0.0, obstacle_penalty if self.obstacles else 0.0)
-            + min(0.0, dangerous_area_penalty if self.dangerous_areas else 0.0)
+            -max_distance + min(0.0, obstacle_penalty if self.obstacles else 0.0) + danger_term_min
         )
-        max_reward = 100.0  # Best case: at target with bonus reward
+        max_reward = 100.0 + danger_term_max
 
         super().__init__(
             discount_factor=discount_factor,

--- a/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py
@@ -1457,6 +1457,21 @@ class TestLaserTagPOMDP:
 
         assert env2.reward_range == (expected_min2, expected_max2)
 
+    def test_zero_mean_danger_shock_expands_both_reward_range_bounds(self):
+        """A zero-mean danger shock advertises both possible shock signs."""
+        env = LaserTagPOMDP(
+            discount_factor=0.95,
+            **_lt_pinned_kwargs(
+                tag_reward=15.0,
+                tag_penalty=20.0,
+                walls=set(),
+                dangerous_areas={(5, 3)},
+                dangerous_area_penalty=5.0,
+                reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+            ),
+        )
+        assert env.reward_range == (-25.0, 20.0)
+
     def test_initial_state_distribution(self):
         """Test initial state distribution properties.
 

--- a/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_pacman_pomdp.py
@@ -32,6 +32,7 @@ from POMDPPlanners.environments.pacman_pomdp import (
     PacManPOMDP,
     create_simple_maze_pacman,
 )
+from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import RewardModelType
 
 # Set seeds for reproducible tests
 np.random.seed(42)
@@ -2933,3 +2934,17 @@ class TestPacManDangerousAreas:
         )
         expected_max = self.pomdp.step_penalty + self.pomdp.pellet_reward + self.pomdp.win_reward
         assert self.pomdp.reward_range == (expected_min, expected_max)
+
+    def test_zero_mean_danger_shock_expands_both_reward_range_bounds(self):
+        """A zero-mean danger shock advertises both possible shock signs."""
+        env = PacManPOMDP(
+            discount_factor=0.95,
+            **pacman_pinned_kwargs(
+                dangerous_areas={(3, 3)},
+                dangerous_area_penalty=5.0,
+                reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+            ),
+        )
+        base_min = env.step_penalty + env.ghost_collision_penalty
+        base_max = env.step_penalty + env.pellet_reward + env.win_reward
+        assert env.reward_range == (base_min - 5.0, base_max + 5.0)

--- a/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py
@@ -19,6 +19,7 @@ import pytest
 from POMDPPlanners.core.policy import PolicyRunData
 from POMDPPlanners.core.simulation import History, StepData
 from POMDPPlanners.environments.push_pomdp import PushPOMDP, _native as push_native
+from POMDPPlanners.environments.push_pomdp.push_pomdp import RewardModelType
 from POMDPPlanners.tests.test_utils.confidence_interval_utils import (
     verify_metrics_within_confidence_intervals,
 )
@@ -1836,6 +1837,20 @@ class TestPushDangerousAreas:
             ),
         )
         assert env_yes.reward_range[0] == pytest.approx(env_no.reward_range[0] - 3.5)
+
+    def test_zero_mean_danger_shock_expands_both_reward_range_bounds(self):
+        """A zero-mean danger shock advertises both possible shock signs."""
+        env = PushPOMDP(
+            discount_factor=0.95,
+            **push_pinned_kwargs(
+                grid_size=10,
+                dangerous_areas=[(2.0, 2.0)],
+                dangerous_area_penalty=-3.5,
+                reward_model_type=RewardModelType.ZERO_MEAN_HAZARD_SHOCK,
+            ),
+        )
+        max_distance = np.sqrt(2) * 9
+        assert env.reward_range == pytest.approx((-max_distance - 3.5, 103.5))
 
 
 class TestSampleNextStepEquivalence:


### PR DESCRIPTION
## Summary
- make Push, PacMan, and LaserTag reward ranges account for both signs of zero-mean danger shocks
- preserve non-shock reward-range behavior while handling signed danger contributions safely
- add one regression test per environment

## Verification
- confirmed all three new regression tests fail before the implementation fix
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0
benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/kobi/Documents/github/POMDPPlanners
configfile: pyproject.toml
plugins: nbval-0.11.0, asyncio-1.2.0, cov-7.0.0, benchmark-5.2.3, anyio-4.11.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 234 items

POMDPPlanners/tests/test_environments/test_push_pomdp/test_push_pomdp.py . [  0%]
........................................................................ [ 31%]
.                                                                        [ 31%]
POMDPPlanners/tests/test_environments/test_pacman_pomdp.py ............. [ 37%]
..................................................................       [ 65%]
POMDPPlanners/tests/test_environments/test_laser_tag_pomdp/test_laser_tag_pomdp.py . [ 65%]
........................................................................ [ 96%]
........                                                                 [100%]

============================= 234 passed in 1.33s ============================== (234 passed)
- pre-commit Black, Pylint, and Pyright checks passed