### PR TITLE
feat(training): fit transition models with an iterative DAgger loop

### DIFF
--- a/POMDPPlanners/core/environment/__init__.py
+++ b/POMDPPlanners/core/environment/__init__.py
@@ -5,7 +5,8 @@
 Re-exports the same names that used to live in ``core/environment.py`` so
 that ``from POMDPPlanners.core.environment import Environment, SpaceInfo, ...``
 continues to work after the package refactor. ``ConstrainedEnvironment`` is
-added here as the new sibling module's public class.
+added here as the new sibling module's public class, and ``TransitionModel`` /
+``RewardModel`` are the generative-model seams a forward-only world injects.
 """
 
 from POMDPPlanners.core.environment.environment import (
@@ -16,6 +17,7 @@ from POMDPPlanners.core.environment.environment import (
     SpaceType,
 )
 from POMDPPlanners.core.environment.constrained_environment import ConstrainedEnvironment
+from POMDPPlanners.core.environment.transition_model import RewardModel, TransitionModel
 
 
 __all__ = [
@@ -23,6 +25,8 @@ __all__ = [
     "DiscreteActionsEnvironment",
     "Environment",
     "EnvironmentGenerator",
+    "RewardModel",
     "SpaceInfo",
     "SpaceType",
+    "TransitionModel",
 ]

--- a/POMDPPlanners/core/environment/transition_model.py
+++ b/POMDPPlanners/core/environment/transition_model.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: MIT
+
+"""Contracts for the two pieces a planner-side generative model injects.
+
+A forward-only world -- a live simulator such as IsaacLab or CARLA -- can step
+itself but cannot resample from an arbitrary state, and cannot say what reward a
+hypothetical in-tree transition would earn. A planner searching such a world
+therefore needs a *separate* generative model, and the two swappable pieces of
+that model are the dynamics and the objective.
+
+Both live here rather than beside any one environment because model *learning*
+is generic: a routine that fits a transition from rollouts and hands it back
+should not have to import an environment package to name what it produced. The
+environments that first defined these interfaces re-export them, so existing
+import paths are unchanged.
+
+The transition is deliberately two methods, not one. A sampler alone is enough
+for a planner that only rolls forward, but a particle filter needs the matching
+density to weight, and a model *fitted by likelihood* needs it to state its own
+training objective. Anything implementing both can be planned with and can be
+learned.
+
+Classes:
+    TransitionModel: Interface for a state-transition model (sample + log-density).
+    RewardModel: Interface for a reward model over a transition.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+import numpy as np
+
+
+class TransitionModel(ABC):
+    """Interface for a state-transition model over the shared state/observation space.
+
+    A concrete transition supplies a generative next-state sampler and the matching
+    log-density, both conditioned on ``(state, action)``. Implementations may be
+    analytic Gaussians or models fitted from rollouts; the planner cannot tell the
+    difference, which is the point.
+
+    Note:
+        This is an abstract base class and cannot be instantiated directly.
+    """
+
+    @abstractmethod
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        """Sample ``n_samples`` next states for ``(state, action)``.
+
+        Args:
+            state: The current state, a length-``dim`` vector.
+            action: The action applied at ``state``.
+            n_samples: Number of next states to draw.
+
+        Returns:
+            A single ``(dim,)`` next state when ``n_samples == 1``, else a
+            ``(n_samples, dim)`` array.
+        """
+
+    @abstractmethod
+    def log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+        """Log-density of each of ``next_states`` under the transition for ``(state, action)``.
+
+        Args:
+            state: The current state, a length-``dim`` vector.
+            action: The action applied at ``state``.
+            next_states: A single ``(dim,)`` next state or a ``(n, dim)`` batch.
+
+        Returns:
+            A ``(n,)`` array of log-densities.
+        """
+
+
+class RewardModel(ABC):
+    """Interface for a reward model over the shared state/observation space.
+
+    A concrete reward model scores a ``(state, action, next_state)`` transition.
+    The planner-side model needs one because the forward-only world cannot be
+    queried for the reward of a hypothetical in-tree transition.
+
+    Note:
+        This is an abstract base class and cannot be instantiated directly.
+    """
+
+    @abstractmethod
+    def reward(self, state: Any, action: Any, next_state: Any) -> float:
+        """Return the scalar reward for a ``(state, action, next_state)`` transition."""

--- a/POMDPPlanners/environments/isaac_lab_pomdp/isaac_lab_model_pomdp.py
+++ b/POMDPPlanners/environments/isaac_lab_pomdp/isaac_lab_model_pomdp.py
@@ -45,18 +45,23 @@ injected, via :class:`RewardModel`. :class:`LinearRewardModel` is fit from the s
 warm-up rollouts as the transition; without it the model's reward is a flat zero
 and the planner has no objective, so the task is never solved.
 
+The :class:`~POMDPPlanners.core.environment.transition_model.TransitionModel` and
+:class:`~POMDPPlanners.core.environment.transition_model.RewardModel` interfaces
+themselves live in core, because fitting one from rollouts is generic work that
+must not depend on an environment package. They are re-exported here so every
+existing import path keeps resolving.
+
 Classes:
-    TransitionModel: Interface for a state-transition model (sample + log-density).
+    TransitionModel: Interface for a state-transition model (re-exported from core).
     GaussianRandomWalkTransition: Action-ignoring Gaussian random-walk transition.
     LinearGaussianTransition: Fit-from-data linear-Gaussian action-conditioned transition.
     IsaacLabSimulatorTransition: Steps the IsaacLab simulator as the true transition.
