### PR TITLE
feat(training): save every fitted model and record model learning in MLflow

### DIFF
--- a/POMDPPlanners/core/environment/transition_model.py
+++ b/POMDPPlanners/core/environment/transition_model.py
@@ -26,7 +26,7 @@ Classes:
 """
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Optional
 
 import numpy as np
 
@@ -69,6 +69,21 @@ class TransitionModel(ABC):
         Returns:
             A ``(n,)`` array of log-densities.
         """
+
+    @property
+    def fingerprint(self) -> Optional[str]:
+        """Hash of the fitted parameters, or ``None`` when there are none to hash.
+
+        An environment holds its transition privately, and ``config_id`` skips
+        private attributes, so nothing about a *fitted* transition reaches the
+        simulation cache key on its own: two rounds of a fitting loop look like
+        the same experiment and the second is served the first's episodes. A
+        transition with fitted parameters overrides this to report them.
+
+        ``None`` -- the default -- says the transition is analytic and its
+        configuration is already covered by the environment holding it.
+        """
+        return None
 
 
 class RewardModel(ABC):

--- a/POMDPPlanners/environments/isaac_lab_pomdp/isaac_generative_models/isaac_factored_model.py
+++ b/POMDPPlanners/environments/isaac_lab_pomdp/isaac_generative_models/isaac_factored_model.py
@@ -141,6 +141,14 @@ class FactoredIsaacModelPOMDP(IsaacModelPOMDP):
             name=name,
         )
         self._transition = transition
+        # config_id skips private attributes, so a fitted transition -- which is
+        # private, like every other -- would leave the key identical across
+        # refits and the simulation cache would serve round n-1's episodes for
+        # round n. A transition that has fitted parameters reports a fingerprint
+        # over them; an analytic one has none, and its key is unchanged.
+        fingerprint = getattr(transition, "fingerprint", None)
+        if fingerprint is not None:
+            self.transition_fingerprint = str(fingerprint)
         self._reward_model = reward_model
         self.transition_channels = (
             tuple(transition_channels) if transition_channels is not None else None

--- a/POMDPPlanners/environments/isaac_lab_pomdp/isaac_lab_model_pomdp.py
+++ b/POMDPPlanners/environments/isaac_lab_pomdp/isaac_lab_model_pomdp.py
@@ -62,8 +62,10 @@ Classes:
     IsaacLabModelPOMDP: Discrete-action generative model POMCPOW searches inside.
 """
 
+import hashlib
 import math
 from collections.abc import Hashable
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import numpy as np
@@ -296,10 +298,9 @@ class LinearGaussianTransition(TransitionModel):
         self._bias = np.asarray(bias, dtype=float).reshape(-1)
         self.dim = self._weight_state.shape[0]
         self.action_dim = self._weight_action.shape[1]
-        self._normal = CovarianceParameterizedMultivariateNormal(
-            np.asarray(covariance, dtype=float)
-        )
-        self._batched = _BatchedGaussian(np.asarray(covariance, dtype=float))
+        self._covariance = np.asarray(covariance, dtype=float)
+        self._normal = CovarianceParameterizedMultivariateNormal(self._covariance)
+        self._batched = _BatchedGaussian(self._covariance)
         self._params = BackendParameters(
             weight_state=self._weight_state,
             weight_action=self._weight_action,
@@ -371,6 +372,67 @@ class LinearGaussianTransition(TransitionModel):
         means, _ = self._mean_rows(state, action)
         candidates, _ = as_rows(as_backend(next_states, means), self.dim)
         return self._batched.log_pdf(means, candidates)
+
+    @property
+    def fingerprint(self) -> str:
+        """Hash of the fitted parameters -- two different fits never share one.
+
+        The model that plans with a transition holds it privately, and an
+        environment's ``config_id`` skips private attributes, so a refitted
+        transition leaves the cache key untouched and the next run is served the
+        previous fit's episodes. An environment planning with a fitted
+        transition exposes this string to move the key with the parameters.
+
+        Returns:
+            A hex digest over ``A``, ``B``, ``b`` and the residual covariance.
+        """
+        digest = hashlib.sha256(type(self).__name__.encode())
+        for parameter in (
+            self._weight_state,
+            self._weight_action,
+            self._bias,
+            self._covariance,
+        ):
+            digest.update(np.asarray(parameter, dtype=float).tobytes())
+        return digest.hexdigest()
+
+    def save(self, path: Union[str, Path]) -> Path:
+        """Write the fitted parameters to one ``.npz`` file.
+
+        Args:
+            path: Destination file. Parent directories are created.
+
+        Returns:
+            The path written.
+        """
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        np.savez(
+            path,
+            weight_state=self._weight_state,
+            weight_action=self._weight_action,
+            bias=self._bias,
+            covariance=self._covariance,
+        )
+        return path
+
+    @classmethod
+    def load(cls, path: Union[str, Path]) -> "LinearGaussianTransition":
+        """Rebuild a transition written by :meth:`save`.
+
+        Args:
+            path: File written by :meth:`save`.
+
+        Returns:
+            The transition.
+        """
+        with np.load(Path(path)) as payload:
+            return cls(
+                weight_state=payload["weight_state"],
+                weight_action=payload["weight_action"],
+                bias=payload["bias"],
+                covariance=payload["covariance"],
+            )
 
     @classmethod
     def fit(

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
@@ -681,6 +681,102 @@ class TestReadableReports:
         }
 
 
+class TestDirectoryLayout:
+    """One level per question: a run owns its rounds, the study owns the comparison."""
+
+    def test_a_run_directory_holds_its_rounds_models_and_plots(self, tmp_path) -> None:
+        """Purpose: Validates that one run is readable on its own
+
+        Given: A run's rounds and the model files it saved
+        When: Its directory is written
+        Then: The tables, the per-round models under readable names, and the
+            plots are all there, so nobody has to open MLflow's hashed tree
+        """
+        from POMDPPlanners.training.model_learning import write_run_directory
+
+        model_file = tmp_path / "staged.pt"
+        _ensemble().save(model_file)
+        rounds = [
+            RoundResult(
+                round_index=index,
+                model=_ensemble(seed=index),
+                dataset_size=100 * index,
+                source_counts={"exploration": 100 * index},
+                training_metrics={"train_nll": [3.0, 2.0], "holdout_nll": [3.1, 2.2]},
+                diagnostics={"held_out_log_likelihood": 2.0, "horizon_drift_ratio": 0.9},
+                control=ControlPoint(index, 100 * index, (-1.0, -2.0)),
+            )
+            for index in (1, 2)
+        ]
+
+        run_dir = tmp_path / "runs" / "dagger_seed0"
+        write_run_directory(rounds, run_dir, models={1: model_file, 2: model_file})
+
+        assert (run_dir / "summary.md").exists()
+        assert (run_dir / "rounds.csv").exists()
+        assert (run_dir / "rounds.json").exists()
+        assert {path.name for path in (run_dir / "models").glob("*")} == {
+            "round_1.pt",
+            "round_2.pt",
+        }
+        assert (run_dir / "plots" / "training_curves.png").exists()
+
+    def test_the_study_level_holds_only_what_compares_runs(self, tmp_path) -> None:
+        """Purpose: Validates that a single run's rounds are not published as the study's
+
+        Given: Curves for two methods
+        When: The study directory is written
+        Then: It holds the method comparison, the curve and a README naming the
+            run directories -- and no rounds table, which belongs to one run
+        """
+        from POMDPPlanners.training.model_learning import write_study_directory
+
+        curves = [
+            LearningCurve(method, 0, (ControlPoint(1, 100, (-1.0, -2.0)),))
+            for method in ("dagger", "batch")
+        ]
+
+        write_study_directory(
+            curves,
+            tmp_path,
+            params={"environment": "FrankaReachFragile"},
+            run_dirs={"dagger seed 0": Path("runs/dagger_seed0")},
+        )
+
+        summary = (tmp_path / "summary.md").read_text(encoding="utf-8")
+        assert "| Method | Seed |" in summary
+        assert "Best holdout epoch" not in summary
+        readme = (tmp_path / "README.md").read_text(encoding="utf-8")
+        assert "runs/dagger_seed0" in readme
+        assert "FrankaReachFragile" in readme
+
+    def test_the_tracker_points_at_the_models_it_saved(self, tmp_path) -> None:
+        """Purpose: Validates that a study can find the saved models to copy
+
+        Given: A tracker with one logged round on a local store
+        When: Its artifact directory is read
+        Then: The round's model file is there under the round's index
+        """
+        pytest.importorskip("mlflow")
+        from POMDPPlanners.training.model_learning import (
+            MLflowModelLearningTracker,
+            load_round_models,
+        )
+
+        tracker = MLflowModelLearningTracker(
+            experiment_name="model_learning_test",
+            method="dagger",
+            seed=5,
+            tracking_uri=f"file://{tmp_path / 'mlruns'}",
+        )
+        tracker.log_round(_round(1))
+        artifacts = tracker.artifact_dir
+        tracker.finish()
+
+        assert artifacts is not None
+        assert set(load_round_models(artifacts)) == {1}
+
+
 class TestCurveSummaries:
     """The one table to read first."""
 

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for saving a fitted model and recording a run.
+
+The property under test for persistence is that a reloaded model *is* the model:
+same predictions, same density, same sampling stream. A round trip that keeps
+the weights and drops the normalization statistics reloads without error and
+predicts nonsense, so "it loaded" is not the assertion.
+
+For the fingerprint the property is that it moves with the parameters and
+reaches the environment's ``config_id``. That is what stops the simulation cache
+from serving round n-1's episodes for round n -- a failure that looks like a flat
+learning curve rather than like an error.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, List
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.isaac_lab_pomdp.isaac_generative_models import (
+    FactoredIsaacModelPOMDP,
+    IsaacChannelSchema,
+)
+from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_model_pomdp import (
+    LinearGaussianTransition,
+)
+from POMDPPlanners.training.model_learning import (
+    ControlPoint,
+    LearningCurve,
+    LinearGaussianLearner,
+    ProbabilisticEnsembleLearner,
+    RoundResult,
+    TransitionDataset,
+    curve_summaries,
+)
+
+def _artifact_dir(run: Any) -> Path:
+    """Local artifact directory of an MLflow run."""
+    return Path(run.info.artifact_uri.replace("file://", ""))
+
+
+SCHEMA = IsaacChannelSchema((("robot", 2), ("hazard_type", 2)))
+PRESETS = [np.array([1.0]), np.array([-1.0])]
+
+
+def _rollouts(num_rows: int, seed: int = 0):
+    """Rollouts from a known linear-Gaussian system."""
+    rng = np.random.default_rng(seed)
+    states = rng.normal(size=(num_rows, 2))
+    actions = rng.normal(size=(num_rows, 1))
+    next_states = (
+        states @ np.array([[0.9, 0.1], [0.0, 0.95]]).T
+        + actions @ np.array([[0.5], [0.2]]).T
+        + rng.normal(scale=0.05, size=(num_rows, 2))
+    )
+    return states, actions, next_states
+
+
+def _dataset(num_rows: int = 400, seed: int = 0) -> TransitionDataset:
+    states, actions, next_states = _rollouts(num_rows, seed)
+    dataset = TransitionDataset(holdout_fraction=0.25, seed=seed + 1)
+    for start in range(0, num_rows, 50):
+        dataset.add_episode(
+            states[start : start + 50],
+            actions[start : start + 50],
+            next_states[start : start + 50],
+            source="exploration",
+        )
+    return dataset
+
+
+def _ensemble(seed: int = 0):
+    return ProbabilisticEnsembleLearner(num_members=2, epochs=3, seed=seed).fit(_dataset(seed=seed))
+
+
+class TestEnsemblePersistence:
+    """Round-tripping a fitted ensemble through a file."""
+
+    def test_a_reloaded_ensemble_predicts_the_same_density(self, tmp_path) -> None:
+        """Purpose: Validates that a saved model reloads as the same model
+
+        Given: A fitted ensemble saved to disk
+        When: It is loaded back and asked for the density of the same candidates
+        Then: The log-densities match the original's exactly, so the reload kept
+            the normalization statistics and not only the weights
+        """
+        from POMDPPlanners.training.model_learning import ProbabilisticEnsembleTransition
+
+        model = _ensemble()
+        state = np.array([0.3, -0.2])
+        action = np.array([1.0])
+        candidates = np.array([[0.25, -0.15], [1.0, 1.0]])
+        expected = model.log_probability(state, action, candidates)
+
+        reloaded = ProbabilisticEnsembleTransition.load(model.save(tmp_path / "round_1.pt"))
+
+        assert np.allclose(reloaded.log_probability(state, action, candidates), expected)
+
+    def test_a_reloaded_ensemble_continues_the_same_sampling_stream(self, tmp_path) -> None:
+        """Purpose: Validates that the sampler's state survives the round trip
+
+        Given: A fitted ensemble saved after some draws have been taken
+        When: The original and the reloaded model each draw again
+        Then: They draw the same successors, so a reloaded model reproduces the
+            run it was scored in rather than restarting its stream
+        """
+        from POMDPPlanners.training.model_learning import ProbabilisticEnsembleTransition
+
+        model = _ensemble()
+        state = np.array([0.3, -0.2])
+        action = np.array([1.0])
+        model.sample_next_state(state, action, n_samples=4)
+
+        reloaded = ProbabilisticEnsembleTransition.load(model.save(tmp_path / "round_1.pt"))
+
+        assert np.allclose(
+            reloaded.sample_next_state(state, action, n_samples=4),
+            model.sample_next_state(state, action, n_samples=4),
+        )
+
+    def test_two_fits_do_not_share_a_fingerprint(self) -> None:
+        """Purpose: Validates that the fingerprint tracks the fitted parameters
+
+        Given: Two ensembles fitted from different seeds, and one fit read twice
+        When: Their fingerprints are compared
+        Then: The two fits differ and the repeated read is stable, which is what
+            a cache key needs from it
+        """
+        first = _ensemble(seed=0)
+        second = _ensemble(seed=1)
+
+        assert first.fingerprint != second.fingerprint
+        assert first.fingerprint == first.fingerprint
+
+
+class TestLinearPersistence:
+    """The floor baseline saves and loads too, or it cannot be compared to."""
+
+    def test_a_reloaded_linear_transition_predicts_the_same_density(self, tmp_path) -> None:
+        """Purpose: Validates the linear model's round trip
+
+        Given: A fitted linear-Gaussian transition saved to disk
+        When: It is loaded back
+        Then: It reports the same log-density as the original
+        """
+        model = LinearGaussianLearner().fit(_dataset())
+        state = np.array([0.3, -0.2])
+        action = np.array([1.0])
+        candidates = np.array([[0.25, -0.15], [1.0, 1.0]])
+        expected = model.log_probability(state, action, candidates)
+
+        reloaded = LinearGaussianTransition.load(model.save(tmp_path / "round_1.npz"))
+
+        assert np.allclose(reloaded.log_probability(state, action, candidates), expected)
+
+    def test_a_refit_moves_the_fingerprint(self) -> None:
+        """Purpose: Validates that the linear fit's fingerprint tracks its parameters
+
+        Given: Two linear fits of different data
+        When: Their fingerprints are compared
+        Then: They differ
+        """
+        first = LinearGaussianLearner().fit(_dataset(seed=0))
+        second = LinearGaussianLearner().fit(_dataset(seed=5))
+
+        assert first.fingerprint != second.fingerprint
+
+
+class TestFittedTransitionReachesTheCacheKey:
+    """The reason the fingerprint exists: ``config_id`` must move with the fit."""
+
+    @staticmethod
+    def _model(transition: Any) -> FactoredIsaacModelPOMDP:
+        return FactoredIsaacModelPOMDP(
+            state_schema=SCHEMA,
+            action_presets=PRESETS,
+            discount_factor=0.99,
+            transition=transition,
+            transition_channels=("robot",),
+        )
+
+    def test_two_rounds_of_a_fit_are_not_the_same_experiment(self) -> None:
+        """Purpose: Validates that a refitted transition changes the environment's config_id
+
+        Given: Two environments identical but for the fitted transition they plan with
+        When: Their config_ids are compared
+        Then: They differ, so the simulation cache cannot serve one round's
+            episodes as the next round's
+        """
+        first = self._model(LinearGaussianLearner().fit(_dataset(seed=0)))
+        second = self._model(LinearGaussianLearner().fit(_dataset(seed=5)))
+
+        assert first.config_id != second.config_id
+
+    def test_an_analytic_transition_leaves_the_key_alone(self) -> None:
+        """Purpose: Validates that envs without a fitted transition keep their key
+
+        Given: An environment whose transition reports no fingerprint
+        When: Its config_id is taken twice, from two equal instances
+        Then: They agree, so adding the fingerprint did not invalidate the cache
+            of every analytic environment
+        """
+
+        class _Analytic:
+            def sample_next_state(self, state, action, n_samples=1):
+                del action, n_samples
+                return np.asarray(state, dtype=float)
+
+        assert self._model(_Analytic()).config_id == self._model(_Analytic()).config_id
+
+
+class _RecordingTracker:
+    """A tracker that keeps what it was handed, so the trainer's calls are visible."""
+
+    def __init__(self) -> None:
+        self.rounds: List[Any] = []
+        self.curves: List[LearningCurve] = []
+
+    def log_round(self, result: Any) -> None:
+        self.rounds.append(result)
+
+    def log_curve(self, curve: LearningCurve) -> None:
+        self.curves.append(curve)
+
+
+class TestTrainerCallsTheTracker:
+    """The loop must hand every round over as it goes, not at the end."""
+
+    def test_every_round_is_recorded_with_its_own_model(self) -> None:
+        """Purpose: Validates that the trainer reports each round to the tracker
+
+        Given: A two-round loop with a recording tracker
+        When: The loop runs
+        Then: Two rounds were recorded, each carrying its own fitted model, so a
+            tracker can save the whole sequence rather than the last round
+        """
+        from POMDPPlanners.training.model_learning import DAggerModelTrainer
+
+        class _World:
+            def initial_state_dist(self):
+                class _Dist:
+                    def sample(self, num_samples: int = 1):
+                        del num_samples
+                        return np.zeros(2)
+
+                return _Dist()
+
+            def sample_next_state(self, state, action, n_samples: int = 1):
+                vector = np.asarray(state, dtype=float).reshape(-1)
+                return vector * 0.9 + np.asarray(action, dtype=float).reshape(-1)[0] * 0.1
+
+            def is_terminal(self, state) -> bool:
+                del state
+                return False
+
+        tracker = _RecordingTracker()
+        trainer = DAggerModelTrainer(
+            world=_World(),
+            learner=LinearGaussianLearner(),
+            dataset=TransitionDataset(holdout_fraction=0.25, seed=1),
+            action_presets=np.array([[1.0], [-1.0]]),
+            planner_rollout_fn=None,
+            num_rounds=2,
+            episodes_per_round=6,
+            steps_per_episode=20,
+            horizon=5,
+            tracker=tracker,
+            seed=0,
+        )
+        rounds = trainer.run()
+
+        assert [result.round_index for result in tracker.rounds] == [1, 2]
+        assert [result.model for result in tracker.rounds] == [r.model for r in rounds]
+
+
+class TestMLflowTracker:
+    """What lands in MLflow, checked against a local file store."""
+
+    def test_a_round_logs_its_metrics_and_its_model(self, tmp_path) -> None:
+        """Purpose: Validates that a round's numbers and model both reach MLflow
+
+        Given: A tracker pointed at a local MLflow store and one round's result
+        When: The round and the curve are logged
+        Then: The run holds the round's return and diagnostics as metrics, and
+            the fitted model as an artifact that loads back
+        """
+        mlflow = pytest.importorskip("mlflow")
+        from POMDPPlanners.training.model_learning import (
+            MLflowModelLearningTracker,
+            ProbabilisticEnsembleTransition,
+            load_round_models,
+        )
+
+        model = _ensemble()
+        result = RoundResult(
+            round_index=1,
+            model=model,
+            dataset_size=120,
+            source_counts={"exploration": 60, "planner": 60},
+            training_metrics={"train_nll": [3.0, 1.5]},
+            diagnostics={"held_out_log_likelihood": 2.5, "horizon_drift_ratio": 0.8},
+            control=ControlPoint(round_index=1, cumulative_transitions=120, returns=(-1.0, -1.4)),
+        )
+        curve = LearningCurve(method="dagger", seed=0, points=(result.control,))
+
+        tracker = MLflowModelLearningTracker(
+            experiment_name="model_learning_test",
+            method="dagger",
+            seed=0,
+            params={"environment": "unit_test"},
+            tracking_uri=f"file://{tmp_path / 'mlruns'}",
+        )
+        tracker.log_round(result)
+        run_id = tracker._run.info.run_id  # pylint: disable=protected-access
+        tracker.log_curve(curve)
+
+        run = mlflow.tracking.MlflowClient(tracking_uri=f"file://{tmp_path / 'mlruns'}").get_run(
+            run_id
+        )
+        assert run.data.metrics["mean_return"] == pytest.approx(-1.2)
+        assert run.data.metrics["horizon_drift_ratio"] == pytest.approx(0.8)
+        assert run.data.metrics["best_round_index"] == pytest.approx(1.0)
+        assert run.data.params["method"] == "dagger"
+
+        saved = load_round_models(_artifact_dir(run))
+        assert set(saved) == {1}
+        reloaded = ProbabilisticEnsembleTransition.load(saved[1])
+        state, action = np.array([0.3, -0.2]), np.array([1.0])
+        assert np.allclose(
+            reloaded.log_probability(state, action, np.array([[0.25, -0.15]])),
+            model.log_probability(state, action, np.array([[0.25, -0.15]])),
+        )
+
+    def test_the_per_round_record_names_the_model_of_each_round(self, tmp_path) -> None:
+        """Purpose: Validates that the run keeps the fit-to-number link
+
+        Given: Two rounds logged with different fitted models
+        When: The run's rounds.json is read
+        Then: Each round names its own model artifact and fingerprint, so a
+            control number can be traced to the parameters that produced it
+        """
+        pytest.importorskip("mlflow")
+        from POMDPPlanners.training.model_learning import MLflowModelLearningTracker
+
+        tracker = MLflowModelLearningTracker(
+            experiment_name="model_learning_test",
+            method="dagger",
+            seed=1,
+            tracking_uri=f"file://{tmp_path / 'mlruns'}",
+        )
+        for index, seed in enumerate((0, 1), start=1):
+            tracker.log_round(
+                RoundResult(
+                    round_index=index,
+                    model=_ensemble(seed=seed),
+                    dataset_size=60 * index,
+                    source_counts={"exploration": 60 * index},
+                    training_metrics={},
+                    diagnostics={"held_out_log_likelihood": 1.0},
+                    control=None,
+                )
+            )
+        run = tracker._run  # pylint: disable=protected-access
+        tracker.finish()
+
+        record = json.loads(
+            (_artifact_dir(run) / "evaluation" / "rounds.json").read_text(encoding="utf-8")
+        )
+        assert [entry["round_index"] for entry in record] == [1, 2]
+        assert record[0]["model_fingerprint"] != record[1]["model_fingerprint"]
+        assert record[0]["model_artifact"] == "models/round_1.pt"
+
+
+class TestCurveSummaries:
+    """The one table to read first."""
+
+    def test_the_summary_reports_the_best_round_not_the_last(self) -> None:
+        """Purpose: Validates that the summary picks the round the guarantee covers
+
+        Given: A curve whose second round is worse than its first
+        When: The summary is taken
+        Then: It reports round 1, because the sequence is not monotone and the
+            bound is on the best model of it
+        """
+        curve = LearningCurve(
+            method="dagger",
+            seed=0,
+            points=(
+                ControlPoint(round_index=1, cumulative_transitions=60, returns=(-1.0, -1.0)),
+                ControlPoint(round_index=2, cumulative_transitions=120, returns=(-4.0, -4.0)),
+            ),
+        )
+
+        summary = curve_summaries([curve])["dagger_0"]
+
+        assert summary["best_round_index"] == 1.0
+        assert summary["mean_return"] == pytest.approx(-1.0)

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
@@ -575,6 +575,112 @@ class TestTrainingPlots:
         }
 
 
