### PR TITLE
feat(training): measure a fitted model by the return it plans to

### DIFF
--- a/POMDPPlanners/tests/test_training/test_model_learning/test_control_evaluation.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_control_evaluation.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the control-performance curve and its comparison harness.
+
+The curve is the only thing that answers whether the fitting loop is working, so
+the ways it can be silently wrong all matter. Its x-axis has to be the data
+spent, or two methods are compared at different budgets. Its spread has to be
+across repetitions, or it answers a question nobody asked. Its reported round
+has to be the best of the sequence, because that is what the guarantee covers
+and the sequence is not monotone.
+
+The harness has one job beyond looping: refusing configurations that still
+produce a plot. A baseline built with planner rollouts is a second iterative run
+under another name, and unpaired seeds leave the methods' difference tangled
+with the draw of start states.
+"""
+
+from pathlib import Path
+from typing import Any, List, Sequence
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.training.model_learning import (
+    ControlPoint,
+    DAggerModelTrainer,
+    LearningCurve,
+    LinearGaussianLearner,
+    TransitionDataset,
+    aggregate_curves,
+    best_point,
+    curves_by_method,
+    evaluate_control,
+    load_learning_curves,
+    run_learning_curves,
+    save_learning_curves,
+)
+
+PRESETS = np.array([[1.0], [-1.0], [0.0]])
+
+
+class _LinearWorld:
+    """A tiny world the loop can be driven against without a simulator."""
+
+    def __init__(self, seed: int = 0) -> None:
+        self._rng = np.random.default_rng(seed)
+
+    def initial_state_dist(self) -> Any:
+        class _Dist:
+            def sample(self, num_samples: int = 1) -> np.ndarray:
+                del num_samples
+                return np.zeros(2)
+
+        return _Dist()
+
+    def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> np.ndarray:
+        state_vector = np.asarray(state, dtype=float).ravel()
+        action_vector = np.asarray(action, dtype=float).ravel()
+        mean = 0.9 * state_vector + np.array([action_vector[0], 0.5 * action_vector[0]])
+        draws = mean + self._rng.normal(scale=0.02, size=(n_samples, 2))
+        return draws[0] if n_samples == 1 else draws
+
+    def is_terminal(self, state: Any) -> bool:
+        del state
+        return False
+
+
+def _planner_rollouts(model: Any, round_index: int, num_episodes: int) -> List[Any]:
+    """Stand-in for running a planner against the fitted model."""
+    del model, round_index
+    rng = np.random.default_rng(0)
+    episodes = []
+    for _ in range(num_episodes):
+        states = rng.normal(size=(6, 2))
+        actions = PRESETS[rng.integers(len(PRESETS), size=6)]
+        episodes.append((states, actions, states + 0.1))
+    return episodes
+
+
+def _returns_by_round(model: Any, round_index: int, num_episodes: int) -> List[float]:
+    """A stand-in evaluator whose return improves with the round, deterministically."""
+    del model
+    return [float(round_index) + 0.1 * index for index in range(num_episodes)]
+
+
+def _trainer(
+    method: str,
+    seed: int,
+    evaluation_fn: Any = _returns_by_round,
+    planner_rollout_fn: Any = _planner_rollouts,
+) -> DAggerModelTrainer:
+    """Build a small trainer, with the planner half switched off for ``batch``."""
+    return DAggerModelTrainer(
+        world=_LinearWorld(seed=seed),
+        learner=LinearGaussianLearner(),
+        dataset=TransitionDataset(seed=seed),
+        action_presets=PRESETS,
+        planner_rollout_fn=None if method == "batch" else planner_rollout_fn,
+        evaluation_fn=evaluation_fn,
+        evaluation_episodes=3,
+        num_rounds=2,
+        episodes_per_round=6,
+        steps_per_episode=6,
+        hold_steps=2,
+        horizon=3,
+        seed=seed,
+    )
+
+
+def test_a_point_carries_the_data_it_cost_not_just_the_round() -> None:
+    """The x-axis is transitions; comparing methods by round compares budgets."""
+    point = evaluate_control(
+        model=object(),
+        evaluation_fn=_returns_by_round,
+        round_index=2,
+        cumulative_transitions=140,
+        num_episodes=3,
+    )
+    assert point.round_index == 2
+    assert point.cumulative_transitions == 140
+    assert point.mean_return == pytest.approx(2.1)
+
+
+def test_evaluate_control_rejects_a_non_positive_episode_count() -> None:
+    with pytest.raises(ValueError, match="num_episodes must be positive"):
+        evaluate_control(
+            model=object(),
+            evaluation_fn=_returns_by_round,
+            round_index=1,
+            cumulative_transitions=0,
+            num_episodes=0,
+        )
+
+
+def test_each_round_records_what_the_planner_scored_in_the_true_world() -> None:
+    """The loop's own numbers describe the model; this one describes the decision."""
+    trainer = _trainer("dagger", seed=0)
+    rounds = trainer.run()
+
+    assert [result.control.round_index for result in rounds] == [1, 2]
+    assert all(result.control.cumulative_transitions == result.dataset_size for result in rounds)
+    assert rounds[1].control.mean_return > rounds[0].control.mean_return
+
+
+def test_no_evaluation_function_leaves_the_curve_empty_rather_than_nan() -> None:
+    """An unevaluated run must not produce a plottable but meaningless curve."""
+    trainer = _trainer("dagger", seed=0, evaluation_fn=None)
+    rounds = trainer.run()
+
+    assert all(result.control is None for result in rounds)
+    assert trainer.learning_curve("dagger").points == ()
+
+
+def test_the_reported_round_is_the_best_of_the_sequence_not_the_last() -> None:
+    """The guarantee covers the best model in the sequence, and it is not monotone."""
+    curve = LearningCurve(
+        method="dagger",
+        seed=0,
+        points=(
+            ControlPoint(1, 100, (1.0, 1.0)),
+            ControlPoint(2, 200, (5.0, 5.0)),
+            ControlPoint(3, 300, (2.0, 2.0)),
+        ),
+    )
+    chosen = best_point(curve)
+    assert chosen is not None
+    assert chosen.round_index == 2
+
+
+def test_best_point_is_none_when_nothing_was_evaluated() -> None:
+    assert best_point(LearningCurve(method="dagger", seed=0, points=())) is None
+
+
+def test_the_band_is_the_spread_across_seeds_not_across_episodes() -> None:
+    """Episode spread says how noisy one run was; seed spread says the methods differed."""
+    # Each seed is internally noisy but the two seed means are 1.0 and 3.0, so a
+    # band computed across episodes would be wide and one across seeds is 1.0.
+    curves = [
+        LearningCurve("dagger", 0, (ControlPoint(1, 100, (-9.0, 11.0)),)),
+        LearningCurve("dagger", 1, (ControlPoint(1, 100, (-7.0, 13.0)),)),
+    ]
+    aggregated = aggregate_curves(curves)
+
+    assert aggregated.num_seeds == 2
+    assert aggregated.mean_returns[0] == pytest.approx(2.0)
+    assert aggregated.standard_errors[0] == pytest.approx(1.0)
+
+
+def test_aggregation_truncates_to_the_shortest_run() -> None:
+    """A run that stopped early must not silently extend the others' average."""
+    curves = [
+        LearningCurve("dagger", 0, (ControlPoint(1, 100, (1.0,)), ControlPoint(2, 200, (2.0,)))),
+        LearningCurve("dagger", 1, (ControlPoint(1, 100, (3.0,)),)),
+    ]
+    assert len(aggregate_curves(curves).mean_returns) == 1
+
+
+def test_aggregation_refuses_to_mix_methods() -> None:
+    curves = [
+        LearningCurve("dagger", 0, (ControlPoint(1, 100, (1.0,)),)),
+        LearningCurve("batch", 0, (ControlPoint(1, 100, (2.0,)),)),
+    ]
+    with pytest.raises(ValueError, match="expects one method"):
+        aggregate_curves(curves)
+
+
+def test_aggregation_refuses_an_empty_set() -> None:
+    with pytest.raises(ValueError, match="at least one curve"):
+        aggregate_curves([])
+
+
+def test_both_methods_run_on_every_seed() -> None:
+    """The paper gives all approaches the same seeds; unpaired draws hide the effect."""
+    seeds = [0, 1]
+    curves = run_learning_curves(trainer_factory=_trainer, seeds=seeds)
+
+    grouped = curves_by_method(curves)
+    assert sorted(grouped) == ["batch", "dagger"]
+    for method_curves in grouped.values():
+        assert [curve.seed for curve in method_curves] == seeds
+        assert all(len(curve.points) == 2 for curve in method_curves)
+
+
+def test_a_baseline_built_with_planner_rollouts_is_rejected() -> None:
+    """It would be a second iterative run under another name, and the gap would vanish."""
+
+    def factory(method: str, seed: int) -> DAggerModelTrainer:
+        del method
+        return _trainer("dagger", seed)
+
+    with pytest.raises(ValueError, match="must be built with planner_rollout_fn=None"):
+        run_learning_curves(trainer_factory=factory, seeds=[0], methods=["batch"])
+
+
+def test_a_trainer_built_on_the_wrong_seed_is_rejected() -> None:
+    """Unpaired seeds leave the method difference tangled with the start-state draw."""
+
+    def factory(method: str, seed: int) -> DAggerModelTrainer:
+        del seed
+        return _trainer(method, seed=99)
+
+    with pytest.raises(ValueError, match="the comparison must be paired"):
+        run_learning_curves(trainer_factory=factory, seeds=[0], methods=["dagger"])
+
+
+def test_a_trainer_with_no_evaluator_is_rejected() -> None:
+    """It would run the full cost of the loop and contribute nothing to the plot."""
+
+    def factory(method: str, seed: int) -> DAggerModelTrainer:
+        return _trainer(method, seed, evaluation_fn=None)
+
+    with pytest.raises(ValueError, match="has no evaluation_fn"):
+        run_learning_curves(trainer_factory=factory, seeds=[0], methods=["dagger"])
+
+
+def test_run_learning_curves_needs_seeds_and_methods() -> None:
+    with pytest.raises(ValueError, match="at least one seed"):
+        run_learning_curves(trainer_factory=_trainer, seeds=[])
+    with pytest.raises(ValueError, match="at least one method"):
+        run_learning_curves(trainer_factory=_trainer, seeds=[0], methods=[])
+
+
+def test_curves_survive_a_round_trip_through_json(tmp_path: Path) -> None:
+    """The plot must be regenerable without paying for the episodes again."""
+    curves = [
+        LearningCurve("dagger", 0, (ControlPoint(1, 100, (1.0, 2.0)),)),
+        LearningCurve("batch", 0, (ControlPoint(1, 100, (0.5,)),)),
+    ]
+    path = save_learning_curves(curves, tmp_path / "curves.json")
+
+    assert load_learning_curves(path) == curves
+
+
+def test_the_trainer_labels_its_curve_with_its_own_seed() -> None:
+    """Aggregation pairs methods by seed, so a curve that forgets it cannot be paired."""
+    trainer = _trainer("batch", seed=7)
+    trainer.run()
+    assert trainer.learning_curve("batch").seed == 7
+
+
+def test_evaluation_episodes_must_be_positive_when_an_evaluator_is_given() -> None:
+    with pytest.raises(ValueError, match="evaluation_episodes must be positive"):
+        DAggerModelTrainer(
+            world=_LinearWorld(),
+            learner=LinearGaussianLearner(),
+            dataset=TransitionDataset(),
+            action_presets=PRESETS,
+            evaluation_fn=_returns_by_round,
+            evaluation_episodes=0,
+        )
+
+
+def test_the_plot_writes_a_file_and_skips_an_empty_comparison(tmp_path: Path) -> None:
+    """Guards the one import that crosses into the visualization layer."""
+    from POMDPPlanners.utils.visualization.model_learning_plots import plot_learning_curves
+
+    curves = [
+        LearningCurve("dagger", seed, (ControlPoint(1, 100, (1.0,)), ControlPoint(2, 200, (2.0,))))
+        for seed in (0, 1)
+    ]
+    written = plot_learning_curves(curves, tmp_path / "curve.png", baseline_return=0.5)
+    assert written is not None and written.exists()
+
+    empty: Sequence[LearningCurve] = [LearningCurve("dagger", 0, ())]
+    assert plot_learning_curves(empty, tmp_path / "empty.png") is None

