### PR TITLE
feat(models): let transitions and rewards take a batch of states

### DIFF
--- a/POMDPPlanners/core/environment/array_backend.py
+++ b/POMDPPlanners/core/environment/array_backend.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: MIT
+
+"""Letting one model serve both a scalar planner and a GPU-vectorized one.
+
+A vectorized planner such as VOPP drives its whole forward search in torch on
+one device, and its contract is that nothing crosses back to the host mid-search
+-- a single ``.numpy()`` per step costs more than the kernels it surrounds. A
+model written in numpy therefore cannot serve it, however fast the numpy is.
+
+The alternative to writing each model twice is to write the arithmetic once and
+let it follow its input: numpy in, numpy out; a tensor in, a tensor out on that
+tensor's device and dtype. The formulas are identical either way -- ``@``,
+``sqrt``, ``sum`` mean the same thing in both libraries -- so what actually has
+to be arranged is the model's *stored parameters*, which are numpy and must
+appear as tensors on the right device without being converted on every call.
+
+That is what :class:`BackendParameters` is: the numpy master copy, plus a
+converted copy per ``(device, dtype)`` built once and reused. Converting per
+call would move the cost from the host boundary into the kernel and give back
+the whole point.
+
+Classes:
+    BackendParameters: Stored arrays, served in the backend of a reference array.
+
+Functions:
+    is_tensor: Whether a value is a torch tensor.
+    as_backend: Convert a value into the backend of a reference array.
+    as_rows: View a vector or a batch of vectors as 2-D, reporting which it was.
+    standard_normal: Standard-normal draw in the backend of a reference array.
+"""
+
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+import numpy as np
+import torch
+
+
+def is_tensor(value: Any) -> bool:
+    """Whether ``value`` is a torch tensor.
+
+    Args:
+        value: Any array-like.
+
+    Returns:
+        True for a :class:`torch.Tensor`, False otherwise.
+    """
+    return isinstance(value, torch.Tensor)
+
+
+class BackendParameters:
+    """Fixed numpy parameters, served in whichever backend the caller is using.
+
+    Args:
+        arrays: Named parameter arrays. Stored as float64 numpy masters.
+
+    Example:
+        >>> import numpy as np
+        >>> params = BackendParameters(weight=np.eye(2))
+        >>> params.matching(np.zeros(2))["weight"].shape
+        (2, 2)
+        >>> import torch
+        >>> params.matching(torch.zeros(2))["weight"].dtype
+        torch.float32
+    """
+
+    def __init__(self, **arrays: Any) -> None:
+        self._numpy: Dict[str, np.ndarray] = {
+            name: np.asarray(value, dtype=float) for name, value in arrays.items()
+        }
+        self._converted: Dict[Tuple[Any, Any], Dict[str, torch.Tensor]] = {}
+
+    @property
+    def numpy(self) -> Mapping[str, np.ndarray]:
+        """The numpy master copies."""
+        return self._numpy
+
+    def matching(self, reference: Any) -> Mapping[str, Any]:
+        """The parameters in the backend, device and dtype of ``reference``.
+
+        Args:
+            reference: An array whose backend the parameters should match.
+
+        Returns:
+            The parameter mapping. For a numpy reference this is the master copy
+            itself; for a tensor it is a per-``(device, dtype)`` copy, built on
+            first use and cached thereafter.
+        """
+        if not is_tensor(reference):
+            return self._numpy
+        key = (reference.device, reference.dtype)
+        if key not in self._converted:
+            self._converted[key] = {
+                name: torch.as_tensor(value, dtype=reference.dtype, device=reference.device)
+                for name, value in self._numpy.items()
+            }
+        return self._converted[key]
+
+
+def as_backend(value: Any, reference: Any) -> Any:
+    """Convert ``value`` into the backend, device and dtype of ``reference``.
+
+    The *state* is what decides a model's backend, and everything else it is
+    handed follows -- an action arriving as a Python list must not silently drag
+    a tensor computation back to the host.
+
+    Args:
+        value: Any array-like.
+        reference: The array whose backend to adopt.
+
+    Returns:
+        ``value`` as a numpy array or as a tensor on the reference's device.
+    """
+    if is_tensor(reference):
+        if is_tensor(value):
+            return value.to(device=reference.device, dtype=reference.dtype)
+        return torch.as_tensor(
+            np.asarray(value, dtype=float), dtype=reference.dtype, device=reference.device
+        )
+    if is_tensor(value):
+        return value.detach().cpu().numpy().astype(float)
+    return np.asarray(value, dtype=float)
+
+
+def as_rows(value: Any, width: int) -> Tuple[Any, bool]:
+    """View ``value`` as a ``(N, width)`` block and report whether it arrived batched.
+
+    A single vector and a one-row batch are the same numbers in different shapes,
+    and the caller has to give back the shape it was handed -- returning a
+    ``(1, width)`` array to someone who passed a ``(width,)`` one breaks every
+    existing call site silently rather than loudly.
+
+    Args:
+        value: A ``(width,)`` vector or a ``(N, width)`` batch.
+        width: Expected trailing width.
+
+    Returns:
+        ``(rows, was_batched)`` where ``rows`` is 2-D.
+
+    Raises:
+        ValueError: If the trailing dimension is not ``width``, or the input has
+            more than two dimensions.
+    """
+    array = value if is_tensor(value) else np.asarray(value, dtype=float)
+    if array.ndim > 2:
+        raise ValueError(f"expected a vector or a batch of vectors, got shape {tuple(array.shape)}")
+    if int(array.shape[-1]) != width:
+        raise ValueError(
+            f"expected trailing dimension {width}, got shape {tuple(array.shape)}"
+        )
+    if array.ndim == 1:
+        return array.reshape(1, width), False
+    return array, True
+
+
+def standard_normal(
+    shape: Tuple[int, ...],
+    reference: Any,
+    rng: Optional[np.random.Generator] = None,
+) -> Any:
+    """Draw standard-normal noise in the backend of ``reference``.
+
+    Args:
+        shape: Shape of the draw.
+        reference: An array whose backend, device and dtype to match.
+        rng: Generator for the numpy path. ``None`` uses the global numpy state,
+            which is what the scalar models have always used.
+
+    Returns:
+        The noise, in the reference's backend.
+    """
+    if is_tensor(reference):
+        return torch.randn(shape, dtype=reference.dtype, device=reference.device)
+    if rng is not None:
+        return rng.standard_normal(shape)
+    return np.random.standard_normal(shape)