+class TestReadableReports:
+    """A run has to be readable without opening JSON."""
+
+    @staticmethod
+    def _rounds():
+        return [
+            {
+                "round_index": index,
+                "dataset_size": 100 * index,
+                "source_counts": {"exploration": 100, "planner": 50 * (index - 1)},
+                "diagnostics": {
+                    "held_out_log_likelihood": 40.0,
+                    "horizon_drift_ratio": 0.5 if index == 1 else 1.8,
+                },
+                "training_metrics": {"holdout_nll": [5.0, 3.0, 4.0]},
+                "model_artifact": f"models/round_{index}.pt",
+                "control": {
+                    "round_index": index,
+                    "cumulative_transitions": 100 * index,
+                    "returns": [-4.0 + index, -3.0 + index],
+                },
+            }
+            for index in (1, 2)
+        ]
+
+    def test_the_table_marks_the_best_round_and_flags_overconfidence(self) -> None:
+        """Purpose: Validates that the table carries the two judgements a reader needs
+
+        Given: Two rounds, the second better but with a drift ratio above one
+        When: The Markdown table is rendered
+        Then: The second round is marked best and its drift ratio is flagged, so
+            neither "report the last round" nor "a confident wrong model" passes
+            unnoticed
+        """
+        from POMDPPlanners.training.model_learning import round_table_markdown
+
+        table = round_table_markdown(self._rounds())
+
+        best_line = [line for line in table.splitlines() if "**(best)**" in line]
+        assert len(best_line) == 1
+        assert best_line[0].startswith("| 2")
+        assert "⚠" in best_line[0]
+
+    def test_the_csv_has_one_row_per_round(self) -> None:
+        """Purpose: Validates that the same rows are available for a spreadsheet
+
+        Given: Two rounds
+        When: The CSV is rendered
+        Then: It has a header and one row per round, with the round's cost and return
+        """
+        from POMDPPlanners.training.model_learning import round_table_csv
+
+        lines = round_table_csv(self._rounds()).strip().splitlines()
+
+        assert lines[0].startswith("round,transitions")
+        assert len(lines) == 3
+
+    def test_write_reports_puts_both_files_beside_the_json(self, tmp_path) -> None:
+        """Purpose: Validates the reports a run writes for a person
+
+        Given: Rounds and a method's curve
+        When: The reports are written
+        Then: A summary Markdown and a rounds CSV exist, and the summary names
+            the method
+        """
+        from POMDPPlanners.training.model_learning import write_reports
+
+        curve = LearningCurve(
+            method="dagger",
+            seed=0,
+            points=(ControlPoint(round_index=1, cumulative_transitions=100, returns=(-1.0, -2.0)),),
+        )
+
+        written = write_reports(self._rounds(), tmp_path, curves=[curve])
+
+        assert set(written) == {"summary", "rounds_csv"}
+        assert "dagger" in written["summary"].read_text(encoding="utf-8")
+
+    def test_a_tracked_run_logs_the_tables(self, tmp_path) -> None:
+        """Purpose: Validates that the tables reach MLflow with the JSON
+
+        Given: A tracker with one logged round
+        When: The run is finished
+        Then: summary.md and rounds.csv sit beside rounds.json in the artifacts
+        """
+        pytest.importorskip("mlflow")
+        from POMDPPlanners.training.model_learning import MLflowModelLearningTracker
+
+        tracker = MLflowModelLearningTracker(
+            experiment_name="model_learning_test",
+            method="dagger",
+            seed=4,
+            tracking_uri=f"file://{tmp_path / 'mlruns'}",
+        )
+        tracker.log_round(_round(1))
+        run = tracker._run  # pylint: disable=protected-access
+        tracker.finish()
+
+        evaluation = _artifact_dir(run) / "evaluation"
+        assert {path.name for path in evaluation.glob("*")} >= {
+            "rounds.json",
+            "summary.md",
+            "rounds.csv",
+        }
+
+
 class TestCurveSummaries:
     """The one table to read first."""
 

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
@@ -72,6 +72,19 @@ def _dataset(num_rows: int = 400, seed: int = 0) -> TransitionDataset:
     return dataset
 
 
+def _round(round_index: int, seed: int = 0) -> RoundResult:
+    """One round's result, with a model of its own."""
+    return RoundResult(
+        round_index=round_index,
+        model=_ensemble(seed=seed + round_index),
+        dataset_size=60 * round_index,
+        source_counts={"exploration": 60 * round_index},
+        training_metrics={},
+        diagnostics={"held_out_log_likelihood": 1.0},
+        control=None,
+    )
+
+
 def _ensemble(seed: int = 0):
     return ProbabilisticEnsembleLearner(num_members=2, epochs=3, seed=seed).fit(_dataset(seed=seed))
 
@@ -372,6 +385,47 @@ class TestMLflowTracker:
         assert [entry["round_index"] for entry in record] == [1, 2]
         assert record[0]["model_fingerprint"] != record[1]["model_fingerprint"]
         assert record[0]["model_artifact"] == "models/round_1.pt"