--- a/POMDPPlanners/training/model_learning/__init__.py
+++ b/POMDPPlanners/training/model_learning/__init__.py
@@ -19,6 +19,13 @@ details that decide whether the loop works, and
 :mod:`~POMDPPlanners.training.model_learning.diagnostics` for why held-out
 prediction error alone will not tell you whether a model is worth planning with.
 
+None of those diagnostics is the measure the algorithm is judged by. That is the
+return of the planner searching each round's model in the true world, against
+the data that round cost, with the non-iterative baseline drawn on the same
+axes -- see
+:mod:`~POMDPPlanners.training.model_learning.control_evaluation` and
+:mod:`~POMDPPlanners.training.model_learning.curve_comparison`.
+
 Classes:
     TransitionDataset: Transitions accumulated across rounds, sliced to named channels.
     TransitionBatch: States, actions and next states as parallel arrays.
@@ -29,13 +36,38 @@ Classes:
     GaussianMLP: One ensemble member.
     DAggerModelTrainer: The round loop.
     RoundResult: What one round produced.
+    ControlPoint: One round's return, with the data it cost.
+    LearningCurve: One method's points for one seed.
+    AggregatedCurve: A method's curve averaged across seeds.
 
 Functions:
     block_indices: Flat indices of named channels in a schema.
     collect_random_preset_episode: One held-random-action exploration rollout.
     evaluate_model: The three diagnostics for a fitted model.