--- a/POMDPPlanners/environments/isaac_lab_pomdp/isaac_lab_model_pomdp.py
+++ b/POMDPPlanners/environments/isaac_lab_pomdp/isaac_lab_model_pomdp.py
@@ -62,6 +62,7 @@ Classes:
     IsaacLabModelPOMDP: Discrete-action generative model POMCPOW searches inside.
 """
 
+import math
 from collections.abc import Hashable
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -82,6 +83,13 @@ from POMDPPlanners.core.environment import (
 from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_pomdp import (
     _build_isaac_env,
     _to_numpy,
+)
+from POMDPPlanners.core.environment.array_backend import (
+    BackendParameters,
+    as_backend,
+    as_rows,
+    is_tensor,
+    standard_normal,
 )
 from POMDPPlanners.utils.multivariate_normal import (
     CovarianceParameterizedMultivariateNormal,
@@ -116,6 +124,86 @@ def _diagonal_covariance(dim: int, std: NoiseStd) -> np.ndarray:
     return np.diag(std_vector**2)
 
 
+def _is_legacy_call(state: Any) -> bool:
+    """Whether this call is the pre-batching case: a numpy/list 1-D state.
+
+    Those calls keep the exact code path they always took -- the shared
+    :class:`~POMDPPlanners.utils.multivariate_normal.CovarianceParameterizedMultivariateNormal`,
+    triangular solve and all. Routing them through the batched kernel instead
+    would be mathematically equivalent and numerically slightly different, and
+    "no existing result moved" is worth more than one less branch.
+    """
+    if is_tensor(state):
+        return False
+    return np.asarray(state, dtype=float).ndim == 1
+
+
+def _shape_samples(samples: Any, batched: bool, n_samples: int) -> Any:
+    """Give a ``(N, n_samples, dim)`` draw back in the shape the caller asked for."""
+    if not batched:
+        return samples[0, 0] if n_samples == 1 else samples[0]
+    return samples[:, 0] if n_samples == 1 else samples
+
+
+class _BatchedGaussian:
+    """Fixed-covariance normal over a batch of means, following its input's backend.
+
+    The scalar models already have a normal --
+    :class:`~POMDPPlanners.utils.multivariate_normal.CovarianceParameterizedMultivariateNormal`
+    -- and it stays the path every pre-existing call takes, bit for bit. This is
+    the batched counterpart: one mean *per row* rather than one mean for the whole
+    call, and tensors out when handed tensors, which is what lets a GPU planner
+    take a step without a host round trip.
+
+    Two normals rather than one widened normal is deliberate. The shared one is
+    used by several environments; widening it would put all of them on new
+    numerics for the sake of this one.
+
+    Args:
+        covariance: Positive-definite ``(dim, dim)`` covariance.
+    """
+
+    def __init__(self, covariance: np.ndarray) -> None:
+        matrix = np.asarray(covariance, dtype=float)
+        self.dim = int(matrix.shape[0])
+        self._params = BackendParameters(
+            cholesky_t=np.linalg.cholesky(matrix).T,
+            precision=np.linalg.inv(matrix),
+        )
+        self._log_normalizer = float(
+            -0.5 * (self.dim * math.log(2.0 * math.pi) + np.linalg.slogdet(matrix)[1])
+        )
+
+    def sample(self, means: Any, n_samples: int) -> Any:
+        """Draw ``n_samples`` per row.
+
+        Args:
+            means: ``(N, dim)`` means, one per row.
+            n_samples: Draws per row.
+
+        Returns:
+            ``(N, n_samples, dim)`` samples.
+        """
+        params = self._params.matching(means)
+        noise = standard_normal((int(means.shape[0]), n_samples, self.dim), means)
+        return means[:, None, :] + noise @ params["cholesky_t"]
+
+    def log_pdf(self, means: Any, values: Any) -> Any:
+        """Row-wise log-density, broadcasting a single mean across many values.
+
+        Args:
+            means: ``(N, dim)`` or ``(1, dim)`` means.
+            values: ``(N, dim)`` points.
+
+        Returns:
+            ``(N,)`` log-densities.
+        """
+        params = self._params.matching(means)
+        residual = values - means
+        mahalanobis = ((residual @ params["precision"]) * residual).sum(-1)
+        return self._log_normalizer - 0.5 * mahalanobis
+
+
 class GaussianRandomWalkTransition(TransitionModel):
     """Action-ignoring Gaussian random walk: ``next_state = state + N(0, Sigma)``.
 
