### PR TITLE
feat(training): one evaluation dir that decides a model, with confidence intervals

### DIFF
--- a/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
@@ -896,6 +896,81 @@ class TestMetricsTable:
         assert metrics["rounds_overconfident"] == 3
 
 
+class TestConfidenceIntervals:
+    """A mean with no interval is a number nobody can act on."""
+
+    @staticmethod
+    def _rounds(returns):
+        return [
+            {
+                "round_index": index,
+                "dataset_size": 100 * index,
+                "source_counts": {"exploration": 100 * index},
+                "diagnostics": {"held_out_log_likelihood": 2.0, "horizon_drift_ratio": 0.8},
+                "training_metrics": {},
+                "control": {
+                    "round_index": index,
+                    "cumulative_transitions": 100 * index,
+                    "returns": list(values),
+                },
+            }
+            for index, values in returns.items()
+        ]
+
+    def test_the_interval_matches_the_repo_t_interval(self) -> None:
+        """Purpose: Validates that model-learning intervals are the repo's, not a new convention
+
+        Given: A round with several evaluation episodes
+        When: Its metrics are computed
+        Then: The bounds equal utils.statistics_utils.confidence_interval, so a
+            model number and a planner number can sit in one table
+        """
+        from POMDPPlanners.training.model_learning import run_metrics
+        from POMDPPlanners.utils.statistics_utils import confidence_interval
+
+        episodes = [-1.0, -1.4, -0.8, -1.2, -1.1]
+
+        metrics = run_metrics(self._rounds({1: episodes}))
+
+        expected = confidence_interval(episodes, confidence=0.95)
+        assert metrics["chosen_return_ci_low"] == pytest.approx(expected[0])
+        assert metrics["chosen_return_ci_high"] == pytest.approx(expected[1])
+
+    def test_one_episode_reports_no_interval(self) -> None:
+        """Purpose: Validates that a single episode is not dressed up as a result
+
+        Given: A round evaluated on one episode
+        When: The rounds table is rendered
+        Then: The interval column is a dash rather than a point pretending to be
+            a range
+        """
+        from POMDPPlanners.training.model_learning import round_table_markdown
+
+        table = round_table_markdown(self._rounds({1: [-1.0]}))
+
+        row = [line for line in table.splitlines() if line.startswith("| 1")][0]
+        assert "[" not in row
+
+    def test_the_method_table_carries_an_interval_per_run(self) -> None:
+        """Purpose: Validates that the comparison table is readable as evidence
+
+        Given: Two methods' curves with several episodes each
+        When: The method table is rendered
+        Then: Each row carries a CI, so a gap between methods can be judged
+        """
+        from POMDPPlanners.training.model_learning import curve_table_markdown
+
+        curves = [
+            LearningCurve(method, 0, (ControlPoint(1, 100, (-1.0, -1.4, -0.9)),))
+            for method in ("dagger", "batch")
+        ]
+
+        table = curve_table_markdown(curves)
+
+        assert table.count("[") >= 2
+        assert "95% CI" in table
+
+
 class TestCurveSummaries:
     """The one table to read first."""
 

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
@@ -632,13 +632,13 @@ class TestReadableReports:
         assert lines[0].startswith("round,transitions")
         assert len(lines) == 3
 
-    def test_write_reports_puts_both_files_beside_the_json(self, tmp_path) -> None:
+    def test_write_reports_puts_the_readable_files_beside_the_json(self, tmp_path) -> None:
         """Purpose: Validates the reports a run writes for a person
 
         Given: Rounds and a method's curve
         When: The reports are written
-        Then: A summary Markdown and a rounds CSV exist, and the summary names
-            the method
+        Then: The rounds table, the metrics table and their CSVs exist, and the
+            summary names the method
         """
         from POMDPPlanners.training.model_learning import write_reports
 
@@ -650,8 +650,9 @@ class TestReadableReports:
 
         written = write_reports(self._rounds(), tmp_path, curves=[curve])
 
-        assert set(written) == {"summary", "rounds_csv"}
+        assert set(written) == {"summary", "rounds_csv", "metrics", "metrics_csv"}
         assert "dagger" in written["summary"].read_text(encoding="utf-8")
+        assert "chosen round" in written["metrics"].read_text(encoding="utf-8")
 
     def test_a_tracked_run_logs_the_tables(self, tmp_path) -> None:
         """Purpose: Validates that the tables reach MLflow with the JSON
@@ -722,11 +723,14 @@ class TestArtifactLayout:
         assert {path.name for path in (artifacts / "models").glob("*")} == {
             "round_1.pt",
             "round_2.pt",
+            "chosen.pt",
         }
         assert {path.name for path in (artifacts / "evaluation").glob("*")} == {
             "rounds.json",
             "summary.md",
             "rounds.csv",
+            "metrics.md",
+            "metrics.csv",
             "learning_curve.json",
             "training_curves.png",
             "member_training_curves.png",
@@ -795,6 +799,101 @@ class TestArtifactLayout:
             )
             == []
         )
+
+
+class TestChosenModel:
+    """A directory of candidates needs the choice made in it, not beside it."""
+
+    def test_the_chosen_model_is_the_best_round_not_the_last(self, tmp_path) -> None:
+        """Purpose: Validates that the model to load is marked, and marked correctly
+
+        Given: Three rounds whose second scored best
+        When: The curve is logged
+        Then: models/chosen.pt is round 2's file and the run records which round
+            it was, so "later is better" cannot be assumed
+        """
+        pytest.importorskip("mlflow")
+        from POMDPPlanners.training.model_learning import (
+            MLflowModelLearningTracker,
+            ProbabilisticEnsembleTransition,
+        )
+
+        tracking_uri = f"file://{tmp_path / 'mlruns'}"
+        tracker = MLflowModelLearningTracker(
+            experiment_name="chosen_test",
+            method="dagger",
+            seed=0,
+            tracking_uri=tracking_uri,
+        )
+        returns = {1: (-5.0, -5.0), 2: (-1.0, -1.0), 3: (-3.0, -3.0)}
+        for index in (1, 2, 3):
+            tracker.log_round(
+                RoundResult(
+                    round_index=index,
+                    model=_ensemble(seed=index),
+                    dataset_size=100 * index,
+                    source_counts={"exploration": 100 * index},
+                    training_metrics={},
+                    diagnostics={"held_out_log_likelihood": 1.0},
+                    control=ControlPoint(index, 100 * index, returns[index]),
+                )
+            )
+        curve = LearningCurve(
+            "dagger",
+            0,
+            tuple(ControlPoint(index, 100 * index, returns[index]) for index in (1, 2, 3)),
+        )
+        artifacts = tracker.artifact_dir
+        tracker.log_curve(curve)
+
+        assert artifacts is not None
+        models = artifacts / "models"
+        assert {path.name for path in models.glob("*")} == {
+            "round_1.pt",
+            "round_2.pt",
+            "round_3.pt",
+            "chosen.pt",
+        }
+        chosen = ProbabilisticEnsembleTransition.load(models / "chosen.pt")
+        round_two = ProbabilisticEnsembleTransition.load(models / "round_2.pt")
+        assert chosen.fingerprint == round_two.fingerprint
+
+
+class TestMetricsTable:
+    """One row that says what the run came to."""
+
+    def test_the_metrics_name_the_chosen_round_and_what_the_last_would_cost(self) -> None:
+        """Purpose: Validates the summary metrics of a run that got worse at the end
+
+        Given: Three rounds whose second scored best
+        When: The metrics are computed
+        Then: The chosen round is 2 and the gain over the final round is the
+            difference reporting round 3 would have cost
+        """
+        from POMDPPlanners.training.model_learning import run_metrics
+
+        returns = {1: (-5.0,), 2: (-1.0,), 3: (-3.0,)}
+        rounds = [
+            {
+                "round_index": index,
+                "dataset_size": 100 * index,
+                "source_counts": {"exploration": 100 * index},
+                "diagnostics": {"held_out_log_likelihood": 2.0, "horizon_drift_ratio": 1.5},
+                "training_metrics": {},
+                "control": {
+                    "round_index": index,
+                    "cumulative_transitions": 100 * index,
+                    "returns": list(returns[index]),
+                },
+            }
+            for index in (1, 2, 3)
+        ]
+
+        metrics = run_metrics(rounds)
+
+        assert metrics["chosen_round"] == 2
+        assert metrics["gain_over_final_round"] == pytest.approx(2.0)
+        assert metrics["rounds_overconfident"] == 3
 
 
 class TestCurveSummaries:

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
@@ -733,61 +733,67 @@ class TestArtifactLayout:
             "round_diagnostics.png",
         }
 
-    def test_the_comparison_is_its_own_run(self, tmp_path) -> None:
-        """Purpose: Validates that the across-run question is recorded beside the runs
+    def test_the_comparison_lands_in_every_run(self, tmp_path) -> None:
+        """Purpose: Validates that one run's evaluation dir is enough to decide with
 
-        Given: Curves for two methods
-        When: The study comparison is logged
-        Then: A run holds the method table and the learning curve in the same
-            evaluation/ directory the per-method runs use, and no rounds table,
-            which belongs to one run
+        Given: Two logged runs and the curves comparing them
+        When: The comparison is logged
+        Then: Each run's evaluation/ gains the learning curve and the method
+            table, so a reader never has to open a second run to judge a model
         """