+    evaluate_control: Score one round's model by running the planner with it.
+    aggregate_curves: Average one method's curves across seeds.
+    best_point: The round a curve should be reported at.
+    run_learning_curves: Run every method at every seed and collect the curves.
+    curves_by_method: Group curves by method name.
+    save_learning_curves: Write curves to JSON.
+    load_learning_curves: Read curves back.
 """
 
+from POMDPPlanners.training.model_learning.control_evaluation import (
+    AggregatedCurve,
+    ControlPoint,
+    LearningCurve,
+    aggregate_curves,
+    best_point,
+    evaluate_control,
+    load_learning_curves,
+    save_learning_curves,
+)
+from POMDPPlanners.training.model_learning.curve_comparison import (
+    DEFAULT_METHODS,
+    curves_by_method,
+    run_learning_curves,
+)
 from POMDPPlanners.training.model_learning.dagger_trainer import (
     DAggerModelTrainer,
     RoundResult,
@@ -65,8 +97,12 @@ from POMDPPlanners.training.model_learning.transition_dataset import (
 )
 
 __all__ = [
+    "DEFAULT_METHODS",
+    "AggregatedCurve",
+    "ControlPoint",
     "DAggerModelTrainer",
     "GaussianMLP",
+    "LearningCurve",
     "LinearGaussianLearner",
     "ProbabilisticEnsembleLearner",
     "ProbabilisticEnsembleTransition",
@@ -74,9 +110,16 @@ __all__ = [
     "TransitionBatch",
     "TransitionDataset",
     "TransitionModelLearner",
+    "aggregate_curves",
+    "best_point",
     "block_indices",
     "collect_random_preset_episode",
+    "curves_by_method",
+    "evaluate_control",
     "evaluate_model",
+    "load_learning_curves",
+    "run_learning_curves",
+    "save_learning_curves",
     "held_out_log_likelihood",
     "horizon_drift_ratio",
     "preset_ranking_agreement",

--- a/POMDPPlanners/training/model_learning/control_evaluation.py
+++ b/POMDPPlanners/training/model_learning/control_evaluation.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: MIT
+
+"""The number the algorithm is actually judged on: return of the planner using the model.
+
+The diagnostics in :mod:`~POMDPPlanners.training.model_learning.diagnostics`
+describe the model. This describes the *decision*. Ross & Bagnell (ICML 2012)
+report nothing else: every figure in the paper is average total cost of the
+controller synthesized from the round-k model, against transitions collected so
+far, and no curve of prediction error appears anywhere. That is deliberate --
+their whole argument is that a model can have small training error and poor
+control performance, so measuring the model cannot settle the question the
+algorithm asks.
+
+Three things make the curve mean something, and each is easy to leave out.
+
+**A baseline on the same seeds.** A single rising curve says only that more data
+helps, which is not in dispute. The paper's result is the *gap* between
+iterating and not: DAgger against Batch, both collecting the same amount of
+data, differing only in where it came from. Batch here is the same loop with the
+planner half switched off, so every other detail is held fixed by construction
+rather than by care.
+
+**Several seeds, shared across methods.** The paper uses 20 repetitions and
+gives all approaches the same 20. Sharing them removes the draw of start states
+from the comparison; without it a gap of one standard error is unreadable.
+
+**The best round, not the last.** The guarantee is on the best model of the
+sequence or a mixture of them. Reporting the final round's return silently
+reports a different quantity than the one the theory bounds, and one that can be
+worse -- the sequence is not monotone.
+
+The x-axis is cumulative transitions rather than round index, because rounds of
+two methods are not the same amount of data and comparing them by index compares
+different budgets.
+
+Classes:
+    ControlPoint: One round's return, with the data it cost.
+    LearningCurve: One method's points for one seed.
+    AggregatedCurve: A method's curve averaged across seeds.
+
+Functions:
+    evaluate_control: Run the evaluation rollouts and build a point.
+    aggregate_curves: Average one method's curves across seeds.
+    best_point: The round a curve should be reported at.
+    save_learning_curves: Write curves to JSON.
+    load_learning_curves: Read curves back.
+"""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class ControlPoint:
+    """One round's closed-loop performance, and what it cost to get there.
+
+    Attributes:
+        round_index: 1-based round the model came from.
+        cumulative_transitions: Transitions the fit had seen, across all rounds.
+            This is the x-axis: it is comparable between methods in a way the
+            round index is not.
+        returns: Per-episode return of the planner searching this round's model
+            in the true world. Kept in full rather than reduced, so a later
+            aggregation can pool episodes instead of averaging averages.
+    """
+
+    round_index: int
+    cumulative_transitions: int
+    returns: Tuple[float, ...]
+
+    @property
+    def mean_return(self) -> float:
+        """Mean return across the evaluation episodes, or ``nan`` if there were none."""
+        return float(np.mean(self.returns)) if self.returns else float("nan")
+
+    @property
+    def standard_error(self) -> float:
+        """Standard error of the mean across episodes, or ``nan`` below two episodes."""
+        if len(self.returns) < 2:
+            return float("nan")
+        return float(np.std(self.returns, ddof=1) / np.sqrt(len(self.returns)))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-serializable view of the point."""
+        return {
+            "round_index": self.round_index,
+            "cumulative_transitions": self.cumulative_transitions,
+            "returns": list(self.returns),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ControlPoint":
+        """Rebuild a point from :meth:`to_dict` output."""
+        return cls(
+            round_index=int(data["round_index"]),
+            cumulative_transitions=int(data["cumulative_transitions"]),
+            returns=tuple(float(value) for value in data["returns"]),
+        )
+
+
+@dataclass(frozen=True)
+class LearningCurve:
+    """One method's per-round performance for one seed.
+
+    Attributes:
+        method: Name of the method the curve belongs to, e.g. ``"dagger"``.
+        seed: The repetition's seed. Two methods compared at the same seed saw
+            the same draws, which is what makes their difference readable.
+        points: One point per round, in round order.
+    """
+
+    method: str
+    seed: int
+    points: Tuple[ControlPoint, ...]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-serializable view of the curve."""
+        return {
+            "method": self.method,
+            "seed": self.seed,
+            "points": [point.to_dict() for point in self.points],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "LearningCurve":
+        """Rebuild a curve from :meth:`to_dict` output."""
+        return cls(
+            method=str(data["method"]),
+            seed=int(data["seed"]),
+            points=tuple(ControlPoint.from_dict(point) for point in data["points"]),
+        )
+
+
+@dataclass(frozen=True)
+class AggregatedCurve:
+    """One method's curve averaged across seeds, ready to plot.
+
+    Attributes:
+        method: The method these seeds ran.
+        num_seeds: Repetitions averaged at each round.
+        cumulative_transitions: Mean transitions at each round. Methods can
+            differ slightly here because episodes end at different lengths, which
+            is why the axis is plotted rather than assumed shared.
+        mean_returns: Mean across seeds of each seed's mean return.
+        standard_errors: Standard error across seeds. This is the interval that
+            answers "did the methods really differ", so it is across
+            repetitions, not across the episodes inside one.
+    """
+
+    method: str
+    num_seeds: int
+    cumulative_transitions: Tuple[float, ...]
+    mean_returns: Tuple[float, ...]
+    standard_errors: Tuple[float, ...]
+
+
+def evaluate_control(
+    model: Any,
+    evaluation_fn: Callable[[Any, int, int], Sequence[float]],
+    round_index: int,
+    cumulative_transitions: int,
+    num_episodes: int,
+) -> ControlPoint:
+    """Run the evaluation rollouts for one round's model and record the returns.
+
+    The rollouts are the caller's business -- which planner, what budget, what
+    device -- for the same reason the training rollouts are: the loop should not
+    decide how a planner is run. All this adds is the bookkeeping that makes one
+    round's number comparable to another's.
+
+    Args:
+        model: The round's fitted transition, which the planner searches.
+        evaluation_fn: Called as ``fn(model, round_index, num_episodes)`` and
+            expected to run the planner against ``model`` in the *true* world,
+            returning one return per episode. Evaluating in the model would
+            measure the model's opinion of itself.
+        round_index: 1-based round the model came from.
+        cumulative_transitions: Transitions the fit had seen by this round.
+        num_episodes: Evaluation episodes to request.
+
+    Returns:
+        The round's point.
+
+    Raises:
+        ValueError: If ``num_episodes`` is not positive.
+    """
+    if num_episodes <= 0:
+        raise ValueError(f"num_episodes must be positive, got {num_episodes}")
+    returns = tuple(float(value) for value in evaluation_fn(model, round_index, num_episodes))
+    return ControlPoint(
+        round_index=round_index,
+        cumulative_transitions=int(cumulative_transitions),
+        returns=returns,
+    )
+
+
+def aggregate_curves(curves: Sequence[LearningCurve]) -> AggregatedCurve:
+    """Average one method's curves across seeds, round by round.
+
+    Each seed contributes its own mean return, and the spread reported is across
+    those -- not across the episodes within a seed. A method can be very
+    consistent inside one repetition and swing wildly between them, and it is
+    the second number that decides whether a gap between methods is real.
+
+    Args:
+        curves: Curves for a single method, one per seed.
+
+    Returns:
+        The averaged curve, truncated to the shortest curve's number of rounds.
+
+    Raises:
+        ValueError: If ``curves`` is empty or mixes methods.
+    """
+    if not curves:
+        raise ValueError("aggregate_curves needs at least one curve")
+    methods = {curve.method for curve in curves}
+    if len(methods) != 1:
+        raise ValueError(f"aggregate_curves expects one method, got {sorted(methods)}")
+
+    num_rounds = min(len(curve.points) for curve in curves)
+    transitions: List[float] = []
+    means: List[float] = []
+    errors: List[float] = []
+    for index in range(num_rounds):
+        per_seed = [curve.points[index] for curve in curves]
+        seed_means = [point.mean_return for point in per_seed]
+        transitions.append(float(np.mean([point.cumulative_transitions for point in per_seed])))
+        means.append(float(np.mean(seed_means)))
+        errors.append(
+            float(np.std(seed_means, ddof=1) / np.sqrt(len(seed_means)))
+            if len(seed_means) > 1
+            else float("nan")
+        )
+    return AggregatedCurve(
+        method=curves[0].method,
+        num_seeds=len(curves),
+        cumulative_transitions=tuple(transitions),
+        mean_returns=tuple(means),
+        standard_errors=tuple(errors),
+    )
+
+
+def best_point(curve: LearningCurve) -> Optional[ControlPoint]:
+    """The round with the highest mean return -- the one the guarantee is about.
+
+    The bound covers the best model of the sequence, not the final one, and the
+    sequence is not monotone: a round can be worse than the one before it and the
+    loop still be working. Reporting the last round instead is the quiet way to
+    report a different, smaller quantity.
+
+    Args:
+        curve: One seed's curve.
+
+    Returns:
+        The best point, or ``None`` if the curve has no points with a return.
+    """
+    scored = [point for point in curve.points if not np.isnan(point.mean_return)]
+    if not scored:
+        return None
+    return max(scored, key=lambda point: point.mean_return)
+
+
+def save_learning_curves(curves: Sequence[LearningCurve], path: Path) -> Path:
+    """Write curves to JSON so a plot can be regenerated without re-running.
+
+    Args:
+        curves: The curves to store, across methods and seeds.
+        path: Destination file. Parent directories are created.
+
+    Returns:
+        The path written.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps([curve.to_dict() for curve in curves], indent=2), encoding="utf-8")
+    return path
+
+
+def load_learning_curves(path: Path) -> List[LearningCurve]:
+    """Read curves written by :func:`save_learning_curves`.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        The stored curves, in the order written.
+    """
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return [LearningCurve.from_dict(entry) for entry in data]