@@ -138,20 +226,33 @@ class GaussianRandomWalkTransition(TransitionModel):
             process_noise_std: Scalar or per-channel std of the process noise.
         """
         self.dim = int(dim)
-        self._normal = CovarianceParameterizedMultivariateNormal(
-            _diagonal_covariance(self.dim, process_noise_std)
-        )
+        covariance = _diagonal_covariance(self.dim, process_noise_std)
+        self._normal = CovarianceParameterizedMultivariateNormal(covariance)
+        self._batched = _BatchedGaussian(covariance)
 
-    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> Any:
+        """Sample successors, accepting either one state or a batch of them.
+
+        Shapes and backend conventions are shared with
+        :meth:`LinearGaussianTransition.sample_next_state`.
+        """
         del action  # random walk ignores the action
-        mean = np.asarray(state, dtype=float).reshape(-1)
-        samples = self._normal.sample(mean, n_samples=n_samples)
-        return samples[0] if n_samples == 1 else samples
+        if _is_legacy_call(state):
+            mean = np.asarray(state, dtype=float).reshape(-1)
+            samples = self._normal.sample(mean, n_samples=n_samples)
+            return samples[0] if n_samples == 1 else samples
+        rows, batched = as_rows(state, self.dim)
+        return _shape_samples(self._batched.sample(rows, n_samples), batched, n_samples)
 
-    def log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
+    def log_probability(self, state: Any, action: Any, next_states: Any) -> Any:
+        """Log-density of the successors, accepting either one state or a batch."""
         del action
-        mean = np.asarray(state, dtype=float).reshape(-1)
-        return self._normal.log_pdf(np.asarray(next_states, dtype=float), mean)
+        if _is_legacy_call(state):
+            mean = np.asarray(state, dtype=float).reshape(-1)
+            return self._normal.log_pdf(np.asarray(next_states, dtype=float), mean)
+        rows, _ = as_rows(state, self.dim)
+        candidates, _ = as_rows(as_backend(next_states, rows), self.dim)
+        return self._batched.log_pdf(rows, candidates)
 
 
 class LinearGaussianTransition(TransitionModel):
@@ -198,20 +299,78 @@ class LinearGaussianTransition(TransitionModel):
         self._normal = CovarianceParameterizedMultivariateNormal(
             np.asarray(covariance, dtype=float)
         )
+        self._batched = _BatchedGaussian(np.asarray(covariance, dtype=float))
+        self._params = BackendParameters(
+            weight_state=self._weight_state,
+            weight_action=self._weight_action,
+            bias=self._bias,
+        )
 
     def _mean(self, state: Any, action: Any) -> np.ndarray:
         state_vector = np.asarray(state, dtype=float).reshape(-1)
         action_vector = np.asarray(action, dtype=float).reshape(-1)
         return self._weight_state @ state_vector + self._weight_action @ action_vector + self._bias
 
-    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
-        mean = self._mean(state, action)
-        samples = self._normal.sample(mean, n_samples=n_samples)
-        return samples[0] if n_samples == 1 else samples
+    def _mean_rows(self, state: Any, action: Any) -> Any:
+        """Per-row transition means, in the backend of ``state``."""
+        states, batched = as_rows(state, self.dim)
+        actions, _ = as_rows(as_backend(action, states), self.action_dim)
+        params = self._params.matching(states)
+        mean = (
+            states @ params["weight_state"].T
+            + actions @ params["weight_action"].T
+            + params["bias"]
+        )
+        return mean, batched
 
-    def log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
-        mean = self._mean(state, action)
-        return self._normal.log_pdf(np.asarray(next_states, dtype=float), mean)
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> Any:
+        """Sample successors, accepting either one state or a batch of them.
+
+        Args:
+            state: A ``(dim,)`` state, or a ``(N, dim)`` batch -- one row per
+                particle, each with its own action.
+            action: A ``(action_dim,)`` action, or a ``(N, action_dim)`` batch.
+                A single action broadcasts across a batch of states.
+            n_samples: Draws per state.
+
+        Returns:
+            For a single state: ``(dim,)`` when ``n_samples == 1``, else
+            ``(n_samples, dim)`` -- unchanged from before batching existed. For a
+            batch: ``(N, dim)`` when ``n_samples == 1``, else
+            ``(N, n_samples, dim)``.
+
+            The result follows the *state's* backend: a numpy state gives a numpy
+            array, a tensor gives a tensor on that tensor's device. That is what
+            lets a vectorized planner take a step with no host round trip.
+        """
+        if _is_legacy_call(state):
+            mean = self._mean(state, action)
+            samples = self._normal.sample(mean, n_samples=n_samples)
+            return samples[0] if n_samples == 1 else samples
+        means, batched = self._mean_rows(state, action)
+        return _shape_samples(self._batched.sample(means, n_samples), batched, n_samples)
+
+    def log_probability(self, state: Any, action: Any, next_states: Any) -> Any:
+        """Log-density of the successors, accepting either one state or a batch.
+
+        Args:
+            state: A ``(dim,)`` state, or a ``(N, dim)`` batch.
+            action: The action, or one per row.
+            next_states: For a single state, a ``(dim,)`` candidate or an
+                ``(n, dim)`` batch scored against that one state. For a batch of
+                states, an ``(N, dim)`` array paired **row-wise** -- candidate
+                ``i`` is scored under state ``i``, which is what a particle filter
+                needs and what the single-state form cannot express.
+
+        Returns:
+            ``(n,)`` or ``(N,)`` log-densities, in the state's backend.
+        """
+        if _is_legacy_call(state):
+            mean = self._mean(state, action)
+            return self._normal.log_pdf(np.asarray(next_states, dtype=float), mean)
+        means, _ = self._mean_rows(state, action)
+        candidates, _ = as_rows(as_backend(next_states, means), self.dim)
+        return self._batched.log_pdf(means, candidates)
 
     @classmethod
     def fit(
@@ -446,15 +605,47 @@ class LinearRewardModel(RewardModel):
         self._weight_action = np.asarray(weight_action, dtype=float).reshape(-1)
         self._weight_next_state = np.asarray(weight_next_state, dtype=float).reshape(-1)
         self._bias = float(bias)
+        self._params = BackendParameters(
+            weight_state=self._weight_state,
+            weight_action=self._weight_action,
+            weight_next_state=self._weight_next_state,
+        )
 
-    def reward(self, state: Any, action: Any, next_state: Any) -> float:
-        state_vector = np.asarray(state, dtype=float).reshape(-1)
-        action_vector = np.asarray(action, dtype=float).reshape(-1)
-        next_vector = np.asarray(next_state, dtype=float).reshape(-1)
-        return float(
-            self._weight_state @ state_vector
-            + self._weight_action @ action_vector
-            + self._weight_next_state @ next_vector
+    def reward(self, state: Any, action: Any, next_state: Any) -> Any:
+        """Score a transition, or a whole batch of them.
+
+        Args:
+            state: A ``(dim,)`` state, or a ``(N, dim)`` batch.
+            action: The action, or one per row.
+            next_state: The successor, or one per row.
+
+        Returns:
+            A Python ``float`` for a single transition -- unchanged from before
+            batching existed -- or an ``(N,)`` array in the state's backend for a
+            batch.
+
+            Batching the reward matters as much as batching the transition: a
+            vectorized rollout that steps on device and then drops to the host to
+            score the reward pays the sync it was built to avoid, once per step.
+        """
+        if _is_legacy_call(state):
+            state_vector = np.asarray(state, dtype=float).reshape(-1)
+            action_vector = np.asarray(action, dtype=float).reshape(-1)
+            next_vector = np.asarray(next_state, dtype=float).reshape(-1)
+            return float(
+                self._weight_state @ state_vector
+                + self._weight_action @ action_vector
+                + self._weight_next_state @ next_vector
+                + self._bias
+            )
+        states, _ = as_rows(state, self._weight_state.shape[0])
+        actions, _ = as_rows(as_backend(action, states), self._weight_action.shape[0])
+        next_states, _ = as_rows(as_backend(next_state, states), self._weight_next_state.shape[0])
+        params = self._params.matching(states)
+        return (
+            states @ params["weight_state"]
+            + actions @ params["weight_action"]
+            + next_states @ params["weight_next_state"]
             + self._bias
         )
 

--- a/POMDPPlanners/tests/test_core/test_batched_model_parity.py
+++ b/POMDPPlanners/tests/test_core/test_batched_model_parity.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: MIT
+
+"""Conformance suite pinning every model's batched path to its scalar one.
+
+A model that answers both a scalar planner and a vectorized one has two
+implementations of the same arithmetic, and nothing forces them to agree. They
+drift the way this kind of thing always drifts: someone fixes a sign or a scale
+on the path their test exercises, the other path keeps the old behaviour, and
+the disagreement surfaces months later as a planner that performs differently on
+GPU than on CPU -- which reads as a hardware problem and is not one.
+
+So the rule is one test file, parameterized over every model that supports both,
+asserting three things per model:
+
+* a batch of identical rows gives the same distribution as the scalar call;
+* a batch of *different* rows gives, row by row, what a Python loop gives -- this
+  is the property `n_samples` cannot express and the reason the batch axis was
+  added at all;
+* a torch input gives a tensor whose values match the numpy answer.
+
+Adding a model to the parameter lists below is how a new model joins the
+contract. Leaving it out is how it silently escapes.
+"""
+
+from typing import Any, Tuple
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_model_pomdp import (
+    GaussianRandomWalkTransition,
+    LinearGaussianTransition,
+    LinearRewardModel,
+)
+from POMDPPlanners.training.model_learning import (
+    ProbabilisticEnsembleLearner,
+    TransitionDataset,
+)
+
+DIM = 3
+ACTION_DIM = 2
+
+
+def _linear_transition() -> LinearGaussianTransition:
+    return LinearGaussianTransition(
+        weight_state=np.array([[0.9, 0.05, 0.0], [0.0, 0.92, 0.05], [0.0, 0.0, 0.95]]),
+        weight_action=np.array([[0.4, 0.0], [0.1, 0.3], [0.0, 0.2]]),
+        bias=np.array([0.01, 0.0, -0.01]),
+        covariance=np.diag([0.01, 0.02, 0.015]),
+    )
+
+
+def _random_walk() -> GaussianRandomWalkTransition:
+    return GaussianRandomWalkTransition(dim=DIM, process_noise_std=0.05)
+
+
+def _reward() -> LinearRewardModel:
+    return LinearRewardModel(
+        weight_state=np.array([1.0, -0.5, 0.25]),
+        weight_action=np.array([2.0, 0.5]),
+        weight_next_state=np.array([0.0, 1.0, -1.0]),
+        bias=0.5,
+    )
+
+
+def _rows(count: int, seed: int = 0) -> Tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    return rng.normal(size=(count, DIM)), rng.normal(size=(count, ACTION_DIM))
+
+
+def _fitted_ensemble() -> Any:
+    """A small ensemble fitted on a linear system, cached across the parameterization."""
+    if _fitted_ensemble.cached is None:  # type: ignore[attr-defined]
+        rng = np.random.default_rng(11)
+        states = rng.normal(size=(600, DIM))
+        actions = rng.normal(size=(600, ACTION_DIM))
+        next_states = states * 0.9 + actions @ np.ones((ACTION_DIM, DIM)) * 0.1
+        next_states = next_states + rng.normal(scale=0.03, size=(600, DIM))
+        dataset = TransitionDataset(holdout_fraction=0.0, seed=0)
+        dataset.add_episode(states, actions, next_states, source="exploration")
+        _fitted_ensemble.cached = ProbabilisticEnsembleLearner(  # type: ignore[attr-defined]
+            num_members=3, hidden_sizes=(32, 32), epochs=15, seed=0
+        ).fit(dataset)
+    return _fitted_ensemble.cached  # type: ignore[attr-defined]
+
+
+_fitted_ensemble.cached = None  # type: ignore[attr-defined]
+
+
+TRANSITIONS = [
+    pytest.param(_linear_transition, id="linear_gaussian"),
+    pytest.param(_random_walk, id="random_walk"),
+    pytest.param(_fitted_ensemble, id="probabilistic_ensemble"),
+]
+
+
+@pytest.mark.parametrize("build", TRANSITIONS)
+def test_batched_sampling_matches_the_scalar_distribution(build: Any) -> None:
+    """Purpose: Validates that batching does not change what the transition samples
+
+    Given: One state and action, drawn 4000 times scalar-wise and 4000 times as a
+        batch of identical rows
+    When: The two sample means and spreads are compared
+    Then: They agree within Monte-Carlo error
+    """
+    model = build()
+    state = np.array([0.4, -0.2, 0.1])
+    action = np.array([0.5, -0.3])
+
+    scalar = np.atleast_2d(model.sample_next_state(state, action, 4000))
+    batch = model.sample_next_state(np.tile(state, (4000, 1)), np.tile(action, (4000, 1)))
+
+    assert np.allclose(scalar.mean(axis=0), batch.mean(axis=0), atol=0.01)
+    assert np.allclose(scalar.std(axis=0), batch.std(axis=0), rtol=0.1)
+
+
+@pytest.mark.parametrize("build", TRANSITIONS)
+def test_batched_log_density_equals_a_loop_over_rows(build: Any) -> None:
+    """Purpose: Validates the row-wise pairing the batch axis exists to provide
+
+    Given: Six *different* states, each with its own action and its own candidate
+        successor
+    When: The batched log-density is compared to a Python loop over the rows
+    Then: They agree exactly -- this is the case n_samples cannot express, since
+        it has one state by construction
+    """
+    model = build()
+    states, actions = _rows(6, seed=1)
+    candidates = states + 0.05
+
+    batched = model.log_probability(states, actions, candidates)
+    looped = np.array(
+        [
+            float(model.log_probability(state, action, candidate[None, :])[0])
+            for state, action, candidate in zip(states, actions, candidates)
+        ]
+    )
+
+    assert np.allclose(batched, looped, atol=1e-9)
+
+
+@pytest.mark.parametrize("build", TRANSITIONS)
+def test_a_tensor_state_returns_a_tensor_with_the_numpy_values(build: Any) -> None:
+    """Purpose: Validates the backend-following rule the vectorized planner needs
+
+    Given: The same six states as numpy and as a float32 tensor
+    When: The log-density is taken both ways
+    Then: A tensor comes back, on the input's device, with the numpy values --
+        so a GPU rollout never has to cross to the host
+    """
+    model = build()
+    states, actions = _rows(6, seed=2)
+    candidates = states + 0.05
+
+    numpy_result = model.log_probability(states, actions, candidates)
+    tensor_result = model.log_probability(
+        torch.as_tensor(states, dtype=torch.float32),
+        torch.as_tensor(actions, dtype=torch.float32),
+        torch.as_tensor(candidates, dtype=torch.float32),
+    )
+
+    assert isinstance(tensor_result, torch.Tensor)
+    assert np.allclose(tensor_result.numpy(), numpy_result, atol=1e-3)
+
+
+@pytest.mark.parametrize("build", TRANSITIONS)
+def test_a_single_state_keeps_the_shapes_it_always_returned(build: Any) -> None:
+    """Purpose: Validates that widening did not move the pre-existing call shapes
+
+    Given: A single state, with n_samples of 1 and of 5
+    When: Successors are sampled
+    Then: The shapes are (dim,) and (n_samples, dim) exactly as before batching
+    """
+    model = build()
+    state = np.array([0.4, -0.2, 0.1])
+    action = np.array([0.5, -0.3])
+
+    assert model.sample_next_state(state, action).shape == (DIM,)
+    assert model.sample_next_state(state, action, 5).shape == (5, DIM)
+
+
+@pytest.mark.parametrize("build", TRANSITIONS)
+def test_a_batch_with_many_draws_nests_the_sample_axis(build: Any) -> None:
+    """Purpose: Validates that the two batch axes compose instead of colliding
+
+    Given: Four states and three draws each
+    When: Successors are sampled
+    Then: The result is (4, 3, dim) -- particles outermost, draws inside
+    """
+    model = build()
+    states, actions = _rows(4, seed=3)
+
+    assert model.sample_next_state(states, actions, 3).shape == (4, 3, DIM)
+
+
+def test_batched_reward_equals_a_loop_over_rows() -> None:
+    """Purpose: Validates the reward's batch path against its scalar one
+
+    Given: Six transitions
+    When: The batched reward is compared to a loop
+    Then: They agree exactly, and a single transition still returns a float
+    """
+    model = _reward()
+    states, actions = _rows(6, seed=4)
+    next_states = states + 0.1
+
+    batched = model.reward(states, actions, next_states)
+    looped = np.array(
+        [
+            model.reward(state, action, next_state)
+            for state, action, next_state in zip(states, actions, next_states)
+        ]
+    )
+
+    assert np.allclose(batched, looped, atol=1e-12)
+    assert isinstance(model.reward(states[0], actions[0], next_states[0]), float)
+
+
+def test_reward_follows_the_state_backend() -> None:
+    """Purpose: Validates that a vectorized rollout can score rewards on device
+
+    Given: A batch of transitions as tensors
+    When: The reward is taken
+    Then: A tensor comes back with the numpy values, so the rollout never syncs
+    """
+    model = _reward()
+    states, actions = _rows(6, seed=5)
+    next_states = states + 0.1
+
+    result = model.reward(
+        torch.as_tensor(states, dtype=torch.float32),
+        torch.as_tensor(actions, dtype=torch.float32),
+        torch.as_tensor(next_states, dtype=torch.float32),
+    )
+
+    assert isinstance(result, torch.Tensor)
+    assert np.allclose(result.numpy(), model.reward(states, actions, next_states), atol=1e-4)
+
+
+def test_a_wrong_width_raises_instead_of_flattening() -> None:
+    """Purpose: Validates that the old silent-flatten failure is now an error
+
+    Given: A state whose trailing dimension is 4 for a 3-dimensional model
+    When: A successor is sampled
+    Then: A ValueError names the expected width. Before batching, reshape(-1)
+        accepted this and returned confident nonsense
+    """
+    model = _linear_transition()
+
+    with pytest.raises(ValueError, match="trailing dimension 3"):
+        model.sample_next_state(np.zeros((5, 4)), np.zeros((5, ACTION_DIM)))
+
+
+def test_the_ensemble_draws_a_member_per_row_not_per_batch() -> None:
+    """Purpose: Validates that batching preserves the ensemble's epistemic spread
+
+    Given: A fitted ensemble and one state repeated across 4000 rows
+    When: One successor is drawn per row
+    Then: The spread across rows matches the spread of 4000 scalar draws. Drawing
+        a single member for the whole batch would collapse it to one member's
+        opinion, which is the spread a risk-sensitive planner is there to price
+    """
+    model = _fitted_ensemble()
+    state = np.array([0.3, -0.4, 0.2])
+    action = np.array([0.5, -0.1])
+
+    scalar = np.atleast_2d(model.sample_next_state(state, action, 4000))
+    batch = model.sample_next_state(np.tile(state, (4000, 1)), np.tile(action, (4000, 1)))
+
+    assert np.allclose(scalar.std(axis=0), batch.std(axis=0), rtol=0.15)

--- a/POMDPPlanners/training/model_learning/ensemble_transition.py
+++ b/POMDPPlanners/training/model_learning/ensemble_transition.py
@@ -37,6 +37,7 @@ import torch
 from torch import nn
 
 from POMDPPlanners.core.environment import TransitionModel
+from POMDPPlanners.core.environment.array_backend import as_backend, as_rows, is_tensor
 
 #: Weight on the soft-bound penalty. Small: it is a nudge keeping the bounds
 #: honest, not a term the fit should trade accuracy against.
@@ -162,24 +163,40 @@ class ProbabilisticEnsembleTransition(TransitionModel):
         """Number of ensemble members."""
         return len(self._members)
 
-    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
-        """Sample ``n_samples`` next states, each from a uniformly drawn member.
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> Any:
+        """Sample next states, each from a uniformly drawn member.
 
         Args:
-            state: The current state block, a length-``dim`` vector.
-            action: The action applied at ``state``.
-            n_samples: Number of next states to draw.
+            state: A ``(dim,)`` state block, or a ``(N, dim)`` batch -- one row
+                per particle, each with its own action.
+            action: The action applied at ``state``, or one per row.
+            n_samples: Draws per state.
 
         Returns:
-            A ``(dim,)`` next state when ``n_samples == 1``, else ``(n_samples, dim)``.
+            For a single state: ``(dim,)`` when ``n_samples == 1``, else
+            ``(n_samples, dim)``. For a batch: ``(N, dim)`` when
+            ``n_samples == 1``, else ``(N, n_samples, dim)``. The result follows
+            the state's backend.
+
+        Note:
+            A member is drawn **per row and per sample**, never once for the whole
+            batch. Drawing one member per call would replace the ensemble's
+            disagreement with a single member's opinion, and that disagreement is
+            the epistemic spread a risk-sensitive planner is there to price.
         """
