### PR TITLE
Stop Optuna studies once the Pareto front plateaus, and plot the evidence

### DIFF
--- a/POMDPPlanners/core/simulation/hyperparameter_tuning.py
+++ b/POMDPPlanners/core/simulation/hyperparameter_tuning.py
@@ -19,6 +19,9 @@ from typing import (
 from POMDPPlanners.utils.config_to_id import config_to_id
 
 if TYPE_CHECKING:
+    from POMDPPlanners.simulations.simulations_deployment.tuning_early_stopping import (
+        EarlyStoppingConfig,
+    )
     from POMDPPlanners.core.belief import Belief
     from POMDPPlanners.core.environment import Environment
     from POMDPPlanners.core.policy import Policy
@@ -255,6 +258,8 @@ class HyperParameterRunParams:
         n_trials: Number of optimization trials to execute (must be positive)
         parameters_to_optimize: List of (metric_name, direction) tuples specifying
             which metrics to optimize and in which direction (maximize/minimize)
+        early_stopping: Optional patience settings. When set, n_trials becomes an
+            upper bound and the study ends once its Pareto front stops improving.
 
     Raises:
         ValueError: If any numerical parameter is non-positive, if hyperparameters
@@ -269,6 +274,7 @@ class HyperParameterRunParams:
     num_steps: int
     n_trials: int
     parameters_to_optimize: List[Tuple[str, HyperParameterOptimizationDirection]]
+    early_stopping: Optional["EarlyStoppingConfig"] = None
 
     def __post_init__(self) -> None:
         """Validate all parameters at construction time."""
@@ -345,6 +351,13 @@ class HyperParameterRunParams:
                 "num_steps": self.num_steps,
                 "n_trials": self.n_trials,
                 "parameters_to_optimize": self.parameters_to_optimize,
+                # Absent unless early stopping is on, so ids of studies
+                # configured before this option existed do not change.
+                **(
+                    {"early_stopping": self.early_stopping.to_dict()}
+                    if self.early_stopping is not None
+                    else {}
+                ),
             }
         )
 

--- a/POMDPPlanners/simulations/hyper_parameter_tuning_simulations.py
+++ b/POMDPPlanners/simulations/hyper_parameter_tuning_simulations.py
@@ -426,6 +426,7 @@ class HyperParameterOptimizer:
                 trial_offset=running_offset,
                 total_trials_globally=total_trials,
                 progress_db_path=self.notification_config.progress_db_path,
+                early_stopping=config.early_stopping,
             )
             tasks.append(task)
             task_identifiers.append(task.get_config_id())

--- a/POMDPPlanners/simulations/simulations_deployment/tasks/hyper_parameter_tuning_simulation_task.py
+++ b/POMDPPlanners/simulations/simulations_deployment/tasks/hyper_parameter_tuning_simulation_task.py
@@ -32,6 +32,11 @@ from POMDPPlanners.simulations.simulation_statistics import (
     compute_statistics_environment_policy_pair,
 )
 from POMDPPlanners.simulations.simulations_deployment.cache_dbs import DiskCacheDB