--- a/POMDPPlanners/training/model_learning/curve_comparison.py
+++ b/POMDPPlanners/training/model_learning/curve_comparison.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MIT
+
+"""Running the iterative loop against its baseline, on the same seeds.
+
+A learning curve on its own establishes that more data helps, which nobody
+doubts. The claim in Ross & Bagnell (ICML 2012) is comparative: collecting under
+the learner's own policy beats collecting from a fixed exploration distribution,
+at equal data. Their figures carry two families of lines for exactly that
+reason, and the paper's robustness claim -- DAgger wins for *every* exploration
+distribution, Batch only for one -- is only visible because both were run.
+
+The baseline is not a separate implementation. ``Batch`` is this package's own
+loop with ``planner_rollout_fn`` set to ``None``: same collector, same fit, same
+aggregation, differing only in where the rows came from. Reimplementing it would
+put an unrelated set of choices on the other side of the comparison and quietly
+attribute their effect to the algorithm.
+
+Two mistakes this module exists to prevent, both of which produce a plausible
+plot:
+
+**The baseline getting on-policy data.** A ``batch`` trainer built with a
+planner rollout function is not the baseline -- it is a second DAgger run under
+a different name, and the gap collapses for a reason that has nothing to do with
+the algorithm. The configuration is checked rather than trusted.
+
+**Methods running on different seeds.** The paper gives all approaches the same
+20 seeds. Independent draws leave the difference between methods entangled with
+the difference between start states, and at these episode counts that noise is
+comparable to the effect. The seed is passed in here, not chosen per method.
+
+Functions:
+    run_learning_curves: Run every method at every seed and collect the curves.
+    curves_by_method: Group a flat list of curves by their method name.
+"""
+
+from typing import Any, Callable, Dict, List, Sequence
+
+from POMDPPlanners.training.model_learning.control_evaluation import LearningCurve
+from POMDPPlanners.training.model_learning.dagger_trainer import DAggerModelTrainer
+from POMDPPlanners.utils.logger import get_logger
+
+#: The iterative method and the baseline it has to beat, in plot order.
+DEFAULT_METHODS = ("dagger", "batch")
+
+#: Method name whose trainer must have no planner rollouts -- see the module
+#: docstring on what a mislabelled baseline does to the comparison.
+BATCH_METHOD = "batch"
+
+
+def run_learning_curves(
+    trainer_factory: Callable[[str, int], DAggerModelTrainer],
+    seeds: Sequence[int],
+    methods: Sequence[str] = DEFAULT_METHODS,
+    logger: Any = None,
+) -> List[LearningCurve]:
+    """Run each method at each seed and return one curve per pair.
+
+    Args:
+        trainer_factory: Called as ``fn(method, seed)`` and expected to return a
+            freshly built :class:`DAggerModelTrainer` -- fresh because a dataset
+            or learner reused across runs carries the previous run's data into
+            the next one. The factory owns the difference between the methods:
+            for ``"batch"`` it must pass ``planner_rollout_fn=None``. Every
+            trainer must be given an ``evaluation_fn``, or there is no curve to
+            collect.
+        seeds: Repetition seeds, used for *every* method so the comparison is
+            paired. The paper uses 20.
+        methods: Method names to run.
+        logger: Optional logger.
+
+    Returns:
+        One curve per ``(method, seed)``, flat, in method-then-seed order.
+
+    Raises:
+        ValueError: If ``seeds`` or ``methods`` is empty, if a trainer's seed
+            does not match the one requested, if the batch trainer was given
+            planner rollouts, or if a trainer has no ``evaluation_fn``.
+    """
+    if not seeds:
+        raise ValueError("run_learning_curves needs at least one seed")
+    if not methods:
+        raise ValueError("run_learning_curves needs at least one method")
+    log = logger or get_logger(__name__)
+
+    curves: List[LearningCurve] = []
+    for method in methods:
+        for seed in seeds:
+            trainer = trainer_factory(method, seed)
+            _check_trainer(trainer, method, seed)
+            log.info("learning curve: method %s, seed %d", method, seed)
+            trainer.run()
+            curves.append(trainer.learning_curve(method))
+    return curves
+
+
+def curves_by_method(curves: Sequence[LearningCurve]) -> Dict[str, List[LearningCurve]]:
+    """Group curves by method name, keeping each method's seed order.
+
+    Args:
+        curves: Curves across methods and seeds.
+
+    Returns:
+        Method name to its curves.
+    """
+    grouped: Dict[str, List[LearningCurve]] = {}
+    for curve in curves:
+        grouped.setdefault(curve.method, []).append(curve)
+    return grouped
+
+
+def _check_trainer(trainer: DAggerModelTrainer, method: str, seed: int) -> None:
+    """Fail loudly on the two misconfigurations that still produce a plot."""
+    if trainer.seed != seed:
+        raise ValueError(
+            f"trainer for method {method!r} was built with seed {trainer.seed}, "
+            f"but seed {seed} was requested; the comparison must be paired"
+        )
+    if trainer.evaluation_fn is None:
+        raise ValueError(
+            f"trainer for method {method!r} at seed {seed} has no evaluation_fn, "
+            "so it records no control performance and contributes no curve"
+        )
+    if method == BATCH_METHOD and trainer.planner_rollout_fn is not None:
+        raise ValueError(
+            f"the {BATCH_METHOD!r} baseline must be built with planner_rollout_fn=None; "
+            "with planner rollouts it is a second iterative run, not a baseline"
+        )