-        state_vector = np.asarray(state, dtype=float).ravel()
-        means, variances = self._predict(state_vector, action)
-        choice = self._rng.integers(len(self._members), size=n_samples)
-        noise = self._rng.standard_normal((n_samples, self.dim))
-        deltas = means[choice] + noise * np.sqrt(variances[choice])
-        next_states = state_vector[None, :] + deltas
-        return next_states[0] if n_samples == 1 else next_states
+        rows, batched = as_rows(state, self.dim)
+        means, variances = self._predict_rows(rows, action)  # (M, N, dim)
+        num_rows = int(rows.shape[0])
+        choice = self._rng.integers(len(self._members), size=(num_rows, n_samples))
+        noise = self._rng.standard_normal((num_rows, n_samples, self.dim))
+        row_index = np.arange(num_rows)[:, None]
+        picked_mean = means[choice, row_index]  # (N, n_samples, dim)
+        picked_var = variances[choice, row_index]
+        deltas = picked_mean + noise * np.sqrt(picked_var)
+        base = rows.detach().cpu().numpy() if is_tensor(rows) else rows
+        next_states = base[:, None, :] + deltas
+        result = _shape_ensemble_samples(next_states, batched, n_samples)
+        return as_backend(result, state) if is_tensor(state) else result
 
     def log_probability(self, state: Any, action: Any, next_states: Any) -> np.ndarray:
         """Log-density of each next state under the uniform mixture over members.
@@ -192,42 +209,87 @@ class ProbabilisticEnsembleTransition(TransitionModel):
         Returns:
             A ``(n,)`` array of log-densities.
         """