-    RewardModel: Interface for a reward model over the state/observation space.
+    RewardModel: Interface for a reward model over a transition (re-exported from core).
     LinearRewardModel: Fit-from-data linear reward model POMCPOW optimizes.
     GaussianObservationModel: Additive-Normal observation model (obs = state + noise).
     IsaacLabModelPOMDP: Discrete-action generative model POMCPOW searches inside.
 """
 
-from abc import ABC, abstractmethod
 from collections.abc import Hashable
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -65,8 +70,10 @@ import numpy as np
 from POMDPPlanners.core.distributions import Distribution
 from POMDPPlanners.core.environment import (
     DiscreteActionsEnvironment,
+    RewardModel,
     SpaceInfo,
     SpaceType,
+    TransitionModel,
 )
 
 # Reuse the world module's launch seam so both share the single per-process
@@ -107,45 +114,6 @@ def _diagonal_covariance(dim: int, std: NoiseStd) -> np.ndarray:
     if np.any(std_vector <= 0.0):
         raise ValueError("noise standard deviations must be strictly positive")
     return np.diag(std_vector**2)
-
-
-class TransitionModel(ABC):
-    """Interface for a state-transition model over the shared state/observation space.
-
-    A concrete transition supplies a generative next-state sampler and the matching
-    log-density, both conditioned on ``(state, action)``. Implementations here are
-    analytic Gaussians; a learned world model can implement the same two methods.
-
-    Note:
-        This is an abstract base class and cannot be instantiated directly.
-    """
-
-    @abstractmethod
-    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
-        """Sample ``n_samples`` next states for ``(state, action)``.
-
-        Args:
-            state: The current state, a length-``dim`` vector.
-            action: The action applied at ``state``.
-            n_samples: Number of next states to draw.
-
-        Returns:
-            A single ``(dim,)`` next state when ``n_samples == 1``, else a
-            ``(n_samples, dim)`` array.
-        """
-
-    @abstractmethod
-    def log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
-        """Log-density of each of ``next_states`` under the transition for ``(state, action)``.
-
-        Args:
-            state: The current state, a length-``dim`` vector.
-            action: The action applied at ``state``.
-            next_states: A single ``(dim,)`` next state or a ``(n, dim)`` batch.
-
-        Returns:
-            A ``(n,)`` array of log-densities.
-        """
 
 
 class GaussianRandomWalkTransition(TransitionModel):
@@ -442,22 +410,6 @@ class IsaacLabSimulatorTransition(TransitionModel):
     def log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
         mean = self._sim_step_mean(state, action)
         return self._normal.log_pdf(np.asarray(next_states, dtype=float), mean)
-
-
-class RewardModel(ABC):
-    """Interface for a reward model over the shared state/observation space.
-
-    A concrete reward model scores a ``(state, action, next_state)`` transition.
-    The planner-side model needs one because the forward-only world cannot be
-    queried for the reward of a hypothetical in-tree transition.
-
-    Note:
-        This is an abstract base class and cannot be instantiated directly.
-    """
-
-    @abstractmethod
-    def reward(self, state: Any, action: Any, next_state: Any) -> float:
-        """Return the scalar reward for a ``(state, action, next_state)`` transition."""
 
 
 class LinearRewardModel(RewardModel):

--- a/POMDPPlanners/tests/test_training/test_model_learning/__init__.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_dagger_trainer.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_dagger_trainer.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the round loop and the exploration collector.
+
+Three properties carry the loop's guarantee, and each fails quietly. The halves
+must stay balanced, or the exploration rows shrink to a fraction the fit stops
+paying for. The dataset must aggregate, or the loop becomes unrelated fits that
+can oscillate. Every round's model must be kept, because the guarantee is on the
+best of the sequence and not on the last one.
+
+The collector has its own two: an action held across several steps, because a
+command redrawn every step measures a transient rather than the system, and no
+transition recorded across an episode boundary, because the simulator resets
+inside its own step and that successor belongs to a different episode.
+"""
+
+from typing import Any, List, Tuple
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.training.model_learning import (
+    DAggerModelTrainer,
+    LinearGaussianLearner,
+    TransitionDataset,
+    collect_random_preset_episode,
+)
+
+PRESETS = np.array([[1.0], [-1.0], [0.0]])
+
+
+class _LinearWorld:
+    """A tiny deterministic-plus-noise world with a controllable terminal rule."""
+
+    def __init__(self, terminal_after: int = 10**6, seed: int = 0) -> None:
+        self._rng = np.random.default_rng(seed)
+        self._terminal_after = terminal_after
+        self._steps = 0
+
+    def restart(self) -> np.ndarray:
+        """Reset the step counter and return the start state."""
+        self._steps = 0
+        return np.zeros(2)
+
+    def initial_state_dist(self) -> Any:
+        world = self
+
+        class _Dist:
+            def sample(self, num_samples: int = 1) -> np.ndarray:
+                del num_samples
+                return world.restart()
+
+        return _Dist()
+
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        self._steps += 1
+        state_vector = np.asarray(state, dtype=float).ravel()
+        action_vector = np.asarray(action, dtype=float).ravel()
+        mean = 0.9 * state_vector + np.array([action_vector[0], 0.5 * action_vector[0]])
+        draws = mean + self._rng.normal(scale=0.02, size=(n_samples, 2))
+        return draws[0] if n_samples == 1 else draws
+
+    def is_terminal(self, state: Any) -> bool:
+        del state
+        return self._steps >= self._terminal_after
+
+
+def _fake_planner_rollouts(model: Any, round_index: int, num_episodes: int) -> List[Tuple]:
+    """Stand-in for running a planner: episodes marked so their source is checkable."""
+    del model, round_index
+    rng = np.random.default_rng(0)
+    episodes = []
+    for _ in range(num_episodes):
+        states = rng.normal(size=(8, 2)) + 100.0
+        actions = PRESETS[rng.integers(len(PRESETS), size=8)]
+        episodes.append((states, actions, states + 0.1))
+    return episodes
+
+
+def test_each_round_takes_half_its_episodes_from_exploration() -> None:
+    """Purpose: Validates the fixed exploration/planner balance the loop depends on
+
+    Given: A round of 10 episodes with a planner rollout function supplied
+    When: Two rounds run
+    Then: Round 2 contributes 5 episodes from each source, so the exploration data
+        does not shrink as a fraction of the buffer. Round 1 has no model to plan
+        with, so its whole budget goes to exploration rather than being halved.
+    """
+    trainer = DAggerModelTrainer(
+        world=_LinearWorld(),
+        learner=LinearGaussianLearner(),
+        dataset=TransitionDataset(holdout_fraction=0.0),
+        action_presets=PRESETS,
+        planner_rollout_fn=_fake_planner_rollouts,
+        initial_model=None,
+        num_rounds=2,
+        episodes_per_round=10,
+        steps_per_episode=8,
+    )
+
+    rounds = trainer.run()
+
+    # Round 1 has no model to plan with, so all 10 episodes explore; round 2 adds
+    # five of each, which is the balance the loop must hold from then on.
+    assert rounds[0].source_counts == {"exploration": 80}
+    assert rounds[1].source_counts["planner"] == 40
+    assert rounds[1].source_counts["exploration"] == 120
+
+
+def test_the_dataset_grows_across_rounds_instead_of_being_replaced() -> None:
+    """Purpose: Validates that round n refits on rounds 1..n, not on round n alone
+
+    Given: Three rounds of 4 episodes each
+    When: The loop runs
+    Then: Each round's fit saw strictly more transitions than the round before
+    """
+    trainer = DAggerModelTrainer(
+        world=_LinearWorld(),
+        learner=LinearGaussianLearner(),
+        dataset=TransitionDataset(holdout_fraction=0.0),
+        action_presets=PRESETS,
+        planner_rollout_fn=_fake_planner_rollouts,
+        num_rounds=3,
+        episodes_per_round=4,
+        steps_per_episode=8,
+    )
+
+    sizes = [result.dataset_size for result in trainer.run()]
+
+    assert sizes == sorted(sizes)
+    assert len(set(sizes)) == 3
+
+
+def test_every_round_model_is_kept() -> None:
+    """Purpose: Validates that the loop returns the sequence, not just the last model
+
+    Given: Three rounds
+    When: The loop runs
+    Then: Three distinct models come back, because the guarantee is on the best of
+        the sequence rather than on the final one
+    """
+    trainer = DAggerModelTrainer(
+        world=_LinearWorld(),
+        learner=LinearGaussianLearner(),
+        dataset=TransitionDataset(holdout_fraction=0.0),
+        action_presets=PRESETS,
+        planner_rollout_fn=None,
+        num_rounds=3,
+        episodes_per_round=4,
+        steps_per_episode=8,
+    )
+
+    rounds = trainer.run()
+
+    assert [result.round_index for result in rounds] == [1, 2, 3]
+    assert len({id(result.model) for result in rounds}) == 3
+
+
+def test_diagnostics_are_reported_per_round() -> None:
+    """Purpose: Validates that each round carries the numbers used to judge its model
+
+    Given: A loop with a holdout split
+    When: Two rounds run
+    Then: Each round reports a finite held-out likelihood and a drift ratio
+    """
+    trainer = DAggerModelTrainer(
+        world=_LinearWorld(),
+        learner=LinearGaussianLearner(),
+        dataset=TransitionDataset(holdout_fraction=0.5, seed=2),
+        action_presets=PRESETS,
+        planner_rollout_fn=None,
+        num_rounds=2,
+        episodes_per_round=8,
+        steps_per_episode=8,
+        horizon=5,
+    )
+
+    rounds = trainer.run()
+
+    for result in rounds:
+        assert np.isfinite(result.diagnostics["held_out_log_likelihood"])
+        assert np.isfinite(result.diagnostics["horizon_drift_ratio"])
+
+
+def test_exploration_holds_each_action_for_several_steps() -> None:
+    """Purpose: Validates that a drawn command is held, not redrawn every step
+
+    Given: A 12-step exploration rollout with a hold of 4
+    When: The recorded actions are inspected
+    Then: They form runs of 4 identical commands, so the rollout excites the
+        system at the timescale it responds on
+    """
+    _, actions, _ = collect_random_preset_episode(
+        world=_LinearWorld(),
+        action_presets=PRESETS,
+        num_steps=12,
+        rng=np.random.default_rng(0),
+        hold_steps=4,
+    )
+
+    for start in range(0, 12, 4):
+        block = actions[start : start + 4]
+        assert np.all(block == block[0])
+
+
+def test_no_transition_is_recorded_across_an_episode_boundary() -> None:
+    """Purpose: Validates that the row spanning a reset is dropped, not fitted
+
+    Given: A world that terminates after 3 steps, and a 10-step rollout
+    When: The rollout is collected
+    Then: Two transitions come back -- the third ends the episode and its
+        successor is a fresh episode, which is not a transition of the system
+    """
+    states, _, _ = collect_random_preset_episode(
+        world=_LinearWorld(terminal_after=3),
+        action_presets=PRESETS,
+        num_steps=10,
+        rng=np.random.default_rng(0),
+        hold_steps=2,
+    )
+
+    assert len(states) == 2
+
+
+def test_a_non_positive_hold_is_rejected() -> None:
+    """Purpose: Validates that a zero hold is refused rather than looping forever
+
+    Given: hold_steps of 0
+    When: A rollout is collected
+    Then: A ValueError is raised
+    """
+    with pytest.raises(ValueError, match="hold_steps"):
+        collect_random_preset_episode(
+            world=_LinearWorld(),
+            action_presets=PRESETS,
+            num_steps=4,
+            rng=np.random.default_rng(0),
+            hold_steps=0,
+        )
+
+
+@pytest.mark.parametrize("field,value", [("num_rounds", 0), ("episodes_per_round", 0)])
+def test_a_loop_that_would_collect_nothing_is_rejected(field: str, value: int) -> None:
+    """Purpose: Validates that a degenerate loop configuration raises at construction
+
+    Given: Zero rounds, or zero episodes per round
+    When: The trainer is constructed
+    Then: A ValueError names the offending field
+    """
+    kwargs: dict = {
+        "world": _LinearWorld(),
+        "learner": LinearGaussianLearner(),
+        "dataset": TransitionDataset(),
+        "action_presets": PRESETS,
+        field: value,
+    }
+    with pytest.raises(ValueError, match=field):
+        DAggerModelTrainer(**kwargs)

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_factored_integration.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_factored_integration.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: MIT
+
+"""Integration test: the loop against a factored world that carries a latent channel.
+
+This is the shape every real use has. The world's state is wider than the block
+being fitted, and the extra width is a latent fixed at episode start -- a hazard
+type -- which the transition must carry unchanged. Fitting over it does not
+raise; it regresses a persistent hidden property as if it were a random variable
+of the dynamics, flattening exactly the belief dispersion a risk-sensitive
+planner is there to grade.
+
+So the property under test is not "the loop runs". It is that a model fitted
+through the loop can be dropped back into the factored model as its transition
+and the latent still survives a step untouched.
+
+No Isaac Sim is involved: these generative models are standalone by design.
+"""
+
+from typing import Any, Tuple
+
+import numpy as np
+
+from POMDPPlanners.environments.isaac_lab_pomdp.isaac_generative_models import (
+    FactoredIsaacModelPOMDP,
+    IsaacChannelSchema,
+)
+from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_model_pomdp import (
+    LinearGaussianTransition,
+)
+from POMDPPlanners.training.model_learning import (
+    DAggerModelTrainer,
+    LinearGaussianLearner,
+    TransitionDataset,
+    block_indices,
+)
+
+SCHEMA = IsaacChannelSchema((("robot", 3), ("hazard_type", 2)))
+ROBOT = ("robot",)
+PRESETS = np.array([[1.0, 0.0], [-1.0, 0.0], [0.0, 1.0]])
+
+
+def _true_world() -> FactoredIsaacModelPOMDP:
+    """A factored world whose transition drives the robot block only."""
+    transition = LinearGaussianTransition(
+        weight_state=np.array([[0.9, 0.05, 0.0], [0.0, 0.92, 0.05], [0.0, 0.0, 0.95]]),
+        weight_action=np.array([[0.4, 0.0], [0.1, 0.3], [0.0, 0.2]]),
+        bias=np.array([0.01, 0.0, -0.01]),
+        covariance=np.diag([0.0025, 0.0025, 0.0025]),
+    )
+    return FactoredIsaacModelPOMDP(
+        state_schema=SCHEMA,
+        action_presets=list(PRESETS),
+        discount_factor=0.99,
+        transition=transition,
+        transition_channels=ROBOT,
+    )
+
+
+class _WorldWithStart:
+    """The factored world plus the start state and terminal rule the loop needs."""
+
+    def __init__(self, model: FactoredIsaacModelPOMDP) -> None:
+        self._model = model
+
+    def initial_state_dist(self) -> Any:
+        schema = SCHEMA
+
+        class _Dist:
+            def sample(self, num_samples: int = 1) -> np.ndarray:
+                del num_samples
+                # A latent drawn once per episode, exactly what must not be fitted.
+                return schema.pack({"robot": np.zeros(3), "hazard_type": np.array([1.0, 0.0])})
+
+        return _Dist()
+
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        return self._model.sample_next_state(state, action, n_samples)
+
+    def is_terminal(self, state: Any) -> bool:
+        del state
+        return False
+
+
+def _robot_view(world: _WorldWithStart) -> Any:
+    """A view of the world over the robot block alone, for the diagnostics."""
+    indices = block_indices(SCHEMA, ROBOT)
+
+    class _View:
+        def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+            full = SCHEMA.pack(
+                {"robot": np.asarray(state, dtype=float), "hazard_type": np.array([1.0, 0.0])}
+            )
+            successors = np.atleast_2d(world.sample_next_state(full, action, n_samples))[
+                :, indices
+            ]
+            return successors[0] if n_samples == 1 else successors
+
+    return _View()
+
+
+def _run_loop(rounds: int) -> Tuple[Any, list]:
+    world = _WorldWithStart(_true_world())
+    dataset = TransitionDataset(
+        state_indices=block_indices(SCHEMA, ROBOT), holdout_fraction=0.25, seed=4
+    )
+    trainer = DAggerModelTrainer(
+        world=world,
+        learner=LinearGaussianLearner(),
+        dataset=dataset,
+        action_presets=PRESETS,
+        # The diagnostics roll model and world side by side, so the world they
+        # get must speak the fitted block, not the full state.
+        diagnostics_world=_robot_view(world),
+        planner_rollout_fn=None,
+        num_rounds=rounds,
+        episodes_per_round=12,
+        steps_per_episode=25,
+        horizon=10,
+        seed=0,
+    )
+    return world, trainer.run()
+
+
+def test_a_model_fitted_through_the_loop_drops_back_into_the_factored_model() -> None:
+    """Purpose: Validates that a learned transition is usable as the factored model's transition
+
+    Given: A learned transition over the 3-wide robot block of a 5-wide state
+    When: It is installed in a factored model and a step is taken
+    Then: The step succeeds and returns a full 5-wide successor
+    """
+    _, rounds = _run_loop(rounds=2)
+
+    planner_model = FactoredIsaacModelPOMDP(
+        state_schema=SCHEMA,
+        action_presets=list(PRESETS),
+        discount_factor=0.99,
+        transition=rounds[-1].model,
+        transition_channels=ROBOT,
+    )
+    state = SCHEMA.pack({"robot": np.zeros(3), "hazard_type": np.array([1.0, 0.0])})
+
+    successor = planner_model.sample_next_state(state, PRESETS[0])
+
+    assert successor.shape == (5,)
+
+
+def test_the_latent_channel_survives_a_step_of_the_learned_model() -> None:
+    """Purpose: Validates that the fit cannot move the carried hazard type
+
+    Given: A learned transition installed over the robot block only, and a state
+        whose latent reads [1, 0]
+    When: Twenty successors are drawn
+    Then: Every one still reads [1, 0], so the belief over the latent keeps its
+        dispersion instead of being regressed away
+    """
+    _, rounds = _run_loop(rounds=2)
+    planner_model = FactoredIsaacModelPOMDP(
+        state_schema=SCHEMA,
+        action_presets=list(PRESETS),
+        discount_factor=0.99,
+        transition=rounds[-1].model,
+        transition_channels=ROBOT,
+    )
+    latent = np.array([1.0, 0.0])
+    state = SCHEMA.pack({"robot": np.array([0.4, -0.2, 0.1]), "hazard_type": latent})
+
+    successors = np.atleast_2d(planner_model.sample_next_state(state, PRESETS[1], 20))
+
+    assert np.allclose(SCHEMA.block(successors, "hazard_type"), latent)
+    # And the robot block did move, so the check above is not passing vacuously.
+    assert not np.allclose(SCHEMA.block(successors, "robot"), state[:3])
+
+
+def test_more_rounds_do_not_degrade_the_held_out_likelihood() -> None:
+    """Purpose: Validates that aggregating rounds improves the fit rather than harming it
+
+    Given: Three rounds against a world the model class can represent exactly
+    When: The per-round held-out likelihoods are compared
+    Then: The last round is at least as good as the first, which is the minimum a
+        loop that refits on strictly more data must deliver
+    """
+    _, rounds = _run_loop(rounds=3)
+
+    likelihoods = [result.diagnostics["held_out_log_likelihood"] for result in rounds]
+
+    assert all(np.isfinite(value) for value in likelihoods)
+    assert likelihoods[-1] >= likelihoods[0] - 0.1
+
+
+def test_the_drift_ratio_is_near_one_when_the_model_class_matches_the_world() -> None:
+    """Purpose: Validates that the overconfidence measure reads sane on an honest model
+
+    Given: A linear fit of a linear world, so the model is right and its noise
+        estimate is right
+    When: The horizon drift ratio is read
+    Then: It is small -- the model's error sits inside its own error bars, which
+        is what the measure is calibrated to say
+    """
+    _, rounds = _run_loop(rounds=2)
+
+    ratio = rounds[-1].diagnostics["horizon_drift_ratio"]
+
+    assert 0.0 < ratio < 3.0

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_learners.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_learners.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the two fitting procedures.
+
+The property under test is recovery: given data from a system the learner's model
+class can represent, the fit must find it. A learner that cannot recover a linear
+system from clean linear data will not be diagnosable on a real one, because
+every failure there is attributable to the environment.
+
+The ensemble's second property is that it reports uncertainty at all. A
+deterministic transition collapses a particle belief to a point, and a planner
+grading a tail measure then has nothing to grade -- so "does it produce spread"
+is not cosmetic, it is the reason the ensemble exists.
+"""
+
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.training.model_learning import (
+    LinearGaussianLearner,
+    ProbabilisticEnsembleLearner,
+    TransitionDataset,
+    held_out_log_likelihood,
+)
+
+WEIGHT_STATE = np.array([[0.9, 0.1], [0.0, 0.95]])
+WEIGHT_ACTION = np.array([[0.5], [0.2]])
+BIAS = np.array([0.01, -0.02])
+NOISE_STD = 0.05
+
+
+def _linear_world(num_rows: int, seed: int = 0) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Rollouts from a known linear-Gaussian system."""
+    rng = np.random.default_rng(seed)
+    states = rng.normal(size=(num_rows, 2))
+    actions = rng.normal(size=(num_rows, 1))
+    next_states = (
+        states @ WEIGHT_STATE.T
+        + actions @ WEIGHT_ACTION.T
+        + BIAS
+        + rng.normal(scale=NOISE_STD, size=(num_rows, 2))
+    )
+    return states, actions, next_states
+
+
+def _dataset(num_rows: int = 2000, holdout_fraction: float = 0.2, seed: int = 0):
+    states, actions, next_states = _linear_world(num_rows, seed)
+    dataset = TransitionDataset(holdout_fraction=holdout_fraction, seed=seed + 1)
+    for start in range(0, num_rows, 50):
+        dataset.add_episode(
+            states[start : start + 50],
+            actions[start : start + 50],
+            next_states[start : start + 50],
+            source="exploration",
+        )
+    return dataset
+
+
+def test_linear_learner_recovers_the_system_it_was_generated_from() -> None:
+    """Purpose: Validates that the linear fit recovers known coefficients and noise
+
+    Given: 2000 transitions from a linear-Gaussian system with a known A, B, b and
+        a noise standard deviation of 0.05
+    When: The linear learner fits them
+    Then: The recovered mean prediction matches the true one to within the noise,
+        and the recovered noise scale is close to 0.05
+    """
+    dataset = _dataset(holdout_fraction=0.0)
+    model = LinearGaussianLearner().fit(dataset)
+
+    state = np.array([0.3, -0.7])
+    action = np.array([0.4])
+    expected = WEIGHT_STATE @ state + WEIGHT_ACTION @ action + BIAS
+
+    draws = np.atleast_2d(model.sample_next_state(state, action, 4000))
+    assert np.allclose(draws.mean(axis=0), expected, atol=5e-3)
+    assert np.allclose(draws.std(axis=0), NOISE_STD, rtol=0.15)
+
+
+def test_ensemble_learner_recovers_the_same_system() -> None:
+    """Purpose: Validates that the ensemble fit finds a linear system too
+
+    Given: The same 2000 transitions, and an ensemble of three small networks
+    When: The ensemble fits them
+    Then: Its mean prediction matches the true one to a looser tolerance than the
+        closed-form fit, which is the price of the larger model class
+    """
+    dataset = _dataset(holdout_fraction=0.0)
+    model = ProbabilisticEnsembleLearner(
+        num_members=3, hidden_sizes=(64, 64), epochs=60, seed=0
+    ).fit(dataset)
+
+    state = np.array([0.3, -0.7])
+    action = np.array([0.4])
+    expected = WEIGHT_STATE @ state + WEIGHT_ACTION @ action + BIAS
+
+    draws = np.atleast_2d(model.sample_next_state(state, action, 4000))
+    assert np.allclose(draws.mean(axis=0), expected, atol=0.05)
+
+
+def test_ensemble_reports_uncertainty_rather_than_a_point() -> None:
+    """Purpose: Validates that the fitted ensemble produces spread, not a point mass
+
+    Given: A fitted ensemble
+    When: Many next states are drawn from one (state, action)
+    Then: They have non-zero spread in every dimension, so a particle belief built
+        from them does not collapse
+    """
+    dataset = _dataset(holdout_fraction=0.0)
+    model = ProbabilisticEnsembleLearner(
+        num_members=3, hidden_sizes=(64, 64), epochs=40, seed=0
+    ).fit(dataset)
+
+    draws = np.atleast_2d(model.sample_next_state(np.array([0.1, 0.2]), np.array([0.0]), 500))
+
+    assert np.all(draws.std(axis=0) > 1e-3)
+
+
+def test_ensemble_density_is_the_mixture_it_actually_samples_from() -> None:
+    """Purpose: Validates that log_probability describes the sampling distribution
+
+    Given: A fitted ensemble and 20000 draws from one (state, action)
+    When: The empirical log-density near the sample mean is compared to the
+        reported one
+    Then: They agree to within Monte-Carlo error, so a particle filter weighting
+        with this density is weighting correctly
+    """
+    dataset = _dataset(holdout_fraction=0.0)
+    model = ProbabilisticEnsembleLearner(
+        num_members=3, hidden_sizes=(64, 64), epochs=40, seed=0
+    ).fit(dataset)
+    state = np.array([0.1, 0.2])
+    action = np.array([0.0])
+
+    draws = np.atleast_2d(model.sample_next_state(state, action, 20000))
+    centre = draws.mean(axis=0)
+    reported = float(model.log_probability(state, action, centre[None, :])[0])
+
+    # Empirical density near the centre: the fraction of draws inside a small box,
+    # divided by the box's volume.
+    half_width = 0.02
+    inside = np.all(np.abs(draws - centre) < half_width, axis=1)
+    empirical = inside.mean() / ((2 * half_width) ** draws.shape[1])
+    assert np.isclose(reported, np.log(empirical), atol=0.4)
+
+
+def test_held_out_likelihood_prefers_the_fit_that_saw_the_data() -> None:
+    """Purpose: Validates that held-out likelihood separates a good fit from a bad one
+
+    Given: A model fitted on the system, and one fitted on shuffled successors
+    When: Both are scored on the same held-out transitions
+    Then: The correctly fitted model scores higher
+    """
+    dataset = _dataset()
+    good = LinearGaussianLearner().fit(dataset)
+
+    shuffled = TransitionDataset(holdout_fraction=0.0, seed=1)
+    states, actions, next_states = _linear_world(1000, seed=5)
+    rng = np.random.default_rng(0)
+    shuffled.add_episode(states, actions, rng.permutation(next_states), source="exploration")
+    bad = LinearGaussianLearner().fit(shuffled)
+
+    holdout = dataset.holdout_batch()
+    assert held_out_log_likelihood(good, holdout) > held_out_log_likelihood(bad, holdout)
+
+
+def test_fitting_too_few_rows_is_refused() -> None:
+    """Purpose: Validates that an under-determined fit raises instead of returning noise
+
+    Given: A dataset holding a single transition
+    When: Either learner fits it
+    Then: A ValueError says how many rows were available
+    """
+    dataset = TransitionDataset(holdout_fraction=0.0)
+    dataset.add_episode(np.zeros((1, 2)), np.zeros((1, 1)), np.zeros((1, 2)), source="x")
+
+    with pytest.raises(ValueError, match="at least 2 rows"):
+        LinearGaussianLearner().fit(dataset)
+    with pytest.raises(ValueError, match="at least 2 rows"):
+        ProbabilisticEnsembleLearner(num_members=2, epochs=1).fit(dataset)
+
+
+def test_an_ensemble_needs_at_least_one_member() -> None:
+    """Purpose: Validates that a zero-member ensemble is rejected at construction
+
+    Given: num_members of 0
+    When: The learner is constructed
+    Then: A ValueError is raised, rather than a fit that returns an empty mixture
+    """
+    with pytest.raises(ValueError, match="num_members"):
+        ProbabilisticEnsembleLearner(num_members=0)

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_transition_dataset.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_transition_dataset.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the accumulating transition dataset.
+
+Two properties matter and both fail silently when broken. Aggregation: the
+iterative loop's guarantee rests on refitting over every round, so a dataset
+that quietly drops the oldest round turns the loop into a sequence of unrelated
+fits. Confinement: a fit that reaches a carried latent channel flattens the
+belief dispersion a risk-sensitive planner grades, and returns a plausible
+number while doing it.
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief import WeightedParticleBelief
+from POMDPPlanners.core.simulation.history import History, StepData
+from POMDPPlanners.training.model_learning import TransitionDataset, block_indices
+
+
+def _rows(count: int, width: int, offset: float = 0.0) -> tuple:
+    rng = np.random.default_rng(int(offset) + 7)
+    states = rng.normal(size=(count, width)) + offset
+    actions = rng.normal(size=(count, 2))
+    next_states = states + 0.1 * rng.normal(size=(count, width))
+    return states, actions, next_states
+
+
+def _step(state: Any, action: Any, next_state: Any) -> StepData:
+    return StepData(
+        state=state,
+        action=action,
+        next_state=next_state,
+        observation=None,
+        reward=0.0,
+        belief=WeightedParticleBelief([np.zeros(3), np.ones(3)], np.array([-0.5, -1.0])),
+    )
+
+
+def test_rounds_aggregate_rather_than_replace() -> None:
+    """Purpose: Validates that a later round adds to the dataset instead of replacing it
+
+    Given: A dataset that has taken one round of 50 transitions
+    When: A second round of 50 is added
+    Then: The dataset holds 100 rows and both rounds' sources are counted
+    """
+    dataset = TransitionDataset(holdout_fraction=0.0, seed=0)
+    dataset.add_episode(*_rows(50, 3, offset=0.0), source="exploration")
+    assert len(dataset) == 50
+
+    dataset.add_episode(*_rows(50, 3, offset=10.0), source="planner")
+
+    assert len(dataset) == 100
+    assert dataset.counts_by_source() == {"exploration": 50, "planner": 50}
+    # The first round's rows are still reachable, not merely counted.
+    assert float(dataset.training_batch().states.min()) < 5.0
+
+
+def test_fit_never_sees_channels_outside_the_named_block() -> None:
+    """Purpose: Validates that a carried latent channel is sliced out before any fit
+
+    Given: A 6-wide state whose last two columns are a latent type, and a dataset
+        restricted to the 4-wide robot block
+    When: The training batch is taken
+    Then: It is 4 columns wide, and the latent values are absent
+    """
+    states = np.hstack([np.ones((20, 4)), np.full((20, 2), 99.0)])
+    next_states = states + 0.01
+    actions = np.zeros((20, 2))
+    dataset = TransitionDataset(state_indices=np.arange(4), holdout_fraction=0.0)
+
+    dataset.add_episode(states, actions, next_states, source="exploration")
+
+    batch = dataset.training_batch()
+    assert batch.states.shape == (20, 4)
+    assert not np.any(np.isclose(batch.states, 99.0))
+    assert not np.any(np.isclose(batch.next_states, 99.0))
+
+
+def test_block_indices_reads_channels_from_a_schema() -> None:
+    """Purpose: Validates that named channels resolve to the right flat indices
+
+    Given: A schema of a 4-wide robot block followed by a 2-wide hazard type
+    When: The robot channel's indices are requested
+    Then: They are the first four positions
+    """
+
+    class _Schema:
+        def indices_of(self, names: Any) -> np.ndarray:
+            del names
+            return np.arange(4)
+
+    assert block_indices(_Schema(), ("robot",)).tolist() == [0, 1, 2, 3]
+
+
+def test_holdout_is_split_by_episode_not_by_row() -> None:
+    """Purpose: Validates that a held-out episode contributes no training rows
+
+    Given: Twenty episodes added with a 0.5 holdout fraction
+    When: The two splits are taken
+    Then: They partition the rows exactly, and each split's size is a multiple of
+        the episode length, which a row-wise split would not guarantee
+    """
+    dataset = TransitionDataset(holdout_fraction=0.5, seed=3)
+    for index in range(20):
+        dataset.add_episode(*_rows(10, 3, offset=float(index)), source="exploration")
+
+    train = dataset.training_batch()
+    holdout = dataset.holdout_batch()
+
+    assert len(train) + len(holdout) == 200
+    assert len(train) % 10 == 0
+    assert len(holdout) % 10 == 0
+    assert len(holdout) > 0
+
+
+def test_terminal_bookkeeping_step_contributes_no_transition() -> None:
+    """Purpose: Validates that the actionless terminal step is dropped
+
+    Given: A history of two real steps followed by the terminal bookkeeping step
+    When: The history is added
+    Then: Two transitions are stored, not three
+    """
+    steps = [
+        _step(np.zeros(3), np.zeros(2), np.ones(3)),
+        _step(np.ones(3), np.zeros(2), 2 * np.ones(3)),
+        _step(2 * np.ones(3), None, None),
+    ]
+    history = History(
+        history=steps,
+        discount_factor=0.99,
+        average_state_sampling_time=0.0,
+        average_action_time=0.0,
+        average_observation_time=0.0,
+        average_belief_update_time=0.0,
+        average_reward_time=0.0,
+        actual_num_steps=len(steps),
+        reach_terminal_state=True,
+        policy_run_data=[],
+    )
+    dataset = TransitionDataset(holdout_fraction=0.0)
+
+    added = dataset.add_history(history, source="planner")
+
+    assert added == 2
+    assert len(dataset) == 2
+
+
+def test_mismatched_lengths_are_rejected() -> None:
+    """Purpose: Validates that a truncated action array is caught rather than zipped short
+
+    Given: 10 states, 9 actions and 10 next states
+    When: They are added
+    Then: A ValueError names the disagreeing lengths
+    """
+    dataset = TransitionDataset()
+    with pytest.raises(ValueError, match="equal length"):
+        dataset.add_episode(np.zeros((10, 3)), np.zeros((9, 2)), np.zeros((10, 3)), source="x")
+
+
+@pytest.mark.parametrize("fraction", [-0.1, 1.0, 1.5])
+def test_impossible_holdout_fractions_are_rejected(fraction: float) -> None:
+    """Purpose: Validates that a holdout fraction leaving no training data is refused
+
+    Given: A holdout fraction outside [0, 1)
+    When: A dataset is constructed
+    Then: A ValueError is raised
+    """
+    with pytest.raises(ValueError, match="holdout_fraction"):
+        TransitionDataset(holdout_fraction=fraction)