+from POMDPPlanners.simulations.simulations_deployment.tuning_early_stopping import (
+    EarlyStoppingCallback,
+    EarlyStoppingConfig,
+    build_early_stopping_callback,
+)
 from POMDPPlanners.simulations.simulations_deployment.run_progress import (
     NotificationConfig,
     ProgressDB,
@@ -94,6 +99,8 @@ class HyperParameterTuningSimulationTask(SimulationTask):
         trial_offset: int = 0,
         total_trials_globally: int = 0,
         progress_db_path: Optional[Path] = None,
+        early_stopping: Optional[EarlyStoppingConfig] = None,
+        diagnostics_dir: Union[Path, str, None] = None,
     ):
         """Initialize a hyperparameter tuning simulation task.
 
@@ -124,6 +131,12 @@ class HyperParameterTuningSimulationTask(SimulationTask):
                 (only used when policy implements TrainablePolicy)
             training_constant_parameters: Constant parameters for PolicyTrainer
                 (only used when policy implements TrainablePolicy)
+            early_stopping: Patience settings that end the study once its Pareto
+                front stops improving. None runs the full n_trials budget.
+            diagnostics_dir: Where to write the tuning diagnostic plots and the
+                per-trial JSON dump. Defaults to
+                ``cache_dir/tuning_diagnostics/<config_id>`` when cache_dir is
+                set; diagnostics are skipped when neither is given.
 
         Raises:
             ValueError: If any input parameter is invalid
@@ -188,6 +201,13 @@ class HyperParameterTuningSimulationTask(SimulationTask):
         self.trial_offset = trial_offset
         self.total_trials_globally = total_trials_globally
         self.progress_db_path = progress_db_path
+
+        # Early stopping turns n_trials into an upper bound; diagnostics record
+        # the evidence that stopping there was justified.
+        self.early_stopping = early_stopping
+        self.diagnostics_dir: Optional[str] = (
+            str(diagnostics_dir) if diagnostics_dir is not None else None
+        )
 
         # Create task manager config for joblib
         task_manager_config = JoblibConfig(n_jobs=n_jobs, console_output=False, no_logs=True)
@@ -782,7 +802,16 @@ class HyperParameterTuningSimulationTask(SimulationTask):
 
         study = optuna.create_study(directions=directions)
 
-        callbacks = [self._build_progress_callback()]
+        callbacks: List[Callable[[optuna.study.Study, FrozenTrial], None]] = [
+            self._build_progress_callback()
+        ]
+        early_stopping_callback = build_early_stopping_callback(
+            config=self.early_stopping,
+            directions=study.directions,
+            logger=self.logger,
+        )
+        if early_stopping_callback is not None:
+            callbacks.append(early_stopping_callback)
 
         self.logger.info("Starting optimization trials...")
         study.optimize(
@@ -795,8 +824,88 @@ class HyperParameterTuningSimulationTask(SimulationTask):
         # Log optimization completion
         self.logger.info("Optimization completed successfully!")
         self.logger.info("Found %d Pareto-optimal trials", len(study.best_trials))
+        self._log_early_stopping_outcome(study, early_stopping_callback, n_trials)
+        self._write_tuning_diagnostics(study, early_stopping_callback)
 
         return study
+
+    def _log_early_stopping_outcome(
+        self,
+        study: optuna.study.Study,
+        callback: Optional[Callable[[optuna.study.Study, FrozenTrial], None]],
+        n_trials: int,
+    ) -> None:
+        """Say whether the study converged or merely ran out of budget."""
+        if not isinstance(callback, EarlyStoppingCallback):
+            return
+        completed = len(
+            [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+        )
+        if callback.stopped_at_trial is None:
+            self.logger.info(
+                "Early stopping did not fire: the front was still improving after "
+                "%d of %d trials.",
+                completed,
+                n_trials,
+            )
+        else:
+            self.logger.info(
+                "Early stopping used %d of the %d allowed trials.", completed, n_trials
+            )
+
+    def _resolve_diagnostics_dir(self) -> Optional[Path]:
+        if self.diagnostics_dir is not None:
+            return Path(self.diagnostics_dir)
+        if self.cache_dir is not None:
+            return Path(self.cache_dir) / "tuning_diagnostics" / self.get_config_id()
+        return None
+
+    def _write_tuning_diagnostics(
+        self,
+        study: optuna.study.Study,
+        callback: Optional[Callable[[optuna.study.Study, FrozenTrial], None]],
+    ) -> None:
+        """Dump per-trial records and diagnostic plots for the finished study.
+
+        Best-effort, like the progress callback: a study that took hours to run
+        must not be lost because a plot backend or an importance evaluator
+        failed.
+        """
+        output_dir = self._resolve_diagnostics_dir()
+        if output_dir is None:
+            return
+
+        try:
+            # Imported here so a tuning run on a headless box without the
+            # plotting extras still completes.
+            from POMDPPlanners.utils.visualization.tuning_plots import (  # pylint: disable=import-outside-toplevel
+                extract_trial_records,
+                plot_tuning_diagnostics,
+                save_trial_records,
+            )
+
+            records = extract_trial_records(
+                study,
+                self.parameters_to_optimize,
+                confidence_interval_level=self.confidence_interval_level,
+            )
+            save_trial_records(records, output_dir / "trial_records.json")
+
+            history = callback.history if isinstance(callback, EarlyStoppingCallback) else None
+            stopped_at = (
+                callback.stopped_at_trial if isinstance(callback, EarlyStoppingCallback) else None
+            )
+            written = plot_tuning_diagnostics(
+                records=records,
+                parameters_to_optimize=self.parameters_to_optimize,
+                output_dir=output_dir,
+                front_quality_history=history,
+                stopped_at_trial=stopped_at,
+                study=study,
+            )
+            self.logger.info("Wrote %d tuning diagnostic plots to %s", len(written), output_dir)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            self.logger.warning("Could not write tuning diagnostics: %s", exc)
 
     def _build_progress_callback(
         self,
@@ -1127,6 +1236,13 @@ class HyperParameterTuningSimulationTask(SimulationTask):
             "use_queue_logger": self.use_queue_logger,
             "training_hyper_parameters": list(self.training_hyper_parameters),
             "training_constant_parameters": self.training_constant_parameters,
+            # Only present when early stopping is on: adding an always-present
+            # key would change the id of every study already cached.
+            **(
+                {"early_stopping": self.early_stopping.to_dict()}
+                if self.early_stopping is not None
+                else {}
+            ),
         }
 
     def __eq__(self, other: object) -> bool:

--- a/POMDPPlanners/simulations/simulations_deployment/tuning_early_stopping.py
+++ b/POMDPPlanners/simulations/simulations_deployment/tuning_early_stopping.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: MIT
+
+"""Early stopping for hyperparameter studies.
+
+Optuna has no "run up to ``n_trials`` but stop when it stops helping" flag.
+Its pruners kill a *trial* mid-way rather than the study, and they are not
+available here at all: pruning needs intermediate ``trial.report`` values and
+Optuna forbids it for multi-objective studies, which is what
+``HyperParameterTuningSimulationTask`` creates. Optuna's
+``TerminatorCallback`` is single-objective only for the same kind of reason.
+
+What is left is ``study.stop()`` from an ``optimize(callbacks=[...])`` hook,
+which is what :class:`EarlyStoppingCallback` does. ``n_trials`` then becomes an
+upper bound: set it to 1000 and the study ends at trial ~100 if the Pareto
+front has not moved in ``patience`` trials.
+
+Measuring "the front has not moved" needs a single number per trial. We use the
+hypervolume of the Pareto front, because it is the only common front-quality
+scalar that improves if and only if the front genuinely gains ground -- a new
+front member that only trades one objective away for another leaves it flat.
+The objectives are normalized against bounds frozen once ``min_trials`` trials
+have finished, so the number is monotone over the run and can be plotted as a
+convergence curve. Without freezing, one late outlier would rescale every past
+value and the curve would not be comparable to itself.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+import optuna
+from optuna.trial import FrozenTrial
+
+# Exact hypervolume by slicing costs O(n^d); with more front points than this we
+# keep an evenly spaced subsample. The measure stays a valid lower bound and the
+# callback only needs to see improvement, not the exact value.
+MAX_FRONT_POINTS_FOR_HYPERVOLUME = 128
+
+
+@dataclass(frozen=True)
+class EarlyStoppingConfig:
+    """When to stop a study before its trial budget is spent.
+
+    Attributes:
+        patience: Stop after this many completed trials with no front
+            improvement. Objective values here are means over ``num_episodes``
+            episodes and are therefore noisy, so a plateau shorter than a
+            hundred trials is often sampling noise rather than convergence.
+        min_trials: Never stop before this many trials have completed. Also the
+            point at which the normalization bounds are frozen, so it must be
+            large enough to have seen both good and bad regions of the space.
+        min_relative_improvement: Front quality must grow by at least this
+            fraction to count as improvement. Guards against a plateau being
+            hidden by floating-point drift in the hypervolume.
+    """
+
+    patience: int = 100
+    min_trials: int = 50
+    min_relative_improvement: float = 1e-3
+
+    def __post_init__(self) -> None:
+        if self.patience <= 0:
+            raise ValueError(f"patience must be positive, got {self.patience}")
+        if self.min_trials <= 0:
+            raise ValueError(f"min_trials must be positive, got {self.min_trials}")
+        if self.min_relative_improvement < 0:
+            raise ValueError(
+                f"min_relative_improvement must be non-negative, "
+                f"got {self.min_relative_improvement}"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Config-id friendly view. Included in task ids because stopping early changes results."""
+        return {
+            "patience": self.patience,
+            "min_trials": self.min_trials,
+            "min_relative_improvement": self.min_relative_improvement,
+        }
+
+
+def non_dominated(points: Sequence[Sequence[float]]) -> List[Tuple[float, ...]]:
+    """Return the maximization-sense Pareto front of ``points``.
+
+    Args:
+        points: Objective vectors, all in maximization sense.
+
+    Returns:
+        The subset of points not dominated by any other point.
+    """
+    front: List[Tuple[float, ...]] = []
+    for candidate in points:
+        cand = tuple(float(v) for v in candidate)
+        if any(
+            all(o >= c for o, c in zip(other, cand)) and any(o > c for o, c in zip(other, cand))
+            for other in points
+            if tuple(float(v) for v in other) != cand
+        ):
+            continue
+        if cand not in front:
+            front.append(cand)
+    return front
+
+
+def hypervolume(points: Sequence[Sequence[float]]) -> float:
+    """Hypervolume of ``points`` in maximization sense with the origin as reference.
+
+    Exact, by the hyperplane-slicing recursion: sort by the last coordinate,
+    and for each slab between consecutive coordinate values multiply the slab
+    thickness by the hypervolume of the projection of the points above it.
+
+    Args:
+        points: Objective vectors with non-negative coordinates.
+
+    Returns:
+        The volume of the union of boxes spanned by the points and the origin.
+        Zero for an empty input.
+    """
+    if not points:
+        return 0.0
+    front = non_dominated(points)
+    if len(front) > MAX_FRONT_POINTS_FOR_HYPERVOLUME:
+        step = len(front) / MAX_FRONT_POINTS_FOR_HYPERVOLUME
+        front = [front[int(i * step)] for i in range(MAX_FRONT_POINTS_FOR_HYPERVOLUME)]
+    return _hypervolume_recursive([tuple(max(0.0, float(v)) for v in p) for p in front])
+
+
+def _hypervolume_recursive(points: List[Tuple[float, ...]]) -> float:
+    if not points:
+        return 0.0
+    dim = len(points[0])
+    if dim == 1:
+        return max(p[0] for p in points)
+
+    ordered = sorted(points, key=lambda p: p[-1], reverse=True)
+    total = 0.0
+    for index, point in enumerate(ordered):
+        upper = point[-1]
+        lower = ordered[index + 1][-1] if index + 1 < len(ordered) else 0.0
+        thickness = upper - lower
+        if thickness <= 0.0:
+            continue
+        projection = [p[:-1] for p in ordered[: index + 1]]
+        total += _hypervolume_recursive(projection) * thickness
+    return total
+
+
+class EarlyStoppingCallback:
+    """Optuna callback that stops a study once its Pareto front stops improving.
+
+    Pass it in ``study.optimize(callbacks=[...])``. After the run, ``history``
+    holds the front-quality curve that is the evidence the study converged, and
+    ``stopped_at_trial`` says whether the stop fired or the budget simply ran
+    out.
+
+    With ``n_jobs > 1`` the stop is not exact: ``study.stop()`` prevents new
+    trials from starting but lets in-flight ones finish, so the study overshoots
+    by up to ``n_jobs - 1`` trials.
+    """
+
+    def __init__(
+        self,
+        config: EarlyStoppingConfig,
+        directions: Sequence[optuna.study.StudyDirection],
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        """Initialize the callback.
+
+        Args:
+            config: Patience settings.
+            directions: The study's optimization directions, used to flip
+                minimized objectives so every objective is maximized.
+            logger: Where to report the stop. Defaults to this module's logger.
+        """
+        self.config = config
+        self.directions = list(directions)
+        self.logger = logger or logging.getLogger(__name__)
+
+        self.history: List[Tuple[int, float]] = []
+        self.stopped_at_trial: Optional[int] = None
+        self._best_quality: Optional[float] = None
+        self._last_improved_at: int = 0
+        self._bounds: Optional[List[Tuple[float, float]]] = None
+
+    def __call__(self, study: optuna.study.Study, trial: FrozenTrial) -> None:
+        """Record front quality for this trial and stop the study if it has plateaued."""
+        completed = [
+            t.values
+            for t in study.trials
+            if t.state == optuna.trial.TrialState.COMPLETE and t.values is not None
+        ]
+        n_done = len(completed)
+        if n_done < self.config.min_trials:
+            return
+
+        quality = self.front_quality(completed)
+        self.history.append((n_done, quality))
+
+        improved = self._best_quality is None or quality > self._best_quality * (
+            1.0 + self.config.min_relative_improvement
+        )
+        if improved:
+            self._best_quality = quality
+            self._last_improved_at = n_done
+            return
+
+        if n_done - self._last_improved_at >= self.config.patience:
+            self.stopped_at_trial = n_done
+            self.logger.info(
+                "Early stopping: Pareto front did not improve over the last %d trials "
+                "(stopping after %d completed trials).",
+                self.config.patience,
+                n_done,
+            )
+            study.stop()
+
+    def front_quality(self, values_per_trial: Sequence[Sequence[float]]) -> float:
+        """Normalized hypervolume of the front formed by ``values_per_trial``.
+
+        Args:
+            values_per_trial: Objective vectors of every completed trial, in the
+                study's own directions.
+
+        Returns:
+            Hypervolume in units of the frozen normalization box, comparable
+            across calls and monotone over the run because the bounds are
+            frozen on the first call. Roughly 1 when the front fills the range
+            seen early on, and larger when later trials beat that range.
+        """
+        maximized = [self._to_maximization(values) for values in values_per_trial]
+        if self._bounds is None:
+            self._bounds = self._compute_bounds(maximized)
+        return hypervolume([self._normalize(values) for values in maximized])
+
+    def _to_maximization(self, values: Sequence[float]) -> List[float]:
+        return [
+            -float(value) if direction == optuna.study.StudyDirection.MINIMIZE else float(value)
+            for value, direction in zip(values, self.directions)
+        ]
+
+    @staticmethod
+    def _compute_bounds(maximized: Sequence[Sequence[float]]) -> List[Tuple[float, float]]:
+        bounds = []
+        for axis in range(len(maximized[0])):
+            column = [values[axis] for values in maximized]
+            low, high = min(column), max(column)
+            # A degenerate axis (every trial identical so far) would divide by
+            # zero; give it unit width so it contributes a constant factor.
+            bounds.append((low, high) if high > low else (low, low + 1.0))
+        return bounds
+
+    def _normalize(self, maximized: Sequence[float]) -> List[float]:
+        """Scale to the frozen bounds, clipping only from below.
+
+        The lower bound is the hypervolume reference point, so anything worse
+        than it contributes nothing and is clipped to zero. There is no upper
+        clip: a study that keeps improving past the range seen in its first
+        ``min_trials`` trials must keep showing improvement, and capping at 1
+        would saturate the measure and stop the study exactly when it was still
+        making progress.
+        """
+        assert self._bounds is not None
+        return [
+            max(0.0, (value - low) / (high - low))
+            for value, (low, high) in zip(maximized, self._bounds)
+        ]
+
+
+def build_early_stopping_callback(
+    config: Optional[EarlyStoppingConfig],
+    directions: Sequence[optuna.study.StudyDirection],
+    logger: Optional[logging.Logger] = None,
+) -> Optional[Callable[[optuna.study.Study, FrozenTrial], None]]:
+    """Build an :class:`EarlyStoppingCallback`, or None when early stopping is off.
+
+    Args:
+        config: Patience settings, or None to disable early stopping.
+        directions: The study's optimization directions.
+        logger: Where the callback reports the stop.
+
+    Returns:
+        The callback, or None if ``config`` is None.
+    """
+    if config is None:
+        return None
+    return EarlyStoppingCallback(config=config, directions=directions, logger=logger)

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_hyper_parameter_tuning_simulation_task.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tasks/test_hyper_parameter_tuning_simulation_task.py
@@ -2058,3 +2058,97 @@ class TestParallelizationLevel:
         )
 
         assert task_optuna.get_config_id() != task_episodes.get_config_id()
+
+
+def _tuning_task(environment, hyper_parameters, cache_dir, **overrides):
+    """Build a minimal tuning task; overrides tweak one setting at a time."""
+    kwargs: Dict[str, Any] = {
+        "environment": environment,
+        "belief": create_test_belief(environment),
+        "policy_cls": SparseSamplingDiscreteActionsPlanner,
+        "hyper_parameters": hyper_parameters,
+        "constant_parameters": {},
+        "num_episodes": 2,
+        "num_steps": 3,
+        "parameters_to_optimize": [
+            ("average_return", HyperParameterOptimizationDirection.MAXIMIZE)
+        ],
+        "n_trials": 4,
+        "cache_dir": cache_dir,
+        "debug": False,
+        "console_output": False,
+        "n_jobs": 1,
+        "seed": 42,
+    }
+    kwargs.update(overrides)
+    return HyperParameterTuningSimulationTask(**kwargs)
+
+
+def test_early_stopping_defaults_to_off(environment, hyper_parameters, temp_cache_dir):
+    """Test that tuning tasks run their full trial budget unless early stopping is configured.
+
+    Purpose: Validates the default keeps the pre-existing behaviour
+
+    Given: A tuning task created without an early_stopping argument
+    When: The task's attributes and config ID inputs are inspected
+    Then: Early stopping is off and the config ID does not mention it
+
+    Test type: unit
+    """
+    task = _tuning_task(environment, hyper_parameters, temp_cache_dir)
+
+    assert task.early_stopping is None
+    assert "early_stopping" not in task.to_dict()
+
+
+def test_early_stopping_changes_the_config_id(environment, hyper_parameters, temp_cache_dir):
+    """Test that enabling early stopping gives the task a different config ID.
+
+    Purpose: Stopping early changes the result, so it must not reuse a cached full-budget study
+
+    Given: Two otherwise identical tuning tasks, one with early stopping configured
+    When: Their config IDs are compared
+    Then: The IDs differ and the early stopping settings appear in the task dict
+
+    Test type: unit
+    """
+    from POMDPPlanners.simulations.simulations_deployment.tuning_early_stopping import (
+        EarlyStoppingConfig,
+    )
+
+    baseline = _tuning_task(environment, hyper_parameters, temp_cache_dir)
+    with_stopping = _tuning_task(
+        environment,
+        hyper_parameters,
+        temp_cache_dir,
+        early_stopping=EarlyStoppingConfig(patience=2, min_trials=2),
+    )
+
+    assert baseline.get_config_id() != with_stopping.get_config_id()
+    assert with_stopping.to_dict()["early_stopping"]["patience"] == 2
+
+
+def test_tuning_writes_diagnostics(environment, hyper_parameters, temp_cache_dir):
+    """Test that a completed study writes its trial records and diagnostic plots.
+
+    Purpose: Validates the convergence evidence is produced automatically
+
+    Given: A tuning task with a diagnostics directory and a small trial budget
+    When: Optimization runs to completion
+    Then: The diagnostics directory holds the trial records and at least one plot
+
+    Test type: integration
+    """
+    diagnostics_dir = temp_cache_dir / "diagnostics"
+    task = _tuning_task(
+        environment,
+        hyper_parameters,
+        temp_cache_dir,
+        diagnostics_dir=diagnostics_dir,
+    )
+
+    result = task.run()
+
+    assert result is not None
+    assert (diagnostics_dir / "trial_records.json").exists()
+    assert list(diagnostics_dir.glob("*.png"))

--- a/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tuning_early_stopping.py
+++ b/POMDPPlanners/tests/test_simulations/test_simulations_deployment/test_tuning_early_stopping.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: MIT
+
+import optuna
+import pytest
+
+from POMDPPlanners.simulations.simulations_deployment.tuning_early_stopping import (
+    EarlyStoppingCallback,
+    EarlyStoppingConfig,
+    build_early_stopping_callback,
+    hypervolume,
+    non_dominated,
+)
+
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+
+class TestHypervolume:
+    def test_single_point_is_its_own_box(self):
+        assert hypervolume([(0.5, 0.4)]) == pytest.approx(0.2)
+
+    def test_dominated_points_add_nothing(self):
+        assert hypervolume([(0.5, 0.4), (0.2, 0.1)]) == pytest.approx(0.2)
+
+    def test_union_of_boxes_is_not_double_counted(self):
+        # Two incomparable points overlap on the [0, 0.3] x [0, 0.3] square.
+        assert hypervolume([(1.0, 0.3), (0.3, 1.0)]) == pytest.approx(0.3 + 0.3 - 0.09)
+
+    def test_three_objectives(self):
+        assert hypervolume([(1.0, 1.0, 1.0)]) == pytest.approx(1.0)
+        assert hypervolume([(1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]) == pytest.approx(0.0)
+
+    def test_one_objective_is_the_best_value(self):
+        assert hypervolume([(0.2,), (0.7,), (0.5,)]) == pytest.approx(0.7)
+
+    def test_empty_front(self):
+        assert hypervolume([]) == 0.0
+
+    def test_non_dominated_drops_dominated_points(self):
+        front = non_dominated([(1.0, 0.0), (0.0, 1.0), (0.4, 0.4), (0.5, 0.5)])
+        assert (0.4, 0.4) not in front
+        assert (0.5, 0.5) in front
+
+
+class TestEarlyStoppingConfig:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"patience": 0},
+            {"min_trials": -1},
+            {"min_relative_improvement": -0.1},
+        ],
+    )
+    def test_rejects_invalid_settings(self, kwargs):
+        with pytest.raises(ValueError):
+            EarlyStoppingConfig(**kwargs)
+
+    def test_to_dict_is_config_id_friendly(self):
+        assert EarlyStoppingConfig(patience=3, min_trials=2).to_dict() == {
+            "patience": 3,
+            "min_trials": 2,
+            "min_relative_improvement": 1e-3,
+        }
+
+
+class TestEarlyStoppingCallback:
+    def test_stops_well_before_the_trial_budget(self):
+        config = EarlyStoppingConfig(patience=5, min_trials=5, min_relative_improvement=1e-3)
+        study = optuna.create_study(directions=["maximize", "minimize"])
+        callback = EarlyStoppingCallback(config=config, directions=study.directions)
+        study.optimize(lambda t: (1.0, 0.5), n_trials=200, callbacks=[callback])
+
+        assert callback.stopped_at_trial is not None
+        assert len(study.trials) < 200
+
+    def test_does_not_stop_before_min_trials(self):
+        config = EarlyStoppingConfig(patience=1, min_trials=20)
+        study = optuna.create_study(directions=["maximize", "minimize"])
+        callback = EarlyStoppingCallback(config=config, directions=study.directions)
+        study.optimize(lambda t: (1.0, 0.5), n_trials=200, callbacks=[callback])
+
+        assert len(study.trials) >= 20
+
+    def test_keeps_running_while_the_front_improves(self):
+        config = EarlyStoppingConfig(patience=5, min_trials=5)
+        study = optuna.create_study(directions=["maximize", "minimize"])
+        callback = EarlyStoppingCallback(config=config, directions=study.directions)
+
+        counter = {"n": 0}
+
+        def improving(trial):
+            counter["n"] += 1
+            return float(counter["n"]), -float(counter["n"])
+
+        study.optimize(improving, n_trials=30, callbacks=[callback])
+
+        assert callback.stopped_at_trial is None
+        assert len(study.trials) == 30
+
+    def test_history_is_monotone_and_recorded(self):
+        config = EarlyStoppingConfig(patience=4, min_trials=6)
+        study = optuna.create_study(directions=["maximize", "minimize"])
+        callback = EarlyStoppingCallback(config=config, directions=study.directions)
+        study.optimize(
+            lambda t: (t.suggest_float("x", 0.0, 1.0), t.suggest_float("y", 0.0, 1.0)),
+            n_trials=60,
+            callbacks=[callback],
+        )
+
+        assert callback.history
+        qualities = [quality for _, quality in callback.history]
+        assert all(later >= earlier - 1e-12 for earlier, later in zip(qualities, qualities[1:]))
+
+    def test_minimized_objectives_are_flipped(self):
+        study = optuna.create_study(directions=["minimize"])
+        callback = EarlyStoppingCallback(
+            config=EarlyStoppingConfig(patience=2, min_trials=2), directions=study.directions
+        )
+        # Freeze the bounds on the observed range, then check the ordering:
+        # lower is better, so 0.0 must score above 1.0.
+        assert callback.front_quality([[0.0], [1.0]]) == pytest.approx(1.0)
+        assert callback.front_quality([[0.0]]) == pytest.approx(1.0)
+        assert callback.front_quality([[1.0]]) == pytest.approx(0.0)
+
+    def test_build_returns_none_when_disabled(self):
+        assert build_early_stopping_callback(None, []) is None
+        assert isinstance(
+            build_early_stopping_callback(EarlyStoppingConfig(), []), EarlyStoppingCallback
+        )

--- a/POMDPPlanners/tests/test_utils/test_visualization/test_tuning_plots.py
+++ b/POMDPPlanners/tests/test_utils/test_visualization/test_tuning_plots.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: MIT
+
+import random
+
+import optuna
+import pytest
+
+from POMDPPlanners.core.simulation.hyperparameter_tuning import (
+    HyperParameterOptimizationDirection,
+)
+from POMDPPlanners.utils.visualization.tuning_plots import (
+    TrialRecord,
+    extract_trial_records,
+    load_trial_records,
+    plot_pareto_front,
+    plot_parameter_history,
+    plot_parameter_slices,
+    plot_secondary_metrics,
+    plot_tuning_diagnostics,
+    save_trial_records,
+)
+
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+PARAMETERS_TO_OPTIMIZE = [
+    ("discounted_return", HyperParameterOptimizationDirection.MAXIMIZE),
+    ("collision_rate", HyperParameterOptimizationDirection.MINIMIZE),
+]
+
+
+def _statistics(name, value):
+    return {
+        "name": name,
+        "value": value,
+        "lower_confidence_bound": value - 0.1,
+        "upper_confidence_bound": value + 0.1,
+    }
+
+
+@pytest.fixture(name="study")
+def study_fixture():
+    """A small two-objective study shaped like a real tuning run."""
+    rng = random.Random(0)
+    study = optuna.create_study(directions=["maximize", "minimize"])
+
+    def objective(trial):
+        simulations = trial.suggest_int("num_simulations", 10, 500)
+        constant = trial.suggest_float("exploration_constant", 0.1, 10.0)
+        trial.suggest_categorical("rollout", ["random", "greedy"])
+
+        returns = -((simulations - 300) / 300) ** 2 - constant / 20 + rng.gauss(0, 0.05)
+        collisions = max(0.0, 0.5 - simulations / 1000)
+
+        trial.set_user_attr("metric_discounted_return", returns)
+        trial.set_user_attr("metric_collision_rate", collisions)
+        trial.set_user_attr(
+            "statistics",
+            [
+                _statistics("discounted_return", returns),
+                _statistics("collision_rate", collisions),
+                # Recorded but never optimized: the metric the search may pay with.
+                _statistics("episode_length", 20 + simulations / 50),
+            ],
+        )
+        return returns, collisions
+
+    study.optimize(objective, n_trials=25)
+    return study
+
+
+@pytest.fixture(name="records")
+def records_fixture(study):
+    return extract_trial_records(study, PARAMETERS_TO_OPTIMIZE, confidence_interval_level=0.95)
+
+
+class TestTrialRecords:
+    def test_extracts_objectives_params_and_statistics(self, records):
+        assert len(records) == 25
+        record = records[0]
+        assert record.state == "COMPLETE"
+        assert set(record.objective_values) == {"discounted_return", "collision_rate"}
+        assert set(record.params) == {"num_simulations", "exploration_constant", "rollout"}
+        assert "episode_length" in record.metric_statistics
+        assert len(record.metric_statistics["episode_length"]) == 3
+
+    def test_marks_the_pareto_front(self, study, records):
+        pareto_numbers = {trial.number for trial in study.best_trials}
+        assert {record.number for record in records if record.is_pareto} == pareto_numbers
+
+    def test_carries_the_confidence_level(self, records):
+        # The plots state the level, so it has to travel with the bounds.
+        assert all(record.confidence_interval_level == 0.95 for record in records)
+
+    def test_json_round_trip(self, records, tmp_path):
+        path = save_trial_records(records, tmp_path / "trial_records.json")
+        reloaded = load_trial_records(path)
+
+        assert [r.number for r in reloaded] == [r.number for r in records]
+        assert reloaded[0].params == records[0].params
+        assert reloaded[0].metric_statistics == records[0].metric_statistics
+        assert reloaded[0].confidence_interval_level == 0.95
+
+    def test_incomplete_trials_do_not_break_extraction(self):
+        study = optuna.create_study(directions=["maximize", "minimize"])
+
+        def failing(trial):
+            raise ValueError("planner blew up")
+
+        study.optimize(failing, n_trials=2, catch=(ValueError,))
+        records = extract_trial_records(study, PARAMETERS_TO_OPTIMIZE)
+
+        assert [record.state for record in records] == ["FAIL", "FAIL"]
+        assert all(not record.objective_values for record in records)
+
+
+class TestTuningPlots:
+    def test_writes_every_diagnostic(self, records, study, tmp_path):
+        written = plot_tuning_diagnostics(
+            records=records,
+            parameters_to_optimize=PARAMETERS_TO_OPTIMIZE,
+            output_dir=tmp_path,
+            front_quality_history=[(i, float(i) / 25) for i in range(5, 25)],
+            stopped_at_trial=25,
+            study=study,
+        )
+        names = {path.name for path in written}
+
+        assert "front_quality_history.png" in names
+        assert "objective_history.png" in names
+        assert "objective_confidence_intervals.png" in names
+        assert "pareto_front.png" in names
+        assert "parameter_history.png" in names
+        assert "parameter_slices.png" in names
+        assert "secondary_metrics.png" in names
+        assert all(path.stat().st_size > 0 for path in written)
+
+    def test_tuned_parameters_are_plotted(self, records, tmp_path):
+        history = plot_parameter_history(records, tmp_path / "parameter_history.png")
+        slices = plot_parameter_slices(
+            records, PARAMETERS_TO_OPTIMIZE, tmp_path / "parameter_slices.png"
+        )
+
+        assert history is not None and history.exists()
+        assert slices is not None and slices.exists()
+
+    def test_secondary_metrics_exclude_the_optimized_ones(self, records, tmp_path):
+        # episode_length is the only non-optimized metric, so dropping it must
+        # leave nothing to plot.
+        stripped = [
+            TrialRecord(
+                number=record.number,
+                state=record.state,
+                params=record.params,
+                objective_values=record.objective_values,
+                metric_statistics={
+                    name: bounds
+                    for name, bounds in record.metric_statistics.items()
+                    if name != "episode_length"
+                },
+            )
+            for record in records
+        ]
+
+        assert (
+            plot_secondary_metrics(records, PARAMETERS_TO_OPTIMIZE, tmp_path / "secondary.png")
+            is not None
+        )
+        assert (
+            plot_secondary_metrics(stripped, PARAMETERS_TO_OPTIMIZE, tmp_path / "none.png") is None
+        )
+
+    def test_single_objective_has_no_pareto_plot(self, records, tmp_path):
+        assert (
+            plot_pareto_front(records, PARAMETERS_TO_OPTIMIZE[:1], tmp_path / "front.png") is None
+        )
+
+    def test_no_completed_trials_writes_nothing(self, tmp_path):
+        records = [TrialRecord(number=0, state="FAIL")]
+        assert plot_tuning_diagnostics(records, PARAMETERS_TO_OPTIMIZE, tmp_path) == []
+
+    def test_confidence_interval_title_says_all_when_nothing_is_trimmed(self, records, tmp_path):
+        from POMDPPlanners.utils.visualization.tuning_plots import (
+            plot_objective_confidence_intervals,
+        )
+
+        # top_k above the trial count must not claim the trials were filtered.
+        path = plot_objective_confidence_intervals(
+            records, PARAMETERS_TO_OPTIMIZE, tmp_path / "all.png", top_k=100
+        )
+        trimmed = plot_objective_confidence_intervals(
+            records, PARAMETERS_TO_OPTIMIZE, tmp_path / "trimmed.png", top_k=5
+        )
+
+        assert path is not None and path.exists()
+        assert trimmed is not None and trimmed.exists()

--- a/POMDPPlanners/utils/visualization/__init__.py
+++ b/POMDPPlanners/utils/visualization/__init__.py
@@ -29,6 +29,18 @@ from POMDPPlanners.utils.visualization.policy_simulation_plots import (
     plot_policy_returns,
 )
 
+# Import from tuning_plots
+from POMDPPlanners.utils.visualization.tuning_plots import (
+    TrialRecord,
+    extract_trial_records,
+    load_trial_records,
+    plot_parameter_history,
+    plot_parameter_importances,
+    plot_parameter_slices,
+    plot_tuning_diagnostics,
+    save_trial_records,
+)
+
 # Import from plot_utils (internal utilities, prefixed with underscore)
 from POMDPPlanners.utils.visualization.plot_utils import _log_or_print, _safe_histplot
 
@@ -45,6 +57,15 @@ __all__ = [
     # Policy simulation plotting
     "plot_policy_returns",
     "AgentPath",
+    # Hyperparameter tuning diagnostics
+    "TrialRecord",
+    "extract_trial_records",
+    "load_trial_records",
+    "plot_parameter_history",
+    "plot_parameter_importances",
+    "plot_parameter_slices",
+    "plot_tuning_diagnostics",
+    "save_trial_records",
     # Utilities (internal, but exported for backward compatibility)
     "_safe_histplot",
     "_log_or_print",

--- a/POMDPPlanners/utils/visualization/tuning_plots.py
+++ b/POMDPPlanners/utils/visualization/tuning_plots.py
@@ -1,0 +1,731 @@
+# SPDX-License-Identifier: MIT
+
+"""Diagnostic plots for a hyperparameter tuning study.
+
+These answer two questions a tuning run should not be trusted without:
+
+1. Did the search converge, or did it just run out of budget? The front-quality
+   curve is the evidence -- it is the same number the early-stopping callback
+   watches, so a flat tail is exactly what made the study stop.
+2. What did the search give up? A study told to maximize return will happily
+   trade away collision rate, so metrics that were recorded but *not* optimized
+   are plotted too.
+
+The plots are built from :class:`TrialRecord` rather than from an Optuna study,
+so they can be regenerated later from the JSON dump without re-running
+anything. The study object itself is in-memory only: its ``user_attrs`` hold
+episode histories, which no Optuna storage backend can serialize.
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+
+matplotlib.use("Agg")  # Use non-interactive backend
+
+logger = logging.getLogger(__name__)
+
+# Objectives are plotted pairwise; beyond this many the grid stops being readable.
+MAX_OBJECTIVE_PAIRS = 6
+
+
+@dataclass(frozen=True)
+class TrialRecord:
+    """One trial, reduced to what the diagnostic plots need.
+
+    Attributes:
+        number: Optuna trial number.
+        state: Optuna trial state name, e.g. ``"COMPLETE"``.
+        params: The hyperparameter values the sampler suggested.
+        objective_values: Optimized metric name to its value for this trial.
+        metric_statistics: Every recorded metric, optimized or not, mapped to
+            ``(value, lower_confidence_bound, upper_confidence_bound)``. The
+            bounds are what tell you whether one trial really beat another or
+            just got a luckier draw of episodes.
+        duration_seconds: Wall-clock time of the trial, or None if unknown.
+        is_pareto: Whether the trial is on the study's final Pareto front.
+        confidence_interval_level: The level the bounds in ``metric_statistics``
+            were computed at, carried alongside them so a plot can label its
+            intervals without the caller having to remember the setting.
+    """
+
+    number: int
+    state: str
+    params: Dict[str, Any] = field(default_factory=dict)
+    objective_values: Dict[str, float] = field(default_factory=dict)
+    metric_statistics: Dict[str, Tuple[float, float, float]] = field(default_factory=dict)
+    duration_seconds: Optional[float] = None
+    is_pareto: bool = False
+    confidence_interval_level: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-serializable view of the record."""
+        return {
+            "number": self.number,
+            "state": self.state,
+            "params": self.params,
+            "objective_values": self.objective_values,
+            "metric_statistics": {
+                name: list(bounds) for name, bounds in self.metric_statistics.items()
+            },
+            "duration_seconds": self.duration_seconds,
+            "is_pareto": self.is_pareto,
+            "confidence_interval_level": self.confidence_interval_level,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TrialRecord":
+        """Rebuild a record from :meth:`to_dict` output."""
+        return cls(
+            number=data["number"],
+            state=data["state"],
+            params=data.get("params", {}),
+            objective_values=data.get("objective_values", {}),
+            metric_statistics={
+                name: tuple(bounds)  # type: ignore[misc]
+                for name, bounds in data.get("metric_statistics", {}).items()
+            },
+            duration_seconds=data.get("duration_seconds"),
+            is_pareto=data.get("is_pareto", False),
+            confidence_interval_level=data.get("confidence_interval_level"),
+        )
+
+
+def extract_trial_records(
+    study, parameters_to_optimize, confidence_interval_level: Optional[float] = None
+) -> List[TrialRecord]:
+    """Reduce an Optuna study to plain records.
+
+    Args:
+        study: The completed Optuna study.
+        parameters_to_optimize: The ``(metric_name, direction)`` pairs the study
+            optimized, in the same order as the study's directions.
+        confidence_interval_level: The level the trial statistics were computed
+            at, so the plots can state it.
+
+    Returns:
+        One record per trial, in trial order.
+    """
+    import optuna  # pylint: disable=import-outside-toplevel
+
+    pareto_numbers = set()
+    try:
+        pareto_numbers = {trial.number for trial in study.best_trials}
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.debug("Could not read Pareto trials from study: %s", exc)
+
+    records = []
+    for trial in study.trials:
+        objective_values = {}
+        for metric_name, _ in parameters_to_optimize:
+            value = trial.user_attrs.get(f"metric_{metric_name}")
+            if value is not None:
+                objective_values[metric_name] = float(value)
+
+        metric_statistics = {}
+        for statistic in trial.user_attrs.get("statistics", []) or []:
+            try:
+                metric_statistics[statistic["name"]] = (
+                    float(statistic["value"]),
+                    float(statistic["lower_confidence_bound"]),
+                    float(statistic["upper_confidence_bound"]),
+                )
+            except (KeyError, TypeError, ValueError):
+                continue
+
+        duration = None
+        if trial.datetime_start is not None and trial.datetime_complete is not None:
+            duration = (trial.datetime_complete - trial.datetime_start).total_seconds()
+
+        records.append(
+            TrialRecord(
+                number=trial.number,
+                state=trial.state.name
+                if isinstance(trial.state, optuna.trial.TrialState)
+                else str(trial.state),
+                params=dict(trial.params),
+                objective_values=objective_values,
+                metric_statistics=metric_statistics,
+                duration_seconds=duration,
+                is_pareto=trial.number in pareto_numbers,
+                confidence_interval_level=confidence_interval_level,
+            )
+        )
+    return records
+
+
+def save_trial_records(records: Sequence[TrialRecord], path: Path) -> Path:
+    """Write records as JSON so the plots can be rebuilt without re-running the study."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps([record.to_dict() for record in records], indent=2)
+    path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def load_trial_records(path: Path) -> List[TrialRecord]:
+    """Read records written by :func:`save_trial_records`."""
+    return [
+        TrialRecord.from_dict(item)
+        for item in json.loads(Path(path).read_text(encoding="utf-8"))
+    ]
+
+
+def _completed(records: Sequence[TrialRecord]) -> List[TrialRecord]:
+    return [record for record in records if record.state == "COMPLETE"]
+
+
+def _confidence_suffix(records: Sequence[TrialRecord]) -> str:
+    """Render the confidence level as a short parenthetical, e.g. " (95% CI)"."""
+    levels = {
+        record.confidence_interval_level
+        for record in records
+        if record.confidence_interval_level is not None
+    }
+    if len(levels) != 1:
+        # No level recorded, or records from runs with different levels: saying
+        # nothing beats stating a number the bounds may not have come from.
+        return " with confidence intervals"
+    return f" ({levels.pop():.0%} CI)"
+
+
+def _finish(fig, output_path: Path) -> Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+    return output_path
+
+
+def plot_front_quality_history(
+    history: Sequence[Tuple[int, float]],
+    output_path: Path,
+    stopped_at_trial: Optional[int] = None,
+) -> Optional[Path]:
+    """Plot normalized front quality against completed trials.
+
+    This is the convergence evidence: the curve is monotone by construction, so
+    a flat tail means later trials added nothing the front did not already have.
+
+    Args:
+        history: ``(completed_trials, front_quality)`` pairs from the
+            early-stopping callback.
+        output_path: Where to write the PNG.
+        stopped_at_trial: Trial count at which early stopping fired, marked with
+            a vertical line. None if the study spent its whole budget.
+
+    Returns:
+        The written path, or None if there was nothing to plot.
+    """
+    if not history:
+        return None
+
+    trials = [point[0] for point in history]
+    quality = [point[1] for point in history]
+
+    fig, axis = plt.subplots(figsize=(9, 5))
+    axis.plot(trials, quality, color="tab:blue", linewidth=2)
+    if stopped_at_trial is not None:
+        axis.axvline(
+            stopped_at_trial,
+            color="tab:red",
+            linestyle="--",
+            label=f"early stop at {stopped_at_trial} trials",
+        )
+        axis.legend()
+    axis.set_xlabel("Completed trials")
+    axis.set_ylabel("Pareto front hypervolume (normalized)")
+    axis.set_title("Front quality vs trials")
+    axis.grid(True, alpha=0.3)
+    return _finish(fig, output_path)
+
+
+def plot_objective_history(
+    records: Sequence[TrialRecord],
+    parameters_to_optimize,
+    output_path: Path,
+) -> Optional[Path]:
+    """Plot each optimized metric per trial, with its running best.
+
+    The scatter shows how noisy the objective is. If its spread is as wide as
+    the gain the running-best line makes, the improvement is not real.
+    """
+    completed = _completed(records)
+    if not completed:
+        return None
+
+    names = [name for name, _ in parameters_to_optimize]
+    fig, axes = plt.subplots(len(names), 1, figsize=(9, 3.2 * len(names)), squeeze=False)
+    for axis, (name, direction) in zip(axes[:, 0], parameters_to_optimize):
+        points = [
+            (r.number, r.objective_values[name])
+            for r in completed
+            if name in r.objective_values
+        ]
+        if not points:
+            axis.set_visible(False)
+            continue
+        numbers = [p[0] for p in points]
+        values = [p[1] for p in points]
+        maximize = getattr(direction, "value", str(direction)) == "maximize"
+        running = np.maximum.accumulate(values) if maximize else np.minimum.accumulate(values)
+
+        axis.scatter(numbers, values, s=14, alpha=0.5, color="tab:blue", label="trial")
+        axis.plot(numbers, running, color="tab:red", linewidth=2, label="running best")
+        axis.set_ylabel(name)
+        axis.set_title(f"{name} ({getattr(direction, 'value', direction)})")
+        axis.grid(True, alpha=0.3)
+        axis.legend(fontsize="small")
+    axes[-1, 0].set_xlabel("Trial")
+    return _finish(fig, output_path)
+
+
+def plot_objective_confidence_intervals(
+    records: Sequence[TrialRecord],
+    parameters_to_optimize,
+    output_path: Path,
+    top_k: int = 20,
+) -> Optional[Path]:
+    """Plot the best trials' objectives with their confidence intervals.
+
+    Answers whether the winner actually beat the runners-up. Overlapping
+    intervals mean the ranking is within episode-sampling noise, and the fix is
+    more episodes per trial rather than more trials.
+
+    The x-axis is ranked by the metric, best on the left, so the trial numbers
+    along it are not in order -- and each panel ranks by its own metric, so a
+    trial sits in a different place in each.
+
+    Args:
+        records: Trial records.
+        parameters_to_optimize: The optimized ``(metric_name, direction)`` pairs.
+        output_path: Where to write the PNG.
+        top_k: How many of the best trials to show per metric. Studies with
+            fewer completed trials than this show all of them.
+    """
+    completed = _completed(records)
+    if not completed:
+        return None
+
+    names = [name for name, _ in parameters_to_optimize]
+    fig, axes = plt.subplots(len(names), 1, figsize=(9, 3.2 * len(names)), squeeze=False)
+    plotted_any = False
+    for axis, (name, direction) in zip(axes[:, 0], parameters_to_optimize):
+        with_stats = [r for r in completed if name in r.metric_statistics]
+        if not with_stats:
+            axis.set_visible(False)
+            continue
+        maximize = getattr(direction, "value", str(direction)) == "maximize"
+        best = sorted(
+            with_stats,
+            key=lambda r, n=name: r.metric_statistics[n][0],
+            reverse=maximize,
+        )[:top_k]
+
+        positions = np.arange(len(best))
+        values = np.array([r.metric_statistics[name][0] for r in best])
+        lower = values - np.array([r.metric_statistics[name][1] for r in best])
+        upper = np.array([r.metric_statistics[name][2] for r in best]) - values
+
+        axis.errorbar(
+            positions,
+            values,
+            yerr=np.vstack([np.maximum(lower, 0), np.maximum(upper, 0)]),
+            fmt="o",
+            color="tab:blue",
+            ecolor="tab:gray",
+            capsize=3,
+        )
+        axis.set_xticks(positions)
+        axis.set_xticklabels([str(r.number) for r in best], rotation=90, fontsize="x-small")
+        axis.set_ylabel(name)
+        # Each panel ranks by its own metric, so a trial sits at a different
+        # position in each -- and "top k" only applies when k actually bit.
+        trimmed = f" (top {len(best)})" if len(best) < len(with_stats) else ""
+        axis.set_title(f"Ranked by {name}{trimmed}", fontsize="medium")
+        axis.grid(True, alpha=0.3)
+        plotted_any = True
+    if not plotted_any:
+        plt.close(fig)
+        return None
+    axes[-1, 0].set_xlabel("Trial number, best first")
+    fig.suptitle(f"Objective values{_confidence_suffix(completed)}")
+    return _finish(fig, output_path)
+
+
+def plot_pareto_front(
+    records: Sequence[TrialRecord],
+    parameters_to_optimize,
+    output_path: Path,
+) -> Optional[Path]:
+    """Scatter every objective pair, highlighting the front.
+
+    Shows the trade-off the study settled on, which a single best-value curve
+    hides. Returns None for single-objective studies, where there is no front.
+    """
+    completed = _completed(records)
+    names = [name for name, _ in parameters_to_optimize]
+    if len(names) < 2 or not completed:
+        return None
+
+    pairs = [(a, b) for i, a in enumerate(names) for b in names[i + 1 :]][:MAX_OBJECTIVE_PAIRS]
+    fig, axes = plt.subplots(1, len(pairs), figsize=(5.5 * len(pairs), 4.5), squeeze=False)
+    for axis, (x_name, y_name) in zip(axes[0], pairs):
+        usable = [
+            r for r in completed if x_name in r.objective_values and y_name in r.objective_values
+        ]
+        axis.scatter(
+            [r.objective_values[x_name] for r in usable if not r.is_pareto],
+            [r.objective_values[y_name] for r in usable if not r.is_pareto],
+            s=16,
+            alpha=0.4,
+            color="tab:gray",
+            label="trial",
+        )
+        front = [r for r in usable if r.is_pareto]
+        axis.scatter(
+            [r.objective_values[x_name] for r in front],
+            [r.objective_values[y_name] for r in front],
+            s=45,
+            color="tab:red",
+            label="Pareto front",
+        )
+        axis.set_xlabel(x_name)
+        axis.set_ylabel(y_name)
+        axis.grid(True, alpha=0.3)
+        axis.legend(fontsize="small")
+    fig.suptitle("Pareto front")
+    return _finish(fig, output_path)
+
+
+def plot_parameter_history(
+    records: Sequence[TrialRecord],
+    output_path: Path,
+) -> Optional[Path]:
+    """Plot each searched hyperparameter against trial number.
+
+    This is convergence of the *parameters* rather than the objective: as the
+    sampler homes in, the cloud should collapse toward a region. A cloud that
+    stays uniform to the last trial means the parameter never mattered, or the
+    budget was too small to tell.
+    """
+    completed = _completed(records)
+    if not completed:
+        return None
+
+    names = sorted({name for record in completed for name in record.params})
+    if not names:
+        return None
+
+    columns = min(3, len(names))
+    rows = int(np.ceil(len(names) / columns))
+    fig, axes = plt.subplots(rows, columns, figsize=(5 * columns, 3.2 * rows), squeeze=False)
+    flat_axes = axes.flatten()
+    for axis, name in zip(flat_axes, names):
+        usable = [r for r in completed if name in r.params]
+        values = [r.params[name] for r in usable]
+        numbers = [r.number for r in usable]
+        is_pareto = [r.is_pareto for r in usable]
+
+        if all(isinstance(value, (int, float)) and not isinstance(value, bool) for value in values):
+            y_values: Sequence[Any] = values
+            tick_labels = None
+        else:
+            # Categorical parameters get a stable integer encoding so they can
+            # share the same "value vs trial" plot shape as numerical ones.
+            categories = sorted({str(value) for value in values})
+            index = {category: position for position, category in enumerate(categories)}
+            y_values = [index[str(value)] for value in values]
+            tick_labels = categories
+
+        axis.scatter(
+            [n for n, pareto in zip(numbers, is_pareto) if not pareto],
+            [v for v, pareto in zip(y_values, is_pareto) if not pareto],
+            s=14,
+            alpha=0.4,
+            color="tab:gray",
+        )
+        axis.scatter(
+            [n for n, pareto in zip(numbers, is_pareto) if pareto],
+            [v for v, pareto in zip(y_values, is_pareto) if pareto],
+            s=36,
+            color="tab:red",
+            label="Pareto front",
+        )
+        if tick_labels is not None:
+            axis.set_yticks(range(len(tick_labels)))
+            axis.set_yticklabels(tick_labels, fontsize="x-small")
+        axis.set_title(name)
+        axis.set_xlabel("Trial")
+        axis.grid(True, alpha=0.3)
+    for axis in flat_axes[len(names) :]:
+        axis.set_visible(False)
+    fig.suptitle("Sampled hyperparameters vs trial")
+    return _finish(fig, output_path)
+
+
+def plot_parameter_slices(
+    records: Sequence[TrialRecord],
+    parameters_to_optimize,
+    output_path: Path,
+) -> Optional[Path]:
+    """Plot each searched hyperparameter against each optimized metric.
+
+    The companion to :func:`plot_parameter_history`: that one shows *where* the
+    search settled, this one shows whether it settled somewhere good. Points are
+    shaded by trial number, so a good region that only late trials reach reads
+    as the search working rather than as luck.
+    """
+    completed = _completed(records)
+    if not completed:
+        return None
+
+    param_names = sorted({name for record in completed for name in record.params})
+    metric_names = [name for name, _ in parameters_to_optimize]
+    if not param_names or not metric_names:
+        return None
+
+    fig, axes = plt.subplots(
+        len(metric_names),
+        len(param_names),
+        figsize=(4.2 * len(param_names), 3.2 * len(metric_names)),
+        squeeze=False,
+    )
+    for row, metric_name in enumerate(metric_names):
+        for column, param_name in enumerate(param_names):
+            axis = axes[row][column]
+            usable = [
+                r
+                for r in completed
+                if param_name in r.params and metric_name in r.objective_values
+            ]
+            if not usable:
+                axis.set_visible(False)
+                continue
+
+            values = [r.params[param_name] for r in usable]
+            if all(
+                isinstance(value, (int, float)) and not isinstance(value, bool)
+                for value in values
+            ):
+                x_values: Sequence[Any] = values
+                tick_labels = None
+            else:
+                categories = sorted({str(value) for value in values})
+                index = {category: position for position, category in enumerate(categories)}
+                x_values = [index[str(value)] for value in values]
+                tick_labels = categories
+
+            scatter = axis.scatter(
+                x_values,
+                [r.objective_values[metric_name] for r in usable],
+                c=[r.number for r in usable],
+                cmap="viridis",
+                s=18,
+                alpha=0.75,
+            )
+            if tick_labels is not None:
+                axis.set_xticks(range(len(tick_labels)))
+                axis.set_xticklabels(tick_labels, rotation=30, ha="right", fontsize="x-small")
+            if row == len(metric_names) - 1:
+                axis.set_xlabel(param_name)
+            if column == 0:
+                axis.set_ylabel(metric_name)
+            axis.grid(True, alpha=0.3)
+    fig.colorbar(scatter, ax=axes, label="Trial", fraction=0.02, pad=0.02)
+    fig.suptitle("Hyperparameter value vs objective")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    return output_path
+
+
+def plot_secondary_metrics(
+    records: Sequence[TrialRecord],
+    parameters_to_optimize,
+    output_path: Path,
+) -> Optional[Path]:
+    """Plot metrics that were recorded but not optimized, against trial number.
+
+    These show the price of the objective. A study told only to maximize return
+    can drive collision rate up for a hundred trials and report success.
+    """
+    completed = _completed(records)
+    if not completed:
+        return None
+
+    optimized = {name for name, _ in parameters_to_optimize}
+    names = sorted({name for record in completed for name in record.metric_statistics} - optimized)
+    if not names:
+        return None
+
+    columns = min(3, len(names))
+    rows = int(np.ceil(len(names) / columns))
+    fig, axes = plt.subplots(rows, columns, figsize=(5 * columns, 3.2 * rows), squeeze=False)
+    flat_axes = axes.flatten()
+    for axis, name in zip(flat_axes, names):
+        usable = [r for r in completed if name in r.metric_statistics]
+        numbers = [r.number for r in usable]
+        values = np.array([r.metric_statistics[name][0] for r in usable])
+        lower = np.array([r.metric_statistics[name][1] for r in usable])
+        upper = np.array([r.metric_statistics[name][2] for r in usable])
+
+        axis.plot(numbers, values, color="tab:blue", linewidth=1, alpha=0.8)
+        axis.fill_between(numbers, lower, upper, color="tab:blue", alpha=0.15)
+        pareto = [r for r in usable if r.is_pareto]
+        if pareto:
+            axis.scatter(
+                [r.number for r in pareto],
+                [r.metric_statistics[name][0] for r in pareto],
+                s=30,
+                color="tab:red",
+                label="Pareto front",
+                zorder=3,
+            )
+            axis.legend(fontsize="small")
+        axis.set_title(name)
+        axis.set_xlabel("Trial")
+        axis.grid(True, alpha=0.3)
+    for axis in flat_axes[len(names) :]:
+        axis.set_visible(False)
+    fig.suptitle("Metrics recorded but not optimized")
+    return _finish(fig, output_path)
+
+
+def plot_trial_durations(
+    records: Sequence[TrialRecord],
+    output_path: Path,
+) -> Optional[Path]:
+    """Plot per-trial wall-clock time.
+
+    Catches budget drift: if later trials take longer per decision, the search
+    has been comparing compute rather than parameters, which breaks the
+    calibration the whole comparison rests on.
+    """
+    usable = [r for r in _completed(records) if r.duration_seconds is not None]
+    if not usable:
+        return None
+
+    fig, axis = plt.subplots(figsize=(9, 4))
+    axis.plot(
+        [r.number for r in usable],
+        [r.duration_seconds for r in usable],
+        marker="o",
+        markersize=3,
+        linewidth=1,
+        color="tab:purple",
+    )
+    axis.set_xlabel("Trial")
+    axis.set_ylabel("Trial duration (s)")
+    axis.set_title("Trial duration vs trial")
+    axis.grid(True, alpha=0.3)
+    return _finish(fig, output_path)
+
+
+def plot_parameter_importances(
+    study,
+    parameters_to_optimize,
+    output_path: Path,
+) -> Optional[Path]:
+    """Plot fANOVA parameter importance, one bar group per optimized metric.
+
+    Needs the live study because Optuna computes importance from its internal
+    search space. A near-zero importance usually means the search range was too
+    narrow to matter, not that the parameter is unimportant in general.
+    """
+    import optuna  # pylint: disable=import-outside-toplevel
+
+    completed = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+    if len(completed) < 2:
+        return None
+
+    importances: Dict[str, Dict[str, float]] = {}
+    for index, (name, _) in enumerate(parameters_to_optimize):
+        try:
+            importances[name] = optuna.importance.get_param_importances(
+                study, target=lambda trial, i=index: trial.values[i]
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            # fANOVA needs scikit-learn and at least two distinct parameter
+            # values; neither is worth failing a finished study over.
+            logger.debug("Parameter importance unavailable for %s: %s", name, exc)
+    if not importances:
+        return None
+
+    param_names = sorted({param for values in importances.values() for param in values})
+    positions = np.arange(len(param_names))
+    width = 0.8 / max(1, len(importances))
+
+    fig, axis = plt.subplots(figsize=(max(7, 1.2 * len(param_names)), 4.5))
+    for offset, (metric_name, values) in enumerate(importances.items()):
+        axis.bar(
+            positions + offset * width,
+            [values.get(param, 0.0) for param in param_names],
+            width=width,
+            label=metric_name,
+        )
+    axis.set_xticks(positions + width * (len(importances) - 1) / 2)
+    axis.set_xticklabels(param_names, rotation=30, ha="right")
+    axis.set_ylabel("fANOVA importance")
+    axis.set_title("Hyperparameter importance per objective")
+    axis.legend(fontsize="small")
+    axis.grid(True, axis="y", alpha=0.3)
+    return _finish(fig, output_path)
+
+
+def plot_tuning_diagnostics(
+    records: Sequence[TrialRecord],
+    parameters_to_optimize,
+    output_dir: Path,
+    front_quality_history: Optional[Sequence[Tuple[int, float]]] = None,
+    stopped_at_trial: Optional[int] = None,
+    study=None,
+) -> List[Path]:
+    """Write the full diagnostic set for a tuning study.
+
+    Args:
+        records: Trial records, from :func:`extract_trial_records` or
+            :func:`load_trial_records`.
+        parameters_to_optimize: The optimized ``(metric_name, direction)`` pairs.
+        output_dir: Directory to write the PNGs into.
+        front_quality_history: Convergence curve from the early-stopping
+            callback. Omitted when early stopping was disabled.
+        stopped_at_trial: Where early stopping fired, if it did.
+        study: The live Optuna study, needed only for parameter importance.
+
+    Returns:
+        Paths actually written, skipping plots with no data behind them.
+    """
+    output_dir = Path(output_dir)
+    written: List[Optional[Path]] = [
+        plot_front_quality_history(
+            front_quality_history or [], output_dir / "front_quality_history.png", stopped_at_trial
+        ),
+        plot_objective_history(
+            records, parameters_to_optimize, output_dir / "objective_history.png"
+        ),
+        plot_objective_confidence_intervals(
+            records, parameters_to_optimize, output_dir / "objective_confidence_intervals.png"
+        ),
+        plot_pareto_front(records, parameters_to_optimize, output_dir / "pareto_front.png"),
+        plot_parameter_history(records, output_dir / "parameter_history.png"),
+        plot_parameter_slices(
+            records, parameters_to_optimize, output_dir / "parameter_slices.png"
+        ),
+        plot_secondary_metrics(
+            records, parameters_to_optimize, output_dir / "secondary_metrics.png"
+        ),
+        plot_trial_durations(records, output_dir / "trial_durations.png"),
+    ]
+    if study is not None:
+        written.append(
+            plot_parameter_importances(
+                study, parameters_to_optimize, output_dir / "parameter_importances.png"
+            )
+        )
+    return [path for path in written if path is not None]


### PR DESCRIPTION
## Why

Two gaps in the tuning path. A study ran its full `n_trials` whether or not the search had converged, and once it finished there was nothing to show whether the budget was enough.

Optuna's own mechanisms do not cover this. Pruners kill a *trial* mid-way rather than the study, and they are forbidden in multi-objective studies — which is what `HyperParameterTuningSimulationTask` creates. `TerminatorCallback` is single-objective only for the same reason.

## Early stopping

`EarlyStoppingCallback` calls `study.stop()` once the Pareto front's hypervolume has not improved for `patience` completed trials. `n_trials` becomes an upper bound: set 1000 and the study can end at 100.

```python
HyperParameterRunParams(
    ...,
    n_trials=1000,
    early_stopping=EarlyStoppingConfig(patience=100, min_trials=50),
)
```

Hypervolume is the measure because it improves only when the front genuinely gains ground — a new front member that trades one objective for another leaves it flat, which is not progress.

Objectives are normalized against bounds frozen once `min_trials` trials have finished. Freezing is what makes the curve monotone and comparable to itself; without it one late outlier would rescale every past value. Values are clipped at the reference point but **not** from above, so a study that beats its early range keeps registering improvement rather than saturating and stopping exactly when it was still working.

With `n_jobs > 1` the stop is soft: `study.stop()` blocks new trials but lets in-flight ones finish, so the study overshoots by up to `n_jobs - 1`.

## Diagnostics

Every finished study writes `trial_records.json` and nine plots to `cache_dir/tuning_diagnostics/<config_id>/`:

| plot | question it answers |
|---|---|
| `front_quality_history` | did the search converge, or run out of budget? |
| `objective_history` | how noisy is the objective relative to the gains? |
| `objective_confidence_intervals` | did the winner beat the runners-up, or get a luckier draw? |
| `pareto_front` | what trade-off did the study settle on? |
| `parameter_history` | did the sampler converge on a region of each knob? |
| `parameter_slices` | is that region the good one? |
| `parameter_importances` | which knobs moved the result (fANOVA)? |
| `secondary_metrics` | what did the objective cost — metrics recorded but not optimized |
| `trial_durations` | did the compute budget drift across trials? |

Plots build from plain `TrialRecord`s rather than the study, so they regenerate offline from the JSON. The study itself cannot be persisted to an Optuna storage backend — its `user_attrs` hold episode histories that no backend can serialize — which is why the JSON dump exists rather than a `storage=` URL.

Diagnostics are best-effort: a study that took hours must not be lost to a plot backend failure, so failures are logged and swallowed.

## Compatibility

Both features are opt-in and off by default. `early_stopping` is absent from the config id unless set, so studies already cached keep their ids and their cached results.

## Verification

193 tests pass, including new suites for the hypervolume arithmetic, the callback's stop and no-stop paths, record extraction and JSON round-trip, and every plot. Two `test_metrics_plots.py` failures are pre-existing on `develop` and unrelated.

Exercised end to end on a real study — PFT-DPW on the discrete-action Continuous Light-Dark POMDP — where early stopping fired at 8 of 10 trials and all nine plots were written.

https://claude.ai/code/session_01AtKrDxoPDQwUkkhBzRwPdX