-        state_vector = np.asarray(state, dtype=float).ravel()
-        candidates = np.atleast_2d(np.asarray(next_states, dtype=float))
-        means, variances = self._predict(state_vector, action)
-        deltas = candidates - state_vector[None, :]
-        # (members, n): each member's Gaussian log-density for every candidate.
-        residual = deltas[None, :, :] - means[:, None, :]
+        rows, batched = as_rows(state, self.dim)
+        base = rows.detach().cpu().numpy() if is_tensor(rows) else np.asarray(rows, dtype=float)
+        candidates = np.atleast_2d(
+            np.asarray(
+                next_states.detach().cpu().numpy() if is_tensor(next_states) else next_states,
+                dtype=float,
+            )
+        )
+        means, variances = self._predict_rows(rows, action)  # (M, N, dim)
+        if batched:
+            # Row-wise pairing: candidate i is scored under state i.
+            deltas = candidates - base
+            residual = deltas[None, :, :] - means
+            var = variances
+        else:
+            # One state, many candidates.
+            deltas = candidates - base[0][None, :]
+            residual = deltas[None, :, :] - means[:, 0][:, None, :]
+            var = variances[:, 0][:, None, :]
         per_member = -0.5 * (
-            np.sum(residual**2 / variances[:, None, :], axis=-1)
-            + np.sum(np.log(variances), axis=-1)[:, None]
+            np.sum(residual**2 / var, axis=-1)
+            + np.sum(np.log(var), axis=-1)
             + self.dim * np.log(2.0 * np.pi)
         )