+
+
+class TestTrackingSurvivesTheSimulator:
+    """The rollouts being evaluated log to MLflow too, and they move the global state."""
+
+    def test_a_hijacked_active_run_does_not_split_the_study(self, tmp_path) -> None:
+        """Purpose: Validates that the tracker keeps its run when another component takes over
+
+        Given: A round logged, then MLflow's tracking URI switched and its active
+            run ended -- what LocalSimulationsAPI does on every rollout batch
+        When: A second round is logged
+        Then: Both rounds are in the same run, rather than round two landing in
+            whichever store the rollouts happened to be writing to
+        """
+        mlflow = pytest.importorskip("mlflow")
+        from POMDPPlanners.training.model_learning import MLflowModelLearningTracker
+
+        tracking_uri = f"file://{tmp_path / 'mlruns'}"
+        tracker = MLflowModelLearningTracker(
+            experiment_name="model_learning_test",
+            method="dagger",
+            seed=2,
+            tracking_uri=tracking_uri,
+        )
+        tracker.log_round(_round(1))
+        run_id = tracker._run.info.run_id  # pylint: disable=protected-access
+
+        mlflow.set_tracking_uri(f"file://{tmp_path / 'other_mlruns'}")
+        mlflow.set_experiment("someone_elses_experiment")
+        mlflow.start_run()
+        mlflow.end_run()
+
+        tracker.log_round(_round(2))
+        tracker.finish()
+
+        run = mlflow.tracking.MlflowClient(tracking_uri=tracking_uri).get_run(run_id)
+        assert run.data.metrics["dataset_size"] == pytest.approx(120.0)
+        record = json.loads(
+            (_artifact_dir(run) / "evaluation" / "rounds.json").read_text(encoding="utf-8")
+        )
+        assert [entry["round_index"] for entry in record] == [1, 2]
 
 
 class TestCurveSummaries:

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
@@ -428,6 +428,146 @@ class TestTrackingSurvivesTheSimulator:
         assert [entry["round_index"] for entry in record] == [1, 2]
 
 
+class TestTrainingCurves:
+    """The ensemble is a network, so the fit needs its own curves."""
+
+    def test_the_fit_records_a_train_and_a_holdout_curve_per_epoch(self) -> None:
+        """Purpose: Validates that the ensemble reports what its training did
+
+        Given: An ensemble fitted for a known number of epochs on a dataset with
+            a holdout split
+        When: The training metrics are read
+        Then: Both the training and the held-out loss have one value per epoch,
+            so overfitting is visible rather than inferred
+        """
+        learner = ProbabilisticEnsembleLearner(num_members=2, epochs=4, seed=0)
+        learner.fit(_dataset())
+
+        metrics = learner.training_metrics()
+
+        assert len(metrics["train_nll"]) == 4
+        assert len(metrics["holdout_nll"]) == 4
+
+    def test_every_member_keeps_its_own_curve(self) -> None:
+        """Purpose: Validates that a diverged member is not hidden by the mean
+
+        Given: A three-member ensemble
+        When: The training metrics are read
+        Then: There is one curve per member beside the mean, because the
+            ensemble's spread is its uncertainty estimate and one failed member
+            corrupts it invisibly
+        """
+        learner = ProbabilisticEnsembleLearner(num_members=3, epochs=2, seed=0)
+        learner.fit(_dataset())
+
+        metrics = learner.training_metrics()
+
+        members = [key for key in metrics if key.startswith("train_nll_member_")]
+        assert len(members) == 3
+
+    def test_a_dataset_with_no_holdout_still_fits(self) -> None:
+        """Purpose: Validates that the holdout curve is optional, not required
+
+        Given: A dataset that holds nothing back
+        When: An ensemble is fitted
+        Then: The fit succeeds and reports a training curve with no holdout one
+        """
+        dataset = TransitionDataset(holdout_fraction=0.0, seed=0)
+        states, actions, next_states = _rollouts(200)
+        dataset.add_episode(states, actions, next_states, source="exploration")
+
+        learner = ProbabilisticEnsembleLearner(num_members=2, epochs=2, seed=0)
+        learner.fit(dataset)
+
+        assert "holdout_nll" not in learner.training_metrics()
+
+
+class TestTrainingPlots:
+    """The plots must be drawable from a finished run, not only from live objects."""
+
+    def test_the_plots_are_written_from_the_tracker_records(self, tmp_path) -> None:
+        """Purpose: Validates that a run's JSON record is enough to redraw the fit
+
+        Given: Per-round records in the shape the tracker writes to rounds.json
+        When: The report is drawn
+        Then: The training, per-member and diagnostic plots are all written, so
+            a study can be re-read without re-fitting anything
+        """
+        from POMDPPlanners.utils.visualization.model_learning_plots import (
+            plot_model_learning_report,
+        )
+
+        rounds = [
+            {
+                "round_index": index,
+                "diagnostics": {"held_out_log_likelihood": 1.0 * index, "horizon_drift_ratio": 1.4},
+                "training_metrics": {
+                    "train_nll": [3.0, 2.0, 1.5],
+                    "holdout_nll": [3.1, 2.4, 2.6],
+                    "train_nll_member_0": [3.0, 2.1, 1.6],
+                    "train_nll_member_1": [3.0, 1.9, 1.4],
+                },
+            }
+            for index in (1, 2)
+        ]
+
+        written = plot_model_learning_report(rounds, tmp_path / "plots")
+
+        assert set(written) == {"training_curves", "member_training_curves", "round_diagnostics"}
+        assert all(path.exists() for path in written.values())
+
+    def test_a_run_without_training_curves_draws_nothing(self, tmp_path) -> None:
+        """Purpose: Validates that an unrecorded fit is reported, not faked
+
+        Given: Rounds with no training metrics
+        When: The training plot is drawn
+        Then: Nothing is written and None comes back, rather than an empty axis
+        """
+        from POMDPPlanners.utils.visualization.model_learning_plots import plot_training_curves
+
+        assert plot_training_curves([{"round_index": 1}], tmp_path / "none.png") is None
+
+    def test_a_tracked_run_logs_its_plots(self, tmp_path) -> None:
+        """Purpose: Validates that the plots reach MLflow with the numbers
+
+        Given: A tracker with two logged rounds from a real ensemble fit
+        When: The run is finished
+        Then: The plots directory holds the training and diagnostic figures
+        """
+        pytest.importorskip("mlflow")
+        from POMDPPlanners.training.model_learning import MLflowModelLearningTracker
+
+        tracker = MLflowModelLearningTracker(
+            experiment_name="model_learning_test",
+            method="dagger",
+            seed=3,
+            tracking_uri=f"file://{tmp_path / 'mlruns'}",
+        )
+        learner = ProbabilisticEnsembleLearner(num_members=2, epochs=3, seed=0)
+        for index in (1, 2):
+            model = learner.fit(_dataset(seed=index))
+            tracker.log_round(
+                RoundResult(
+                    round_index=index,
+                    model=model,
+                    dataset_size=60 * index,
+                    source_counts={"exploration": 60 * index},
+                    training_metrics=learner.training_metrics(),
+                    diagnostics={"held_out_log_likelihood": 1.0, "horizon_drift_ratio": 1.2},
+                    control=None,
+                )
+            )
+        run = tracker._run  # pylint: disable=protected-access
+        tracker.finish()
+
+        plots = _artifact_dir(run) / "plots"
+        assert {path.name for path in plots.glob("*.png")} == {
+            "training_curves.png",
+            "member_training_curves.png",
+            "round_diagnostics.png",
+        }
+
+
 class TestCurveSummaries:
     """The one table to read first."""
 

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
@@ -29,6 +29,7 @@ from POMDPPlanners.environments.isaac_lab_pomdp.isaac_lab_model_pomdp import (
 )
 from POMDPPlanners.training.model_learning import (
     ControlPoint,
+    ProbabilisticEnsembleTransition,
     LearningCurve,
     LinearGaussianLearner,
     ProbabilisticEnsembleLearner,
@@ -85,8 +86,18 @@ def _round(round_index: int, seed: int = 0) -> RoundResult:
     )
 
 
-def _ensemble(seed: int = 0):
-    return ProbabilisticEnsembleLearner(num_members=2, epochs=3, seed=seed).fit(_dataset(seed=seed))
+def _ensemble(seed: int = 0) -> ProbabilisticEnsembleTransition:
+    """A fitted ensemble, as its own type -- the save and fingerprint hooks are its."""
+    model = ProbabilisticEnsembleLearner(num_members=2, epochs=3, seed=seed).fit(_dataset(seed=seed))
+    assert isinstance(model, ProbabilisticEnsembleTransition)
+    return model
+
+
+def _linear(seed: int = 0) -> LinearGaussianTransition:
+    """A fitted linear-Gaussian transition, as its own type."""
+    model = LinearGaussianLearner().fit(_dataset(seed=seed))
+    assert isinstance(model, LinearGaussianTransition)
+    return model
 
 
 class TestEnsemblePersistence:
@@ -100,8 +111,6 @@ class TestEnsemblePersistence:
         Then: The log-densities match the original's exactly, so the reload kept
             the normalization statistics and not only the weights
         """
-        from POMDPPlanners.training.model_learning import ProbabilisticEnsembleTransition
-
         model = _ensemble()
         state = np.array([0.3, -0.2])
         action = np.array([1.0])
@@ -120,8 +129,6 @@ class TestEnsemblePersistence:
         Then: They draw the same successors, so a reloaded model reproduces the
             run it was scored in rather than restarting its stream
         """
-        from POMDPPlanners.training.model_learning import ProbabilisticEnsembleTransition
-
         model = _ensemble()
         state = np.array([0.3, -0.2])
         action = np.array([1.0])
@@ -159,7 +166,7 @@ class TestLinearPersistence:
         When: It is loaded back
         Then: It reports the same log-density as the original
         """
-        model = LinearGaussianLearner().fit(_dataset())
+        model = _linear()
         state = np.array([0.3, -0.2])
         action = np.array([1.0])
         candidates = np.array([[0.25, -0.15], [1.0, 1.0]])
@@ -176,8 +183,8 @@ class TestLinearPersistence:
         When: Their fingerprints are compared
         Then: They differ
         """
-        first = LinearGaussianLearner().fit(_dataset(seed=0))
-        second = LinearGaussianLearner().fit(_dataset(seed=5))
+        first = _linear(seed=0)
+        second = _linear(seed=5)
 
         assert first.fingerprint != second.fingerprint
 
@@ -203,8 +210,8 @@ class TestFittedTransitionReachesTheCacheKey:
         Then: They differ, so the simulation cache cannot serve one round's
             episodes as the next round's
         """
-        first = self._model(LinearGaussianLearner().fit(_dataset(seed=0)))
-        second = self._model(LinearGaussianLearner().fit(_dataset(seed=5)))
+        first = self._model(_linear(seed=0))
+        second = self._model(_linear(seed=5))
 
         assert first.config_id != second.config_id
 
@@ -303,7 +310,6 @@ class TestMLflowTracker:
         mlflow = pytest.importorskip("mlflow")
         from POMDPPlanners.training.model_learning import (
             MLflowModelLearningTracker,
-            ProbabilisticEnsembleTransition,
             load_round_models,
         )
 
@@ -317,6 +323,7 @@ class TestMLflowTracker:
             diagnostics={"held_out_log_likelihood": 2.5, "horizon_drift_ratio": 0.8},
             control=ControlPoint(round_index=1, cumulative_transitions=120, returns=(-1.0, -1.4)),
         )
+        assert result.control is not None
         curve = LearningCurve(method="dagger", seed=0, points=(result.control,))
 
         tracker = MLflowModelLearningTracker(

--- a/POMDPPlanners/training/model_learning/__init__.py
+++ b/POMDPPlanners/training/model_learning/__init__.py
@@ -90,6 +90,12 @@ from POMDPPlanners.training.model_learning.learners import (
     ProbabilisticEnsembleLearner,
     TransitionModelLearner,
 )
+from POMDPPlanners.training.model_learning.reporting import (
+    curve_table_markdown,
+    round_table_csv,
+    round_table_markdown,
+    write_reports,
+)
 from POMDPPlanners.training.model_learning.tracking import (
     MLflowModelLearningTracker,
     ModelLearningTracker,
@@ -123,13 +129,17 @@ __all__ = [
     "block_indices",
     "collect_random_preset_episode",
     "curve_summaries",
+    "curve_table_markdown",
     "curves_by_method",
     "evaluate_control",
     "evaluate_model",
     "load_learning_curves",
     "load_round_models",
+    "round_table_csv",
+    "round_table_markdown",
     "run_learning_curves",
     "save_learning_curves",
+    "write_reports",
     "held_out_log_likelihood",
     "horizon_drift_ratio",
     "preset_ranking_agreement",

--- a/POMDPPlanners/training/model_learning/__init__.py
+++ b/POMDPPlanners/training/model_learning/__init__.py
@@ -90,6 +90,12 @@ from POMDPPlanners.training.model_learning.learners import (
     ProbabilisticEnsembleLearner,
     TransitionModelLearner,
 )
+from POMDPPlanners.training.model_learning.tracking import (
+    MLflowModelLearningTracker,
+    ModelLearningTracker,
+    curve_summaries,
+    load_round_models,
+)
 from POMDPPlanners.training.model_learning.transition_dataset import (
     TransitionBatch,
     TransitionDataset,
@@ -104,6 +110,8 @@ __all__ = [
     "GaussianMLP",
     "LearningCurve",
     "LinearGaussianLearner",
+    "MLflowModelLearningTracker",
+    "ModelLearningTracker",
     "ProbabilisticEnsembleLearner",
     "ProbabilisticEnsembleTransition",
     "RoundResult",
@@ -114,10 +122,12 @@ __all__ = [
     "best_point",
     "block_indices",
     "collect_random_preset_episode",
+    "curve_summaries",
     "curves_by_method",
     "evaluate_control",
     "evaluate_model",
     "load_learning_curves",
+    "load_round_models",
     "run_learning_curves",
     "save_learning_curves",
     "held_out_log_likelihood",

--- a/POMDPPlanners/training/model_learning/__init__.py
+++ b/POMDPPlanners/training/model_learning/__init__.py
@@ -95,6 +95,8 @@ from POMDPPlanners.training.model_learning.reporting import (
     round_table_csv,
     round_table_markdown,
     write_reports,
+    write_run_directory,
+    write_study_directory,
 )
 from POMDPPlanners.training.model_learning.tracking import (
     MLflowModelLearningTracker,
@@ -140,6 +142,8 @@ __all__ = [
     "run_learning_curves",
     "save_learning_curves",
     "write_reports",
+    "write_run_directory",
+    "write_study_directory",
     "held_out_log_likelihood",
     "horizon_drift_ratio",
     "preset_ranking_agreement",

--- a/POMDPPlanners/training/model_learning/curve_comparison.py
+++ b/POMDPPlanners/training/model_learning/curve_comparison.py
@@ -89,7 +89,14 @@ def run_learning_curves(
             _check_trainer(trainer, method, seed)
             log.info("learning curve: method %s, seed %d", method, seed)
             trainer.run()
-            curves.append(trainer.learning_curve(method))
+            curve = trainer.learning_curve(method)
+            # A tracker recorded every round as the loop went; the curve is the
+            # last thing this (method, seed) produces, so hand it over here
+            # rather than making every caller remember to.
+            tracker = getattr(trainer, "tracker", None)
+            if tracker is not None and hasattr(tracker, "log_curve"):
+                tracker.log_curve(curve)
+            curves.append(curve)
     return curves
 
 

--- a/POMDPPlanners/training/model_learning/dagger_trainer.py
+++ b/POMDPPlanners/training/model_learning/dagger_trainer.py
@@ -143,6 +143,11 @@ class DAggerModelTrainer:
         hold_steps: Control steps an exploration action is held for.
         horizon: Steps used for the drift diagnostic; use the planner's depth.
         reward_model: Reward used for the ranking diagnostic. ``None`` skips it.
+        tracker: Optional recorder, called once per round with that round's
+            result, and expected to save the model beside the numbers -- see
+            :class:`~POMDPPlanners.training.model_learning.tracking.ModelLearningTracker`.
+            ``None`` keeps every fitted model in memory only, which makes the run
+            unreproducible the moment the process exits.
         seed: Seed for exploration draws and diagnostics.
         logger: Optional logger.
 
@@ -180,6 +185,7 @@ class DAggerModelTrainer:
         hold_steps: int = DEFAULT_HOLD_STEPS,
         horizon: int = 40,
         reward_model: Optional[Any] = None,
+        tracker: Optional[Any] = None,
         seed: int = 0,
         logger: Optional[Any] = None,
     ) -> None:
@@ -206,6 +212,7 @@ class DAggerModelTrainer:
         self.hold_steps = hold_steps
         self.horizon = horizon
         self.reward_model = reward_model
+        self.tracker = tracker
         self.seed = seed
         self._logger = logger or get_logger(__name__)
         self._rounds: List[RoundResult] = []
@@ -249,6 +256,8 @@ class DAggerModelTrainer:
                 control=self._evaluate_control(current_model, round_index),
             )
             self._rounds.append(result)
+            if self.tracker is not None:
+                self.tracker.log_round(result)
             self._logger.info(
                 "round %d/%d: %d transitions (%s), %s, return %s",
                 round_index,

--- a/POMDPPlanners/training/model_learning/ensemble_transition.py
+++ b/POMDPPlanners/training/model_learning/ensemble_transition.py
@@ -25,12 +25,21 @@ negative log-likelihood early in training is to declare enormous variance on the
 hard dimensions and stop modelling them. Soft bounds, learned but penalized,
 stop that without hard-clipping a variance that genuinely should be large.
 
+Why the model is saved rather than refitted. A round's model is the object a
+control number was measured on; refitting it later from the same data reproduces
+neither the initialisations nor the batch order, so the reloaded model is a
+different model with the same provenance. Every round is written to disk,
+because the guarantee is on the best model of the sequence and the best round is
+only known after the whole sequence has been scored.
+
 Classes:
     GaussianMLP: One ensemble member -- predicts mean and variance of the state change.
     ProbabilisticEnsembleTransition: Ensemble of members, usable as a TransitionModel.
 """
 