--- a/POMDPPlanners/training/model_learning/__init__.py
+++ b/POMDPPlanners/training/model_learning/__init__.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: MIT
+
+"""Fitting a planner's transition model from rollouts, iteratively.
+
+Every planner needs a generative model to search, and a forward-only world -- a
+live simulator -- cannot serve as one. Where the model has been written by hand
+and calibrated, its error against the real simulator is unmeasured; where it is
+fitted from a fixed batch of rollouts, it is accurate only where those rollouts
+went, which is not where the planner goes. This package addresses the second
+problem, and gives you the measurement for the first.
+
+The loop is the one from Ross & Bagnell (ICML 2012): plan with the current model,
+record what the planner actually did in the true world, aggregate it with
+everything collected before, refit, repeat. Its guarantee survives the true
+system being outside the model class, which is the realistic case.
+
+See :mod:`~POMDPPlanners.training.model_learning.dagger_trainer` for the three
+details that decide whether the loop works, and
+:mod:`~POMDPPlanners.training.model_learning.diagnostics` for why held-out
+prediction error alone will not tell you whether a model is worth planning with.
+
+Classes:
+    TransitionDataset: Transitions accumulated across rounds, sliced to named channels.
+    TransitionBatch: States, actions and next states as parallel arrays.
+    TransitionModelLearner: Interface for a fitting procedure.
+    LinearGaussianLearner: Ridge fit of a linear-Gaussian transition.
+    ProbabilisticEnsembleLearner: Gaussian-likelihood fit of an ensemble.
+    ProbabilisticEnsembleTransition: The ensemble, usable as a transition model.
+    GaussianMLP: One ensemble member.
+    DAggerModelTrainer: The round loop.
+    RoundResult: What one round produced.
+
+Functions:
+    block_indices: Flat indices of named channels in a schema.
+    collect_random_preset_episode: One held-random-action exploration rollout.
+    evaluate_model: The three diagnostics for a fitted model.
+"""
+
+from POMDPPlanners.training.model_learning.dagger_trainer import (
+    DAggerModelTrainer,
+    RoundResult,
+)
+from POMDPPlanners.training.model_learning.diagnostics import (
+    evaluate_model,
+    held_out_log_likelihood,
+    horizon_drift_ratio,
+    preset_ranking_agreement,
+)
+from POMDPPlanners.training.model_learning.ensemble_transition import (
+    GaussianMLP,
+    ProbabilisticEnsembleTransition,
+)
+from POMDPPlanners.training.model_learning.exploration import (
+    collect_random_preset_episode,
+)
+from POMDPPlanners.training.model_learning.learners import (
+    LinearGaussianLearner,
+    ProbabilisticEnsembleLearner,
+    TransitionModelLearner,
+)
+from POMDPPlanners.training.model_learning.transition_dataset import (
+    TransitionBatch,
+    TransitionDataset,
+    block_indices,
+)
+
+__all__ = [
+    "DAggerModelTrainer",
+    "GaussianMLP",
+    "LinearGaussianLearner",
+    "ProbabilisticEnsembleLearner",
+    "ProbabilisticEnsembleTransition",
+    "RoundResult",
+    "TransitionBatch",
+    "TransitionDataset",
+    "TransitionModelLearner",
+    "block_indices",
+    "collect_random_preset_episode",
+    "evaluate_model",
+    "held_out_log_likelihood",
+    "horizon_drift_ratio",
+    "preset_ranking_agreement",
+]