-        return _log_mean_exp(per_member, axis=0)
+        result = _log_mean_exp(per_member, axis=0)
+        return as_backend(result, state) if is_tensor(state) else result
 
-    def _predict(self, state: np.ndarray, action: Any) -> Tuple[np.ndarray, np.ndarray]:
-        """Per-member mean and variance of the state change, in the raw state units."""
-        action_vector = np.asarray(action, dtype=float).ravel()
+    def _predict_rows(self, rows: Any, action: Any) -> Tuple[np.ndarray, np.ndarray]:
+        """Per-member mean and variance of the state change, one column per row.
+
+        Args:
+            rows: ``(N, dim)`` states.
+            action: The action, or one per row.
+
+        Returns:
+            ``(means, variances)``, each ``(num_members, N, dim)`` in raw state
+            units.
+
+        Note:
+            Every member sees the whole batch in one forward pass. The scalar path
+            used to build a one-row tensor per call, which for a learned model is
+            the awkward case -- batching is the natural shape here, not an
+            optimization bolted on afterwards.
+        """
+        states = rows.detach().cpu().numpy() if is_tensor(rows) else np.asarray(rows, dtype=float)
+        actions, _ = as_rows(
+            np.asarray(
+                action.detach().cpu().numpy() if is_tensor(action) else action, dtype=float
+            ),
+            self._action_mean.size,
+        )
+        actions = np.broadcast_to(actions, (states.shape[0], actions.shape[1]))
         normalized = np.concatenate(
             [
-                (state - self._state_mean) / self._state_scale,
-                (action_vector - self._action_mean) / self._action_scale,
-            ]
+                (states - self._state_mean) / self._state_scale,
+                (actions - self._action_mean) / self._action_scale,
+            ],
+            axis=1,
         )