-from typing import Any, List, Optional, Sequence, Tuple
+import hashlib
+from pathlib import Path
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -76,7 +85,9 @@ class GaussianMLP(nn.Module):
             width = hidden
         layers.append(nn.Linear(width, 2 * output_dim))
         self._net = nn.Sequential(*layers)
+        self._input_dim = input_dim
         self._output_dim = output_dim
+        self._hidden_sizes = tuple(hidden_sizes)
         self.max_log_variance = nn.Parameter(torch.full((output_dim,), 0.5))
         self.min_log_variance = nn.Parameter(torch.full((output_dim,), -10.0))
 
@@ -104,6 +115,11 @@ class GaussianMLP(nn.Module):
     def bound_penalty(self) -> torch.Tensor:
         """Penalty pulling the soft bounds inward, so they track the data."""
         return _BOUND_PENALTY * (self.max_log_variance.sum() - self.min_log_variance.sum())
+
+    @property
+    def shape(self) -> Tuple[int, int, Tuple[int, ...]]:
+        """``(input_dim, output_dim, hidden_sizes)`` -- what rebuilding this member needs."""
+        return self._input_dim, self._output_dim, self._hidden_sizes
 
 
 class ProbabilisticEnsembleTransition(TransitionModel):
@@ -151,6 +167,7 @@ class ProbabilisticEnsembleTransition(TransitionModel):
         self._action_scale = np.asarray(action_scale, dtype=float)
         self._delta_mean = np.asarray(delta_mean, dtype=float)
         self._delta_scale = np.asarray(delta_scale, dtype=float)
+        self._seed = int(seed)
         self._rng = np.random.default_rng(seed)
 
     @property
@@ -162,6 +179,113 @@ class ProbabilisticEnsembleTransition(TransitionModel):
     def num_members(self) -> int:
         """Number of ensemble members."""
         return len(self._members)
+
+    @property
+    def fingerprint(self) -> str:
+        """Hash of the fitted parameters -- two different fits never share one.
+
+        A learned transition is held privately by the model that plans with it,
+        and an environment's ``config_id`` skips private attributes, so nothing
+        about the fit reaches the simulation cache key on its own. Two rounds of
+        a loop would then be *the same experiment* as far as the cache is
+        concerned, and round two would be scored on round one's episodes. An
+        environment planning with a fitted transition exposes this string so the
+        cache key moves when the weights do.
+
+        Returns:
+            A hex digest over every member's parameters, the normalization
+            statistics and the seed.
+        """
+        digest = hashlib.sha256(type(self).__name__.encode())
+        for member in self._members:
+            for name, tensor in sorted(member.state_dict().items()):
+                digest.update(name.encode())
+                digest.update(tensor.detach().cpu().numpy().astype(np.float64).tobytes())
+        for statistic in (
+            self._state_mean,
+            self._state_scale,
+            self._action_mean,
+            self._action_scale,
+            self._delta_mean,
+            self._delta_scale,
+        ):
+            digest.update(np.asarray(statistic, dtype=float).tobytes())
+        digest.update(str(self._seed).encode())
+        return digest.hexdigest()
+
+    def save(self, path: Union[str, Path]) -> Path:
+        """Write the whole model to one file, ready to be planned with again.
+
+        The weights alone are not the model. Without the normalization
+        statistics the network is handed inputs on a scale it never trained on,
+        and a reload that dropped them would return a model that runs, predicts
+        nonsense, and blames the fit. The sampler's stream is saved too, so a
+        reloaded model continues the draws it was scored on rather than
+        restarting them.
+
+        Args:
+            path: Destination file. Parent directories are created.
+
+        Returns:
+            The path written.
+        """
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        input_dim, output_dim, hidden_sizes = self._members[0].shape
+        torch.save(
+            {
+                "member_state_dicts": [member.state_dict() for member in self._members],
+                "input_dim": input_dim,
+                "output_dim": output_dim,
+                "hidden_sizes": list(hidden_sizes),
+                "state_mean": self._state_mean,
+                "state_scale": self._state_scale,
+                "action_mean": self._action_mean,
+                "action_scale": self._action_scale,
+                "delta_mean": self._delta_mean,
+                "delta_scale": self._delta_scale,
+                "seed": self._seed,
+                "rng_state": self._rng.bit_generator.state,
+            },
+            path,
+        )
+        return path
+
+    @classmethod
+    def load(cls, path: Union[str, Path]) -> "ProbabilisticEnsembleTransition":
+        """Rebuild a model written by :meth:`save`.
+
+        Args:
+            path: File written by :meth:`save`.
+
+        Returns:
+            The model, on CPU, in eval mode, with the saved sampler stream.
+        """
+        # weights_only=False: the payload deliberately carries the normalization
+        # statistics and the sampler state beside the tensors, and without them
+        # the members are not a usable model. Only load files you wrote.
+        payload = torch.load(Path(path), map_location="cpu", weights_only=False)
+        members = build_members(
+            input_dim=int(payload["input_dim"]),
+            output_dim=int(payload["output_dim"]),
+            num_members=len(payload["member_state_dicts"]),
+            hidden_sizes=tuple(payload["hidden_sizes"]),
+            seed=int(payload["seed"]),
+        )
+        for member, state_dict in zip(members, payload["member_state_dicts"]):
+            member.load_state_dict(state_dict)
+        model = cls(
+            members=members,
+            state_mean=payload["state_mean"],
+            state_scale=payload["state_scale"],
+            action_mean=payload["action_mean"],
+            action_scale=payload["action_scale"],
+            delta_mean=payload["delta_mean"],
+            delta_scale=payload["delta_scale"],
+            seed=int(payload["seed"]),
+        )
+        model._rng.bit_generator.state = payload["rng_state"]  # pylint: disable=protected-access
+        return model
 
     def sample_next_state(self, state: Any, action: Any, n_samples: int = 1) -> Any:
         """Sample next states, each from a uniformly drawn member.

--- a/POMDPPlanners/training/model_learning/learners.py
+++ b/POMDPPlanners/training/model_learning/learners.py
@@ -380,7 +380,7 @@ def _train_member(
             optimizer.step()
             epoch_loss += float(loss.detach())
         losses.append(epoch_loss / steps)
-        if holdout_input_tensor is not None:
+        if holdout_input_tensor is not None and holdout_target_tensor is not None:
             member.eval()
             with torch.no_grad():
                 holdout_losses.append(

--- a/POMDPPlanners/training/model_learning/learners.py
+++ b/POMDPPlanners/training/model_learning/learners.py
@@ -24,7 +24,7 @@ Classes:
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import torch
@@ -226,26 +226,41 @@ class ProbabilisticEnsembleLearner(TransitionModelLearner):
             seed=self._seed,
             device=self._device,
         )
+        holdout = dataset.holdout_batch()
+        holdout_inputs, holdout_targets = _normalized(
+            holdout, state_mean, state_scale, action_mean, action_scale, delta_mean, delta_scale
+        )
+
         rng = np.random.default_rng(self._seed)
-        per_epoch: List[List[float]] = []
+        train_curves: List[List[float]] = []
+        holdout_curves: List[List[float]] = []
         for index, member in enumerate(members):
             resample = rng.integers(len(batch), size=len(batch))
-            per_epoch.append(
-                _train_member(
-                    member,
-                    inputs[resample],
-                    targets[resample],
-                    epochs=self._epochs,
-                    batch_size=self._batch_size,
-                    learning_rate=self._learning_rate,
-                    weight_decay=self._weight_decay,
-                    seed=self._seed + index,
-                    device=self._device,
-                )
+            train_curve, holdout_curve = _train_member(
+                member,
+                inputs[resample],
+                targets[resample],
+                epochs=self._epochs,
+                batch_size=self._batch_size,
+                learning_rate=self._learning_rate,
+                weight_decay=self._weight_decay,
+                seed=self._seed + index,
+                device=self._device,
+                holdout_inputs=holdout_inputs,
+                holdout_targets=holdout_targets,
             )
-        # One curve for the ensemble: the members train independently, so the
-        # mean over members is the only per-epoch number that describes the fit.
-        self._metrics = {"train_nll": list(np.mean(np.asarray(per_epoch), axis=0))}
+            train_curves.append(train_curve)
+            holdout_curves.append(holdout_curve)
+        # The mean over members describes the ensemble; the per-member curves are
+        # kept beside it because a single member that diverged is invisible in the
+        # mean and is exactly what makes an ensemble's spread meaningless. The
+        # holdout curve is what says whether more epochs are still buying
+        # anything -- a training curve alone cannot tell fitting from memorizing.
+        self._metrics = {"train_nll": list(np.mean(np.asarray(train_curves), axis=0))}
+        if holdout_inputs is not None:
+            self._metrics["holdout_nll"] = list(np.mean(np.asarray(holdout_curves), axis=0))
+        for index, curve in enumerate(train_curves):
+            self._metrics[f"train_nll_member_{index}"] = list(curve)
         return ProbabilisticEnsembleTransition(
             members=members,
             state_mean=state_mean,
@@ -258,8 +273,53 @@ class ProbabilisticEnsembleLearner(TransitionModelLearner):
         )
 
     def training_metrics(self) -> Dict[str, List[float]]:
-        """Per-epoch mean training negative log-likelihood across members."""
+        """Per-epoch curves of the most recent fit.
+
+        Returns:
+            ``train_nll`` and, when the dataset held rows back, ``holdout_nll``
+            -- both means across members -- plus one ``train_nll_member_i`` per
+            member.
+        """
         return dict(self._metrics)
+
+
+def _normalized(
+    batch: Any,
+    state_mean: np.ndarray,
+    state_scale: np.ndarray,
+    action_mean: np.ndarray,
+    action_scale: np.ndarray,
+    delta_mean: np.ndarray,
+    delta_scale: np.ndarray,
+) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+    """Normalized inputs and targets of a batch, using the training split's statistics.
+
+    The statistics are the *training* split's on purpose: normalizing the holdout
+    by its own would make its loss incomparable to the training loss it is
+    plotted against.
+
+    Returns:
+        ``(inputs, targets)``, or ``(None, None)`` for an empty batch.
+    """
+    if len(batch) == 0:
+        return None, None
+    inputs = np.concatenate(
+        [
+            (batch.states - state_mean) / state_scale,
+            (batch.actions - action_mean) / action_scale,
+        ],
+        axis=1,
+    )
+    return inputs, (batch.deltas - delta_mean) / delta_scale
+
+
+def _gaussian_nll(member: Any, inputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+    """Gaussian negative log-likelihood, up to the constant term."""
+    mean, log_variance = member(inputs)
+    residual = targets - mean
+    # The constant term shifts every model equally and only makes the reported
+    # number harder to compare against a hand-computed one.
+    return torch.mean(torch.sum(residual**2 * torch.exp(-log_variance) + log_variance, dim=-1))
 
 
 def _train_member(
@@ -272,8 +332,15 @@ def _train_member(
     weight_decay: float,
     seed: int,
     device: Optional[torch.device],
-) -> List[float]:
-    """Train one member by Gaussian negative log-likelihood; return its epoch losses."""
+    holdout_inputs: Optional[np.ndarray] = None,
+    holdout_targets: Optional[np.ndarray] = None,
+) -> Tuple[List[float], List[float]]:
+    """Train one member by Gaussian negative log-likelihood.
+
+    Returns:
+        ``(train_losses, holdout_losses)``, one entry per epoch. The second is
+        empty when no holdout rows were given.
+    """
     optimizer = torch.optim.Adam(
         member.parameters(), lr=learning_rate, weight_decay=weight_decay
     )
@@ -283,11 +350,21 @@ def _train_member(
         input_tensor = input_tensor.to(device)
         target_tensor = target_tensor.to(device)
 
+    holdout_input_tensor = None
+    holdout_target_tensor = None
+    if holdout_inputs is not None and holdout_targets is not None:
+        holdout_input_tensor = torch.as_tensor(holdout_inputs, dtype=torch.float32)
+        holdout_target_tensor = torch.as_tensor(holdout_targets, dtype=torch.float32)
+        if device is not None:
+            holdout_input_tensor = holdout_input_tensor.to(device)
+            holdout_target_tensor = holdout_target_tensor.to(device)
+
     rng = np.random.default_rng(seed)
     num_rows = input_tensor.shape[0]
     steps = max(num_rows // batch_size, 1)
     member.train()
     losses: List[float] = []
+    holdout_losses: List[float] = []
     for _ in range(epochs):
         order = rng.permutation(num_rows)
         epoch_loss = 0.0
@@ -296,22 +373,22 @@ def _train_member(
             if rows.size == 0:
                 continue
             index = torch.as_tensor(rows, dtype=torch.long, device=input_tensor.device)
-            mean, log_variance = member(input_tensor[index])
-            residual = target_tensor[index] - mean
-            # Gaussian NLL up to the constant term: the constant shifts every
-            # model equally and only makes the reported number harder to compare
-            # against a hand-computed one.
-            loss = torch.mean(
-                torch.sum(residual**2 * torch.exp(-log_variance) + log_variance, dim=-1)
-            )
+            loss = _gaussian_nll(member, input_tensor[index], target_tensor[index])
             loss = loss + member.bound_penalty()
             optimizer.zero_grad()
             loss.backward()
             optimizer.step()
             epoch_loss += float(loss.detach())
         losses.append(epoch_loss / steps)
+        if holdout_input_tensor is not None:
+            member.eval()
+            with torch.no_grad():
+                holdout_losses.append(
+                    float(_gaussian_nll(member, holdout_input_tensor, holdout_target_tensor))
+                )
+            member.train()
     member.eval()
-    return losses
+    return losses, holdout_losses
 
 
 def _mean_negative_log_likelihood(model: TransitionModel, batch: TransitionBatch) -> float:

--- a/POMDPPlanners/training/model_learning/reporting.py
+++ b/POMDPPlanners/training/model_learning/reporting.py
@@ -22,15 +22,25 @@ planning horizon is outside the spread it claims, which is the failure that make
 a risk-sensitive planner confidently wrong. A table without the flag leaves the
 reader to remember the threshold.
 
+One directory shape, two levels, and nothing at the wrong one. A run --
+one method at one seed -- owns its rounds, its models and its training curves.
+The study owns only what compares runs: the method table and the learning curve.
+A rounds table sitting at study level is a single run's numbers wearing the
+study's name, which is how the wrong method gets reported.
+
 Functions:
     round_table_markdown: Per-round table of cost, return and model quality.
     round_table_csv: The same rows, for a spreadsheet.
     curve_table_markdown: Best round per method and seed.
     write_reports: Write both tables into a directory.
+    write_run_directory: One run's rounds, models and plots, under its own name.
+    write_study_directory: The comparison across runs, plus a README pointing at them.
 """
 
 import csv
 import io