--- a/POMDPPlanners/training/model_learning/dagger_trainer.py
+++ b/POMDPPlanners/training/model_learning/dagger_trainer.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: MIT
+
+"""The round loop: plan with the current model, record what happened, refit.
+
+A model fitted once on a fixed batch of rollouts is accurate where that batch was
+collected and unconstrained everywhere else. The planner then does the one thing
+guaranteed to expose that: it seeks out whatever the model says is cheap, which
+includes regions no rollout visited and the model is optimistic about by
+accident. Performance can be arbitrarily bad while training error is tiny. Ross
+& Bagnell (ICML 2012) prove the fix -- collect under the learner's own policy,
+aggregate, refit -- holds even when the true system is outside the model class,
+which is always our situation.
+
+Three details decide whether the loop works, and none of them is optional.
+
+**Half the data comes from exploration, every round.** The paper singles this out
+as its difference from earlier iterative methods: without a fixed balance,
+exploration rows become a shrinking fraction of the buffer, the fit stops paying
+for them, and the loop settles into a model that is excellent along the current
+trajectory and blind beside it. Earlier methods that used exploration data only
+in the first round plateau, measurably.
+
+**The fit aggregates.** Round n refits on every transition from rounds 1..n, not
+on round n's alone. That is the "no-regret" part; dropping it turns the loop into
+a sequence of unrelated fits that can oscillate.
+
+**Every round is kept.** The guarantee is on the best model in the sequence, or
+their mixture -- not on the last one. Keeping only the final model discards the
+object the theory is about.
+
+Two things the loop deliberately does not do. It does not learn the reward: the
+objective is our design, not a fact about the world, and holding it fixed is what
+makes a model comparison about dynamics. And it does not claim its guarantee
+covers a risk-sensitive objective -- the bound is stated for expected discounted
+cost, and a nested CVaR is not that.
+
+Classes:
+    RoundResult: What one round produced.
+    DAggerModelTrainer: The round loop.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+import numpy as np
+
+from POMDPPlanners.core.environment import TransitionModel
+from POMDPPlanners.training.model_learning.diagnostics import evaluate_model
+from POMDPPlanners.training.model_learning.exploration import (
+    DEFAULT_HOLD_STEPS,
+    collect_random_preset_episode,
+)
+from POMDPPlanners.training.model_learning.learners import TransitionModelLearner
+from POMDPPlanners.training.model_learning.transition_dataset import TransitionDataset
+from POMDPPlanners.utils.logger import get_logger
+
+#: Fraction of each round's episodes drawn from the exploration policy. The
+#: paper's value, and the one detail it calls out as its own contribution over
+#: prior iterative methods -- see the module docstring.
+EXPLORATION_FRACTION = 0.5
+
+
+@dataclass
+class RoundResult:
+    """What one round of the loop produced.
+
+    Attributes:
+        round_index: 1-based round number.
+        model: The model fitted at the end of this round, on all data so far.
+        dataset_size: Total transitions the fit saw.
+        source_counts: Transitions contributed by each source, cumulative.
+        training_metrics: Per-epoch training metrics from the fit.
+        diagnostics: Held-out diagnostics for this round's model.
+    """
+
+    round_index: int
+    model: TransitionModel
+    dataset_size: int
+    source_counts: Dict[str, int] = field(default_factory=dict)
+    training_metrics: Dict[str, List[float]] = field(default_factory=dict)
+    diagnostics: Dict[str, float] = field(default_factory=dict)
+
+
+class DAggerModelTrainer:
+    """Alternates collecting transitions and refitting a transition model.
+
+    Args:
+        world: The true world, stepped forward to generate data. Must expose
+            ``sample_next_state``, ``is_terminal`` and ``initial_state_dist``.
+            It works in the world's own full-width state; the dataset does the
+            slicing.
+        diagnostics_world: A view of the same world over the *fitted block*, used
+            by the diagnostics that roll the model and the world forward side by
+            side. ``None`` reuses ``world``, which is correct only when the
+            dataset fits the whole state. The two cannot be one object whenever a
+            latent is being carried, and passing the full-width world by mistake
+            does not raise -- it compares vectors of different meaning -- so the
+            seam is explicit rather than inferred.
+        learner: The fitting procedure to use each round.
+        dataset: The store transitions accumulate in. Its ``state_indices``
+            decide which channels the fit ever sees, which is how a carried
+            latent is kept out of it.
+        action_presets: Table of action vectors the exploration policy draws from.
+        planner_rollout_fn: Called as ``fn(model, round_index, num_episodes)`` and
+            expected to run the planner against ``model`` in the true world,
+            returning one ``(states, actions, next_states)`` triple per episode.
+            Injected rather than built here because how a planner is run --
+            budget, parallelism, caching -- is the caller's business. ``None``
+            skips the on-policy half, which makes the loop a plain batch fit and
+            forfeits the guarantee; useful only for testing the plumbing.
+        initial_model: The model round 1's planner searches. Supplying the
+            calibrated analytic model starts the loop warm, so no round is spent
+            with the planner driving a model fitted on nothing.
+        num_rounds: Rounds to run.
+        episodes_per_round: Episodes collected per round, split by
+            :data:`EXPLORATION_FRACTION`.
+        steps_per_episode: Steps attempted per exploration episode.
+        hold_steps: Control steps an exploration action is held for.
+        horizon: Steps used for the drift diagnostic; use the planner's depth.
+        reward_model: Reward used for the ranking diagnostic. ``None`` skips it.
+        seed: Seed for exploration draws and diagnostics.
+        logger: Optional logger.
+
+    Raises:
+        ValueError: If ``num_rounds`` or ``episodes_per_round`` is not positive.
+
+    Example:
+        Fit against a world with no planner in the loop, for wiring checks::
+
+            trainer = DAggerModelTrainer(
+                world=world,
+                learner=LinearGaussianLearner(),
+                dataset=TransitionDataset(state_indices=robot_indices),
+                action_presets=presets,
+                planner_rollout_fn=None,
+                num_rounds=2,
+            )
+            rounds = trainer.run()
+    """
+
+    def __init__(
+        self,
+        world: Any,
+        learner: TransitionModelLearner,
+        dataset: TransitionDataset,
+        action_presets: Any,
+        diagnostics_world: Optional[Any] = None,
+        planner_rollout_fn: Optional[Callable[[TransitionModel, int, int], Sequence[Any]]] = None,
+        initial_model: Optional[TransitionModel] = None,
+        num_rounds: int = 5,
+        episodes_per_round: int = 40,
+        steps_per_episode: int = 40,
+        hold_steps: int = DEFAULT_HOLD_STEPS,
+        horizon: int = 40,
+        reward_model: Optional[Any] = None,
+        seed: int = 0,
+        logger: Optional[Any] = None,
+    ) -> None:
+        if num_rounds <= 0:
+            raise ValueError(f"num_rounds must be positive, got {num_rounds}")
+        if episodes_per_round <= 0:
+            raise ValueError(f"episodes_per_round must be positive, got {episodes_per_round}")
+        self.world = world
+        self.diagnostics_world = world if diagnostics_world is None else diagnostics_world
+        self.learner = learner
+        self.dataset = dataset
+        self.action_presets = np.asarray(action_presets, dtype=float)
+        self.planner_rollout_fn = planner_rollout_fn
+        self.initial_model = initial_model
+        self.num_rounds = num_rounds
+        self.episodes_per_round = episodes_per_round
+        self.steps_per_episode = steps_per_episode
+        self.hold_steps = hold_steps
+        self.horizon = horizon
+        self.reward_model = reward_model
+        self.seed = seed
+        self._logger = logger or get_logger(__name__)
+        self._rounds: List[RoundResult] = []
+
+    @property
+    def rounds(self) -> List[RoundResult]:
+        """Every round's result, in order. All are kept, not just the last."""
+        return list(self._rounds)
+
+    def run(self) -> List[RoundResult]:
+        """Run the loop and return one result per round.
+
+        Returns:
+            The rounds, in order. The caller picks among them -- typically by
+            evaluating each, since the guarantee is on the best of the sequence.
+        """
+        current_model = self.initial_model
+        for round_index in range(1, self.num_rounds + 1):
+            explore_episodes, planner_episodes = self._split(round_index, current_model)
+            for states, actions, next_states in explore_episodes:
+                self.dataset.add_episode(states, actions, next_states, source="exploration")
+            for states, actions, next_states in planner_episodes:
+                self.dataset.add_episode(states, actions, next_states, source="planner")
+
+            current_model = self.learner.fit(self.dataset)
+            result = RoundResult(
+                round_index=round_index,
+                model=current_model,
+                dataset_size=len(self.dataset),
+                source_counts=self.dataset.counts_by_source(),
+                training_metrics=self.learner.training_metrics(),
+                diagnostics=evaluate_model(
+                    model=current_model,
+                    world=self.diagnostics_world,
+                    holdout=self.dataset.holdout_batch(),
+                    action_presets=self.action_presets,
+                    horizon=self.horizon,
+                    reward_model=self.reward_model,
+                    seed=self.seed + round_index,
+                ),
+            )
+            self._rounds.append(result)
+            self._logger.info(
+                "round %d/%d: %d transitions (%s), %s",
+                round_index,
+                self.num_rounds,
+                result.dataset_size,
+                result.source_counts,
+                result.diagnostics,
+            )
+        return self.rounds
+
+    def _split(self, round_index: int, model: Optional[TransitionModel]) -> Any:
+        """Collect this round's two halves.
+
+        The exploration half always runs. The planner half runs only once a model
+        exists to plan with; in round 1 with no initial model there is nothing to
+        drive, so the whole round's budget goes to exploration rather than being
+        halved and half of it discarded, and the balance holds from round 2 on.
+        """
+        can_plan = self.planner_rollout_fn is not None and model is not None
+        num_explore = (
+            max(1, int(round(self.episodes_per_round * EXPLORATION_FRACTION)))
+            if can_plan
+            else self.episodes_per_round
+        )
+        num_planner = self.episodes_per_round - num_explore
+
+        rng = np.random.default_rng(self.seed + 1000 * round_index)
+        explore_episodes = [
+            collect_random_preset_episode(
+                world=self.world,
+                action_presets=self.action_presets,
+                num_steps=self.steps_per_episode,
+                rng=rng,
+                hold_steps=self.hold_steps,
+            )
+            for _ in range(num_explore)
+        ]
+
+        planner_episodes: List[Any] = []
+        if self.planner_rollout_fn is not None and model is not None and num_planner > 0:
+            planner_episodes = list(self.planner_rollout_fn(model, round_index, num_planner))
+        return explore_episodes, planner_episodes