--- a/POMDPPlanners/training/model_learning/dagger_trainer.py
+++ b/POMDPPlanners/training/model_learning/dagger_trainer.py
@@ -28,6 +28,13 @@ a sequence of unrelated fits that can oscillate.
 their mixture -- not on the last one. Keeping only the final model discards the
 object the theory is about.
 
+Supply ``evaluation_fn`` and each round also records what the planner actually
+scored in the true world with that round's model. That is the only quantity the
+paper reports, and the only one that settles whether the loop is working -- see
+:mod:`~POMDPPlanners.training.model_learning.control_evaluation`. It costs
+episodes, so it is opt-in, but a run without it cannot answer the question it
+was started to ask.
+
 Two things the loop deliberately does not do. It does not learn the reward: the
 objective is our design, not a fact about the world, and holding it fixed is what
 makes a model comparison about dynamics. And it does not claim its guarantee
@@ -45,6 +52,11 @@ from typing import Any, Callable, Dict, List, Optional, Sequence
 import numpy as np
 
 from POMDPPlanners.core.environment import TransitionModel
+from POMDPPlanners.training.model_learning.control_evaluation import (
+    ControlPoint,
+    LearningCurve,
+    evaluate_control,
+)
 from POMDPPlanners.training.model_learning.diagnostics import evaluate_model
 from POMDPPlanners.training.model_learning.exploration import (
     DEFAULT_HOLD_STEPS,
@@ -71,6 +83,10 @@ class RoundResult:
         source_counts: Transitions contributed by each source, cumulative.
         training_metrics: Per-epoch training metrics from the fit.
         diagnostics: Held-out diagnostics for this round's model.
+        control: What the planner scored in the true world with this round's
+            model, or ``None`` when no ``evaluation_fn`` was supplied. This is
+            the quantity the algorithm is judged on; the diagnostics beside it
+            describe the model rather than the decision.
     """
 
     round_index: int
@@ -79,6 +95,7 @@ class RoundResult:
     source_counts: Dict[str, int] = field(default_factory=dict)
     training_metrics: Dict[str, List[float]] = field(default_factory=dict)
     diagnostics: Dict[str, float] = field(default_factory=dict)
+    control: Optional[ControlPoint] = None
 
 
 class DAggerModelTrainer:
@@ -107,7 +124,15 @@ class DAggerModelTrainer:
             Injected rather than built here because how a planner is run --
             budget, parallelism, caching -- is the caller's business. ``None``
             skips the on-policy half, which makes the loop a plain batch fit and
-            forfeits the guarantee; useful only for testing the plumbing.
+            forfeits the guarantee. That is the paper's ``Batch`` baseline, and
+            the thing an iterative run has to beat, so it is a supported
+            configuration rather than only a plumbing test.
+        evaluation_fn: Called as ``fn(model, round_index, num_episodes)`` after
+            each fit, and expected to run the planner against that round's model
+            in the *true* world, returning one return per episode. ``None``
+            records no control performance, which leaves only model-quality
+            numbers and cannot show whether the loop is working.
+        evaluation_episodes: Episodes requested from ``evaluation_fn`` each round.
         initial_model: The model round 1's planner searches. Supplying the
             calibrated analytic model starts the loop warm, so no round is spent
             with the planner driving a model fitted on nothing.
@@ -146,6 +171,8 @@ class DAggerModelTrainer:
         action_presets: Any,
         diagnostics_world: Optional[Any] = None,
         planner_rollout_fn: Optional[Callable[[TransitionModel, int, int], Sequence[Any]]] = None,
+        evaluation_fn: Optional[Callable[[TransitionModel, int, int], Sequence[float]]] = None,
+        evaluation_episodes: int = 20,
         initial_model: Optional[TransitionModel] = None,
         num_rounds: int = 5,
         episodes_per_round: int = 40,
@@ -160,12 +187,18 @@ class DAggerModelTrainer:
             raise ValueError(f"num_rounds must be positive, got {num_rounds}")
         if episodes_per_round <= 0:
             raise ValueError(f"episodes_per_round must be positive, got {episodes_per_round}")
+        if evaluation_fn is not None and evaluation_episodes <= 0:
+            raise ValueError(
+                f"evaluation_episodes must be positive, got {evaluation_episodes}"
+            )
         self.world = world
         self.diagnostics_world = world if diagnostics_world is None else diagnostics_world
         self.learner = learner
         self.dataset = dataset
         self.action_presets = np.asarray(action_presets, dtype=float)
         self.planner_rollout_fn = planner_rollout_fn
+        self.evaluation_fn = evaluation_fn
+        self.evaluation_episodes = evaluation_episodes
         self.initial_model = initial_model
         self.num_rounds = num_rounds
         self.episodes_per_round = episodes_per_round
@@ -213,17 +246,50 @@ class DAggerModelTrainer:
                     reward_model=self.reward_model,
                     seed=self.seed + round_index,
                 ),
+                control=self._evaluate_control(current_model, round_index),
             )
             self._rounds.append(result)
             self._logger.info(
-                "round %d/%d: %d transitions (%s), %s",
+                "round %d/%d: %d transitions (%s), %s, return %s",
                 round_index,
                 self.num_rounds,
                 result.dataset_size,
                 result.source_counts,
                 result.diagnostics,
+                "n/a" if result.control is None else f"{result.control.mean_return:.3f}",
             )
         return self.rounds
+
+    def learning_curve(self, method: str) -> LearningCurve:
+        """The rounds that were evaluated, as a curve ready to aggregate or plot.
+
+        Args:
+            method: Name to label the curve with, e.g. ``"dagger"`` or ``"batch"``.
+
+        Returns:
+            One point per evaluated round. Rounds with no control evaluation are
+            left out rather than filled with ``nan``, so an unevaluated run gives
+            an empty curve instead of a plottable but meaningless one.
+        """
+        return LearningCurve(
+            method=method,
+            seed=self.seed,
+            points=tuple(result.control for result in self._rounds if result.control is not None),
+        )
+
+    def _evaluate_control(
+        self, model: TransitionModel, round_index: int
+    ) -> Optional[ControlPoint]:
+        """Score this round's model in the true world, if an evaluator was given."""
+        if self.evaluation_fn is None:
+            return None
+        return evaluate_control(
+            model=model,
+            evaluation_fn=self.evaluation_fn,
+            round_index=round_index,
+            cumulative_transitions=len(self.dataset),
+            num_episodes=self.evaluation_episodes,
+        )
 
     def _split(self, round_index: int, model: Optional[TransitionModel]) -> Any:
         """Collect this round's two halves.

--- a/POMDPPlanners/utils/visualization/model_learning_plots.py
+++ b/POMDPPlanners/utils/visualization/model_learning_plots.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+
+"""The learning curve a model-fitting run is judged by.
+
+One plot: return of the planner searching each round's model, against the
+transitions that round cost, one line per method, averaged over shared seeds.
+It is the figure Ross & Bagnell (ICML 2012) report and the only thing that
+answers whether iterating on the data collection was worth it.
+
+Three choices in here are the plot rather than decoration.
+
+**The x-axis is transitions, not rounds.** Two methods' rounds are not the same
+amount of data, so a round-indexed plot compares different budgets and flatters
+whichever collects more per round.
+
+**The band is across seeds.** Spread across the episodes inside one repetition
+says how noisy an evaluation was; spread across repetitions says whether the
+methods actually differed. Only the second belongs next to a claim.
+
+**A reference line for the starting model.** Without it a curve that rises says
+nothing about whether the fitted models ever beat the hand-built one they
+started from, which is usually the decision being made.
+
+Unlike its neighbours this module is not re-exported from the package's
+``__init__``. That import is eager, so exporting it would make every importer of
+``utils.visualization`` -- including ones with no interest in model fitting --
+pull in the training layer, and would leave a cycle waiting for the first time
+training wants a plot. Import it by module path.
+
+Functions:
+    plot_learning_curves: Return against data, one line per method.
+"""
+
+import logging
+from pathlib import Path
+from typing import Dict, Optional, Sequence
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+
+from POMDPPlanners.training.model_learning.control_evaluation import (
+    AggregatedCurve,
+    LearningCurve,
+    aggregate_curves,
+)
+
+matplotlib.use("Agg")  # Use non-interactive backend
+
+logger = logging.getLogger(__name__)
+
+# Enough distinct colors for the method families a comparison plausibly carries;
+# beyond this the lines stop being separable and the plot should be split.
+_METHOD_COLORS = ("tab:blue", "tab:orange", "tab:green", "tab:red", "tab:purple")
+
+
+def plot_learning_curves(
+    curves: Sequence[LearningCurve],
+    output_path: Path,
+    baseline_return: Optional[float] = None,
+    baseline_label: str = "initial model",
+    log_scale: bool = False,
+    title: str = "Control performance vs collected data",
+) -> Optional[Path]:
+    """Plot mean return against cumulative transitions, one line per method.
+
+    Args:
+        curves: Curves across methods and seeds, as returned by
+            :func:`~POMDPPlanners.training.model_learning.curve_comparison.run_learning_curves`.
+            Curves sharing a method are averaged together.
+        output_path: Where to write the PNG.
+        baseline_return: Return of the model the loop started from, drawn as a
+            horizontal reference. ``None`` omits it.
+        baseline_label: Label for that reference line.
+        log_scale: Log-scale the y-axis. The paper does, because its quantity is
+            a cost spanning five orders of magnitude; a bounded return usually
+            reads better linear, so this is off by default.
+        title: Plot title.
+
+    Returns:
+        The written path, or ``None`` if no curve had any points.
+    """
+    grouped: Dict[str, list] = {}
+    for curve in curves:
+        if curve.points:
+            grouped.setdefault(curve.method, []).append(curve)
+    if not grouped:
+        logger.warning("plot_learning_curves: no evaluated rounds to plot")
+        return None
+
+    fig, axis = plt.subplots(figsize=(9, 5))
+    for index, (method, method_curves) in enumerate(sorted(grouped.items())):
+        aggregated = aggregate_curves(method_curves)
+        _draw(axis, aggregated, _METHOD_COLORS[index % len(_METHOD_COLORS)])
+
+    if baseline_return is not None:
+        axis.axhline(
+            baseline_return,
+            color="black",
+            linestyle="--",
+            linewidth=1.5,
+            label=baseline_label,
+        )
+
+    if log_scale:
+        axis.set_yscale("log")
+    axis.set_xlabel("Transitions collected")
+    axis.set_ylabel("Mean return of the planner in the true world")
+    axis.set_title(title)
+    axis.grid(True, alpha=0.3)
+    axis.legend()
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+    return output_path
+
+
+def _draw(axis, curve: AggregatedCurve, color: str) -> None:
+    """One method's mean line, with a band of one standard error across seeds."""
+    transitions = np.asarray(curve.cumulative_transitions, dtype=float)
+    means = np.asarray(curve.mean_returns, dtype=float)
+    errors = np.asarray(curve.standard_errors, dtype=float)
+    axis.plot(
+        transitions,
+        means,
+        color=color,
+        linewidth=2,
+        marker="o",
+        markersize=4,
+        label=f"{curve.method} ({curve.num_seeds} seeds)",
+    )
+    if np.isfinite(errors).any():
+        band = np.nan_to_num(errors, nan=0.0)
+        axis.fill_between(transitions, means - band, means + band, color=color, alpha=0.2)


### PR DESCRIPTION
> **Stacked on #246.** This branch is cut from `feat/batched-transition-and-reward`, so until #246 merges the diff against `develop` also shows its commit. Review `b0a66e18` alone, and merge this after #246.

## Why

`model_learning` reported three numbers about the fitted model — held-out log-likelihood, horizon drift over claimed noise, preset-ranking agreement — and none about the decision the model exists to make.

The paper the package implements reports the opposite. Every figure in Ross & Bagnell (ICML 2012) is *average total cost of the controller synthesized from the round-k model*, plotted against *transitions collected so far*, averaged over 20 shared seeds. No curve of prediction error appears anywhere in it. That is not an oversight — it is the paper's argument. A model can have small training error and poor control performance, because the policy that comes out of it visits states the training data never covered. Measuring the model cannot settle the question the algorithm asks.

So a run of this package could not answer whether the loop was working.

## What changed

Each round can now score its own model by running the planner with it in the true world, and the rounds become a curve.

```python
trainer = DAggerModelTrainer(
    ...,
    evaluation_fn=lambda model, round_index, n: run_planner_episodes(model, n),
    evaluation_episodes=20,
)
trainer.run()
curve = trainer.learning_curve("dagger")
```

| | before | after |
|---|---|---|
| `RoundResult.diagnostics` | 3 model-quality numbers | unchanged |
| `RoundResult.control` | — | returns of the planner using this round's model |
| comparison against a baseline | — | `run_learning_curves` over shared seeds |
| plot | — | `plot_learning_curves` |

`evaluation_fn` is optional and off by default. It costs episodes, and it is the caller's business how a planner is run — same reasoning as the existing `planner_rollout_fn`.

## The four decisions that are the point

**The x-axis is cumulative transitions, not round index.** DAgger and Batch rounds are not the same amount of data. A round-indexed plot compares different budgets and flatters whichever method collects more per round.

**Batch is this loop with `planner_rollout_fn=None`.** Not a reimplementation. Same collector, same fit, same aggregation, differing only in where the rows came from. A separate implementation would put an unrelated set of choices on the other side of the comparison and attribute their effect to the algorithm.

**The band is across seeds, not across episodes.** Spread over the episodes inside one repetition says how noisy that evaluation was. Spread over repetitions says whether the methods actually differed. Only the second belongs next to a claim, and at realistic episode counts they are very different numbers.

**`best_point` reports the best round, not the last.** The bound covers the best model of the sequence or a mixture; the sequence is not monotone. Reporting the final round quietly reports a different, smaller quantity.

## What the harness refuses

Three misconfigurations, each of which still produces a plausible-looking plot — which is why they are checked and not documented:

- a `"batch"` trainer built **with** planner rollouts. It is a second DAgger run under another name; the gap collapses for a reason unrelated to the algorithm.
- a trainer whose seed differs from the one requested. Unpaired seeds leave the difference between methods tangled with the draw of start states.
- a trainer with no `evaluation_fn`. It pays the full cost of the loop and contributes nothing to the plot.

An unevaluated run yields an **empty** curve rather than one padded with `nan`, so it cannot be plotted by accident.

## Layering

`utils/visualization/model_learning_plots.py` is deliberately **not** re-exported from `utils/visualization/__init__.py`. That import is eager, so exporting it would make every importer of `utils.visualization` pull in the training layer, and would leave a cycle waiting for the first time training wants a plot. Import it by module path. The one test that touches it imports it inside the test for the same reason.

## Testing

**Not run.** No Python environment on this machine has numpy or pytest, and the remote host was unreachable (`ubuntu64.nord` does not resolve — VPN down). The files byte-compile; nothing beyond that is verified. 18 tests are added in `tests/test_training/test_model_learning/test_control_evaluation.py` and need a run of pytest, pylint and pyright before this merges.

## Next

The curve makes one thing measurable that the paper cannot tell us: whether `preset_ranking_agreement` predicts control performance on these environments. If it does, tuning can use the cheap metric instead of full evaluations.

https://claude.ai/code/session_01AtKrDxoPDQwUkkhBzRwPdX