-        mlflow = pytest.importorskip("mlflow")
-        from POMDPPlanners.training.model_learning import log_study_comparison
+        pytest.importorskip("mlflow")
+        from POMDPPlanners.training.model_learning import (
+            MLflowModelLearningTracker,
+            log_study_comparison,
+        )
 
         tracking_uri = f"file://{tmp_path / 'mlruns'}"
-        curves = [
-            LearningCurve(method, 0, (ControlPoint(1, 100, (-1.0, -2.0)),))
-            for method in ("dagger", "batch")
-        ]
+        artifact_dirs = []
+        curves = []
+        for method in ("dagger", "batch"):
+            tracker = MLflowModelLearningTracker(
+                experiment_name="comparison_test",
+                method=method,
+                seed=0,
+                tracking_uri=tracking_uri,
+            )
+            tracker.log_round(_round(1))
+            artifact_dirs.append(tracker.artifact_dir)
+            curve = LearningCurve(method, 0, (ControlPoint(1, 100, (-1.0, -2.0)),))
+            curves.append(curve)
+            tracker.log_curve(curve)
 
-        run_id = log_study_comparison(
-            "model_learning_test",
+        updated = log_study_comparison(
+            "comparison_test",
             curves,
             params={"environment": "FrankaReachFragile"},
             tracking_uri=tracking_uri,
         )
 
-        assert run_id is not None
-        run = mlflow.tracking.MlflowClient(tracking_uri=tracking_uri).get_run(run_id)
-        evaluation = _artifact_dir(run) / "evaluation"
-        assert {path.name for path in evaluation.glob("*")} == {
-            "summary.md",
-            "learning_curves.json",
-            "learning_curves.png",
-        }
-        summary = (evaluation / "summary.md").read_text(encoding="utf-8")
-        assert "| Method | Seed |" in summary
-        assert "Best holdout epoch" not in summary
-        assert run.data.params["environment"] == "FrankaReachFragile"
+        assert len(updated) == 2
+        for directory in artifact_dirs:
+            assert directory is not None
+            assert {path.name for path in directory.iterdir()} == {"models", "evaluation"}
+            names = {path.name for path in (directory / "evaluation").glob("*")}
+            assert {"learning_curves.png", "methods.md", "summary.md"} <= names
 
-    def test_no_curves_means_no_study_run(self, tmp_path) -> None:
-        """Purpose: Validates that an unevaluated study reports nothing rather than an empty run
+    def test_no_curves_means_nothing_is_written(self, tmp_path) -> None:
+        """Purpose: Validates that an unevaluated study reports nothing
 
         Given: Curves with no evaluated rounds
         When: The comparison is logged
-        Then: None comes back
+        Then: No run is updated
         """
         pytest.importorskip("mlflow")
         from POMDPPlanners.training.model_learning import log_study_comparison
 
         assert (
             log_study_comparison(
-                "model_learning_test",
+                "comparison_test",
                 [LearningCurve("dagger", 0, ())],
                 tracking_uri=f"file://{tmp_path / 'mlruns'}",
             )
-            is None
+            == []
         )
 
 

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
@@ -539,7 +539,7 @@ class TestTrainingPlots:
 
         Given: A tracker with two logged rounds from a real ensemble fit
         When: The run is finished
-        Then: The plots directory holds the training and diagnostic figures
+        Then: The evaluation directory holds the training and diagnostic figures
         """
         pytest.importorskip("mlflow")
         from POMDPPlanners.training.model_learning import MLflowModelLearningTracker
@@ -567,8 +567,8 @@ class TestTrainingPlots:
         run = tracker._run  # pylint: disable=protected-access
         tracker.finish()
 
-        plots = _artifact_dir(run) / "plots"
-        assert {path.name for path in plots.glob("*.png")} == {
+        evaluation = _artifact_dir(run) / "evaluation"
+        assert {path.name for path in evaluation.glob("*.png")} == {
             "training_curves.png",
             "member_training_curves.png",
             "round_diagnostics.png",
@@ -681,100 +681,114 @@ class TestReadableReports:
         }
 
 
-class TestDirectoryLayout:
-    """One level per question: a run owns its rounds, the study owns the comparison."""
+class TestArtifactLayout:
+    """Two directories per run: the models, and what says which one to use."""
 
-    def test_a_run_directory_holds_its_rounds_models_and_plots(self, tmp_path) -> None:
-        """Purpose: Validates that one run is readable on its own
+    def test_a_run_holds_only_models_and_evaluation(self, tmp_path) -> None:
+        """Purpose: Validates that a finished run has one place for each question
 
-        Given: A run's rounds and the model files it saved
-        When: Its directory is written
-        Then: The tables, the per-round models under readable names, and the
-            plots are all there, so nobody has to open MLflow's hashed tree
+        Given: A tracker with two logged rounds and a curve
+        When: The run is finished
+        Then: Its artifacts are exactly models/ and evaluation/, with the models
+            named by round and the tables and figures together in evaluation
         """
-        from POMDPPlanners.training.model_learning import write_run_directory
+        pytest.importorskip("mlflow")
+        from POMDPPlanners.training.model_learning import MLflowModelLearningTracker
 
-        model_file = tmp_path / "staged.pt"
-        _ensemble().save(model_file)
-        rounds = [
-            RoundResult(
-                round_index=index,
-                model=_ensemble(seed=index),
-                dataset_size=100 * index,
-                source_counts={"exploration": 100 * index},
-                training_metrics={"train_nll": [3.0, 2.0], "holdout_nll": [3.1, 2.2]},
-                diagnostics={"held_out_log_likelihood": 2.0, "horizon_drift_ratio": 0.9},
-                control=ControlPoint(index, 100 * index, (-1.0, -2.0)),
+        tracker = MLflowModelLearningTracker(
+            experiment_name="model_learning_test",
+            method="dagger",
+            seed=6,
+            tracking_uri=f"file://{tmp_path / 'mlruns'}",
+        )
+        learner = ProbabilisticEnsembleLearner(num_members=2, epochs=2, seed=0)
+        for index in (1, 2):
+            tracker.log_round(
+                RoundResult(
+                    round_index=index,
+                    model=learner.fit(_dataset(seed=index)),
+                    dataset_size=100 * index,
+                    source_counts={"exploration": 100 * index},
+                    training_metrics=learner.training_metrics(),
+                    diagnostics={"held_out_log_likelihood": 2.0, "horizon_drift_ratio": 0.9},
+                    control=ControlPoint(index, 100 * index, (-1.0, -2.0)),
+                )
             )
-            for index in (1, 2)
-        ]
+        tracker.log_curve(LearningCurve("dagger", 6, (ControlPoint(1, 100, (-1.0,)),)))
 
-        run_dir = tmp_path / "runs" / "dagger_seed0"
-        write_run_directory(rounds, run_dir, models={1: model_file, 2: model_file})
-
-        assert (run_dir / "summary.md").exists()
-        assert (run_dir / "rounds.csv").exists()
-        assert (run_dir / "rounds.json").exists()
-        assert {path.name for path in (run_dir / "models").glob("*")} == {
+        artifacts = tracker.artifact_dir
+        assert artifacts is not None
+        assert {path.name for path in artifacts.iterdir()} == {"models", "evaluation"}
+        assert {path.name for path in (artifacts / "models").glob("*")} == {
             "round_1.pt",
             "round_2.pt",
         }
-        assert (run_dir / "plots" / "training_curves.png").exists()
+        assert {path.name for path in (artifacts / "evaluation").glob("*")} == {
+            "rounds.json",
+            "summary.md",
+            "rounds.csv",
+            "learning_curve.json",
+            "training_curves.png",
+            "member_training_curves.png",
+            "round_diagnostics.png",
+        }
 
-    def test_the_study_level_holds_only_what_compares_runs(self, tmp_path) -> None:
-        """Purpose: Validates that a single run's rounds are not published as the study's
+    def test_the_comparison_is_its_own_run(self, tmp_path) -> None:
+        """Purpose: Validates that the across-run question is recorded beside the runs
 
         Given: Curves for two methods
-        When: The study directory is written
-        Then: It holds the method comparison, the curve and a README naming the
-            run directories -- and no rounds table, which belongs to one run
+        When: The study comparison is logged
+        Then: A run holds the method table and the learning curve in the same
+            evaluation/ directory the per-method runs use, and no rounds table,
+            which belongs to one run
         """
-        from POMDPPlanners.training.model_learning import write_study_directory
+        mlflow = pytest.importorskip("mlflow")
+        from POMDPPlanners.training.model_learning import log_study_comparison
 
+        tracking_uri = f"file://{tmp_path / 'mlruns'}"
         curves = [
             LearningCurve(method, 0, (ControlPoint(1, 100, (-1.0, -2.0)),))
             for method in ("dagger", "batch")
         ]
 
-        write_study_directory(
+        run_id = log_study_comparison(
+            "model_learning_test",
             curves,
-            tmp_path,
             params={"environment": "FrankaReachFragile"},
-            run_dirs={"dagger seed 0": Path("runs/dagger_seed0")},
+            tracking_uri=tracking_uri,
         )
 
-        summary = (tmp_path / "summary.md").read_text(encoding="utf-8")
+        assert run_id is not None
+        run = mlflow.tracking.MlflowClient(tracking_uri=tracking_uri).get_run(run_id)
+        evaluation = _artifact_dir(run) / "evaluation"
+        assert {path.name for path in evaluation.glob("*")} == {
+            "summary.md",
+            "learning_curves.json",
+            "learning_curves.png",
+        }
+        summary = (evaluation / "summary.md").read_text(encoding="utf-8")
         assert "| Method | Seed |" in summary
         assert "Best holdout epoch" not in summary
-        readme = (tmp_path / "README.md").read_text(encoding="utf-8")
-        assert "runs/dagger_seed0" in readme
-        assert "FrankaReachFragile" in readme
+        assert run.data.params["environment"] == "FrankaReachFragile"
 
-    def test_the_tracker_points_at_the_models_it_saved(self, tmp_path) -> None:
-        """Purpose: Validates that a study can find the saved models to copy
+    def test_no_curves_means_no_study_run(self, tmp_path) -> None:
+        """Purpose: Validates that an unevaluated study reports nothing rather than an empty run
 
-        Given: A tracker with one logged round on a local store
-        When: Its artifact directory is read
-        Then: The round's model file is there under the round's index
+        Given: Curves with no evaluated rounds
+        When: The comparison is logged
+        Then: None comes back
         """
         pytest.importorskip("mlflow")
-        from POMDPPlanners.training.model_learning import (
-            MLflowModelLearningTracker,
-            load_round_models,
-        )
+        from POMDPPlanners.training.model_learning import log_study_comparison
 
-        tracker = MLflowModelLearningTracker(
-            experiment_name="model_learning_test",
-            method="dagger",
-            seed=5,
-            tracking_uri=f"file://{tmp_path / 'mlruns'}",
+        assert (
+            log_study_comparison(
+                "model_learning_test",
+                [LearningCurve("dagger", 0, ())],
+                tracking_uri=f"file://{tmp_path / 'mlruns'}",
+            )
+            is None
         )
-        tracker.log_round(_round(1))
-        artifacts = tracker.artifact_dir
-        tracker.finish()
-
-        assert artifacts is not None
-        assert set(load_round_models(artifacts)) == {1}
 
 
 class TestCurveSummaries:

--- a/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
+++ b/POMDPPlanners/tests/test_training/test_model_learning/test_persistence_and_tracking.py
@@ -514,13 +514,23 @@ class TestTrainingPlots:
                     "train_nll_member_0": [3.0, 2.1, 1.6],
                     "train_nll_member_1": [3.0, 1.9, 1.4],
                 },
+                "control": {
+                    "round_index": index,
+                    "cumulative_transitions": 100 * index,
+                    "returns": [-1.0, -2.0, -1.4],
+                },
             }
             for index in (1, 2)
         ]
 
         written = plot_model_learning_report(rounds, tmp_path / "plots")
 
-        assert set(written) == {"training_curves", "member_training_curves", "round_diagnostics"}
+        assert set(written) == {
+            "training_curves",
+            "member_training_curves",
+            "round_diagnostics",
+            "round_returns",
+        }
         assert all(path.exists() for path in written.values())
 
     def test_a_run_without_training_curves_draws_nothing(self, tmp_path) -> None:
@@ -561,7 +571,7 @@ class TestTrainingPlots:
                     source_counts={"exploration": 60 * index},
                     training_metrics=learner.training_metrics(),
                     diagnostics={"held_out_log_likelihood": 1.0, "horizon_drift_ratio": 1.2},
-                    control=None,
+                    control=ControlPoint(index, 100 * index, (-1.0, -2.0, -1.4)),
                 )
             )
         run = tracker._run  # pylint: disable=protected-access
@@ -572,6 +582,7 @@ class TestTrainingPlots:
             "training_curves.png",
             "member_training_curves.png",
             "round_diagnostics.png",
+            "round_returns.png",
         }
 
 
@@ -726,6 +737,7 @@ class TestArtifactLayout:
             "chosen.pt",
         }
         assert {path.name for path in (artifacts / "evaluation").glob("*")} == {
+            "round_returns.png",
             "rounds.json",
             "summary.md",
             "rounds.csv",
@@ -969,6 +981,50 @@ class TestConfidenceIntervals:
 
         assert table.count("[") >= 2
         assert "95% CI" in table
+
+
+class TestPlotIntervals:
+    """A band with no stated meaning is worse than no band."""
+
+    def test_the_round_return_plot_is_written_with_error_bars(self, tmp_path) -> None:
+        """Purpose: Validates the per-round return plot exists and needs evaluated rounds
+
+        Given: Rounds with evaluation episodes, and rounds without
+        When: The plot is drawn for each
+        Then: The evaluated rounds produce a file and the unevaluated ones
+            produce nothing, rather than an empty axis
+        """
+        from POMDPPlanners.utils.visualization.model_learning_plots import plot_round_returns
+
+        rounds = [
+            {
+                "round_index": index,
+                "control": {
+                    "round_index": index,
+                    "cumulative_transitions": 100 * index,
+                    "returns": [-1.0, -2.0, -1.5],
+                },
+            }
+            for index in (1, 2)
+        ]
+
+        assert plot_round_returns(rounds, tmp_path / "returns.png") is not None
+        assert plot_round_returns([{"round_index": 1}], tmp_path / "none.png") is None
+
+    def test_a_single_seed_band_is_labelled_as_episodes(self, tmp_path) -> None:
+        """Purpose: Validates that the learning curve's band never changes meaning silently
+
+        Given: One seed, where there is no spread across repetitions to show
+        When: The learning curve is drawn
+        Then: A file is written -- the band falls back to the episode interval,
+            which the legend labels, rather than vanishing or being passed off
+            as an across-seed spread
+        """
+        from POMDPPlanners.utils.visualization.model_learning_plots import plot_learning_curves
+
+        curves = [LearningCurve("dagger", 0, (ControlPoint(1, 100, (-1.0, -2.0, -1.5)),))]
+
+        assert plot_learning_curves(curves, tmp_path / "one_seed.png") is not None
 
 
 class TestCurveSummaries:

--- a/POMDPPlanners/training/model_learning/__init__.py
+++ b/POMDPPlanners/training/model_learning/__init__.py
@@ -92,6 +92,9 @@ from POMDPPlanners.training.model_learning.learners import (
 )
 from POMDPPlanners.training.model_learning.reporting import (
     curve_table_markdown,
+    metrics_table_csv,
+    metrics_table_markdown,
+    run_metrics,
     round_table_csv,
     round_table_markdown,
     write_reports,
@@ -136,6 +139,9 @@ __all__ = [
     "evaluate_model",
     "load_learning_curves",
     "load_round_models",
+    "metrics_table_csv",
+    "metrics_table_markdown",
+    "run_metrics",
     "log_study_comparison",
     "round_table_csv",
     "round_table_markdown",

--- a/POMDPPlanners/training/model_learning/__init__.py
+++ b/POMDPPlanners/training/model_learning/__init__.py
@@ -95,14 +95,13 @@ from POMDPPlanners.training.model_learning.reporting import (
     round_table_csv,
     round_table_markdown,
     write_reports,
-    write_run_directory,
-    write_study_directory,
 )
 from POMDPPlanners.training.model_learning.tracking import (
     MLflowModelLearningTracker,
     ModelLearningTracker,
     curve_summaries,
     load_round_models,
+    log_study_comparison,
 )
 from POMDPPlanners.training.model_learning.transition_dataset import (
     TransitionBatch,
@@ -137,13 +136,13 @@ __all__ = [
     "evaluate_model",
     "load_learning_curves",
     "load_round_models",
+    "log_study_comparison",
     "round_table_csv",
     "round_table_markdown",
     "run_learning_curves",
     "save_learning_curves",
     "write_reports",
-    "write_run_directory",
-    "write_study_directory",
+
     "held_out_log_likelihood",
     "horizon_drift_ratio",
     "preset_ranking_agreement",

--- a/POMDPPlanners/training/model_learning/reporting.py
+++ b/POMDPPlanners/training/model_learning/reporting.py
@@ -22,25 +22,24 @@ planning horizon is outside the spread it claims, which is the failure that make
 a risk-sensitive planner confidently wrong. A table without the flag leaves the
 reader to remember the threshold.
 
-One directory shape, two levels, and nothing at the wrong one. A run --
-one method at one seed -- owns its rounds, its models and its training curves.
-The study owns only what compares runs: the method table and the learning curve.
-A rounds table sitting at study level is a single run's numbers wearing the
-study's name, which is how the wrong method gets reported.
+These are text, not files. Where they land is the tracker's business, and it
+puts them in one place -- the run's own artifacts -- rather than mirroring them
+into a second tree that then has to be kept in step.
+
+A rounds table belongs to one run, and the method table to the study, so the two
+are separate functions: a rounds table published at study level is a single
+run's numbers wearing the study's name, which is how the wrong method gets
+reported.
 
 Functions:
     round_table_markdown: Per-round table of cost, return and model quality.
     round_table_csv: The same rows, for a spreadsheet.
     curve_table_markdown: Best round per method and seed.
     write_reports: Write both tables into a directory.
-    write_run_directory: One run's rounds, models and plots, under its own name.
-    write_study_directory: The comparison across runs, plus a README pointing at them.
 """
 
 import csv
 import io
-import json
-import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -296,156 +295,3 @@ def write_reports(
     csv_path.write_text(round_table_csv(rounds), encoding="utf-8")
     written["rounds_csv"] = csv_path
     return written
-
-
-def write_run_directory(
-    rounds: Sequence[Any],
-    output_dir: Path,
-    curve: Optional[LearningCurve] = None,
-    models: Optional[Dict[int, Path]] = None,
-) -> Dict[str, Path]:
-    """Write everything about one run -- one method at one seed -- under one name.
-
-    Args:
-        rounds: The run's rounds, as results or as the tracker's dictionaries.
-        output_dir: The run's directory, e.g. ``runs/dagger_seed0``. Created if
-            missing.
-        curve: The run's control curve, written beside the rounds so the run can
-            be read without the study around it.
-        models: ``{round_index: file}`` to copy into ``models/``. The models are
-            the point of the run, and a directory that names its rounds but not
-            its models sends the reader back to MLflow's hashed tree.
-
-    Returns:
-        Report name to written path.
-    """
-    output_dir = Path(output_dir)
-    written = write_reports(rounds, output_dir)
-    (output_dir / "rounds.json").write_text(
-        json.dumps([_as_record(entry) for entry in rounds], indent=2), encoding="utf-8"
-    )
-    written["rounds_json"] = output_dir / "rounds.json"
-
-    if curve is not None:
-        (output_dir / "learning_curve.json").write_text(
-            json.dumps(curve.to_dict(), indent=2), encoding="utf-8"
-        )
-        written["learning_curve"] = output_dir / "learning_curve.json"
-
-    if models:
-        models_dir = output_dir / "models"
-        models_dir.mkdir(parents=True, exist_ok=True)
-        for round_index, source in sorted(models.items()):
-            destination = models_dir / f"round_{round_index}{Path(source).suffix}"
-            shutil.copyfile(source, destination)
-            written[f"model_round_{round_index}"] = destination
-
-    # Deferred: matplotlib is heavy and a caller may only want the tables.
-    # pylint: disable-next=import-outside-toplevel
-    from POMDPPlanners.utils.visualization.model_learning_plots import (
-        plot_model_learning_report,
-    )
-
-    written.update(plot_model_learning_report(rounds, output_dir / "plots"))
-    return written
-
-
-def write_study_directory(
-    curves: Sequence[LearningCurve],
-    output_dir: Path,
-    params: Optional[Dict[str, Any]] = None,
-    run_dirs: Optional[Dict[str, Path]] = None,
-) -> Dict[str, Path]:
-    """Write what compares the runs, and a README saying where everything is.
-
-    Args:
-        curves: Curves across methods and seeds.
-        output_dir: The study directory.
-        params: What was run -- environment, learner, planner budget, commit.
-            Written into the README, because a results directory whose settings
-            live only in the script that produced it is not a result.
-        run_dirs: Run name to its directory, listed in the README.
-
-    Returns:
-        Report name to written path.
-    """
-    output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    written: Dict[str, Path] = {}
-
-    summary_path = output_dir / "summary.md"
-    summary_path.write_text(curve_table_markdown(curves), encoding="utf-8")
-    written["summary"] = summary_path
-
-    curves_path = output_dir / "learning_curves.json"
-    curves_path.write_text(
-        json.dumps([curve.to_dict() for curve in curves], indent=2), encoding="utf-8"
-    )
-    written["learning_curves"] = curves_path
-
-    # pylint: disable-next=import-outside-toplevel
-    from POMDPPlanners.utils.visualization.model_learning_plots import plot_learning_curves
-
-    plot = plot_learning_curves(curves, output_dir / "learning_curves.png")
-    if plot is not None:
-        written["learning_curve_plot"] = plot
-
-    written["readme"] = _write_readme(output_dir, params or {}, run_dirs or {})
-    return written
-
-
-def _write_readme(output_dir: Path, params: Dict[str, Any], run_dirs: Dict[str, Path]) -> Path:
-    """A map of the directory and the settings that produced it."""
-    lines = [
-        "# Model-learning study",
-        "",
-        "## What ran",
-        "",
-        "| Setting | Value |",
-        "|---|---|",
-    ]
-    lines += [f"| {key} | {value} |" for key, value in sorted(params.items())]
-    lines += [
-        "",
-        "## Where things are",
-        "",
-        "| Path | What it holds |",
-        "|---|---|",
-        "| `summary.md` | Best round per method and seed -- read this first. |",
-        "| `learning_curves.png` | Return against transitions, one line per method. |",
-        "| `learning_curves.json` | The same curves, for replotting. |",
-    ]
-    for name, path in sorted(run_dirs.items()):
-        lines.append(f"| `{path}/` | Everything about the {name} run. |")
-    lines += [
-        "| `mlruns/` | The same records, queryable with `mlflow ui`. |",
-        "| `sim_cache/` | Rollout cache. Disposable; delete it to force a re-run. |",
-        "",
-        "Each run directory holds `summary.md` (its rounds), `rounds.csv`,",
-        "`rounds.json`, `models/round_k.pt` and `plots/`. The model of *every*",
-        "round is kept: which round was best is known only after the whole",
-        "sequence has been scored.",
-        "",
-    ]
-    path = output_dir / "README.md"
-    path.write_text("\n".join(lines), encoding="utf-8")
-    return path
-
-
-def _as_record(entry: Any) -> Dict[str, Any]:
-    """One round as a JSON-safe dictionary, whichever shape it arrived in."""
-    if isinstance(entry, dict):
-        return entry
-    control = _field(entry, "control")
-    return {
-        "round_index": _field(entry, "round_index"),
-        "dataset_size": _field(entry, "dataset_size"),
-        "source_counts": dict(_field(entry, "source_counts", {}) or {}),
-        "diagnostics": {k: float(v) for k, v in (_field(entry, "diagnostics", {}) or {}).items()},
-        "training_metrics": {
-            name: [float(value) for value in values]
-            for name, values in (_field(entry, "training_metrics", {}) or {}).items()
-        },
-        "model_fingerprint": _short_fingerprint(entry) or None,
-        "control": None if control is None else control.to_dict(),
-    }

--- a/POMDPPlanners/training/model_learning/reporting.py
+++ b/POMDPPlanners/training/model_learning/reporting.py
@@ -32,6 +32,8 @@ run's numbers wearing the study's name, which is how the wrong method gets
 reported.
 
 Functions:
+    metrics_table_markdown: The run reduced to the numbers a decision needs.
+    metrics_table_csv: The same numbers, for a spreadsheet.
     round_table_markdown: Per-round table of cost, return and model quality.
     round_table_csv: The same rows, for a spreadsheet.
     curve_table_markdown: Best round per method and seed.
@@ -294,4 +296,113 @@ def write_reports(
     csv_path = output_dir / "rounds.csv"
     csv_path.write_text(round_table_csv(rounds), encoding="utf-8")
     written["rounds_csv"] = csv_path
+
+    curve = curves[0] if curves and len(curves) == 1 else None
+    metrics_path = output_dir / "metrics.md"
+    metrics_path.write_text(metrics_table_markdown(rounds, curve), encoding="utf-8")
+    written["metrics"] = metrics_path
+
+    metrics_csv = output_dir / "metrics.csv"
+    metrics_csv.write_text(metrics_table_csv(rounds, curve), encoding="utf-8")
+    written["metrics_csv"] = metrics_csv
     return written
+
+
+def run_metrics(rounds: Sequence[Any], curve: Optional[LearningCurve] = None) -> Dict[str, Any]:
+    """The whole run reduced to the numbers a decision is made on.
+
+    The per-round table says what happened; this says what it came to. Both are
+    kept because a single row cannot show a curve that rose and then collapsed,
+    and a table of rounds does not answer "so which model, and is it any good".
+
+    Args:
+        rounds: The run's rounds, as results or as the tracker's dictionaries.
+        curve: The run's control curve, if it was evaluated.
+
+    Returns:
+        Metric name to value.
+    """
+    rows = _rows(rounds)
+    scored = [row for row in rows if np.isfinite(row["mean_return"])]
+    best_row = max(scored, key=lambda row: row["mean_return"]) if scored else None
+    last = rows[-1] if rows else None
+    drifts = [row["horizon_drift_ratio"] for row in rows if np.isfinite(row["horizon_drift_ratio"])]
+    epochs = [row["best_holdout_epoch"] for row in rows if row["best_holdout_epoch"]]
+
+    metrics: Dict[str, Any] = {
+        "rounds": len(rows),
+        "transitions_total": last["transitions"] if last else 0,
+        "transitions_exploration": last["exploration"] if last else 0,
+        "transitions_planner": last["planner"] if last else 0,
+        "chosen_round": best_row["round"] if best_row else None,
+        "chosen_return": best_row["mean_return"] if best_row else float("nan"),
+        "chosen_return_standard_error": best_row["standard_error"] if best_row else float("nan"),
+        "final_round_return": last["mean_return"] if last else float("nan"),
+        # The gap the loop is judged on: a chosen round far above the last one
+        # means the sequence went backwards, which a final-round report hides.
+        "gain_over_final_round": (
+            best_row["mean_return"] - last["mean_return"]
+            if best_row and last and np.isfinite(last["mean_return"])
+            else float("nan")
+        ),
+        "final_held_out_log_likelihood": last["held_out_log_likelihood"] if last else float("nan"),
+        "max_horizon_drift_ratio": max(drifts) if drifts else float("nan"),
+        # Above one at any round means the model was overconfident somewhere in
+        # the sequence, which is the failure that does not announce itself.
+        "rounds_overconfident": sum(1 for value in drifts if value > DRIFT_WARNING_THRESHOLD),
+        "median_best_holdout_epoch": float(np.median(epochs)) if epochs else float("nan"),
+    }
+    if curve is not None:
+        metrics["evaluation_episodes_per_round"] = (
+            len(curve.points[0].returns) if curve.points else 0
+        )
+    return metrics
+
+
+def metrics_table_markdown(
+    rounds: Sequence[Any],
+    curve: Optional[LearningCurve] = None,
+    title: str = "Metrics",
+) -> str:
+    """The run's headline metrics as a Markdown table.
+
+    Args:
+        rounds: The run's rounds.
+        curve: The run's control curve, if it was evaluated.
+        title: Heading above the table.
+
+    Returns:
+        A Markdown document.
+    """
+    lines = [f"# {title}", "", "| Metric | Value |", "|---|---|"]
+    for name, value in run_metrics(rounds, curve).items():
+        lines.append(f"| {name.replace('_', ' ')} | {_number(value)} |")
+    lines += [
+        "",
+        "`chosen round` is the round to load -- `models/chosen`. `gain over final "
+        "round` is how much reporting the last round instead would have cost.",
+        "",
+        "`rounds overconfident` counts rounds whose horizon drift exceeded the "
+        "spread the model claimed. Any at all is a reason not to trust the model "
+        "in a risk-sensitive planner, however good the return looks.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def metrics_table_csv(rounds: Sequence[Any], curve: Optional[LearningCurve] = None) -> str:
+    """The same metrics as one CSV row.
+
+    Args:
+        rounds: The run's rounds.
+        curve: The run's control curve, if it was evaluated.
+
+    Returns:
+        CSV text with a header row.
+    """
+    metrics = run_metrics(rounds, curve)
+    buffer = io.StringIO()
+    writer: csv.DictWriter = csv.DictWriter(buffer, fieldnames=list(metrics))
+    writer.writeheader()
+    writer.writerow(metrics)
+    return buffer.getvalue()

--- a/POMDPPlanners/training/model_learning/reporting.py
+++ b/POMDPPlanners/training/model_learning/reporting.py
@@ -43,7 +43,7 @@ Functions:
 import csv
 import io
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -52,9 +52,15 @@ from POMDPPlanners.training.model_learning.control_evaluation import (
     aggregate_curves,
     best_point,
 )
+from POMDPPlanners.utils.statistics_utils import confidence_interval
 
 #: Drift above this means the model's horizon error exceeds its claimed spread.
 DRIFT_WARNING_THRESHOLD = 1.0
+
+#: Confidence level for every interval reported here -- the repo's t-interval,
+#: the same one the simulation statistics and the paper's tables use, so a
+#: model-learning number and a planner number can sit in one table.
+CONFIDENCE_LEVEL = 0.95
 
 _COLUMNS = (
     "round",
@@ -63,6 +69,8 @@ _COLUMNS = (
     "planner",
     "mean_return",
     "standard_error",
+    "return_ci_low",
+    "return_ci_high",
     "held_out_log_likelihood",
     "horizon_drift_ratio",
     "best_holdout_epoch",
@@ -101,6 +109,8 @@ def _rows(rounds: Sequence[Any]) -> List[Dict[str, Any]]:
                     if len(returns) > 1
                     else float("nan")
                 ),
+                "return_ci_low": _interval(returns)[0],
+                "return_ci_high": _interval(returns)[1],
                 "held_out_log_likelihood": float(
                     diagnostics.get("held_out_log_likelihood", float("nan"))
                 ),
@@ -128,6 +138,25 @@ def _short_fingerprint(entry: Any) -> str:
         model = _field(entry, "model")
         fingerprint = getattr(model, "fingerprint", None)
     return str(fingerprint)[:10] if fingerprint else ""
+
+
+def _interval(values: Sequence[float]) -> Tuple[float, float]:
+    """The repo's t-interval for a mean, or ``(nan, nan)`` when it is undefined.
+
+    Below two episodes there is no interval, and reporting the point estimate as
+    though it were one is the way a single lucky episode becomes a result.
+    """
+    if len(values) < 2:
+        return float("nan"), float("nan")
+    low, high = confidence_interval(list(values), confidence=CONFIDENCE_LEVEL)
+    return float(low), float(high)
+
+
+def _range(low: float, high: float, digits: int = 3) -> str:
+    """Render an interval, or an em dash when there was not enough data for one."""
+    if not (np.isfinite(low) and np.isfinite(high)):
+        return "--"
+    return f"[{low:.{digits}f}, {high:.{digits}f}]"
 
 
 def _number(value: Any, digits: int = 3) -> str:
@@ -162,8 +191,9 @@ def round_table_markdown(rounds: Sequence[Any], title: str = "Rounds") -> str:
     lines = [
         f"# {title}",
         "",
-        "| Round | Transitions | Explore / Planner | Mean return | Held-out LL | Drift ratio | Best holdout epoch | Model |",
-        "|---|---|---|---|---|---|---|---|",
+        f"| Round | Transitions | Explore / Planner | Mean return | {int(CONFIDENCE_LEVEL * 100)}% CI | "
+        "Held-out LL | Drift ratio | Best holdout epoch | Model |",
+        "|---|---|---|---|---|---|---|---|---|",
     ]
     for row in rows:
         mark = " **(best)**" if row["round"] == best_round else ""
@@ -177,10 +207,15 @@ def round_table_markdown(rounds: Sequence[Any], title: str = "Rounds") -> str:
             f"| {row['round']}{mark} | {row['transitions']} | "
             f"{row['exploration']} / {row['planner']} | "
             f"{_number(row['mean_return'])} ± {error} | "
+            f"{_range(row['return_ci_low'], row['return_ci_high'])} | "
             f"{_number(row['held_out_log_likelihood'], 1)} | {drift} | "
             f"{_number(row['best_holdout_epoch'])} | {row['model'] or '--'} |"
         )
     lines += [
+        "",
+        f"Intervals are the repo's {int(CONFIDENCE_LEVEL * 100)}% t-intervals across the "
+        "round's evaluation episodes -- the same ones the planner tables use. A round with "
+        "fewer than two episodes has no interval and shows a dash.",
         "",
         f"Drift ratio above {DRIFT_WARNING_THRESHOLD:.0f} (⚠) means the model's error over the "
         "planning horizon is larger than the spread it predicts -- it is confident and wrong, "
@@ -226,17 +261,18 @@ def curve_table_markdown(curves: Sequence[LearningCurve]) -> str:
     lines = [
         "# Methods",
         "",
-        "| Method | Seed | Best round | Transitions | Mean return |",
-        "|---|---|---|---|---|",
+        f"| Method | Seed | Best round | Transitions | Mean return | {int(CONFIDENCE_LEVEL * 100)}% CI |",
+        "|---|---|---|---|---|---|",
     ]
     for curve in scored:
         best = best_point(curve)
         if best is None:
             continue
+        low, high = _interval(best.returns)
         lines.append(
             f"| {curve.method} | {curve.seed} | {best.round_index} | "
             f"{best.cumulative_transitions} | {_number(best.mean_return)} ± "
-            f"{_number(best.standard_error)} |"
+            f"{_number(best.standard_error)} | {_range(low, high)} |"
         )
 
     grouped: Dict[str, List[LearningCurve]] = {}
@@ -259,8 +295,10 @@ def curve_table_markdown(curves: Sequence[LearningCurve]) -> str:
         )
     lines += [
         "",
-        "The spread is across seeds, not across the episodes inside one: only the "
-        "first says whether two methods actually differed.",
+        f"Intervals are the repo's {int(CONFIDENCE_LEVEL * 100)}% t-intervals. Per method "
+        "and seed they are across that run's evaluation episodes; in the table above they "
+        "are across seeds. Only the second answers whether two methods differed -- a "
+        "method can be very consistent within one repetition and swing between them.",
         "",
     ]
     return "\n".join(lines)
@@ -337,7 +375,11 @@ def run_metrics(rounds: Sequence[Any], curve: Optional[LearningCurve] = None) ->
         "chosen_round": best_row["round"] if best_row else None,
         "chosen_return": best_row["mean_return"] if best_row else float("nan"),
         "chosen_return_standard_error": best_row["standard_error"] if best_row else float("nan"),
+        "chosen_return_ci_low": best_row["return_ci_low"] if best_row else float("nan"),
+        "chosen_return_ci_high": best_row["return_ci_high"] if best_row else float("nan"),
         "final_round_return": last["mean_return"] if last else float("nan"),
+        "final_round_ci_low": last["return_ci_low"] if last else float("nan"),
+        "final_round_ci_high": last["return_ci_high"] if last else float("nan"),
         # The gap the loop is judged on: a chosen round far above the last one
         # means the sequence went backwards, which a final-round report hides.
         "gain_over_final_round": (

--- a/POMDPPlanners/training/model_learning/tracking.py
+++ b/POMDPPlanners/training/model_learning/tracking.py
@@ -12,9 +12,15 @@ MLflow rather than a directory convention, because the rollouts inside this loop
 already run through it: every planner episode goes through
 ``LocalSimulationsAPI``, which logs to MLflow, so a run of the loop with a
 separate results tree would leave the control numbers and the models they came
-from in two systems that agree by hand. One run per ``(method, seed)`` with one
-child run per round keeps the sequence together, and the per-round metrics are
-step-indexed so the learning curve is a chart rather than a file to plot.
+from in two systems that agree by hand. One run per ``(method, seed)``, plus one run for the
+study that compares them, and the per-round metrics are step-indexed so the
+learning curve is a chart rather than a file to plot.
+
+Each run holds exactly two artifact directories, because there are exactly two
+things anyone comes for: ``models/`` -- one file per round, the objects to plan
+with -- and ``evaluation/`` -- the tables and figures that say which of them to
+use. Nothing is mirrored into a second tree: a copy has to be kept in step, and
+the copy is what people then find stale.
 
 Three things are logged that are easy to omit and hard to reconstruct later.
 
@@ -42,6 +48,11 @@ failure a risk-sensitive planner turns into confident bad decisions.
 Classes:
     ModelLearningTracker: Protocol the trainer calls; implement it to record elsewhere.
     MLflowModelLearningTracker: Logs rounds, models and curves to MLflow.
+
+Functions:
+    log_study_comparison: Record the across-run comparison as its own run.
+    load_round_models: Find a finished run's saved models.
+    curve_summaries: Best round per curve, as a mapping.
 """
 
 import json
@@ -63,9 +74,6 @@ MODELS_ARTIFACT_PATH = "models"
 
 #: Artifact sub-directory holding the curve and the per-round record.
 EVALUATION_ARTIFACT_PATH = "evaluation"
-
-#: Artifact sub-directory holding the fit's diagnostic plots.
-PLOTS_ARTIFACT_PATH = "plots"
 
 
 class ModelLearningTracker(Protocol):
@@ -192,12 +200,8 @@ class MLflowModelLearningTracker:
     def artifact_dir(self) -> Optional[Path]:
         """Local artifact directory of this run, when the store is on disk.
 
-        The models are written here, under hashed run ids. A study that wants
-        them under a readable name copies from here -- see
-        :func:`~POMDPPlanners.training.model_learning.reporting.write_run_directory`.
-
-        It outlives :meth:`finish`, because a study copies the models *after*
-        the run that wrote them has been closed.
+        It holds ``models/`` and ``evaluation/``, and outlives :meth:`finish` so
+        a caller can read a finished run's files.
 
         Returns:
             The directory, or ``None`` before the run starts or when the store
@@ -344,7 +348,9 @@ class MLflowModelLearningTracker:
             with tempfile.TemporaryDirectory() as staging:
                 written = plot_model_learning_report(self._rounds, Path(staging))
                 for path in written.values():
-                    self._client.log_artifact(self._run.info.run_id, str(path), PLOTS_ARTIFACT_PATH)
+                    self._client.log_artifact(
+                        self._run.info.run_id, str(path), EVALUATION_ARTIFACT_PATH
+                    )
         except Exception as error:  # pylint: disable=broad-except
             self._logger.warning("could not draw the model-learning plots: %s", error)
 
@@ -356,6 +362,84 @@ class MLflowModelLearningTracker:
             self._client.log_artifact(
                 self._run.info.run_id, str(path), EVALUATION_ARTIFACT_PATH
             )
+
+
+def log_study_comparison(
+    experiment_name: str,
+    curves: Sequence[LearningCurve],
+    params: Optional[Dict[str, Any]] = None,
+    tracking_uri: Optional[str] = None,
+    run_name: str = "study",
+    logger: Optional[Any] = None,
+) -> Optional[str]:
+    """Record the comparison across runs as a run of its own.
+
+    The per-method table and the learning curve answer a question no single run
+    can -- did iterating on the collection beat not iterating -- so they belong
+    beside the runs rather than inside one of them. Logged as a run named
+    ``study``, holding the same ``evaluation/`` directory the others do.
+
+    Args:
+        experiment_name: The experiment the runs were logged under.
+        curves: Curves across methods and seeds.
+        params: What was run -- environment, learner, planner budget, commit.
+            A result whose settings live only in the script that produced it is
+            not a result.
+        tracking_uri: MLflow tracking URI. ``None`` uses the ambient setting.
+        run_name: Name for the study run.
+        logger: Optional logger.
+
+    Returns:
+        The run id, or ``None`` if no curve had an evaluated round.
+    """
+    # pylint: disable-next=import-outside-toplevel
+    from mlflow.tracking import MlflowClient
+
+    # pylint: disable-next=import-outside-toplevel
+    from POMDPPlanners.training.model_learning.reporting import curve_table_markdown
+
+    log = logger or get_logger(__name__)
+    if not any(curve.points for curve in curves):
+        log.warning("log_study_comparison: no evaluated rounds, nothing to compare")
+        return None
+
+    os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
+    client = MlflowClient(tracking_uri=tracking_uri)
+    experiment = client.get_experiment_by_name(experiment_name)
+    experiment_id = (
+        experiment.experiment_id
+        if experiment is not None
+        else client.create_experiment(experiment_name)
+    )
+    run = client.create_run(experiment_id, run_name=run_name)
+    run_id = run.info.run_id
+    for key, value in (params or {}).items():
+        client.log_param(run_id, key, value)
+
+    with tempfile.TemporaryDirectory() as staging:
+        summary = Path(staging) / "summary.md"
+        summary.write_text(curve_table_markdown(curves), encoding="utf-8")
+        client.log_artifact(run_id, str(summary), EVALUATION_ARTIFACT_PATH)
+
+        curves_json = Path(staging) / "learning_curves.json"
+        curves_json.write_text(
+            json.dumps([curve.to_dict() for curve in curves], indent=2), encoding="utf-8"
+        )
+        client.log_artifact(run_id, str(curves_json), EVALUATION_ARTIFACT_PATH)
+
+        # pylint: disable-next=import-outside-toplevel
+        from POMDPPlanners.utils.visualization.model_learning_plots import plot_learning_curves
+
+        plot = plot_learning_curves(curves, Path(staging) / "learning_curves.png")
+        if plot is not None:
+            client.log_artifact(run_id, str(plot), EVALUATION_ARTIFACT_PATH)
+
+    for curve in curves:
+        best = best_point(curve)
+        if best is not None:
+            client.log_metric(run_id, f"{curve.method}_best_return", best.mean_return)
+    client.set_terminated(run_id)
+    return run_id
 
 
 def load_round_models(run_artifacts_dir: Path) -> Dict[int, Path]:

--- a/POMDPPlanners/training/model_learning/tracking.py
+++ b/POMDPPlanners/training/model_learning/tracking.py
@@ -12,9 +12,9 @@ MLflow rather than a directory convention, because the rollouts inside this loop
 already run through it: every planner episode goes through
 ``LocalSimulationsAPI``, which logs to MLflow, so a run of the loop with a
 separate results tree would leave the control numbers and the models they came
-from in two systems that agree by hand. One run per ``(method, seed)``, plus one run for the
-study that compares them, and the per-round metrics are step-indexed so the
-learning curve is a chart rather than a file to plot.
+from in two systems that agree by hand. One run per ``(method, seed)``, and the per-round
+metrics are step-indexed so the learning curve is a chart rather than a file to
+plot.
 
 Each run holds exactly two artifact directories, because there are exactly two
 things anyone comes for: ``models/`` -- one file per round, the objects to plan
@@ -50,7 +50,7 @@ Classes:
     MLflowModelLearningTracker: Logs rounds, models and curves to MLflow.
 
 Functions:
-    log_study_comparison: Record the across-run comparison as its own run.
+    log_study_comparison: Add the across-run comparison to every run's evaluation.
     load_round_models: Find a finished run's saved models.
     curve_summaries: Best round per curve, as a mapping.
 """
@@ -59,7 +59,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, Optional, Protocol, Sequence
+from typing import Any, Dict, List, Optional, Protocol, Sequence
 
 import numpy as np
 
@@ -369,28 +369,27 @@ def log_study_comparison(
     curves: Sequence[LearningCurve],
     params: Optional[Dict[str, Any]] = None,
     tracking_uri: Optional[str] = None,
-    run_name: str = "study",
     logger: Optional[Any] = None,
-) -> Optional[str]:
-    """Record the comparison across runs as a run of its own.
+) -> List[str]:
+    """Add the across-run comparison to every run's ``evaluation/``.
 
-    The per-method table and the learning curve answer a question no single run
-    can -- did iterating on the collection beat not iterating -- so they belong
-    beside the runs rather than inside one of them. Logged as a run named
-    ``study``, holding the same ``evaluation/`` directory the others do.
+    The learning curve and the method table are what actually decide whether a
+    model is worth using, and they are only known once every run has finished.
+    They are copied into each run rather than parked in a run of their own: a
+    reader opens one run's ``evaluation/`` and has everything the decision
+    needs, instead of holding two directories in their head.
 
     Args:
         experiment_name: The experiment the runs were logged under.
         curves: Curves across methods and seeds.
-        params: What was run -- environment, learner, planner budget, commit.
-            A result whose settings live only in the script that produced it is
-            not a result.
+        params: What was run -- environment, learner, planner budget, commit --
+            pinned to every run, because a result whose settings live only in
+            the script that produced it is not a result.
         tracking_uri: MLflow tracking URI. ``None`` uses the ambient setting.
-        run_name: Name for the study run.
         logger: Optional logger.
 
     Returns:
-        The run id, or ``None`` if no curve had an evaluated round.
+        The run ids that were updated.
     """
     # pylint: disable-next=import-outside-toplevel
     from mlflow.tracking import MlflowClient
@@ -401,45 +400,47 @@ def log_study_comparison(
     log = logger or get_logger(__name__)
     if not any(curve.points for curve in curves):
         log.warning("log_study_comparison: no evaluated rounds, nothing to compare")
-        return None
+        return []
 
     os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
     client = MlflowClient(tracking_uri=tracking_uri)
     experiment = client.get_experiment_by_name(experiment_name)
-    experiment_id = (
-        experiment.experiment_id
-        if experiment is not None
-        else client.create_experiment(experiment_name)
-    )
-    run = client.create_run(experiment_id, run_name=run_name)
-    run_id = run.info.run_id
-    for key, value in (params or {}).items():
-        client.log_param(run_id, key, value)
+    if experiment is None:
+        log.warning("log_study_comparison: no experiment named %s", experiment_name)
+        return []
+    runs = client.search_runs([experiment.experiment_id])
+    if not runs:
+        log.warning("log_study_comparison: experiment %s has no runs", experiment_name)
+        return []
 
     with tempfile.TemporaryDirectory() as staging:
-        summary = Path(staging) / "summary.md"
-        summary.write_text(curve_table_markdown(curves), encoding="utf-8")
-        client.log_artifact(run_id, str(summary), EVALUATION_ARTIFACT_PATH)
+        table = Path(staging) / "methods.md"
+        table.write_text(curve_table_markdown(curves), encoding="utf-8")
+        files = [table]
 
         curves_json = Path(staging) / "learning_curves.json"
         curves_json.write_text(
             json.dumps([curve.to_dict() for curve in curves], indent=2), encoding="utf-8"
         )
-        client.log_artifact(run_id, str(curves_json), EVALUATION_ARTIFACT_PATH)
+        files.append(curves_json)
 
         # pylint: disable-next=import-outside-toplevel
         from POMDPPlanners.utils.visualization.model_learning_plots import plot_learning_curves
 
         plot = plot_learning_curves(curves, Path(staging) / "learning_curves.png")
         if plot is not None:
-            client.log_artifact(run_id, str(plot), EVALUATION_ARTIFACT_PATH)
+            files.append(plot)
 
-    for curve in curves:
-        best = best_point(curve)
-        if best is not None:
-            client.log_metric(run_id, f"{curve.method}_best_return", best.mean_return)
-    client.set_terminated(run_id)
-    return run_id
+        updated: List[str] = []
+        for run in runs:
+            run_id = run.info.run_id
+            for key, value in (params or {}).items():
+                if key not in run.data.params:
+                    client.log_param(run_id, key, value)
+            for path in files:
+                client.log_artifact(run_id, str(path), EVALUATION_ARTIFACT_PATH)
+            updated.append(run_id)
+    return updated
 
 
 def load_round_models(run_artifacts_dir: Path) -> Dict[int, Path]:

--- a/POMDPPlanners/training/model_learning/tracking.py
+++ b/POMDPPlanners/training/model_learning/tracking.py
@@ -27,7 +27,9 @@ Three things are logged that are easy to omit and hard to reconstruct later.
 **The model of every round, not the best one.** Which round was best is known
 only after the whole sequence has been scored, and the guarantee is about the
 best model of the sequence. Saving as you go costs a file per round; saving at
-the end costs a re-run.
+the end costs a re-run. The one to load is copied to ``models/chosen`` at the
+end, so nobody has to pick from a directory of candidates -- and nobody reaches
+for the last round on the assumption that later is better.
 
 **The fingerprint beside the model.** It is what ties a control number to the
 exact parameters that produced it, and it is what the environment's cache key
@@ -57,6 +59,7 @@ Functions:
 
 import json
 import os
+import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Protocol, Sequence
@@ -287,6 +290,7 @@ class MLflowModelLearningTracker:
             self._client.log_metric(
                 run_id, "best_round_transitions", float(best.cumulative_transitions)
             )
+            self._log_chosen_model(best.round_index)
         self.finish()
 
     def _log_model(self, model: Any, round_index: int) -> Optional[str]:
@@ -314,6 +318,41 @@ class MLflowModelLearningTracker:
                 self._run.info.run_id, str(written), MODELS_ARTIFACT_PATH
             )
             return f"{MODELS_ARTIFACT_PATH}/{written.name}"
+
+    def _log_chosen_model(self, round_index: int) -> None:
+        """Copy the best round's model to ``models/chosen`` -- the one to load.
+
+        Every round is kept because the sequence is not monotone and the best of
+        it is known only at the end. That leaves a directory of equally-named
+        candidates, and picking from it by eye is how the last round gets used
+        for being last. The choice is made once, here, by the same rule the
+        table reports.
+
+        Args:
+            round_index: The round :func:`best_point` selected.
+        """
+        source = next(
+            (
+                entry.get("model_artifact")
+                for entry in self._rounds
+                if entry["round_index"] == round_index and entry.get("model_artifact")
+            ),
+            None,
+        )
+        if source is None:
+            self._logger.warning(
+                "round %d has no saved model, so none was marked chosen", round_index
+            )
+            return
+        run_id = self._run.info.run_id
+        with tempfile.TemporaryDirectory() as staging:
+            downloaded = Path(
+                self._client.download_artifacts(run_id, source, staging)
+            )
+            chosen = Path(staging) / f"chosen{downloaded.suffix}"
+            shutil.copyfile(downloaded, chosen)
+            self._client.log_artifact(run_id, str(chosen), MODELS_ARTIFACT_PATH)
+        self._client.log_param(run_id, "chosen_round", round_index)
 
     def _log_reports(self) -> None:
         """Write the readable tables beside the JSON and log them.

--- a/POMDPPlanners/utils/visualization/model_learning_plots.py
+++ b/POMDPPlanners/utils/visualization/model_learning_plots.py
@@ -51,6 +51,7 @@ it can grow while the likelihood also improves.
 
 Functions:
     plot_learning_curves: Return against data, one line per method.
+    plot_round_returns: One run's per-round return with its confidence interval.
     plot_training_curves: Train and holdout loss per epoch, one panel per round.
     plot_member_training_curves: Every ensemble member's training curve.
     plot_round_diagnostics: Held-out likelihood and drift ratio per round.
@@ -64,6 +65,7 @@ from typing import Any, Dict, List, Optional, Sequence
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+from scipy import stats
 
 from POMDPPlanners.training.model_learning.control_evaluation import (
     AggregatedCurve,
@@ -74,6 +76,10 @@ from POMDPPlanners.training.model_learning.control_evaluation import (
 matplotlib.use("Agg")  # Use non-interactive backend
 
 logger = logging.getLogger(__name__)
+
+#: Confidence level of every band and error bar here -- the same one the tables
+#: report, so a figure and a table cannot disagree.
+CONFIDENCE_LEVEL = 0.95
 
 # Enough distinct colors for the method families a comparison plausibly carries;
 # beyond this the lines stop being separable and the plot should be split.
@@ -117,7 +123,7 @@ def plot_learning_curves(
     fig, axis = plt.subplots(figsize=(9, 5))
     for index, (method, method_curves) in enumerate(sorted(grouped.items())):
         aggregated = aggregate_curves(method_curves)
-        _draw(axis, aggregated, _METHOD_COLORS[index % len(_METHOD_COLORS)])
+        _draw(axis, aggregated, _METHOD_COLORS[index % len(_METHOD_COLORS)], method_curves)
 
     if baseline_return is not None:
         axis.axhline(
@@ -144,11 +150,26 @@ def plot_learning_curves(
     return output_path
 
 
-def _draw(axis, curve: AggregatedCurve, color: str) -> None:
-    """One method's mean line, with a band of one standard error across seeds."""
+def _draw(axis, curve: AggregatedCurve, color: str, episode_curves=None) -> None:
+    """One method's mean line, with a 95% t-interval band.
+
+    Across seeds when there is more than one, because that is the spread that
+    answers whether two methods differed. With a single seed there is no such
+    spread, so the band falls back to the interval across that run's evaluation
+    episodes and says so in the label -- a plot with no band at all reads as a
+    measurement without noise, and one whose band silently changes meaning is
+    worse than either.
+    """
     transitions = np.asarray(curve.cumulative_transitions, dtype=float)
     means = np.asarray(curve.mean_returns, dtype=float)
-    errors = np.asarray(curve.standard_errors, dtype=float)
+    across_seeds = curve.num_seeds > 1
+    if across_seeds:
+        errors = np.asarray(curve.standard_errors, dtype=float)
+        half = _t_half_width(errors, curve.num_seeds)
+        band_label = f"{curve.num_seeds} seeds"
+    else:
+        half = _episode_half_widths(episode_curves)
+        band_label = "episodes, 1 seed"
     axis.plot(
         transitions,
         means,
@@ -156,11 +177,113 @@ def _draw(axis, curve: AggregatedCurve, color: str) -> None:
         linewidth=2,
         marker="o",
         markersize=4,
-        label=f"{curve.method} ({curve.num_seeds} seeds)",
+        label=f"{curve.method} ({band_label}, {int(CONFIDENCE_LEVEL * 100)}% CI)",
     )
-    if np.isfinite(errors).any():
-        band = np.nan_to_num(errors, nan=0.0)
+    if half is not None and np.isfinite(half).any():
+        band = np.nan_to_num(half, nan=0.0)[: means.size]
         axis.fill_between(transitions, means - band, means + band, color=color, alpha=0.2)
+
+
+def _t_half_width(standard_errors: np.ndarray, sample_size: int) -> Optional[np.ndarray]:
+    """Half-width of the t-interval implied by a standard error."""
+    if sample_size < 2:
+        return None
+    return np.asarray(standard_errors, dtype=float) * float(
+        stats.t.ppf(0.5 + CONFIDENCE_LEVEL / 2.0, sample_size - 1)
+    )
+
+
+def _episode_half_widths(curves) -> Optional[np.ndarray]:
+    """Per-round half-widths across a single run's evaluation episodes."""
+    if not curves:
+        return None
+    points = curves[0].points
+    half = []
+    for point in points:
+        returns = np.asarray(point.returns, dtype=float)
+        if returns.size < 2:
+            half.append(np.nan)
+            continue
+        error = float(np.std(returns, ddof=1) / np.sqrt(returns.size))
+        half.append(error * float(stats.t.ppf(0.5 + CONFIDENCE_LEVEL / 2.0, returns.size - 1)))
+    return np.asarray(half, dtype=float)
+
+
+def plot_round_returns(
+    rounds: Sequence[Any],
+    output_path: Path,
+    baseline_return: Optional[float] = None,
+    title: str = "Return per round, with 95% confidence intervals",
+) -> Optional[Path]:
+    """Plot each round's return with its interval, against the data it cost.
+
+    The learning curve compares methods; this reads one run. An interval that
+    spans the whole plot is the answer to "did round 3 beat round 2" -- no -- and
+    it is the plot that stops a noise gap being read as progress.
+
+    Args:
+        rounds: The run's rounds, as results or as the tracker's dictionaries.
+        output_path: Where to write the PNG.
+        baseline_return: Return of the model the loop started from, drawn as a
+            horizontal reference.
+        title: Plot title.
+
+    Returns:
+        The written path, or ``None`` if no round was evaluated.
+    """
+    transitions, means, lows, highs = [], [], [], []
+    for entry in rounds:
+        control = entry.get("control") if isinstance(entry, dict) else getattr(entry, "control", None)
+        if control is None:
+            continue
+        if not isinstance(control, dict):
+            control = control.to_dict()
+        returns = np.asarray(control["returns"], dtype=float)
+        if returns.size == 0:
+            continue
+        transitions.append(float(control["cumulative_transitions"]))
+        means.append(float(np.mean(returns)))
+        if returns.size < 2:
+            lows.append(0.0)
+            highs.append(0.0)
+        else:
+            error = float(np.std(returns, ddof=1) / np.sqrt(returns.size))
+            half = error * float(stats.t.ppf(0.5 + CONFIDENCE_LEVEL / 2.0, returns.size - 1))
+            lows.append(half)
+            highs.append(half)
+    if not means:
+        logger.warning("plot_round_returns: no round was evaluated")
+        return None
+
+    fig, axis = plt.subplots(figsize=(7, 4.5))
+    axis.errorbar(
+        transitions,
+        means,
+        yerr=[lows, highs],
+        color="tab:blue",
+        linewidth=2,
+        marker="o",
+        capsize=4,
+        label="round return",
+    )
+    best = int(np.argmax(means))
+    axis.scatter(
+        [transitions[best]],
+        [means[best]],
+        color="tab:green",
+        zorder=5,
+        s=90,
+        label="chosen round",
+    )
+    if baseline_return is not None:
+        axis.axhline(baseline_return, color="black", linestyle="--", linewidth=1.5,
+                     label="initial model")
+    axis.set_xlabel("Transitions collected")
+    axis.set_ylabel("Return in the true world")
+    axis.set_title(title)
+    axis.grid(True, alpha=0.3)
+    axis.legend()
+    return _finish(fig, output_path)
 
 
 def _finish(fig, output_path: Path) -> Path:
@@ -215,6 +338,25 @@ def plot_training_curves(
     for axis, (round_index, entry) in zip(axes[0], drawable):
         epochs = np.arange(1, len(entry["train_nll"]) + 1)
         axis.plot(epochs, entry["train_nll"], color="tab:blue", linewidth=2, label="train")
+        members = [
+            entry[key] for key in sorted(entry) if key.startswith("train_nll_member_")
+        ]
+        if len(members) > 1:
+            # Across members, at the same confidence as every other interval
+            # here: a mean line hides the ensemble disagreeing with itself,
+            # which is the quantity the planner treats as uncertainty.
+            stacked = np.asarray(members, dtype=float)
+            mean = stacked.mean(axis=0)
+            error = stacked.std(axis=0, ddof=1) / np.sqrt(stacked.shape[0])
+            half = error * float(stats.t.ppf(0.5 + CONFIDENCE_LEVEL / 2.0, stacked.shape[0] - 1))
+            axis.fill_between(
+                np.arange(1, stacked.shape[1] + 1),
+                mean - half,
+                mean + half,
+                color="tab:blue",
+                alpha=0.2,
+                label=f"members, {int(CONFIDENCE_LEVEL * 100)}% CI",
+            )
         holdout = entry.get("holdout_nll")
         if holdout:
             axis.plot(
@@ -355,6 +497,9 @@ def plot_model_learning_report(
     output_dir = Path(output_dir)
     written: Dict[str, Path] = {}
     candidates = {
+        "round_returns": lambda: plot_round_returns(
+            rounds, output_dir / "round_returns.png", baseline_return=baseline_return
+        ),
         "training_curves": lambda: plot_training_curves(
             rounds, output_dir / "training_curves.png"
         ),


### PR DESCRIPTION
Follow-up to #248, on the same branch: five commits pushed after it merged.

## What changed

**One run, two directories.** Every run's artifacts are now `models/` and `evaluation/` and nothing else. The previous version mirrored tables and plots into a second tree (`runs/<method>_seed<n>/`, a top-level README, a duplicate `plots/`), so the same numbers existed twice and the copy was the one that would go stale.

**`evaluation/` is self-sufficient.** The learning curve and the method comparison used to live in a separate `study` run, so judging a model meant opening two runs. They are copied into every run instead. One folder now holds: `summary.md` (per-round table), `metrics.md` (the run reduced to a decision), `methods.md` (method comparison), `rounds.csv`/`metrics.csv`, and four figures — `round_returns`, `learning_curves`, `training_curves`, `member_training_curves`.

**`models/chosen`.** The directory held one model per round with nothing marking which to load, and the habit is to take the last — the exact mistake the round table exists to prevent. The best round's file is copied to `models/chosen` and the round is logged as a parameter.

**Confidence intervals, in the tables and the figures.** Everything reports the repo's 95% t-interval from `utils.statistics_utils`, the same one the planner tables use, so a model-learning number and a planner number can sit in one table. The learning curve's band was one standard error — a different quantity from the tables beside it; it is now the t-interval across seeds, falling back at one seed to the interval across that run's episodes, labelled as such in the legend, because a band whose meaning changes silently is worse than no band. `round_returns.png` is new: one run's per-round return with error bars and the chosen round marked.

## Verification

- 104 tests in `test_training`, including: the interval matches `confidence_interval` exactly, a single-episode round reports no interval, `chosen.pt` is the best round rather than the last, and a run's artifacts are exactly `models/` + `evaluation/`.
- pyright clean on every touched file.
- Re-ran the PETS study on FrankaReachFragile end to end after each change. The intervals immediately earn their place: at 5 evaluation episodes every round's interval spans ±10 return and all of them overlap, so the round-to-round differences in that run are noise — which the previous tables did not show.

https://claude.ai/code/session_01AtKrDxoPDQwUkkhBzRwPdX