--- a/POMDPPlanners/training/model_learning/diagnostics.py
+++ b/POMDPPlanners/training/model_learning/diagnostics.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: MIT
+
+"""The three numbers that say whether a fitted model is worth planning with.
+
+One-step prediction error is the obvious measure and the wrong one. A model can
+be excellent on one step and useless over a horizon, because errors compound;
+and it can be mediocre everywhere yet plan perfectly, because the planner only
+needs the *ranking* of its action presets to be right. The decision-aware model
+learning literature makes this precise -- what matters is the error weighted by
+how much it moves the value, not the error itself. These three are the
+computable stand-ins.
+
+**Held-out log-likelihood** is the loss the fit is guaranteed against, evaluated
+where the fit could not see it. It is the only one of the three the training
+procedure optimizes directly, which is exactly why it is not sufficient on its
+own.
+
+**Horizon drift over claimed noise** catches the failure that quietly ruins a
+risk-sensitive planner: a model whose predictions are wrong by far more than the
+uncertainty it reports. A ratio near 1 means the model's error is inside its own
+error bars, so a belief built from it is honest. A ratio of 5 means the planner
+is confidently searching a world that does not exist.
+
+**Preset-ranking agreement** is the closest cheap proxy for what the planner
+actually does with the model. If the model and the world disagree about which
+preset is best from a state, no amount of likelihood will save the decision.
+
+Reading them together is the point. Likelihood improving while ranking agreement
+stays flat means the fit is buying accuracy the planner cannot spend -- worth
+knowing before committing to a long evaluation.
+
+One shared precondition. Two of the three roll the model and the world forward
+side by side, so both must speak the same state vector. When the dataset slices
+a block out of a wider state -- which it should, whenever the state carries a
+latent the fit must not touch -- the ``world`` passed here has to be a view over
+that same block, not the full-width world. Passing the full-width world does not
+raise; it silently compares vectors of different meaning.
+
+Functions:
+    held_out_log_likelihood: Mean log-density of unseen successors.
+    horizon_drift_ratio: Open-loop drift over the horizon, in units of claimed noise.
+    preset_ranking_agreement: How often model and world pick the same best preset.
+    evaluate_model: All three, as one metrics mapping.
+"""
+
+from typing import Any, Dict, List, Optional, Sequence
+
+import numpy as np
+
+from POMDPPlanners.core.environment import TransitionModel
+from POMDPPlanners.training.model_learning.transition_dataset import TransitionBatch
+
+
+def held_out_log_likelihood(model: TransitionModel, batch: TransitionBatch) -> float:
+    """Mean log-density the model assigns to successors it was not fitted on.
+
+    Args:
+        model: The fitted transition.
+        batch: Held-out transitions.
+
+    Returns:
+        Mean log-density per transition, or ``nan`` for an empty batch.
+    """
+    if len(batch) == 0:
+        return float("nan")
+    total = 0.0
+    for state, action, next_state in zip(batch.states, batch.actions, batch.next_states):
+        total += float(model.log_probability(state, action, next_state[None, :])[0])
+    return total / len(batch)
+
+
+def horizon_drift_ratio(
+    model: TransitionModel,
+    world: Any,
+    start_states: Sequence[Any],
+    action_presets: Any,
+    horizon: int,
+    rng: np.random.Generator,
+) -> float:
+    """Open-loop drift over ``horizon`` steps, divided by the noise the model claims.
+
+    Both the model and the world are rolled forward under the *same* action
+    sequence from the same start state, and the gap between where they end up is
+    compared against the spread the model itself predicts over that horizon. The
+    ratio, not the raw drift, is the useful number: a drift of half a metre is
+    fine for a model that says it is unsure to within a metre, and alarming for
+    one that claims centimetres.
+
+    Args:
+        model: The fitted transition, operating on the fitted state block.
+        world: The true world, operating on the same block.
+        start_states: States to roll out from.
+        action_presets: Table of action vectors.
+        horizon: Steps to roll forward -- use the planner's own depth.
+        rng: Source of the action sequence and the model's own sampling.
+
+    Returns:
+        Mean ratio across start states. Values near 1 mean the model's error sits
+        inside its own error bars; well above 1 means it is overconfident.
+    """
+    presets = np.asarray(action_presets, dtype=float)
+    ratios: List[float] = []
+    for start in start_states:
+        actions = presets[rng.integers(len(presets), size=horizon)]
+        world_state = np.asarray(start, dtype=float).ravel()
+        model_state = world_state.copy()
+        # The model's own claimed spread, accumulated as the standard deviation
+        # of the per-step samples it draws along the way.
+        claimed = 0.0
+        for action in actions:
+            world_state = np.asarray(
+                world.sample_next_state(world_state, action), dtype=float
+            ).ravel()
+            draws = np.atleast_2d(model.sample_next_state(model_state, action, n_samples=16))
+            claimed += float(np.mean(np.std(draws, axis=0)))
+            model_state = draws[int(rng.integers(draws.shape[0]))]
+        drift = float(np.linalg.norm(world_state - model_state))
+        ratios.append(drift / max(claimed, 1e-9))
+    return float(np.mean(ratios)) if ratios else float("nan")
+
+
+def preset_ranking_agreement(
+    model: TransitionModel,
+    world: Any,
+    reward_model: Any,
+    start_states: Sequence[Any],
+    action_presets: Any,
+    num_samples: int = 32,
+) -> float:
+    """Fraction of start states where model and world rank the same preset best.
+
+    Each preset is scored by its mean one-step reward under the model and under
+    the world, using the *same* reward model for both -- the objective is our
+    design, not something the fit is allowed to change, so holding it fixed is
+    what makes the comparison about dynamics.
+
+    Args:
+        model: The fitted transition.
+        world: The true world.
+        reward_model: Anything exposing ``reward(state, action, next_state)``.
+        start_states: States to compare rankings at.
+        action_presets: Table of action vectors.
+        num_samples: Successors drawn per preset when averaging the reward.
+
+    Returns:
+        Agreement in ``[0, 1]``, or ``nan`` when no start states are given.
+    """
+    presets = np.asarray(action_presets, dtype=float)
+    if len(start_states) == 0:
+        return float("nan")
+    agreements: List[bool] = []
+    for start in start_states:
+        state = np.asarray(start, dtype=float).ravel()
+        model_scores = [
+            _mean_reward(reward_model, state, action, model, num_samples) for action in presets
+        ]
+        world_scores = [
+            _mean_reward(reward_model, state, action, world, num_samples) for action in presets
+        ]
+        agreements.append(int(np.argmax(model_scores)) == int(np.argmax(world_scores)))
+    return float(np.mean(agreements))
+
+
+def evaluate_model(
+    model: TransitionModel,
+    world: Any,
+    holdout: TransitionBatch,
+    action_presets: Any,
+    horizon: int,
+    reward_model: Optional[Any] = None,
+    num_start_states: int = 16,
+    seed: int = 0,
+) -> Dict[str, float]:
+    """Compute all three diagnostics for one round's model.
+
+    Args:
+        model: The fitted transition.
+        world: The true world.
+        holdout: Held-out transitions; their source states double as the start
+            states for the other two diagnostics, so every number describes the
+            same region of the state space.
+        action_presets: Table of action vectors.
+        horizon: Steps for the drift measurement -- the planner's own depth.
+        reward_model: Reward used for the ranking check. ``None`` skips it.
+        num_start_states: How many held-out states to roll out from.
+        seed: Seed for the action sequences and sampling.
+
+    Returns:
+        A mapping with ``held_out_log_likelihood``, ``horizon_drift_ratio`` and,
+        when a reward model is supplied, ``preset_ranking_agreement``.
+    """
+    rng = np.random.default_rng(seed)
+    metrics = {"held_out_log_likelihood": held_out_log_likelihood(model, holdout)}
+    if len(holdout) == 0:
+        metrics["horizon_drift_ratio"] = float("nan")
+        return metrics
+
+    count = min(num_start_states, len(holdout))
+    chosen = rng.choice(len(holdout), size=count, replace=False)
+    start_states = [holdout.states[index] for index in chosen]
+    metrics["horizon_drift_ratio"] = horizon_drift_ratio(
+        model, world, start_states, action_presets, horizon, rng
+    )
+    if reward_model is not None:
+        metrics["preset_ranking_agreement"] = preset_ranking_agreement(
+            model, world, reward_model, start_states, action_presets
+        )
+    return metrics
+
+
+def _mean_reward(
+    reward_model: Any,
+    state: np.ndarray,
+    action: np.ndarray,
+    transition: Any,
+    num_samples: int,
+) -> float:
+    """Mean one-step reward of ``action`` at ``state`` under one transition."""
+    successors = np.atleast_2d(transition.sample_next_state(state, action, num_samples))
+    return float(
+        np.mean([reward_model.reward(state, action, successor) for successor in successors])
+    )