+import json
+import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -286,3 +296,156 @@ def write_reports(
     csv_path.write_text(round_table_csv(rounds), encoding="utf-8")
     written["rounds_csv"] = csv_path
     return written
+
+
+def write_run_directory(
+    rounds: Sequence[Any],
+    output_dir: Path,
+    curve: Optional[LearningCurve] = None,
+    models: Optional[Dict[int, Path]] = None,
+) -> Dict[str, Path]:
+    """Write everything about one run -- one method at one seed -- under one name.
+
+    Args:
+        rounds: The run's rounds, as results or as the tracker's dictionaries.
+        output_dir: The run's directory, e.g. ``runs/dagger_seed0``. Created if
+            missing.
+        curve: The run's control curve, written beside the rounds so the run can
+            be read without the study around it.
+        models: ``{round_index: file}`` to copy into ``models/``. The models are
+            the point of the run, and a directory that names its rounds but not
+            its models sends the reader back to MLflow's hashed tree.
+
+    Returns:
+        Report name to written path.
+    """
+    output_dir = Path(output_dir)
+    written = write_reports(rounds, output_dir)
+    (output_dir / "rounds.json").write_text(
+        json.dumps([_as_record(entry) for entry in rounds], indent=2), encoding="utf-8"
+    )
+    written["rounds_json"] = output_dir / "rounds.json"
+
+    if curve is not None:
+        (output_dir / "learning_curve.json").write_text(
+            json.dumps(curve.to_dict(), indent=2), encoding="utf-8"
+        )
+        written["learning_curve"] = output_dir / "learning_curve.json"
+
+    if models:
+        models_dir = output_dir / "models"
+        models_dir.mkdir(parents=True, exist_ok=True)
+        for round_index, source in sorted(models.items()):
+            destination = models_dir / f"round_{round_index}{Path(source).suffix}"
+            shutil.copyfile(source, destination)
+            written[f"model_round_{round_index}"] = destination
+
+    # Deferred: matplotlib is heavy and a caller may only want the tables.
+    # pylint: disable-next=import-outside-toplevel
+    from POMDPPlanners.utils.visualization.model_learning_plots import (
+        plot_model_learning_report,
+    )
+
+    written.update(plot_model_learning_report(rounds, output_dir / "plots"))
+    return written
+
+
+def write_study_directory(
+    curves: Sequence[LearningCurve],
+    output_dir: Path,
+    params: Optional[Dict[str, Any]] = None,
+    run_dirs: Optional[Dict[str, Path]] = None,
+) -> Dict[str, Path]:
+    """Write what compares the runs, and a README saying where everything is.
+
+    Args:
+        curves: Curves across methods and seeds.
+        output_dir: The study directory.
+        params: What was run -- environment, learner, planner budget, commit.
+            Written into the README, because a results directory whose settings
+            live only in the script that produced it is not a result.
+        run_dirs: Run name to its directory, listed in the README.
+
+    Returns:
+        Report name to written path.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written: Dict[str, Path] = {}
+
+    summary_path = output_dir / "summary.md"
+    summary_path.write_text(curve_table_markdown(curves), encoding="utf-8")
+    written["summary"] = summary_path
+
+    curves_path = output_dir / "learning_curves.json"
+    curves_path.write_text(
+        json.dumps([curve.to_dict() for curve in curves], indent=2), encoding="utf-8"
+    )
+    written["learning_curves"] = curves_path
+
+    # pylint: disable-next=import-outside-toplevel
+    from POMDPPlanners.utils.visualization.model_learning_plots import plot_learning_curves
+
+    plot = plot_learning_curves(curves, output_dir / "learning_curves.png")
+    if plot is not None:
+        written["learning_curve_plot"] = plot
+
+    written["readme"] = _write_readme(output_dir, params or {}, run_dirs or {})
+    return written
+
+
+def _write_readme(output_dir: Path, params: Dict[str, Any], run_dirs: Dict[str, Path]) -> Path:
+    """A map of the directory and the settings that produced it."""
+    lines = [
+        "# Model-learning study",
+        "",
+        "## What ran",
+        "",
+        "| Setting | Value |",
+        "|---|---|",
+    ]
+    lines += [f"| {key} | {value} |" for key, value in sorted(params.items())]
+    lines += [
+        "",
+        "## Where things are",
+        "",
+        "| Path | What it holds |",
+        "|---|---|",
+        "| `summary.md` | Best round per method and seed -- read this first. |",
+        "| `learning_curves.png` | Return against transitions, one line per method. |",
+        "| `learning_curves.json` | The same curves, for replotting. |",
+    ]
+    for name, path in sorted(run_dirs.items()):
+        lines.append(f"| `{path}/` | Everything about the {name} run. |")
+    lines += [
+        "| `mlruns/` | The same records, queryable with `mlflow ui`. |",
+        "| `sim_cache/` | Rollout cache. Disposable; delete it to force a re-run. |",
+        "",
+        "Each run directory holds `summary.md` (its rounds), `rounds.csv`,",
+        "`rounds.json`, `models/round_k.pt` and `plots/`. The model of *every*",
+        "round is kept: which round was best is known only after the whole",
+        "sequence has been scored.",
+        "",
+    ]
+    path = output_dir / "README.md"
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _as_record(entry: Any) -> Dict[str, Any]:
+    """One round as a JSON-safe dictionary, whichever shape it arrived in."""
+    if isinstance(entry, dict):
+        return entry
+    control = _field(entry, "control")
+    return {
+        "round_index": _field(entry, "round_index"),
+        "dataset_size": _field(entry, "dataset_size"),
+        "source_counts": dict(_field(entry, "source_counts", {}) or {}),
+        "diagnostics": {k: float(v) for k, v in (_field(entry, "diagnostics", {}) or {}).items()},
+        "training_metrics": {
+            name: [float(value) for value in values]
+            for name, values in (_field(entry, "training_metrics", {}) or {}).items()
+        },
+        "model_fingerprint": _short_fingerprint(entry) or None,
+        "control": None if control is None else control.to_dict(),
+    }

--- a/POMDPPlanners/training/model_learning/reporting.py
+++ b/POMDPPlanners/training/model_learning/reporting.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: MIT
+
+"""The tables a person reads a fitting run from.
+
+JSON is what a plot is rebuilt from; it is not what anyone reads to decide
+whether a model is worth planning with. That decision needs four numbers side by
+side per round -- what the round cost, what the planner scored with it, whether
+the fit improved, and whether the model's confidence is honest -- and reading
+them out of a nested record is work that gets skipped.
+
+The tables are derived from the same records the plots are, so a table and a
+figure never disagree.
+
+Two columns here are judgements rather than measurements.
+
+**The best round is marked, not the last.** The guarantee is on the best model of
+the sequence, and the sequence is not monotone, so a table that reads bottom-up
+reports the wrong model.
+
+**The drift ratio is flagged above one.** Above one the model's error over a
+planning horizon is outside the spread it claims, which is the failure that makes
+a risk-sensitive planner confidently wrong. A table without the flag leaves the
+reader to remember the threshold.
+
+Functions:
+    round_table_markdown: Per-round table of cost, return and model quality.
+    round_table_csv: The same rows, for a spreadsheet.
+    curve_table_markdown: Best round per method and seed.
+    write_reports: Write both tables into a directory.
+"""
+
+import csv
+import io
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import numpy as np
+
+from POMDPPlanners.training.model_learning.control_evaluation import (
+    LearningCurve,
+    aggregate_curves,
+    best_point,
+)
+
+#: Drift above this means the model's horizon error exceeds its claimed spread.
+DRIFT_WARNING_THRESHOLD = 1.0
+
+_COLUMNS = (
+    "round",
+    "transitions",
+    "exploration",
+    "planner",
+    "mean_return",
+    "standard_error",
+    "held_out_log_likelihood",
+    "horizon_drift_ratio",
+    "best_holdout_epoch",
+    "model",
+)
+
+
+def _field(entry: Any, name: str, default: Any = None) -> Any:
+    """Read a field from a round result or from the tracker's dictionary form."""
+    if isinstance(entry, dict):
+        return entry.get(name, default)
+    return getattr(entry, name, default)
+
+
+def _rows(rounds: Sequence[Any]) -> List[Dict[str, Any]]:
+    """Flatten each round into the columns the tables share."""
+    rows: List[Dict[str, Any]] = []
+    for position, entry in enumerate(rounds, start=1):
+        diagnostics = _field(entry, "diagnostics", {}) or {}
+        sources = _field(entry, "source_counts", {}) or {}
+        training = _field(entry, "training_metrics", {}) or {}
+        control = _field(entry, "control")
+        if control is not None and not isinstance(control, dict):
+            control = control.to_dict()
+        returns = list(control["returns"]) if control else []
+        holdout = list(training.get("holdout_nll", []))
+        rows.append(
+            {
+                "round": int(_field(entry, "round_index", position) or position),
+                "transitions": int(_field(entry, "dataset_size", 0) or 0),
+                "exploration": int(sources.get("exploration", 0)),
+                "planner": int(sources.get("planner", 0)),
+                "mean_return": float(np.mean(returns)) if returns else float("nan"),
+                "standard_error": (
+                    float(np.std(returns, ddof=1) / np.sqrt(len(returns)))
+                    if len(returns) > 1
+                    else float("nan")
+                ),
+                "held_out_log_likelihood": float(
+                    diagnostics.get("held_out_log_likelihood", float("nan"))
+                ),
+                "horizon_drift_ratio": float(
+                    diagnostics.get("horizon_drift_ratio", float("nan"))
+                ),
+                # Where the holdout loss bottomed out: past it the epochs bought
+                # training loss with generalization.
+                "best_holdout_epoch": (
+                    int(np.argmin(holdout)) + 1 if holdout else None
+                ),
+                "model": _field(entry, "model_artifact") or "",
+            }
+        )
+    return rows
+
+
+def _number(value: Any, digits: int = 3) -> str:
+    """Render a number for a table, or an em dash when it was never measured."""
+    if value is None:
+        return "--"
+    if isinstance(value, float) and not np.isfinite(value):
+        return "--"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def round_table_markdown(rounds: Sequence[Any], title: str = "Rounds") -> str:
+    """Per-round table of what the round cost and what it bought.
+
+    Args:
+        rounds: Round results, or the dictionaries written to ``rounds.json``.
+        title: Heading above the table.
+
+    Returns:
+        A Markdown document. The best round by mean return is marked, and a
+        drift ratio above one is flagged.
+    """
+    rows = _rows(rounds)
+    if not rows:
+        return f"# {title}\n\nNo rounds recorded.\n"
+
+    scored = [row for row in rows if np.isfinite(row["mean_return"])]
+    best_round = max(scored, key=lambda row: row["mean_return"])["round"] if scored else None
+
+    lines = [
+        f"# {title}",
+        "",
+        "| Round | Transitions | Explore / Planner | Mean return | Held-out LL | Drift ratio | Best holdout epoch | Model |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for row in rows:
+        mark = " **(best)**" if row["round"] == best_round else ""
+        error = _number(row["standard_error"])
+        drift = _number(row["horizon_drift_ratio"])
+        if np.isfinite(row["horizon_drift_ratio"]) and (
+            row["horizon_drift_ratio"] > DRIFT_WARNING_THRESHOLD
+        ):
+            drift += " ⚠"
+        lines.append(
+            f"| {row['round']}{mark} | {row['transitions']} | "
+            f"{row['exploration']} / {row['planner']} | "
+            f"{_number(row['mean_return'])} ± {error} | "
+            f"{_number(row['held_out_log_likelihood'], 1)} | {drift} | "
+            f"{_number(row['best_holdout_epoch'])} | {row['model'] or '--'} |"
+        )
+    lines += [
+        "",
+        f"Drift ratio above {DRIFT_WARNING_THRESHOLD:.0f} (⚠) means the model's error over the "
+        "planning horizon is larger than the spread it predicts -- it is confident and wrong, "
+        "which is the failure a risk-sensitive planner cannot absorb.",
+        "",
+        "The best round is the one to report: the guarantee covers the best model of the "
+        "sequence, and the sequence is not monotone.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def round_table_csv(rounds: Sequence[Any]) -> str:
+    """The same rows as :func:`round_table_markdown`, as CSV.
+
+    Args:
+        rounds: Round results, or the dictionaries written to ``rounds.json``.
+
+    Returns:
+        CSV text with a header row.
+    """
+    buffer = io.StringIO()
+    writer: csv.DictWriter = csv.DictWriter(buffer, fieldnames=list(_COLUMNS))
+    writer.writeheader()
+    for row in _rows(rounds):
+        writer.writerow(row)
+    return buffer.getvalue()
+
+
+def curve_table_markdown(curves: Sequence[LearningCurve]) -> str:
+    """Best round per method and seed, and each method's mean over seeds.
+
+    Args:
+        curves: Curves across methods and seeds.
+
+    Returns:
+        A Markdown document, empty-handed if no curve had an evaluated round.
+    """
+    scored = [curve for curve in curves if curve.points]
+    if not scored:
+        return "# Methods\n\nNo evaluated rounds.\n"
+
+    lines = [
+        "# Methods",
+        "",
+        "| Method | Seed | Best round | Transitions | Mean return |",
+        "|---|---|---|---|---|",
+    ]
+    for curve in scored:
+        best = best_point(curve)
+        if best is None:
+            continue
+        lines.append(
+            f"| {curve.method} | {curve.seed} | {best.round_index} | "
+            f"{best.cumulative_transitions} | {_number(best.mean_return)} ± "
+            f"{_number(best.standard_error)} |"
+        )
+
+    grouped: Dict[str, List[LearningCurve]] = {}
+    for curve in scored:
+        grouped.setdefault(curve.method, []).append(curve)
+    lines += [
+        "",
+        "## Final round, averaged over seeds",
+        "",
+        "| Method | Seeds | Transitions | Mean return | SE across seeds |",
+        "|---|---|---|---|---|",
+    ]
+    for method, method_curves in sorted(grouped.items()):
+        aggregated = aggregate_curves(method_curves)
+        lines.append(
+            f"| {method} | {aggregated.num_seeds} | "
+            f"{_number(aggregated.cumulative_transitions[-1], 0)} | "
+            f"{_number(aggregated.mean_returns[-1])} | "
+            f"{_number(aggregated.standard_errors[-1])} |"
+        )
+    lines += [
+        "",
+        "The spread is across seeds, not across the episodes inside one: only the "
+        "first says whether two methods actually differed.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_reports(
+    rounds: Sequence[Any],
+    output_dir: Path,
+    curves: Optional[Sequence[LearningCurve]] = None,
+) -> Dict[str, Path]:
+    """Write the readable summary of a run beside its JSON.
+
+    Args:
+        rounds: Round results, or the dictionaries written to ``rounds.json``.
+        output_dir: Directory to write into; created if missing.
+        curves: Control curves across methods and seeds. ``None`` writes the
+            per-round table only.
+
+    Returns:
+        Report name to written path.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written: Dict[str, Path] = {}
+
+    summary = round_table_markdown(rounds)
+    if curves:
+        summary = f"{summary}\n{curve_table_markdown(curves)}"
+    summary_path = output_dir / "summary.md"
+    summary_path.write_text(summary, encoding="utf-8")
+    written["summary"] = summary_path
+
+    csv_path = output_dir / "rounds.csv"
+    csv_path.write_text(round_table_csv(rounds), encoding="utf-8")
+    written["rounds_csv"] = csv_path
+    return written

--- a/POMDPPlanners/training/model_learning/reporting.py
+++ b/POMDPPlanners/training/model_learning/reporting.py
@@ -101,10 +101,22 @@ def _rows(rounds: Sequence[Any]) -> List[Dict[str, Any]]:
                 "best_holdout_epoch": (
                     int(np.argmin(holdout)) + 1 if holdout else None
                 ),
-                "model": _field(entry, "model_artifact") or "",
+                # The tracker's records name the saved file; a live round result
+                # has the model itself, and its fingerprint is what ties the row
+                # to a set of parameters either way.
+                "model": _field(entry, "model_artifact") or _short_fingerprint(entry),
             }
         )
     return rows
+
+
+def _short_fingerprint(entry: Any) -> str:
+    """First characters of the round model's fingerprint, or an empty string."""
+    fingerprint = _field(entry, "model_fingerprint")
+    if fingerprint is None:
+        model = _field(entry, "model")
+        fingerprint = getattr(model, "fingerprint", None)
+    return str(fingerprint)[:10] if fingerprint else ""
 
 
 def _number(value: Any, digits: int = 3) -> str:

--- a/POMDPPlanners/training/model_learning/tracking.py
+++ b/POMDPPlanners/training/model_learning/tracking.py
@@ -185,6 +185,23 @@ class MLflowModelLearningTracker:
         self._client.set_terminated(self._run.info.run_id)
         self._run = None
 
+    @property
+    def artifact_dir(self) -> Optional[Path]:
+        """Local artifact directory of this run, when the store is on disk.
+
+        The models are written here, under hashed run ids. A study that wants
+        them under a readable name copies from here -- see
+        :func:`~POMDPPlanners.training.model_learning.reporting.write_run_directory`.
+
+        Returns:
+            The directory, or ``None`` before the run starts or when the store
+            is remote.
+        """
+        if self._run is None:
+            return None
+        uri = self._run.info.artifact_uri
+        return Path(uri[len("file://") :]) if uri.startswith("file://") else None
+
     def log_round(self, result: Any) -> None:
         """Record one round's metrics and save its model as an artifact.
 

--- a/POMDPPlanners/training/model_learning/tracking.py
+++ b/POMDPPlanners/training/model_learning/tracking.py
@@ -126,6 +126,7 @@ class MLflowModelLearningTracker:
         self._logger = logger or get_logger(__name__)
         self._client: Any = None
         self._run = None
+        self._artifact_dir: Optional[Path] = None
         self._curves: list = []
         self._rounds: list = []
 
@@ -168,6 +169,8 @@ class MLflowModelLearningTracker:
             else self._client.create_experiment(self.experiment_name)
         )
         self._run = self._client.create_run(experiment_id, run_name=self.run_name)
+        uri = self._run.info.artifact_uri
+        self._artifact_dir = Path(uri[len("file://") :]) if uri.startswith("file://") else None
         run_id = self._run.info.run_id
         self._client.log_param(run_id, "method", self.method)
         self._client.log_param(run_id, "seed", self.seed)
@@ -193,14 +196,14 @@ class MLflowModelLearningTracker:
         them under a readable name copies from here -- see
         :func:`~POMDPPlanners.training.model_learning.reporting.write_run_directory`.
 
+        It outlives :meth:`finish`, because a study copies the models *after*
+        the run that wrote them has been closed.
+
         Returns:
             The directory, or ``None`` before the run starts or when the store
             is remote.
         """
-        if self._run is None:
-            return None
-        uri = self._run.info.artifact_uri
-        return Path(uri[len("file://") :]) if uri.startswith("file://") else None
+        return self._artifact_dir
 
     def log_round(self, result: Any) -> None:
         """Record one round's metrics and save its model as an artifact.

--- a/POMDPPlanners/training/model_learning/tracking.py
+++ b/POMDPPlanners/training/model_learning/tracking.py
@@ -116,6 +116,7 @@ class MLflowModelLearningTracker:
         self.tracking_uri = tracking_uri
         self.run_name = run_name or f"{method}_seed{seed}"
         self._logger = logger or get_logger(__name__)
+        self._client: Any = None
         self._run = None
         self._rounds: list = []
 
@@ -134,33 +135,43 @@ class MLflowModelLearningTracker:
         A run started in a factory and finished by whoever collects the curve is
         the shape :func:`...curve_comparison.run_learning_curves` needs; requiring
         a ``with`` block there would put the tracker's lifetime in the wrong place.
+
+        Everything afterwards goes through a client bound to this run's id rather
+        than through MLflow's ambient "active run". The rollouts this loop
+        evaluates with run through ``LocalSimulationsAPI``, which sets its own
+        tracking URI and ends whatever run is active -- so a fluent-API tracker
+        loses its run in the middle of round one and silently logs the rest of
+        the study somewhere else.
         """
         # Deferred: importing MLflow costs seconds, and the loop runs without it.
-        import mlflow  # pylint: disable=import-outside-toplevel
+        from mlflow.tracking import MlflowClient  # pylint: disable=import-outside-toplevel
 
         if self._run is not None:
             return
         # MLflow >= 3.6 gates the local filesystem backend behind an opt-in, and
         # this project stores runs locally -- the same default the simulator sets.
         os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
-        if self.tracking_uri is not None:
-            mlflow.set_tracking_uri(self.tracking_uri)
-        mlflow.set_experiment(self.experiment_name)
-        self._run = mlflow.start_run(run_name=self.run_name)
-        mlflow.log_param("method", self.method)
-        mlflow.log_param("seed", self.seed)
+        self._client = MlflowClient(tracking_uri=self.tracking_uri)
+        experiment = self._client.get_experiment_by_name(self.experiment_name)
+        experiment_id = (
+            experiment.experiment_id
+            if experiment is not None
+            else self._client.create_experiment(self.experiment_name)
+        )
+        self._run = self._client.create_run(experiment_id, run_name=self.run_name)
+        run_id = self._run.info.run_id
+        self._client.log_param(run_id, "method", self.method)
+        self._client.log_param(run_id, "seed", self.seed)
         for key, value in self.params.items():
-            mlflow.log_param(key, value)
+            self._client.log_param(run_id, key, value)
 
     def finish(self) -> None:
         """Write the per-round record and close the run. Safe to call twice."""
-        import mlflow  # pylint: disable=import-outside-toplevel
-
         if self._run is None:
             return
         if self._rounds:
-            _log_json_artifact(self._rounds, "rounds.json", EVALUATION_ARTIFACT_PATH)
-        mlflow.end_run()
+            self._log_json_artifact(self._rounds, "rounds.json")
+        self._client.set_terminated(self._run.info.run_id)
         self._run = None
 
     def log_round(self, result: Any) -> None:
@@ -170,8 +181,6 @@ class MLflowModelLearningTracker:
             result: The round's
                 :class:`~POMDPPlanners.training.model_learning.dagger_trainer.RoundResult`.
         """
-        import mlflow  # pylint: disable=import-outside-toplevel
-
         self._ensure_run()
         step = int(result.round_index)
         metrics: Dict[str, float] = {"dataset_size": float(result.dataset_size)}
@@ -187,11 +196,12 @@ class MLflowModelLearningTracker:
             metrics["mean_return"] = result.control.mean_return
             metrics["return_standard_error"] = result.control.standard_error
             metrics["cumulative_transitions"] = float(result.control.cumulative_transitions)
+        run_id = self._run.info.run_id
         for name, value in metrics.items():
             # A NaN metric is rejected by some backends and silently plotted as a
             # gap by others; both hide that the quantity was never measured.
             if np.isfinite(value):
-                mlflow.log_metric(name, float(value), step=step)
+                self._client.log_metric(run_id, name, float(value), step=step)
 
         fingerprint = getattr(result.model, "fingerprint", None)
         model_artifact = self._log_model(result.model, step)
@@ -218,10 +228,9 @@ class MLflowModelLearningTracker:
         Args:
             curve: The run's curve, from ``trainer.learning_curve(method)``.
         """
-        import mlflow  # pylint: disable=import-outside-toplevel
-
         self._ensure_run()
-        _log_json_artifact(curve.to_dict(), "learning_curve.json", EVALUATION_ARTIFACT_PATH)
+        run_id = self._run.info.run_id
+        self._log_json_artifact(curve.to_dict(), "learning_curve.json")
         best = best_point(curve)
         if best is None:
             self._logger.warning(
@@ -230,9 +239,11 @@ class MLflowModelLearningTracker:
                 curve.seed,
             )
         else:
-            mlflow.log_metric("best_round_index", float(best.round_index))
-            mlflow.log_metric("best_round_mean_return", best.mean_return)
-            mlflow.log_metric("best_round_transitions", float(best.cumulative_transitions))
+            self._client.log_metric(run_id, "best_round_index", float(best.round_index))
+            self._client.log_metric(run_id, "best_round_mean_return", best.mean_return)
+            self._client.log_metric(
+                run_id, "best_round_transitions", float(best.cumulative_transitions)
+            )
         self.finish()
 
     def _log_model(self, model: Any, round_index: int) -> Optional[str]:
@@ -243,8 +254,6 @@ class MLflowModelLearningTracker:
             in which case the round's numbers still land, and the log says which
             model is missing rather than the run looking complete.
         """
-        import mlflow  # pylint: disable=import-outside-toplevel
-
         save = getattr(model, "save", None)
         if not callable(save):
             self._logger.warning(
@@ -258,18 +267,19 @@ class MLflowModelLearningTracker:
             path = save(Path(staging) / f"round_{round_index}{suffix}")
             # save() may append its own suffix (np.savez does), so log what exists.
             written = Path(path) if Path(path).exists() else Path(f"{path}.npz")
-            mlflow.log_artifact(str(written), MODELS_ARTIFACT_PATH)
+            self._client.log_artifact(
+                self._run.info.run_id, str(written), MODELS_ARTIFACT_PATH
+            )
             return f"{MODELS_ARTIFACT_PATH}/{written.name}"
 
-
-def _log_json_artifact(payload: Any, filename: str, artifact_path: str) -> None:
-    """Write ``payload`` as JSON and log it under ``artifact_path``."""
-    import mlflow  # pylint: disable=import-outside-toplevel
-
-    with tempfile.TemporaryDirectory() as staging:
-        path = Path(staging) / filename
-        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-        mlflow.log_artifact(str(path), artifact_path)
+    def _log_json_artifact(self, payload: Any, filename: str) -> None:
+        """Write ``payload`` as JSON and log it under the evaluation artifacts."""
+        with tempfile.TemporaryDirectory() as staging:
+            path = Path(staging) / filename
+            path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            self._client.log_artifact(
+                self._run.info.run_id, str(path), EVALUATION_ARTIFACT_PATH
+            )
 
 
 def load_round_models(run_artifacts_dir: Path) -> Dict[int, Path]:

--- a/POMDPPlanners/training/model_learning/tracking.py
+++ b/POMDPPlanners/training/model_learning/tracking.py
@@ -1,0 +1,314 @@
+# SPDX-License-Identifier: MIT
+
+"""Recording a model-learning run in MLflow: the numbers and the models themselves.
+
+The loop already produces everything needed to decide whether a fitted model is
+worth planning with. It produced it in memory, printed a log line, and dropped
+it -- so the model a round was scored on could not be reloaded, and the curve
+could not be redrawn without re-running the whole study. This module is where a
+round is written down.
+
+MLflow rather than a directory convention, because the rollouts inside this loop
+already run through it: every planner episode goes through
+``LocalSimulationsAPI``, which logs to MLflow, so a run of the loop with a
+separate results tree would leave the control numbers and the models they came
+from in two systems that agree by hand. One run per ``(method, seed)`` with one
+child run per round keeps the sequence together, and the per-round metrics are
+step-indexed so the learning curve is a chart rather than a file to plot.
+
+Three things are logged that are easy to omit and hard to reconstruct later.
+
+**The model of every round, not the best one.** Which round was best is known
+only after the whole sequence has been scored, and the guarantee is about the
+best model of the sequence. Saving as you go costs a file per round; saving at
+the end costs a re-run.
+
+**The fingerprint beside the model.** It is what ties a control number to the
+exact parameters that produced it, and it is what the environment's cache key
+moves on. A run whose fingerprints repeat across rounds is a run whose later
+rounds were scored on an earlier round's episodes -- visible in the log rather
+than as an unexplained flat curve.
+
+**Both halves of the judgement.** The return says whether the model plans well;
+the diagnostics say why it does not. A drift ratio above one means the model's
+own error bars do not cover its error over the planning horizon, which is the
+failure a risk-sensitive planner turns into confident bad decisions.
+
+Classes:
+    ModelLearningTracker: Protocol the trainer calls; implement it to record elsewhere.
+    MLflowModelLearningTracker: Logs rounds, models and curves to MLflow.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Optional, Protocol, Sequence
+
+import numpy as np
+
+from POMDPPlanners.training.model_learning.control_evaluation import (
+    LearningCurve,
+    best_point,
+)
+from POMDPPlanners.utils.logger import get_logger
+
+#: Artifact sub-directory holding one file per round's fitted model.
+MODELS_ARTIFACT_PATH = "models"
+
+#: Artifact sub-directory holding the curve and the per-round record.
+EVALUATION_ARTIFACT_PATH = "evaluation"
+
+
+class ModelLearningTracker(Protocol):
+    """What :class:`~...dagger_trainer.DAggerModelTrainer` needs of a tracker.
+
+    A protocol rather than a base class so the trainer never imports MLflow: the
+    loop is useful without tracking, and a test should be able to assert what was
+    recorded without a tracking server.
+    """
+
+    def log_round(self, result: Any) -> None:
+        """Record one round: its metrics and its fitted model."""
+
+    def log_curve(self, curve: LearningCurve) -> None:
+        """Record the finished curve, the round to report, and close the run."""
+
+
+class MLflowModelLearningTracker:
+    """Log a method-and-seed run of the loop to MLflow, models included.
+
+    Args:
+        experiment_name: MLflow experiment to log under.
+        method: The method this run is, e.g. ``"dagger"`` or ``"batch"``. Logged
+            as a parameter so curves of two methods can be pulled apart later.
+        seed: The repetition's seed, logged for the same reason.
+        params: Extra parameters worth pinning to the run -- environment name,
+            learner settings, planner budget, commit. Anything the run cannot be
+            reproduced without.
+        tracking_uri: MLflow tracking URI. ``None`` uses the ambient setting.
+        run_name: Name for the parent run. ``None`` builds one from method and seed.
+        logger: Optional logger.
+
+    Example:
+        Wrap a trainer's run so every round is recorded::
+
+            with MLflowModelLearningTracker("model_learning", "dagger", 0) as tracker:
+                trainer = DAggerModelTrainer(..., tracker=tracker)
+                trainer.run()
+                tracker.log_curve(trainer.learning_curve("dagger"))
+    """
+
+    def __init__(
+        self,
+        experiment_name: str,
+        method: str,
+        seed: int,
+        params: Optional[Dict[str, Any]] = None,
+        tracking_uri: Optional[str] = None,
+        run_name: Optional[str] = None,
+        logger: Optional[Any] = None,
+    ) -> None:
+        self.experiment_name = experiment_name
+        self.method = method
+        self.seed = int(seed)
+        self.params = dict(params or {})
+        self.tracking_uri = tracking_uri
+        self.run_name = run_name or f"{method}_seed{seed}"
+        self._logger = logger or get_logger(__name__)
+        self._run = None
+        self._rounds: list = []
+
+    def __enter__(self) -> "MLflowModelLearningTracker":
+        """Start the parent run and pin the parameters to it."""
+        self._ensure_run()
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        """Write the per-round record and close the run."""
+        self.finish()
+
+    def _ensure_run(self) -> None:
+        """Start the run on first use, so a tracker can be built before it is needed.
+
+        A run started in a factory and finished by whoever collects the curve is
+        the shape :func:`...curve_comparison.run_learning_curves` needs; requiring
+        a ``with`` block there would put the tracker's lifetime in the wrong place.
+        """
+        # Deferred: importing MLflow costs seconds, and the loop runs without it.
+        import mlflow  # pylint: disable=import-outside-toplevel
+
+        if self._run is not None:
+            return
+        # MLflow >= 3.6 gates the local filesystem backend behind an opt-in, and
+        # this project stores runs locally -- the same default the simulator sets.
+        os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
+        if self.tracking_uri is not None:
+            mlflow.set_tracking_uri(self.tracking_uri)
+        mlflow.set_experiment(self.experiment_name)
+        self._run = mlflow.start_run(run_name=self.run_name)
+        mlflow.log_param("method", self.method)
+        mlflow.log_param("seed", self.seed)
+        for key, value in self.params.items():
+            mlflow.log_param(key, value)
+
+    def finish(self) -> None:
+        """Write the per-round record and close the run. Safe to call twice."""
+        import mlflow  # pylint: disable=import-outside-toplevel
+
+        if self._run is None:
+            return
+        if self._rounds:
+            _log_json_artifact(self._rounds, "rounds.json", EVALUATION_ARTIFACT_PATH)
+        mlflow.end_run()
+        self._run = None
+
+    def log_round(self, result: Any) -> None:
+        """Record one round's metrics and save its model as an artifact.
+
+        Args:
+            result: The round's
+                :class:`~POMDPPlanners.training.model_learning.dagger_trainer.RoundResult`.
+        """
+        import mlflow  # pylint: disable=import-outside-toplevel
+
+        self._ensure_run()
+        step = int(result.round_index)
+        metrics: Dict[str, float] = {"dataset_size": float(result.dataset_size)}
+        for source, count in result.source_counts.items():
+            metrics[f"transitions_{source}"] = float(count)
+        for name, value in result.diagnostics.items():
+            metrics[name] = float(value)
+        for name, values in result.training_metrics.items():
+            if values:
+                # The last epoch's value: the fit that was actually used.
+                metrics[f"train_{name}"] = float(values[-1])
+        if result.control is not None:
+            metrics["mean_return"] = result.control.mean_return
+            metrics["return_standard_error"] = result.control.standard_error
+            metrics["cumulative_transitions"] = float(result.control.cumulative_transitions)
+        for name, value in metrics.items():
+            # A NaN metric is rejected by some backends and silently plotted as a
+            # gap by others; both hide that the quantity was never measured.
+            if np.isfinite(value):
+                mlflow.log_metric(name, float(value), step=step)
+
+        fingerprint = getattr(result.model, "fingerprint", None)
+        model_artifact = self._log_model(result.model, step)
+        self._rounds.append(
+            {
+                "round_index": step,
+                "dataset_size": int(result.dataset_size),
+                "source_counts": dict(result.source_counts),
+                "diagnostics": {k: float(v) for k, v in result.diagnostics.items()},
+                "metrics": {k: float(v) for k, v in metrics.items()},
+                "model_fingerprint": fingerprint,
+                "model_artifact": model_artifact,
+                "control": None if result.control is None else result.control.to_dict(),
+            }
+        )
+
+    def log_curve(self, curve: LearningCurve) -> None:
+        """Record the finished curve and the round it should be reported at.
+
+        The best round is logged rather than the last one, because that is the
+        round the guarantee covers and the sequence is not monotone. This closes
+        the run: a curve is the last thing a ``(method, seed)`` produces.
+
+        Args:
+            curve: The run's curve, from ``trainer.learning_curve(method)``.
+        """
+        import mlflow  # pylint: disable=import-outside-toplevel
+
+        self._ensure_run()
+        _log_json_artifact(curve.to_dict(), "learning_curve.json", EVALUATION_ARTIFACT_PATH)
+        best = best_point(curve)
+        if best is None:
+            self._logger.warning(
+                "no evaluated round for method %s seed %d: nothing to report",
+                curve.method,
+                curve.seed,
+            )
+        else:
+            mlflow.log_metric("best_round_index", float(best.round_index))
+            mlflow.log_metric("best_round_mean_return", best.mean_return)
+            mlflow.log_metric("best_round_transitions", float(best.cumulative_transitions))
+        self.finish()
+
+    def _log_model(self, model: Any, round_index: int) -> Optional[str]:
+        """Save the round's model and log it under ``models/``.
+
+        Returns:
+            The artifact path, or ``None`` when the model cannot save itself --
+            in which case the round's numbers still land, and the log says which
+            model is missing rather than the run looking complete.
+        """
+        import mlflow  # pylint: disable=import-outside-toplevel
+
+        save = getattr(model, "save", None)
+        if not callable(save):
+            self._logger.warning(
+                "round %d: %s has no save(); its metrics are logged but the model is not",
+                round_index,
+                type(model).__name__,
+            )
+            return None
+        suffix = ".npz" if type(model).__name__ == "LinearGaussianTransition" else ".pt"
+        with tempfile.TemporaryDirectory() as staging:
+            path = save(Path(staging) / f"round_{round_index}{suffix}")
+            # save() may append its own suffix (np.savez does), so log what exists.
+            written = Path(path) if Path(path).exists() else Path(f"{path}.npz")
+            mlflow.log_artifact(str(written), MODELS_ARTIFACT_PATH)
+            return f"{MODELS_ARTIFACT_PATH}/{written.name}"
+
+
+def _log_json_artifact(payload: Any, filename: str, artifact_path: str) -> None:
+    """Write ``payload`` as JSON and log it under ``artifact_path``."""
+    import mlflow  # pylint: disable=import-outside-toplevel
+
+    with tempfile.TemporaryDirectory() as staging:
+        path = Path(staging) / filename
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        mlflow.log_artifact(str(path), artifact_path)
+
+
+def load_round_models(run_artifacts_dir: Path) -> Dict[int, Path]:
+    """Map round index to the saved model file, for a downloaded run's artifacts.
+
+    Args:
+        run_artifacts_dir: The run's artifact directory, containing ``models/``.
+
+    Returns:
+        ``{round_index: path}``, so the round a curve names can be loaded without
+        guessing at file names.
+    """
+    models_dir = Path(run_artifacts_dir) / MODELS_ARTIFACT_PATH
+    found: Dict[int, Path] = {}
+    for path in sorted(models_dir.glob("round_*")):
+        index = path.stem.split("_")[-1]
+        if index.isdigit():
+            found[int(index)] = path
+    return found
+
+
+def curve_summaries(curves: Sequence[LearningCurve]) -> Dict[str, Dict[str, float]]:
+    """Best round per curve, keyed by ``method_seed`` -- the table to read first.
+
+    Args:
+        curves: Curves across methods and seeds.
+
+    Returns:
+        Per curve: the best round, its return and what it cost in transitions.
+    """
+    summaries: Dict[str, Dict[str, float]] = {}
+    for curve in curves:
+        best = best_point(curve)
+        if best is None:
+            continue
+        summaries[f"{curve.method}_{curve.seed}"] = {
+            "best_round_index": float(best.round_index),
+            "mean_return": best.mean_return,
+            "standard_error": best.standard_error,
+            "cumulative_transitions": float(best.cumulative_transitions),
+        }
+    return summaries

--- a/POMDPPlanners/training/model_learning/tracking.py
+++ b/POMDPPlanners/training/model_learning/tracking.py
@@ -280,7 +280,7 @@ class MLflowModelLearningTracker:
             return None
         suffix = ".npz" if type(model).__name__ == "LinearGaussianTransition" else ".pt"
         with tempfile.TemporaryDirectory() as staging:
-            path = save(Path(staging) / f"round_{round_index}{suffix}")
+            path = str(save(Path(staging) / f"round_{round_index}{suffix}"))
             # save() may append its own suffix (np.savez does), so log what exists.
             written = Path(path) if Path(path).exists() else Path(f"{path}.npz")
             self._client.log_artifact(

--- a/POMDPPlanners/training/model_learning/tracking.py
+++ b/POMDPPlanners/training/model_learning/tracking.py
@@ -126,6 +126,7 @@ class MLflowModelLearningTracker:
         self._logger = logger or get_logger(__name__)
         self._client: Any = None
         self._run = None
+        self._curves: list = []
         self._rounds: list = []
 
     def __enter__(self) -> "MLflowModelLearningTracker":
@@ -179,6 +180,7 @@ class MLflowModelLearningTracker:
             return
         if self._rounds:
             self._log_json_artifact(self._rounds, "rounds.json")
+            self._log_reports()
             self._log_plots()
         self._client.set_terminated(self._run.info.run_id)
         self._run = None
@@ -246,6 +248,7 @@ class MLflowModelLearningTracker:
         """
         self._ensure_run()
         run_id = self._run.info.run_id
+        self._curves.append(curve)
         self._log_json_artifact(curve.to_dict(), "learning_curve.json")
         best = best_point(curve)
         if best is None:
@@ -287,6 +290,21 @@ class MLflowModelLearningTracker:
                 self._run.info.run_id, str(written), MODELS_ARTIFACT_PATH
             )
             return f"{MODELS_ARTIFACT_PATH}/{written.name}"
+
+    def _log_reports(self) -> None:
+        """Write the readable tables beside the JSON and log them.
+
+        JSON is what a plot is rebuilt from; a person deciding whether to plan
+        with a model reads the table.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from POMDPPlanners.training.model_learning.reporting import write_reports
+
+        with tempfile.TemporaryDirectory() as staging:
+            for path in write_reports(self._rounds, Path(staging), curves=self._curves).values():
+                self._client.log_artifact(
+                    self._run.info.run_id, str(path), EVALUATION_ARTIFACT_PATH
+                )
 
     def _log_plots(self) -> None:
         """Draw the fit's diagnostic plots and log them under ``plots/``.

--- a/POMDPPlanners/training/model_learning/tracking.py
+++ b/POMDPPlanners/training/model_learning/tracking.py
@@ -29,6 +29,11 @@ moves on. A run whose fingerprints repeat across rounds is a run whose later
 rounds were scored on an earlier round's episodes -- visible in the log rather
 than as an unexplained flat curve.
 
+**The fit's own curves, and the plots of them.** A learning curve that does not
+rise has two causes -- the network never fitted, or it fitted and the model still
+does not help the planner -- and only the per-epoch train and holdout losses
+separate them, so they are logged in full and drawn at the end of the run.
+
 **Both halves of the judgement.** The return says whether the model plans well;
 the diagnostics say why it does not. A drift ratio above one means the model's
 own error bars do not cover its error over the planning horizon, which is the
@@ -58,6 +63,9 @@ MODELS_ARTIFACT_PATH = "models"
 
 #: Artifact sub-directory holding the curve and the per-round record.
 EVALUATION_ARTIFACT_PATH = "evaluation"
+
+#: Artifact sub-directory holding the fit's diagnostic plots.
+PLOTS_ARTIFACT_PATH = "plots"
 
 
 class ModelLearningTracker(Protocol):
@@ -171,6 +179,7 @@ class MLflowModelLearningTracker:
             return
         if self._rounds:
             self._log_json_artifact(self._rounds, "rounds.json")
+            self._log_plots()
         self._client.set_terminated(self._run.info.run_id)
         self._run = None
 
@@ -211,6 +220,13 @@ class MLflowModelLearningTracker:
                 "dataset_size": int(result.dataset_size),
                 "source_counts": dict(result.source_counts),
                 "diagnostics": {k: float(v) for k, v in result.diagnostics.items()},
+                # The full per-epoch curves, not just their last value: they are
+                # what the training plots are drawn from, and re-fitting to
+                # recover them would not reproduce the fit that was scored.
+                "training_metrics": {
+                    name: [float(value) for value in values]
+                    for name, values in result.training_metrics.items()
+                },
                 "metrics": {k: float(v) for k, v in metrics.items()},
                 "model_fingerprint": fingerprint,
                 "model_artifact": model_artifact,
@@ -271,6 +287,28 @@ class MLflowModelLearningTracker:
                 self._run.info.run_id, str(written), MODELS_ARTIFACT_PATH
             )
             return f"{MODELS_ARTIFACT_PATH}/{written.name}"
+
+    def _log_plots(self) -> None:
+        """Draw the fit's diagnostic plots and log them under ``plots/``.
+
+        Drawn from the same records that were just written, so a plot in the run
+        and a plot redrawn later from ``rounds.json`` are the same figure. A
+        failure here loses pictures, not data, so it is logged and swallowed
+        rather than taking the run down at its last step.
+        """
+        # Deferred: matplotlib is a heavy import and the loop does not need it.
+        # pylint: disable-next=import-outside-toplevel
+        from POMDPPlanners.utils.visualization.model_learning_plots import (
+            plot_model_learning_report,
+        )
+
+        try:
+            with tempfile.TemporaryDirectory() as staging:
+                written = plot_model_learning_report(self._rounds, Path(staging))
+                for path in written.values():
+                    self._client.log_artifact(self._run.info.run_id, str(path), PLOTS_ARTIFACT_PATH)
+        except Exception as error:  # pylint: disable=broad-except
+            self._logger.warning("could not draw the model-learning plots: %s", error)
 
     def _log_json_artifact(self, payload: Any, filename: str) -> None:
         """Write ``payload`` as JSON and log it under the evaluation artifacts."""

--- a/POMDPPlanners/utils/visualization/model_learning_plots.py
+++ b/POMDPPlanners/utils/visualization/model_learning_plots.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: MIT
 
-"""The learning curve a model-fitting run is judged by.
+"""The plots a model-fitting run is judged and debugged by.
 
-One plot: return of the planner searching each round's model, against the
+The headline plot: return of the planner searching each round's model, against the
 transitions that round cost, one line per method, averaged over shared seeds.
 It is the figure Ross & Bagnell (ICML 2012) report and the only thing that
 answers whether iterating on the data collection was worth it.
@@ -27,13 +27,39 @@ Unlike its neighbours this module is not re-exported from the package's
 pull in the training layer, and would leave a cycle waiting for the first time
 training wants a plot. Import it by module path.
 
+Beside it are the fit's own diagnostics, which the headline plot cannot give.
+A learning curve that fails to rise has two very different causes -- the network
+never fitted the data, or it fitted it and the model still does not help the
+planner -- and only the training curves separate them. So the same run also
+produces:
+
+**Train and holdout loss per epoch, per round.** The gap between them is the
+number to read: a holdout curve that turns up while the training curve keeps
+falling is a fit spending its epochs memorizing, and more data will not fix it.
+A round is one line pair, so a fit that degraded as the dataset grew is visible
+as the curves separating round over round.
+
+**Per-member training curves.** The ensemble's spread *is* its uncertainty
+estimate, so a single member that diverged silently poisons every belief the
+planner grades -- and it is invisible in the mean the ensemble reports.
+
+**The model diagnostics per round.** Held-out likelihood says whether the fit
+improved; the horizon drift ratio says whether the model's error over a planning
+horizon stays inside the error bars it claims. A drift ratio above one is the
+overconfidence a risk-sensitive planner turns into confident bad decisions, and
+it can grow while the likelihood also improves.
+
 Functions:
     plot_learning_curves: Return against data, one line per method.
+    plot_training_curves: Train and holdout loss per epoch, one panel per round.
+    plot_member_training_curves: Every ensemble member's training curve.
+    plot_round_diagnostics: Held-out likelihood and drift ratio per round.
+    plot_model_learning_report: Every plot above, into one directory.
 """
 
 import logging
 from pathlib import Path
-from typing import Dict, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -135,3 +161,216 @@ def _draw(axis, curve: AggregatedCurve, color: str) -> None:
     if np.isfinite(errors).any():
         band = np.nan_to_num(errors, nan=0.0)
         axis.fill_between(transitions, means - band, means + band, color=color, alpha=0.2)
+
+
+def _finish(fig, output_path: Path) -> Path:
+    """Write a figure and close it, creating the parent directory."""
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+    return output_path
+
+
+def _training_metrics(rounds: Sequence[Any]) -> List[Dict[str, List[float]]]:
+    """Per-round training metrics, from round results or from the tracker's JSON."""
+    extracted: List[Dict[str, List[float]]] = []
+    for entry in rounds:
+        metrics = (
+            entry.get("training_metrics", {})
+            if isinstance(entry, dict)
+            else getattr(entry, "training_metrics", {})
+        )
+        extracted.append({key: list(values) for key, values in (metrics or {}).items()})
+    return extracted
+
+
+def plot_training_curves(
+    rounds: Sequence[Any],
+    output_path: Path,
+    title: str = "Fit per round: training and held-out loss",
+) -> Optional[Path]:
+    """Plot training and holdout loss against epoch, one panel per round.
+
+    Args:
+        rounds: The run's rounds -- ``RoundResult`` objects, or the dictionaries
+            the tracker writes to ``evaluation/rounds.json``, so a plot can be
+            rebuilt from a finished run without re-fitting anything.
+        output_path: Where to write the PNG.
+        title: Figure title.
+
+    Returns:
+        The written path, or ``None`` if no round recorded a training curve.
+    """
+    metrics = _training_metrics(rounds)
+    drawable = [(index, entry) for index, entry in enumerate(metrics, start=1) if entry.get("train_nll")]
+    if not drawable:
+        logger.warning("plot_training_curves: no round recorded a training curve")
+        return None
+
+    fig, axes = plt.subplots(
+        1, len(drawable), figsize=(4.5 * len(drawable), 4), squeeze=False, sharey=True
+    )
+    for axis, (round_index, entry) in zip(axes[0], drawable):
+        epochs = np.arange(1, len(entry["train_nll"]) + 1)
+        axis.plot(epochs, entry["train_nll"], color="tab:blue", linewidth=2, label="train")
+        holdout = entry.get("holdout_nll")
+        if holdout:
+            axis.plot(
+                np.arange(1, len(holdout) + 1),
+                holdout,
+                color="tab:red",
+                linewidth=2,
+                label="held out",
+            )
+            best = int(np.argmin(holdout))
+            # The epoch the fit should have stopped at: past it the network is
+            # buying training loss with held-out loss.
+            axis.axvline(best + 1, color="tab:red", linestyle=":", linewidth=1)
+        axis.set_title(f"round {round_index}")
+        axis.set_xlabel("Epoch")
+        axis.grid(True, alpha=0.3)
+    axes[0][0].set_ylabel("Gaussian NLL")
+    axes[0][0].legend()
+    fig.suptitle(title)
+    return _finish(fig, output_path)
+
+
+def plot_member_training_curves(
+    rounds: Sequence[Any],
+    output_path: Path,
+    title: str = "Ensemble members, training loss per epoch",
+) -> Optional[Path]:
+    """Plot every member's training curve, one panel per round.
+
+    Args:
+        rounds: The run's rounds, as for :func:`plot_training_curves`.
+        output_path: Where to write the PNG.
+        title: Figure title.
+
+    Returns:
+        The written path, or ``None`` if no per-member curve was recorded.
+    """
+    metrics = _training_metrics(rounds)
+    drawable = [
+        (index, entry)
+        for index, entry in enumerate(metrics, start=1)
+        if any(key.startswith("train_nll_member_") for key in entry)
+    ]
+    if not drawable:
+        logger.warning("plot_member_training_curves: no per-member curve was recorded")
+        return None
+
+    fig, axes = plt.subplots(
+        1, len(drawable), figsize=(4.5 * len(drawable), 4), squeeze=False, sharey=True
+    )
+    for axis, (round_index, entry) in zip(axes[0], drawable):
+        members = sorted(key for key in entry if key.startswith("train_nll_member_"))
+        for member in members:
+            curve = entry[member]
+            axis.plot(
+                np.arange(1, len(curve) + 1),
+                curve,
+                linewidth=1.2,
+                alpha=0.8,
+                label=member.rsplit("_", 1)[-1],
+            )
+        axis.set_title(f"round {round_index}")
+        axis.set_xlabel("Epoch")
+        axis.grid(True, alpha=0.3)
+    axes[0][0].set_ylabel("Gaussian NLL")
+    axes[0][0].legend(title="member", fontsize="small")
+    fig.suptitle(title)
+    return _finish(fig, output_path)
+
+
+def plot_round_diagnostics(
+    rounds: Sequence[Any],
+    output_path: Path,
+    title: str = "Model quality per round",
+) -> Optional[Path]:
+    """Plot the per-round model diagnostics against round index.
+
+    Args:
+        rounds: The run's rounds, as for :func:`plot_training_curves`.
+        output_path: Where to write the PNG.
+        title: Figure title.
+
+    Returns:
+        The written path, or ``None`` if no diagnostics were recorded.
+    """
+    series: Dict[str, List[float]] = {}
+    indices: List[int] = []
+    for position, entry in enumerate(rounds, start=1):
+        diagnostics = (
+            entry.get("diagnostics", {})
+            if isinstance(entry, dict)
+            else getattr(entry, "diagnostics", {})
+        )
+        if not diagnostics:
+            continue
+        indices.append(position)
+        for name, value in diagnostics.items():
+            series.setdefault(name, []).append(float(value))
+    if not series:
+        logger.warning("plot_round_diagnostics: no round recorded diagnostics")
+        return None
+
+    names = sorted(series)
+    fig, axes = plt.subplots(1, len(names), figsize=(4.5 * len(names), 4), squeeze=False)
+    for axis, name in zip(axes[0], names):
+        values = series[name]
+        axis.plot(indices[: len(values)], values, color="tab:green", linewidth=2, marker="o")
+        if name == "horizon_drift_ratio":
+            # One is the line the measure is calibrated against: above it the
+            # model's error over the horizon is outside its own error bars.
+            axis.axhline(1.0, color="black", linestyle="--", linewidth=1.2, label="claimed spread")
+            axis.legend()
+        axis.set_title(name.replace("_", " "))
+        axis.set_xlabel("Round")
+        axis.grid(True, alpha=0.3)
+    fig.suptitle(title)
+    return _finish(fig, output_path)
+
+
+def plot_model_learning_report(
+    rounds: Sequence[Any],
+    output_dir: Path,
+    curves: Optional[Sequence[LearningCurve]] = None,
+    baseline_return: Optional[float] = None,
+) -> Dict[str, Path]:
+    """Write every plot a fitting run should be read with, into one directory.
+
+    Args:
+        rounds: The run's rounds, as for :func:`plot_training_curves`.
+        output_dir: Directory to write the PNGs into.
+        curves: Control curves across methods and seeds. ``None`` skips the
+            headline plot, which needs more than one run to be worth drawing.
+        baseline_return: Return of the model the loop started from.
+
+    Returns:
+        Plot name to written path, omitting the plots that had no data.
+    """
+    output_dir = Path(output_dir)
+    written: Dict[str, Path] = {}
+    candidates = {
+        "training_curves": lambda: plot_training_curves(
+            rounds, output_dir / "training_curves.png"
+        ),
+        "member_training_curves": lambda: plot_member_training_curves(
+            rounds, output_dir / "member_training_curves.png"
+        ),
+        "round_diagnostics": lambda: plot_round_diagnostics(
+            rounds, output_dir / "round_diagnostics.png"
+        ),
+    }
+    if curves:
+        candidates["learning_curves"] = lambda: plot_learning_curves(
+            curves, output_dir / "learning_curves.png", baseline_return=baseline_return
+        )
+    for name, draw in candidates.items():
+        path = draw()
+        if path is not None:
+            written[name] = path
+    return written


### PR DESCRIPTION
Stacks on #247 — merge that first; the two commits it carries show up here until then.

A fitted model existed only in memory. The object a control number was measured on could not be reloaded, and refitting it later reproduces neither the initialisations nor the batch order, so a study could not be revisited without re-running it.

## What changed

**Fitted models save and load.** `ProbabilisticEnsembleTransition.save/load` writes every member's weights *and* the normalization statistics and the sampler stream — weights alone reload into a model that runs and predicts nonsense. `LinearGaussianTransition` gets the same, as `.npz`.

**Both report a `fingerprint`, and a factored model planning with one exposes it.** `config_id` skips private attributes and a transition is private, so without this a refitted transition left the environment's cache key unchanged and round *n* was served round *n−1*'s episodes — visible as a flat learning curve, never as an error. Analytic transitions report no fingerprint, so their keys and caches are untouched.

**`MLflowModelLearningTracker` records a run.** One MLflow run per `(method, seed)`; per round it logs the return and its standard error, the diagnostics, the dataset split, and the fitted model as an artifact under `models/round_k.pt`. `evaluation/rounds.json` ties each round's number to the fingerprint that produced it; `log_curve` adds the **best** round, which is the one the guarantee covers. `DAggerModelTrainer` takes an optional `tracker`; `run_learning_curves` hands it the curve.

The tracker logs through an `MlflowClient` bound to its run id, not the fluent API. The rollouts it evaluates with go through `LocalSimulationsAPI`, which sets its own tracking URI and ends whatever run is active — with the fluent API the tracker lost its run inside round one and wrote everything after it somewhere else. Second commit; there's a regression test for it.

## Verification

- 60 tests in `test_model_learning`, including reload-predicts-the-same-density, the sampler stream surviving the round trip, `config_id` moving with a refit and *not* moving for analytic transitions, and the hijacked-active-run case.
- Full `test_core` + `test_environments` + `test_training`: 4198 passed. Two failures (`test_laser_tag_hazard_terminal`, and an order-dependent flake in `test_factored_integration`) reproduce on develop without these changes.
- End to end on FrankaReachFragile (DAgger vs Batch, 2 rounds, ensemble fit, PFT-DPW rollouts through `LocalSimulationsAPI`): both runs logged all rounds with distinct fingerprints and loadable models, sharing one simulation cache — which round 2 could not have done before the fingerprint reached the key.

https://claude.ai/code/session_01AtKrDxoPDQwUkkhBzRwPdX