-        inputs = torch.as_tensor(normalized, dtype=torch.float32).unsqueeze(0)
-        means = np.empty((len(self._members), self.dim), dtype=float)
+        inputs = torch.as_tensor(normalized, dtype=torch.float32)
+        num_rows = states.shape[0]
+        means = np.empty((len(self._members), num_rows, self.dim), dtype=float)
         variances = np.empty_like(means)
         with torch.no_grad():
             for index, member in enumerate(self._members):
                 mean, log_variance = member(inputs)
-                means[index] = mean.squeeze(0).numpy()
-                variances[index] = np.exp(log_variance.squeeze(0).numpy())
+                means[index] = mean.numpy()
+                variances[index] = np.exp(log_variance.numpy())
         # Undo the target normalization: a scaled Gaussian scales its variance by
         # the square of the same factor.
         return (
             means * self._delta_scale + self._delta_mean,
             variances * self._delta_scale**2,
         )
+
+
+def _shape_ensemble_samples(samples: np.ndarray, batched: bool, n_samples: int) -> np.ndarray:
+    """Give a ``(N, n_samples, dim)`` draw back in the shape the caller asked for."""
+    if not batched:
+        return samples[0, 0] if n_samples == 1 else samples[0]
+    return samples[:, 0] if n_samples == 1 else samples
 
 
 def normalization_stats(values: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:


### PR DESCRIPTION
## Why

VOPP drives its forward search in torch on one device, and its contract is that nothing crosses back to the host mid-search. A numpy model answering one state at a time can't serve that — so today the only route to a vectorized planner is a hand-written vectorized class per environment. There are three, and each reaches into the *private parameter layout* of the models it wraps:

```python
def _build_transition(self, transition: LinearGaussianTransition) -> None:
    self._weight_state = self._to_tensor(transition._weight_state)   # pylint: disable=protected-access
    self._weight_action = self._to_tensor(transition._weight_action) # pylint: disable=protected-access
    ...
```

Nine `protected-access` waivers across transition, observation and reward, plus a type-check for the linear class. A learned model can't be supported this way at all — its parameters are `nn.Module`s, with nothing to copy out.

## What changed

Widen the **existing** methods rather than add a second interface or a capability protocol. `state` and `action` now take a leading batch dimension, and the result follows the state's backend: numpy in → numpy out; tensor in → tensor out on that tensor's device.

| `state` | `action` | `n_samples` | returns |
|---|---|---|---|
| `[ds]` | `[da]` | N | `[N, ds]` — unchanged |
| `[N, ds]` | `[N, da]` | 1 | `[N, ds]` — what VOPP needs |
| `[N, ds]` | `[N, da]` | M | `[N, M, ds]` |

Widened: `LinearGaussianTransition`, `GaussianRandomWalkTransition`, `LinearRewardModel`, `ProbabilisticEnsembleTransition`.

## The batch axis is not `n_samples`

Worth being explicit, since the obvious reading is that `n_samples` already covers this. It doesn't: `n_samples` is **one** state and N draws of the noise. A planner needs **N different** states with one draw each — one per particle, each with its own action. The single-state form can't express it, and it failed silently:

```python
def _mean(self, state, action):
    state_vector = np.asarray(state, dtype=float).reshape(-1)   # ← flattened any batch
```

Passing `[N, ds]` didn't raise. It flattened to `[N*ds]` and returned confident garbage. That is now a `ValueError` naming the expected width — the one deliberate behaviour change, on a path that could only ever have been a bug.

## What deliberately did not move

A numpy 1-D state still takes the **old code path**, through the shared `CovarianceParameterizedMultivariateNormal`, triangular solve and all. Routing it through the batched kernel would be mathematically equivalent and numerically slightly different, and "no existing result moved" is worth more than one less branch.

The batched kernel is a second normal for the same reason: the shared one is used by several environments, and widening it would put all of them on new numerics for the sake of this one.

## Measured

N=4096 over an 8-dimensional state, best of 5:

| | time | speedup |
|---|---|---|
| Python loop over rows | 11.11 ms | — |
| Batched numpy | 0.38 ms | **29×** |
| Batched torch (CPU) | 0.24 ms | **45×** |

On GPU the win is larger, and the bigger prize isn't the kernel — it's that a rollout stepping on device no longer syncs to the host once per step to score its reward. That's why the reward is widened here too and not left for later; a batched transition feeding a numpy reward pays back most of what it saved.

## Parity suite

`tests/test_core/test_batched_model_parity.py`, 19 tests, parameterized over every model supporting both paths. Per model:

- a batch of identical rows matches the scalar call's distribution;
- a batch of *different* rows matches a Python loop row by row — the property `n_samples` cannot express;
- a tensor input returns a tensor with the numpy values;
- single-state calls keep the exact shapes they always returned.

Plus one specific to the ensemble: **a member is drawn per row and per sample, never once per batch.** Drawing one member for the whole batch is the natural-looking mistake, and it would replace the ensemble's disagreement with a single member's opinion — which is the epistemic spread ICVaR exists to price. The test pins the batched spread to the scalar spread.

Adding a model to the parameter list is how it joins the contract; leaving it out is how it silently escapes. Drift between the two paths is the failure mode that survives review and later presents as "the planner behaves differently on GPU", which reads as a hardware problem and is not one.

## Testing

- `pytest tests/test_core/test_batched_model_parity.py` — 19 passed
- `pytest tests/test_training/ tests/test_environments/test_isaac_lab_pomdp/` — 413 passed, 3 skipped
- Full suite: **5732 passed**, 89 skipped, 12 xfailed. The 2 failures and 2 packaging errors reproduce on `develop` untouched and are not from this branch.
- pylint 10.00/10, pyright clean on every changed file.

## Next

The composite. This covers three of the vectorized protocol's eight methods; `terminal_mask`, `action_keys`, `observation_keys` and the observation kernels aren't the transition's business, and neither is the driven/carried block scatter. A generic `FactoredVectorizedModel` composing widened models can then replace the three hand-written classes — and it's now a much smaller job, since it composes models instead of copying their private parameters out.

https://claude.ai/code/session_014D7R8755y8XoA4nCe7Lzdd