--- a/POMDPPlanners/training/model_learning/ensemble_transition.py
+++ b/POMDPPlanners/training/model_learning/ensemble_transition.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: MIT
+
+"""A transition fitted as an ensemble of Gaussian networks over the state change.
+
+Why a *distribution* and not a point prediction. The guarantee that makes
+iterative model learning work runs through the distance between the predicted
+and the true next-state distributions, so a model trained on squared error sits
+outside it entirely. The practical consequence is sharper than the theoretical
+one: a deterministic transition collapses a particle belief to a point, and a
+planner grading a tail measure then has no tail to grade. The model must be able
+to say how unsure it is, and be right about it.
+
+Why an ensemble and not one network. Two kinds of uncertainty matter and they
+behave differently. Noise the system really has (a slipping foot) is aleatoric,
+and a single network's variance head captures it. Ignorance about a region no
+rollout visited is epistemic, and a single network is confidently wrong there --
+which is precisely the region an iterative loop drives into. Disagreement
+between independently initialised members is the cheap estimate of it. Sampling
+therefore draws a *member* first and then draws from that member, so
+disagreement widens the belief instead of being averaged into a mean nobody
+predicted.
+
+Why the variance head is bounded. Left free, the fastest way to reduce Gaussian
+negative log-likelihood early in training is to declare enormous variance on the
+hard dimensions and stop modelling them. Soft bounds, learned but penalized,
+stop that without hard-clipping a variance that genuinely should be large.
+
+Classes:
+    GaussianMLP: One ensemble member -- predicts mean and variance of the state change.
+    ProbabilisticEnsembleTransition: Ensemble of members, usable as a TransitionModel.
+"""
+
+from typing import Any, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+from torch import nn
+
+from POMDPPlanners.core.environment import TransitionModel
+
+#: Weight on the soft-bound penalty. Small: it is a nudge keeping the bounds
+#: honest, not a term the fit should trade accuracy against.
+_BOUND_PENALTY = 0.01
+
+#: Floor on a normalization scale, so a channel that never moves in the training
+#: data does not divide the whole design matrix by zero.
+_MIN_SCALE = 1e-6
+
+
+class GaussianMLP(nn.Module):
+    """One ensemble member: ``(state, action) -> mean and variance of the state change``.
+
+    Args:
+        input_dim: Width of the concatenated ``(state, action)`` input.
+        output_dim: Width of the state block being predicted.
+        hidden_sizes: Widths of the hidden layers.
+
+    Attributes:
+        max_log_variance: Learned upper soft bound on the log-variance.
+        min_log_variance: Learned lower soft bound on the log-variance.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        hidden_sizes: Sequence[int] = (200, 200),
+    ) -> None:
+        super().__init__()
+        layers: List[nn.Module] = []
+        width = input_dim
+        for hidden in hidden_sizes:
+            layers.append(nn.Linear(width, hidden))
+            layers.append(nn.SiLU())
+            width = hidden
+        layers.append(nn.Linear(width, 2 * output_dim))
+        self._net = nn.Sequential(*layers)
+        self._output_dim = output_dim
+        self.max_log_variance = nn.Parameter(torch.full((output_dim,), 0.5))
+        self.min_log_variance = nn.Parameter(torch.full((output_dim,), -10.0))
+
+    def forward(self, inputs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Predict the mean and log-variance of the normalized state change.
+
+        Args:
+            inputs: ``(N, input_dim)`` normalized ``(state, action)`` rows.
+
+        Returns:
+            ``(mean, log_variance)``, each ``(N, output_dim)``. The log-variance
+            is squeezed between the two learned bounds with softplus, so it
+            approaches them smoothly instead of being clipped flat.
+        """
+        raw = self._net(inputs)
+        mean, raw_log_variance = raw[..., : self._output_dim], raw[..., self._output_dim :]
+        log_variance = self.max_log_variance - nn.functional.softplus(
+            self.max_log_variance - raw_log_variance
+        )
+        log_variance = self.min_log_variance + nn.functional.softplus(
+            log_variance - self.min_log_variance
+        )
+        return mean, log_variance
+
+    def bound_penalty(self) -> torch.Tensor:
+        """Penalty pulling the soft bounds inward, so they track the data."""
+        return _BOUND_PENALTY * (self.max_log_variance.sum() - self.min_log_variance.sum())
+
+
+class ProbabilisticEnsembleTransition(TransitionModel):
+    """Ensemble of Gaussian networks, planned with as an ordinary transition.
+
+    Sampling draws one member uniformly per sample and then draws from that
+    member's Gaussian, so the model's own disagreement is what widens a belief.
+    The density is the matching uniform mixture over members -- the honest
+    log-density of what sampling actually does, which is what a particle filter
+    needs in order to weight correctly.
+
+    Args:
+        members: Trained :class:`GaussianMLP` members.
+        state_mean: ``(dim,)`` mean of the training states, for input normalization.
+        state_scale: ``(dim,)`` scale of the training states.
+        action_mean: ``(action_dim,)`` mean of the training actions.
+        action_scale: ``(action_dim,)`` scale of the training actions.
+        delta_mean: ``(dim,)`` mean of the training state changes.
+        delta_scale: ``(dim,)`` scale of the training state changes.
+        seed: Seed for the member choice and the noise draw.
+
+    Raises:
+        ValueError: If no members are supplied.
+    """
+
+    def __init__(
+        self,
+        members: Sequence[GaussianMLP],
+        state_mean: np.ndarray,
+        state_scale: np.ndarray,
+        action_mean: np.ndarray,
+        action_scale: np.ndarray,
+        delta_mean: np.ndarray,
+        delta_scale: np.ndarray,
+        seed: int = 0,
+    ) -> None:
+        if not members:
+            raise ValueError("a probabilistic ensemble needs at least one member")
+        self._members = list(members)
+        for member in self._members:
+            member.eval()
+        self._state_mean = np.asarray(state_mean, dtype=float)
+        self._state_scale = np.asarray(state_scale, dtype=float)
+        self._action_mean = np.asarray(action_mean, dtype=float)
+        self._action_scale = np.asarray(action_scale, dtype=float)
+        self._delta_mean = np.asarray(delta_mean, dtype=float)
+        self._delta_scale = np.asarray(delta_scale, dtype=float)
+        self._rng = np.random.default_rng(seed)
+
+    @property
+    def dim(self) -> int:
+        """Width of the state block this transition predicts."""
+        return int(self._delta_mean.size)
+
+    @property
+    def num_members(self) -> int:
+        """Number of ensemble members."""
+        return len(self._members)
+
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        """Sample ``n_samples`` next states, each from a uniformly drawn member.
+
+        Args:
+            state: The current state block, a length-``dim`` vector.
+            action: The action applied at ``state``.
+            n_samples: Number of next states to draw.
+
+        Returns:
+            A ``(dim,)`` next state when ``n_samples == 1``, else ``(n_samples, dim)``.
+        """
+        state_vector = np.asarray(state, dtype=float).ravel()
+        means, variances = self._predict(state_vector, action)
+        choice = self._rng.integers(len(self._members), size=n_samples)
+        noise = self._rng.standard_normal((n_samples, self.dim))
+        deltas = means[choice] + noise * np.sqrt(variances[choice])
+        next_states = state_vector[None, :] + deltas
+        return next_states[0] if n_samples == 1 else next_states
+
+    def log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+        """Log-density of each next state under the uniform mixture over members.
+
+        Args:
+            state: The current state block, a length-``dim`` vector.
+            action: The action applied at ``state``.
+            next_states: A ``(dim,)`` next state or a ``(n, dim)`` batch.
+
+        Returns:
+            A ``(n,)`` array of log-densities.
+        """
+        state_vector = np.asarray(state, dtype=float).ravel()
+        candidates = np.atleast_2d(np.asarray(next_states, dtype=float))
+        means, variances = self._predict(state_vector, action)
+        deltas = candidates - state_vector[None, :]
+        # (members, n): each member's Gaussian log-density for every candidate.
+        residual = deltas[None, :, :] - means[:, None, :]
+        per_member = -0.5 * (
+            np.sum(residual**2 / variances[:, None, :], axis=-1)
+            + np.sum(np.log(variances), axis=-1)[:, None]
+            + self.dim * np.log(2.0 * np.pi)
+        )
+        return _log_mean_exp(per_member, axis=0)
+
+    def _predict(self, state: np.ndarray, action: Any) -> Tuple[np.ndarray, np.ndarray]:
+        """Per-member mean and variance of the state change, in the raw state units."""
+        action_vector = np.asarray(action, dtype=float).ravel()
+        normalized = np.concatenate(
+            [
+                (state - self._state_mean) / self._state_scale,
+                (action_vector - self._action_mean) / self._action_scale,
+            ]
+        )
+        inputs = torch.as_tensor(normalized, dtype=torch.float32).unsqueeze(0)
+        means = np.empty((len(self._members), self.dim), dtype=float)
+        variances = np.empty_like(means)
+        with torch.no_grad():
+            for index, member in enumerate(self._members):
+                mean, log_variance = member(inputs)
+                means[index] = mean.squeeze(0).numpy()
+                variances[index] = np.exp(log_variance.squeeze(0).numpy())
+        # Undo the target normalization: a scaled Gaussian scales its variance by
+        # the square of the same factor.
+        return (
+            means * self._delta_scale + self._delta_mean,
+            variances * self._delta_scale**2,
+        )
+
+
+def normalization_stats(values: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Mean and scale of ``values``, with a floor on the scale.
+
+    Args:
+        values: ``(N, dim)`` array.
+
+    Returns:
+        ``(mean, scale)``, each ``(dim,)``. A channel that never moves gets the
+        floor rather than a zero, so normalizing it is a no-op instead of a
+        divide-by-zero.
+    """
+    mean = values.mean(axis=0)
+    scale = np.maximum(values.std(axis=0), _MIN_SCALE)
+    return mean, scale
+
+
+def _log_mean_exp(values: np.ndarray, axis: int) -> np.ndarray:
+    """Numerically stable ``log(mean(exp(values)))`` along ``axis``."""
+    peak = np.max(values, axis=axis, keepdims=True)
+    shifted = np.exp(values - peak)
+    return np.squeeze(peak, axis=axis) + np.log(shifted.mean(axis=axis))
+
+
+def build_members(
+    input_dim: int,
+    output_dim: int,
+    num_members: int,
+    hidden_sizes: Sequence[int],
+    seed: int,
+    device: Optional[torch.device] = None,
+) -> List[GaussianMLP]:
+    """Construct ``num_members`` independently initialised members.
+
+    The initialisations must differ, because that difference *is* the epistemic
+    uncertainty estimate; identical members would agree everywhere and report
+    confidence the ensemble has not earned.
+
+    Args:
+        input_dim: Width of the concatenated ``(state, action)`` input.
+        output_dim: Width of the predicted state block.
+        num_members: Number of members.
+        hidden_sizes: Hidden layer widths, shared by every member.
+        seed: Base seed; member ``i`` is seeded with ``seed + i``.
+        device: Device to place the members on.
+
+    Returns:
+        The constructed members.
+    """
+    members: List[GaussianMLP] = []
+    for index in range(num_members):
+        torch.manual_seed(seed + index)
+        member = GaussianMLP(input_dim, output_dim, hidden_sizes)
+        if device is not None:
+            member.to(device)
+        members.append(member)
+    return members

--- a/POMDPPlanners/training/model_learning/exploration.py
+++ b/POMDPPlanners/training/model_learning/exploration.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+
+"""Collecting the exploration half of a round, without setting the world's state.
+
+The algorithm this package implements asks for transitions drawn from an
+exploration distribution over ``(state, action)`` pairs -- place the system in a
+state, apply an action, record the successor. A live IsaacLab world cannot do
+that: it has no state setter, and asking it for the successor of any state other
+than the one it is currently in raises. Its only entry point is a reset followed
+by forward stepping.
+
+That is the "reset model" case the algorithm's authors treat explicitly, and it
+is the case where iterating helps *most* -- a one-shot fit's guarantee carries a
+train/test mismatch factor that the iterative version does not. Their sanctioned
+substitute is a base policy with randomized actions, which is what this module
+collects.
+
+Two rules, both learned the expensive way:
+
+**The action is held for several steps.** A rollout has to excite the system at
+the timescale it responds on. Redrawing every control step measures a permanent
+transient: on the ANYmal navigation task the fraction of a commanded velocity
+the base actually achieves reads 0.25 when the command changes every 0.2 s
+against 0.71 when it is held ten steps. A model fitted on redrawn commands
+describes a robot that is never allowed to follow one. Holding costs nothing in
+coverage, because the action set is a small preset table.
+
+**Boundary rows are dropped, not fitted.** The simulator auto-resets inside its
+step, so the successor of a terminal transition is a fresh episode metres away.
+Keeping those rows teaches a model that some action teleports.
+
+Functions:
+    collect_random_preset_episode: One held-random-action rollout, boundaries dropped.
+"""
+
+from typing import Any, List, Optional, Tuple
+
+import numpy as np
+
+#: Control steps a drawn action is held for. Ten is the ANYmal figure above; it
+#: is roughly the settling time of a velocity command, which is the quantity
+#: that matters rather than the number itself.
+DEFAULT_HOLD_STEPS = 10
+
+
+def collect_random_preset_episode(
+    world: Any,
+    action_presets: Any,
+    num_steps: int,
+    rng: np.random.Generator,
+    hold_steps: int = DEFAULT_HOLD_STEPS,
+    initial_state: Optional[Any] = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Roll out held random presets and return the usable transitions.
+
+    Args:
+        world: The true world. Must expose ``sample_next_state(state, action)``,
+            ``is_terminal(state)`` and, when ``initial_state`` is omitted,
+            ``initial_state_dist()``.
+        action_presets: The table of action vectors to draw from.
+        num_steps: Steps to attempt. Fewer transitions are returned when the
+            episode ends early, because boundary rows are dropped.
+        rng: Source of the action draws, so a round can be reproduced.
+        hold_steps: Control steps each drawn action is held for.
+        initial_state: State to start from. ``None`` draws one from the world's
+            initial-state distribution.
+
+    Returns:
+        ``(states, actions, next_states)``, each ``(N, .)`` with ``N <= num_steps``.
+
+    Raises:
+        ValueError: If ``hold_steps`` is not positive.
+    """
+    if hold_steps <= 0:
+        raise ValueError(f"hold_steps must be positive, got {hold_steps}")
+    presets = np.asarray(action_presets, dtype=float)
+
+    states: List[np.ndarray] = []
+    actions: List[np.ndarray] = []
+    next_states: List[np.ndarray] = []
+
+    state = (
+        np.asarray(world.initial_state_dist().sample(), dtype=float).ravel()
+        if initial_state is None
+        else np.asarray(initial_state, dtype=float).ravel()
+    )
+    action = presets[0]
+    held_for = 0
+    for _ in range(num_steps):
+        if held_for == 0:
+            action = presets[int(rng.integers(len(presets)))]
+        next_state = np.asarray(world.sample_next_state(state, action), dtype=float).ravel()
+        ended = bool(world.is_terminal(next_state))
+        if not ended:
+            states.append(state)
+            actions.append(action)
+            next_states.append(next_state)
+        state = next_state
+        held_for = (held_for + 1) % hold_steps
+        if ended:
+            break
+
+    if not states:
+        width = int(np.asarray(state).size)
+        return (
+            np.zeros((0, width)),
+            np.zeros((0, presets.shape[-1])),
+            np.zeros((0, width)),
+        )
+    return (
+        np.asarray(states, dtype=float),
+        np.asarray(actions, dtype=float),
+        np.asarray(next_states, dtype=float),
+    )

--- a/POMDPPlanners/training/model_learning/learners.py
+++ b/POMDPPlanners/training/model_learning/learners.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: MIT
+
+"""Fitting procedures that turn a dataset of transitions into a transition model.
+
+Fitting is the only thing that differs between model classes, so it is the only
+thing this package asks a caller to swap. The loop, the data, the diagnostics
+and the plumbing back into the planner are identical whichever learner is used,
+which is what makes a run comparing two model classes a comparison of the models
+and not of everything around them.
+
+Two ship here. The linear-Gaussian learner wraps the ridge fit the package
+already had; it is the floor, and its job is to make "the ensemble helped" a
+statement with a baseline behind it. The ensemble learner is the candidate.
+
+Both are trained by likelihood, not squared error. That is not a preference: the
+bound relating model quality to control performance is stated in the distance
+between predicted and true next-state distributions, and likelihood is the part
+of it that can be computed from samples.
+
+Classes:
+    TransitionModelLearner: Interface for a fitting procedure.
+    LinearGaussianLearner: Ridge fit of a linear-Gaussian transition.
+    ProbabilisticEnsembleLearner: Gaussian-likelihood fit of an ensemble.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Sequence
+
+import numpy as np
+import torch
+
+from POMDPPlanners.core.environment import TransitionModel
+from POMDPPlanners.training.model_learning.ensemble_transition import (
+    ProbabilisticEnsembleTransition,
+    build_members,
+    normalization_stats,
+)
+from POMDPPlanners.training.model_learning.transition_dataset import (
+    TransitionBatch,
+    TransitionDataset,
+)
+
+
+class TransitionModelLearner(ABC):
+    """Interface for a procedure that fits a transition model from transitions.
+
+    Note:
+        This is an abstract base class and cannot be instantiated directly.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Short identifier, used to label a round's checkpoint and its metrics."""
+
+    @abstractmethod
+    def fit(self, dataset: TransitionDataset) -> TransitionModel:
+        """Fit a transition model on the dataset's training split.
+
+        Args:
+            dataset: The transitions collected so far.
+
+        Returns:
+            The fitted model.
+
+        Raises:
+            ValueError: If the training split holds too few transitions to fit.
+        """
+
+    @abstractmethod
+    def training_metrics(self) -> Dict[str, List[float]]:
+        """Per-epoch metrics from the most recent fit, keyed by metric name.
+
+        The shape matches what the package's callbacks already consume, so early
+        stopping and checkpointing work against a model fit unchanged.
+        """
+
+
+class LinearGaussianLearner(TransitionModelLearner):
+    """Ridge fit of ``next = A @ state + B @ action + b + N(0, Sigma)``.
+
+    The floor baseline. It has a closed-form solution, so it cannot fail to
+    converge and cannot be blamed on a learning rate -- which is what makes it
+    useful as the thing an ensemble has to beat.
+
+    Args:
+        regularization: Ridge penalty on the normal-equations diagonal.
+        min_variance: Floor on each residual variance, keeping the covariance
+            positive definite.
+    """
+
+    def __init__(self, regularization: float = 1e-4, min_variance: float = 1e-6) -> None:
+        self._regularization = regularization
+        self._min_variance = min_variance
+        self._metrics: Dict[str, List[float]] = {}
+
+    @property
+    def name(self) -> str:
+        """Short identifier for this learner."""
+        return "linear"
+
+    def fit(self, dataset: TransitionDataset) -> TransitionModel:
+        """Fit the linear-Gaussian transition on the training split.
+
+        Args:
+            dataset: The transitions collected so far.
+
+        Returns:
+            A fitted
+            :class:`~POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_model_pomdp.LinearGaussianTransition`.
+
+        Raises:
+            ValueError: If fewer than two training transitions exist.
+        """
+        # Deferred: the concrete linear model lives in the environments layer,
+        # and importing it at module scope would make every use of this package
+        # pay for the Isaac import chain.
+        # pylint: disable-next=import-outside-toplevel
+        from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_model_pomdp import (
+            LinearGaussianTransition,
+        )
+
+        batch = dataset.training_batch()
+        if len(batch) < 2:
+            raise ValueError(f"fitting a linear transition needs at least 2 rows, got {len(batch)}")
+        model = LinearGaussianTransition.fit(
+            batch.states,
+            batch.actions,
+            batch.next_states,
+            regularization=self._regularization,
+            min_variance=self._min_variance,
+        )
+        self._metrics = {"train_nll": [_mean_negative_log_likelihood(model, batch)]}
+        return model
+
+    def training_metrics(self) -> Dict[str, List[float]]:
+        """Mean training negative log-likelihood of the most recent fit."""
+        return dict(self._metrics)
+
+
+class ProbabilisticEnsembleLearner(TransitionModelLearner):
+    """Fit an ensemble of Gaussian networks on the state change, by likelihood.
+
+    Args:
+        num_members: Number of independently initialised members.
+        hidden_sizes: Hidden layer widths, shared by every member.
+        epochs: Passes over the training split.
+        batch_size: Rows per gradient step.
+        learning_rate: Adam learning rate.
+        weight_decay: Adam weight decay.
+        seed: Seed for the member initialisations, the batch order and sampling.
+        device: Device to train on. ``None`` trains on CPU, which is the right
+            default: these are small networks and the batches are small, so the
+            transfer cost outweighs the kernel.
+
+    Raises:
+        ValueError: If ``num_members`` is not positive.
+    """
+
+    def __init__(
+        self,
+        num_members: int = 5,
+        hidden_sizes: Sequence[int] = (200, 200),
+        epochs: int = 50,
+        batch_size: int = 256,
+        learning_rate: float = 1e-3,
+        weight_decay: float = 1e-4,
+        seed: int = 0,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        if num_members <= 0:
+            raise ValueError(f"num_members must be positive, got {num_members}")
+        self._num_members = num_members
+        self._hidden_sizes = tuple(hidden_sizes)
+        self._epochs = epochs
+        self._batch_size = batch_size
+        self._learning_rate = learning_rate
+        self._weight_decay = weight_decay
+        self._seed = seed
+        self._device = device
+        self._metrics: Dict[str, List[float]] = {}
+
+    @property
+    def name(self) -> str:
+        """Short identifier for this learner."""
+        return "ensemble"
+
+    def fit(self, dataset: TransitionDataset) -> TransitionModel:
+        """Fit every member on the training split and return the ensemble.
+
+        Each member sees a bootstrap resample of the training rows, so members
+        differ in data as well as in initialisation -- two independent sources of
+        the disagreement the ensemble reads as uncertainty.
+
+        Args:
+            dataset: The transitions collected so far.
+
+        Returns:
+            A fitted :class:`ProbabilisticEnsembleTransition`.
+
+        Raises:
+            ValueError: If fewer than two training transitions exist.
+        """
+        batch = dataset.training_batch()
+        if len(batch) < 2:
+            raise ValueError(f"fitting an ensemble needs at least 2 rows, got {len(batch)}")
+
+        state_mean, state_scale = normalization_stats(batch.states)
+        action_mean, action_scale = normalization_stats(batch.actions)
+        delta_mean, delta_scale = normalization_stats(batch.deltas)
+
+        inputs = np.concatenate(
+            [
+                (batch.states - state_mean) / state_scale,
+                (batch.actions - action_mean) / action_scale,
+            ],
+            axis=1,
+        )
+        targets = (batch.deltas - delta_mean) / delta_scale
+
+        members = build_members(
+            input_dim=inputs.shape[1],
+            output_dim=targets.shape[1],
+            num_members=self._num_members,
+            hidden_sizes=self._hidden_sizes,
+            seed=self._seed,
+            device=self._device,
+        )
+        rng = np.random.default_rng(self._seed)
+        per_epoch: List[List[float]] = []
+        for index, member in enumerate(members):
+            resample = rng.integers(len(batch), size=len(batch))
+            per_epoch.append(
+                _train_member(
+                    member,
+                    inputs[resample],
+                    targets[resample],
+                    epochs=self._epochs,
+                    batch_size=self._batch_size,
+                    learning_rate=self._learning_rate,
+                    weight_decay=self._weight_decay,
+                    seed=self._seed + index,
+                    device=self._device,
+                )
+            )
+        # One curve for the ensemble: the members train independently, so the
+        # mean over members is the only per-epoch number that describes the fit.
+        self._metrics = {"train_nll": list(np.mean(np.asarray(per_epoch), axis=0))}
+        return ProbabilisticEnsembleTransition(
+            members=members,
+            state_mean=state_mean,
+            state_scale=state_scale,
+            action_mean=action_mean,
+            action_scale=action_scale,
+            delta_mean=delta_mean,
+            delta_scale=delta_scale,
+            seed=self._seed,
+        )
+
+    def training_metrics(self) -> Dict[str, List[float]]:
+        """Per-epoch mean training negative log-likelihood across members."""
+        return dict(self._metrics)
+
+
+def _train_member(
+    member: Any,
+    inputs: np.ndarray,
+    targets: np.ndarray,
+    epochs: int,
+    batch_size: int,
+    learning_rate: float,
+    weight_decay: float,
+    seed: int,
+    device: Optional[torch.device],
+) -> List[float]:
+    """Train one member by Gaussian negative log-likelihood; return its epoch losses."""
+    optimizer = torch.optim.Adam(
+        member.parameters(), lr=learning_rate, weight_decay=weight_decay
+    )
+    input_tensor = torch.as_tensor(inputs, dtype=torch.float32)
+    target_tensor = torch.as_tensor(targets, dtype=torch.float32)
+    if device is not None:
+        input_tensor = input_tensor.to(device)
+        target_tensor = target_tensor.to(device)
+
+    rng = np.random.default_rng(seed)
+    num_rows = input_tensor.shape[0]
+    steps = max(num_rows // batch_size, 1)
+    member.train()
+    losses: List[float] = []
+    for _ in range(epochs):
+        order = rng.permutation(num_rows)
+        epoch_loss = 0.0
+        for step in range(steps):
+            rows = order[step * batch_size : (step + 1) * batch_size]
+            if rows.size == 0:
+                continue
+            index = torch.as_tensor(rows, dtype=torch.long, device=input_tensor.device)
+            mean, log_variance = member(input_tensor[index])
+            residual = target_tensor[index] - mean
+            # Gaussian NLL up to the constant term: the constant shifts every
+            # model equally and only makes the reported number harder to compare
+            # against a hand-computed one.
+            loss = torch.mean(
+                torch.sum(residual**2 * torch.exp(-log_variance) + log_variance, dim=-1)
+            )
+            loss = loss + member.bound_penalty()
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            epoch_loss += float(loss.detach())
+        losses.append(epoch_loss / steps)
+    member.eval()
+    return losses
+
+
+def _mean_negative_log_likelihood(model: TransitionModel, batch: TransitionBatch) -> float:
+    """Mean negative log-density the model assigns to the observed successors."""
+    if len(batch) == 0:
+        return float("nan")
+    total = 0.0
+    for state, action, next_state in zip(batch.states, batch.actions, batch.next_states):
+        total += float(model.log_probability(state, action, next_state[None, :])[0])
+    return -total / len(batch)

--- a/POMDPPlanners/training/model_learning/transition_dataset.py
+++ b/POMDPPlanners/training/model_learning/transition_dataset.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: MIT
+
+"""Rollout transitions accumulated across rounds, sliced to a named state block.
+
+The iterative model-learning loop refits on *every* transition seen so far, which
+is what removes the train/test mismatch a one-shot fit carries (Ross & Bagnell,
+ICML 2012). The package's existing training buffer cannot serve that: it is
+built around iteration slots and drops the oldest, which is right for a policy
+chasing a moving target and wrong for a model that should only ever see more
+data.
+
+Two rules are enforced here rather than left to the caller, because both fail
+silently:
+
+**The fit only sees named channels.** A persistent latent -- a hazard type fixed
+at episode start -- is not a random variable of the dynamics, and a fit that
+regresses over it flattens exactly the belief dispersion a risk-sensitive
+planner grades. Slicing at dataset level means a learner cannot touch it by
+accident.
+
+**Held-out rows are split by episode, not by row.** Consecutive transitions of
+one trajectory are near-duplicates; a row-wise split puts a row's own neighbours
+in the training set and reports a held-out likelihood that flatters every model
+equally, which is worse than no number at all.
+
+Classes:
+    TransitionBatch: States, actions and next states as parallel arrays.
+    TransitionDataset: Growing store of transitions with an episode-wise holdout.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+@dataclass(frozen=True)
+class TransitionBatch:
+    """A set of transitions as parallel arrays.
+
+    Attributes:
+        states: ``(N, dim)`` source states, already sliced to the fitted block.
+        actions: ``(N, action_dim)`` applied action vectors.
+        next_states: ``(N, dim)`` resulting states, sliced the same way.
+    """
+
+    states: np.ndarray
+    actions: np.ndarray
+    next_states: np.ndarray
+
+    def __len__(self) -> int:
+        """Number of transitions in the batch."""
+        return int(self.states.shape[0])
+
+    @property
+    def deltas(self) -> np.ndarray:
+        """``next_states - states``, the target a learner should predict.
+
+        Regressing onto the change rather than the absolute successor removes the
+        identity part of the map, which is most of it over one control step, and
+        leaves the residual the model is actually being asked to learn.
+        """
+        return self.next_states - self.states
+
+
+class TransitionDataset:
+    """Growing store of ``(state, action, next_state)`` rows with an episode-wise holdout.
+
+    Args:
+        state_indices: Flat-vector indices of the block to fit, typically from
+            ``IsaacChannelSchema.indices_of(...)``. ``None`` keeps the whole
+            state, which is only right when the state has no carried latent.
+        holdout_fraction: Fraction of *episodes* reserved for evaluation.
+        seed: Seed for the train/holdout episode assignment. The assignment is a
+            property of the episode index, so re-adding the same episodes in the
+            same order reproduces the same split.
+
+    Raises:
+        ValueError: If ``holdout_fraction`` is outside ``[0, 1)``.
+
+    Example:
+        >>> import numpy as np
+        >>> dataset = TransitionDataset(state_indices=np.array([0, 1]))
+        >>> states = np.array([[0.0, 0.0, 9.0], [1.0, 0.0, 9.0]])
+        >>> actions = np.array([[1.0], [1.0]])
+        >>> next_states = np.array([[1.0, 0.0, 9.0], [2.0, 0.0, 9.0]])
+        >>> _ = dataset.add_episode(states, actions, next_states, source="exploration")
+        >>> len(dataset)
+        2
+        >>> dataset.training_batch().states.shape
+        (2, 2)
+    """
+
+    def __init__(
+        self,
+        state_indices: Optional[ArrayLike] = None,
+        holdout_fraction: float = 0.2,
+        seed: int = 0,
+    ) -> None:
+        if not 0.0 <= holdout_fraction < 1.0:
+            raise ValueError(f"holdout_fraction must be in [0, 1), got {holdout_fraction}")
+        self._indices = None if state_indices is None else np.asarray(state_indices, dtype=int)
+        self._holdout_fraction = float(holdout_fraction)
+        self._rng = np.random.default_rng(seed)
+        self._episodes: List[Dict[str, Any]] = []
+
+    def __len__(self) -> int:
+        """Total number of stored transitions, across every round."""
+        return sum(int(episode["states"].shape[0]) for episode in self._episodes)
+
+    @property
+    def num_episodes(self) -> int:
+        """Number of episodes contributed so far."""
+        return len(self._episodes)
+
+    def counts_by_source(self) -> Dict[str, int]:
+        """Transitions contributed by each named source, e.g. exploration vs planner.
+
+        The loop's correctness depends on the two sources staying balanced, so the
+        count has to be observable rather than assumed.
+        """
+        counts: Dict[str, int] = {}
+        for episode in self._episodes:
+            counts[episode["source"]] = counts.get(episode["source"], 0) + int(
+                episode["states"].shape[0]
+            )
+        return counts
+
+    def add_episode(
+        self,
+        states: ArrayLike,
+        actions: ArrayLike,
+        next_states: ArrayLike,
+        source: str,
+    ) -> int:
+        """Append one episode's transitions.
+
+        Args:
+            states: ``(N, full_dim)`` source states, full width.
+            actions: ``(N, action_dim)`` applied actions.
+            next_states: ``(N, full_dim)`` resulting states, full width.
+            source: Where the episode came from, e.g. ``"exploration"`` or
+                ``"planner"``.
+
+        Returns:
+            The number of transitions added.
+
+        Raises:
+            ValueError: If the three arrays disagree in length.
+        """
+        states_2d = np.atleast_2d(np.asarray(states, dtype=float))
+        actions_2d = np.atleast_2d(np.asarray(actions, dtype=float))
+        next_2d = np.atleast_2d(np.asarray(next_states, dtype=float))
+        if not states_2d.shape[0] == actions_2d.shape[0] == next_2d.shape[0]:
+            raise ValueError(
+                "states, actions and next_states must have equal length, got "
+                f"{states_2d.shape[0]}, {actions_2d.shape[0]}, {next_2d.shape[0]}"
+            )
+        if states_2d.shape[0] == 0:
+            return 0
+        if self._indices is not None:
+            states_2d = states_2d[:, self._indices]
+            next_2d = next_2d[:, self._indices]
+        self._episodes.append(
+            {
+                "states": states_2d,
+                "actions": actions_2d,
+                "next_states": next_2d,
+                "source": source,
+                "holdout": bool(self._rng.random() < self._holdout_fraction),
+            }
+        )
+        return int(states_2d.shape[0])
+
+    def add_history(self, history: Any, source: str) -> int:
+        """Append the transitions of one recorded episode.
+
+        The terminal bookkeeping step carries no action and no successor, and a
+        step whose successor is a post-reset observation is not a transition of
+        the system at all -- the simulator auto-resets inside ``step()``, so that
+        successor belongs to a fresh episode metres away. Both are dropped.
+
+        Args:
+            history: A :class:`~POMDPPlanners.core.simulation.history.History`.
+            source: Where the episode came from.
+
+        Returns:
+            The number of usable transitions added.
+        """
+        states: List[Any] = []
+        actions: List[Any] = []
+        next_states: List[Any] = []
+        for step in history.history:
+            if step.action is None or step.next_state is None:
+                continue
+            states.append(np.asarray(step.state, dtype=float).ravel())
+            actions.append(np.asarray(step.action, dtype=float).ravel())
+            next_states.append(np.asarray(step.next_state, dtype=float).ravel())
+        if not states:
+            return 0
+        return self.add_episode(states, actions, next_states, source=source)
+
+    def training_batch(self) -> TransitionBatch:
+        """Every transition from episodes not held out."""
+        return self._batch(holdout=False)
+
+    def holdout_batch(self) -> TransitionBatch:
+        """Every transition from held-out episodes."""
+        return self._batch(holdout=True)
+
+    def _batch(self, holdout: bool) -> TransitionBatch:
+        selected = [episode for episode in self._episodes if episode["holdout"] is holdout]
+        if not selected:
+            width = self._width()
+            empty_state = np.zeros((0, width), dtype=float)
+            return TransitionBatch(empty_state, np.zeros((0, self._action_width())), empty_state)
+        return TransitionBatch(
+            np.concatenate([episode["states"] for episode in selected]),
+            np.concatenate([episode["actions"] for episode in selected]),
+            np.concatenate([episode["next_states"] for episode in selected]),
+        )
+
+    def _width(self) -> int:
+        if self._indices is not None:
+            return int(self._indices.size)
+        return int(self._episodes[0]["states"].shape[1]) if self._episodes else 0
+
+    def _action_width(self) -> int:
+        return int(self._episodes[0]["actions"].shape[1]) if self._episodes else 0
+
+
+def block_indices(schema: Any, channels: Sequence[str]) -> np.ndarray:
+    """Flat-vector indices of ``channels`` in ``schema``.
+
+    A thin pass-through so a caller building a dataset does not have to import
+    the Isaac schema module for one call, and so the intent -- "fit only these
+    channels" -- reads at the call site.
+
+    Args:
+        schema: Anything exposing ``indices_of(names)``, e.g.
+            ``IsaacChannelSchema``.
+        channels: Channel names to fit.
+
+    Returns:
+        The concatenated flat indices, in the order given.
+    """
+    return np.asarray(schema.indices_of(channels), dtype=int)


### PR DESCRIPTION
## Why

Every Isaac result we have is **model-is-world**: the planner searches the exact model it is evaluated in, so approximation error is zero by construction, and none of the reported numbers say whether the conclusions survive a real simulator. Measuring that needs a way to fit a transition from rollouts and plug it back in while the world stays separate.

A one-shot fit does not work, and the reason is known. [Ross & Bagnell, ICML 2012](https://arxiv.org/abs/1203.1007) show that a model fitted on a fixed exploration distribution is accurate only where that data was collected; the planner then drives into states the fit never saw, and performance is unbounded away from optimal while training error stays tiny. Their fix — plan with the current model, record what the planner did, aggregate, refit — holds even when the true system is outside the model class, which is our case.

## What is here

New package `POMDPPlanners/training/model_learning/`:

| Module | What it does |
|---|---|
| `transition_dataset` | Transitions accumulated across rounds, sliced to named channels, held out by episode |
| `learners` | `LinearGaussianLearner` (the floor) and `ProbabilisticEnsembleLearner` (PETS-style) |
| `ensemble_transition` | The ensemble as a plain `TransitionModel` — mixture density, per-sample member choice |
| `exploration` | Held-random-preset rollouts, episode boundaries dropped |
| `dagger_trainer` | The round loop |
| `diagnostics` | Held-out likelihood, horizon drift over claimed noise, preset-ranking agreement |

Plus: `TransitionModel` and `RewardModel` move to `core/environment/`. Fitting one is generic work that must not depend on an environment package. The Isaac module re-exports both, so **every existing import path is unchanged** — verified by the existing Isaac suite (362 passed).

## Three details that decide whether the loop works

Each is enforced in code rather than left to a caller, because each fails silently:

1. **Half of every round's data comes from exploration.** The paper singles this out as its difference from earlier iterative methods. Without a fixed ratio, exploration rows become a shrinking fraction of the buffer and the loop settles on a model that is excellent along the current trajectory and blind beside it.
2. **The fit aggregates.** Round *n* refits on rounds 1..*n*. Dropping this turns the loop into unrelated fits that can oscillate.
3. **Every round's model is kept.** The guarantee is on the best of the sequence, not the last one.

Both learners train by **likelihood, not squared error** — the bound runs through the distance between predicted and true next-state distributions, so a point predictor sits outside it entirely, and a deterministic transition would collapse the belief dispersion ICVaR grades.

## Two constraints discovered while building

**The world cannot be set to a chosen state.** `IsaacLabPOMDP` has no `set_state`, and asking it for the successor of anything but the live state raises. So the exploration distribution is a randomized base policy instead — which is the paper's own reset-model fallback, and the case where iterating helps most.

**Collection and diagnostics need different views of the world.** Collection works in full-width state; the diagnostics roll model and world side by side and need the fitted block. `diagnostics_world` is an explicit parameter because passing the full-width world by mistake does not raise — it compares vectors of different meaning.

## Deliberately out of scope

- **A vectorized torch wrapper.** The hazard environments the studies run are scalar numpy models, so a fitted model plugs straight in. A batched ensemble class is a separate change, worth doing once we know the ensemble is worth planning with.
- **Learning the reward.** The hazard cost is our design, not a fact about the world. Holding it fixed is what makes a model comparison about dynamics.

## Caveat recorded in the code

The guarantee is stated for expected discounted cost. A nested CVaR is not that. The loop is still the right procedure; the theorem does not cover the objective, and nothing here claims it does.

## Testing

- `pytest POMDPPlanners/tests/test_training/` — **53 passed**. Covers coefficient recovery for both learners, that the ensemble reports spread rather than a point, that its `log_probability` matches the distribution it actually samples from (checked against an empirical density), block confinement, aggregation, the ½ split, the action hold, and boundary-row dropping.
- Integration: the loop end to end against a factored world carrying a latent hazard channel, then the fitted model dropped back in as the factored model's transition — the latent survives a step untouched while the robot block moves.
- `pytest POMDPPlanners/tests/test_core/test_core_layering.py` and the full Isaac suite pass after the interface move.
- Full suite: 5712 passed. Three failures, two of which (`test_laser_tag_hazard_terminal`, `test_constrained_pft_dpw`) reproduce on `develop` unchanged and are **not from this branch**; the packaging errors are likewise pre-existing.
- pylint 10.00/10, pyright clean on every new and changed file.

## Next step this unblocks

Once ubuntu64 is reachable: run the loop with live Isaac as the world, then the standard 100-episode evaluation with three model arms — analytic, fitted, and the simulator itself as the planner's model. That is the model-error number the `cc_baseline` and `isaac_severity` reports currently have at zero.

https://claude.ai/code/session_014D7R8755y8XoA4nCe7Lzdd