### PR TITLE
Add AdaOPS and HyP-DESPOT planners, and fix six review findings

### DIFF
--- a/POMDPPlanners/core/environment/__init__.py
+++ b/POMDPPlanners/core/environment/__init__.py
@@ -18,6 +18,7 @@ from POMDPPlanners.core.environment.environment import (
 )
 from POMDPPlanners.core.environment.constrained_environment import ConstrainedEnvironment
 from POMDPPlanners.core.environment.transition_model import RewardModel, TransitionModel
+from POMDPPlanners.core.environment.hyp_despot_cuda_model import HypDESPOTCUDAmodel
 
 
 __all__ = [
@@ -29,4 +30,5 @@ __all__ = [
     "SpaceInfo",
     "SpaceType",
     "TransitionModel",
+    "HypDESPOTCUDAmodel",
 ]

--- a/POMDPPlanners/core/environment/hyp_despot_cuda_model.py
+++ b/POMDPPlanners/core/environment/hyp_despot_cuda_model.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+"""Strict deterministic CUDA model protocol used by HyP-DESPOT."""
+from typing import Protocol, Tuple, runtime_checkable
+import torch
+from torch import Tensor
+
+
+@runtime_checkable
+class HypDESPOTCUDAmodel(Protocol):
+    """All leaf transition, observation, reward, terminal, and bound kernels."""
+
+    @property
+    def device(self) -> torch.device:
+        ...
+
+    @property
+    def supports_factored_step(self) -> bool:
+        ...
+
+    def scenario_randomness(self, scenario_ids: Tensor, depth: int, seed: int) -> Tensor:
+        ...
+
+    def sample_next_states(self, states: Tensor, actions: Tensor, random_values: Tensor) -> Tensor:
+        ...
+
+    def sample_observations(
+        self, next_states: Tensor, actions: Tensor, random_values: Tensor
+    ) -> Tensor:
+        ...
+
+    def rewards(self, states: Tensor, actions: Tensor, next_states: Tensor) -> Tensor:
+        ...
+
+    def terminal_mask(self, states: Tensor) -> Tensor:
+        ...
+
+    def observation_keys(self, observations: Tensor) -> Tensor:
+        ...
+
+    def leaf_bounds(self, states: Tensor, remaining_depth: int) -> Tuple[Tensor, Tensor]:
+        ...
+
+
+__all__ = ["HypDESPOTCUDAmodel"]

--- a/POMDPPlanners/planners/__init__.py
+++ b/POMDPPlanners/planners/__init__.py
@@ -29,6 +29,7 @@ from POMDPPlanners.planners.sparse_sampling_planners.icvar_sparse_sampling impor
     ICVaRSparseSampling,
 )
 from POMDPPlanners.planners.scenario_tree_planners.ardespot import ARDESPOT
+from POMDPPlanners.planners.scenario_tree_planners.adaops import AdaOPS
 from POMDPPlanners.planners.scenario_tree_planners.despot import DESPOT
 
 __all__ = [
@@ -48,6 +49,7 @@ __all__ = [
     "ICVaRSparseSampling",
     "DESPOT",
     "ARDESPOT",
+    "AdaOPS",
 ]
 
 # Registry of available policies
@@ -67,6 +69,7 @@ POLICY_REGISTRY: Dict[str, Type] = {
     "ICVaRSparseSampling": ICVaRSparseSampling,
     "DESPOT": DESPOT,
     "ARDESPOT": ARDESPOT,
+    "AdaOPS": AdaOPS,
 }
 
 

--- a/POMDPPlanners/planners/__init__.py
+++ b/POMDPPlanners/planners/__init__.py
@@ -31,6 +31,7 @@ from POMDPPlanners.planners.sparse_sampling_planners.icvar_sparse_sampling impor
 from POMDPPlanners.planners.scenario_tree_planners.ardespot import ARDESPOT
 from POMDPPlanners.planners.scenario_tree_planners.adaops import AdaOPS
 from POMDPPlanners.planners.scenario_tree_planners.despot import DESPOT
+from POMDPPlanners.planners.scenario_tree_planners.hyp_despot import HypDESPOT
 
 __all__ = [
     "POMCP",
@@ -50,6 +51,7 @@ __all__ = [
     "DESPOT",
     "ARDESPOT",
     "AdaOPS",
+    "HypDESPOT",
 ]
 
 # Registry of available policies
@@ -70,6 +72,7 @@ POLICY_REGISTRY: Dict[str, Type] = {
     "DESPOT": DESPOT,
     "ARDESPOT": ARDESPOT,
     "AdaOPS": AdaOPS,
+    "HypDESPOT": HypDESPOT,
 }
 
 

--- a/POMDPPlanners/planners/scenario_tree_planners/__init__.py
+++ b/POMDPPlanners/planners/scenario_tree_planners/__init__.py
@@ -28,6 +28,7 @@ from POMDPPlanners.planners.scenario_tree_planners.ardespot import (
 )
 from POMDPPlanners.planners.scenario_tree_planners.adaops import AdaOPS, AdaOPSMetrics
 from POMDPPlanners.planners.scenario_tree_planners.despot import DESPOT, DESPOTMetrics
+from POMDPPlanners.planners.scenario_tree_planners.hyp_despot import HypDESPOT, HypDESPOTMetrics
 
 __all__ = [
     "DESPOT",
@@ -36,4 +37,6 @@ __all__ = [
     "ARDESPOTMetrics",
     "AdaOPS",
     "AdaOPSMetrics",
+    "HypDESPOT",
+    "HypDESPOTMetrics",
 ]

--- a/POMDPPlanners/planners/scenario_tree_planners/__init__.py
+++ b/POMDPPlanners/planners/scenario_tree_planners/__init__.py
@@ -26,6 +26,14 @@ from POMDPPlanners.planners.scenario_tree_planners.ardespot import (
     ARDESPOT,
     ARDESPOTMetrics,
 )
+from POMDPPlanners.planners.scenario_tree_planners.adaops import AdaOPS, AdaOPSMetrics
 from POMDPPlanners.planners.scenario_tree_planners.despot import DESPOT, DESPOTMetrics
 
-__all__ = ["DESPOT", "DESPOTMetrics", "ARDESPOT", "ARDESPOTMetrics"]
+__all__ = [
+    "DESPOT",
+    "DESPOTMetrics",
+    "ARDESPOT",
+    "ARDESPOTMetrics",
+    "AdaOPS",
+    "AdaOPSMetrics",
+]

--- a/POMDPPlanners/planners/scenario_tree_planners/adaops.py
+++ b/POMDPPlanners/planners/scenario_tree_planners/adaops.py
@@ -45,7 +45,11 @@ from POMDPPlanners.planners.scenario_tree_planners.adaptive_particles import (
     l1_weight_distance,
     normalize_weights,
 )
-from POMDPPlanners.planners.scenario_tree_planners.despot import DESPOT, TINY
+from POMDPPlanners.planners.scenario_tree_planners.despot import (
+    DESPOT,
+    TERMINAL_OBSERVATION,
+    TINY,
+)
 from POMDPPlanners.utils.config_to_id import config_to_id
 from POMDPPlanners.utils.tree_statistics import TreeMetrics, compute_arena_tree_metrics
 
@@ -363,7 +367,9 @@ class AdaOPS(DESPOT):
     def _root_particles(self, belief: Belief) -> Tuple[List[Any], np.ndarray]:
         particles = getattr(belief, "particles", None)
         if particles is None or len(particles) == 0:
-            particles = [belief.sample() for _ in range(self.max_particles)]
+            # Inherited so the draw is seeded from the planner's own generator
+            # and the caller's global RNG streams are restored afterwards.
+            particles = self._sample_from_belief_sampler(belief, self.max_particles)
             weights = np.full(len(particles), 1.0 / len(particles))
         else:
             particles = list(particles)
@@ -426,8 +432,8 @@ class AdaOPS(DESPOT):
             generated_mass: Dict[Any, float] = {}
             for state, weight in zip(particles, weights):
                 if self.environment.is_terminal(state=state):
-                    next_state, observation, reward = state, "<terminal>", 0.0
-                    key = "<terminal>"
+                    next_state, observation, reward = state, TERMINAL_OBSERVATION, 0.0
+                    key = TERMINAL_OBSERVATION
                 else:
                     next_state, observation, reward = self.environment.sample_next_step(
                         state, action
@@ -446,10 +452,10 @@ class AdaOPS(DESPOT):
             tree.set_immediate_reward(action_id, float(np.dot(weights, rewards)))
             retained: List[Tuple[int, np.ndarray]] = []
             for key, observation in unique.items():
-                if key == "<terminal>":
+                if key is TERMINAL_OBSERVATION:
                     posterior = normalize_weights(
                         [
-                            weight if obs == "<terminal>" else 0.0
+                            weight if obs is TERMINAL_OBSERVATION else 0.0
                             for weight, obs in zip(weights, observations)
                         ]
                     )

--- a/POMDPPlanners/planners/scenario_tree_planners/adaops.py
+++ b/POMDPPlanners/planners/scenario_tree_planners/adaops.py
@@ -1,0 +1,728 @@
+# SPDX-License-Identifier: MIT
+
+"""Adaptive Online Packing-guided Search (AdaOPS).
+
+This implementation follows Wu et al., NeurIPS 2021, Algorithms 2, 5 and 6.
+Beliefs are weighted particles. Sibling posteriors initially share propagated
+particles, KLD-sized resampling is triggered by design effect, and observation
+branches at L1 distance at most ``delta`` are packed. Search descends through
+the action with the largest upper bound and the packed child with the largest
+probability-weighted excess uncertainty. It returns the root action with the
+largest lower bound.
+
+Paper: https://papers.nips.cc/paper_files/paper/2021/file/
+ef41d488755367316f04fc0e0e9dc9fc-Paper.pdf
+Author code inspected: https://github.com/JuliaPOMDP/AdaOPS.jl (main, 2026-09-08).
+The author code is MIT licensed. This is a Python implementation from the
+paper's equations; no Julia source was copied.
+
+Deliberate differences: bounds use this repository's finite ``depth`` contract;
+KLD adaptation needs an explicit ``state_binner`` and is otherwise explicitly
+disabled; fixed trials and wall-clock timeout are mutually exclusive so cached
+runs have one unambiguous compute control.
+"""
+
+import copy
+import importlib
+import json
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, cast
+
+import numpy as np
+
+from POMDPPlanners.core.belief import Belief, WeightedParticleBelief
+from POMDPPlanners.core.environment import DiscreteActionsEnvironment, SpaceType
+from POMDPPlanners.core.policy import PolicyInfoVariable, PolicyRunData, PolicySpaceInfo
+from POMDPPlanners.core.tree.arena import ACTION, BELIEF, Tree
+from POMDPPlanners.planners.planners_utils.scenario_streams import ScenarioRandomStreams
+from POMDPPlanners.planners.scenario_tree_planners.adaptive_particles import (
+    adaptive_resample,
+    design_effect,
+    effective_sample_size,
+    l1_weight_distance,
+    normalize_weights,
+)
+from POMDPPlanners.planners.scenario_tree_planners.despot import DESPOT, TINY
+from POMDPPlanners.utils.config_to_id import config_to_id
+from POMDPPlanners.utils.tree_statistics import TreeMetrics, compute_arena_tree_metrics
+
+
+class AdaOPSMetrics(Enum):
+    """Numeric diagnostics reset for every :meth:`AdaOPS.action` call."""
+
+    N_TRIALS = "adaops_n_trials"
+    ROOT_LOWER_BOUND = "adaops_root_lower_bound"
+    ROOT_UPPER_BOUND = "adaops_root_upper_bound"
+    ROOT_GAP = "adaops_root_gap"
+    N_BELIEF_NODES = "adaops_n_belief_nodes"
+    N_ACTION_NODES = "adaops_n_action_nodes"
+    PACKED_BRANCHES = "adaops_packed_branches"
+    MERGED_BRANCHES = "adaops_merged_branches"
+    RESAMPLE_COUNT = "adaops_resample_count"
+    MIN_PARTICLES = "adaops_min_particles"
+    MAX_PARTICLES = "adaops_max_particles"
+    MEAN_PARTICLES = "adaops_mean_particles"
+    MEAN_ESS = "adaops_mean_effective_sample_size"
+    MAX_DESIGN_EFFECT = "adaops_max_design_effect"
+    BOUND_CORRECTIONS = "adaops_bound_corrections"
+    ZERO_WEIGHT_CORRECTIONS = "adaops_zero_weight_corrections"
+    STOPPED_BY_GAP = "adaops_stopped_by_gap"
+    STOPPED_BY_TIMEOUT = "adaops_stopped_by_timeout"
+    STOPPED_BY_TRIALS = "adaops_stopped_by_trials"
+    STOPPED_BY_DEPTH = "adaops_stopped_by_depth"
+    STALLED = "adaops_stalled"
+
+
+@dataclass
+class _AdaBeliefData:
+    depth: int
+    weights: np.ndarray
+    default_value: float
+    expanded: bool = False
+    terminal: bool = False
+    in_tree: bool = False
+    best_upper_action_id: Optional[int] = None
+    scenario_ids: List[int] = field(default_factory=list)
+    observation_probability: float = 1.0
+    packed_observations: List[Any] = field(default_factory=list)
+    occupied_bins: int = 0
+    resampled: bool = False
+
+
+BoundProvider = Callable[[Sequence[Any], np.ndarray, int], float]
+
+
+class AdaOPS(DESPOT):
+    """AdaOPS planner for discrete actions and scoreable observations.
+
+    ``state_binner`` maps a state to a hashable bin. Passing ``None`` disables
+    KLD adaptation explicitly and resampling uses ``max_particles``. A callable
+    requires ``state_binner_id`` so its semantics enter ``config_id``.
+    """
+
+    # pylint: disable=too-many-instance-attributes,too-many-arguments,too-many-locals
+
+    def __init__(
+        self,
+        environment: DiscreteActionsEnvironment,
+        discount_factor: float,
+        depth: int,
+        name: str,
+        epsilon_0: float = 1e-3,
+        xi: float = 0.95,
+        delta: float = 0.1,
+        min_particles: int = 30,
+        max_particles: int = 200,
+        zeta: float = 0.05,
+        kld_confidence: float = 0.95,
+        design_effect_threshold: float = 2.0,
+        state_binner: Optional[Any] = None,
+        state_binner_id: Optional[str] = None,
+        lower_bound: Optional[BoundProvider] = None,
+        upper_bound: Optional[BoundProvider] = None,
+        max_reward: Optional[float] = None,
+        min_reward: Optional[float] = None,
+        rollout_depth: Optional[int] = None,
+        random_seed: int = 0,
+        time_out_in_seconds: Optional[int] = None,
+        n_simulations: Optional[int] = None,
+        reserve_capacity: int = 0,
+        log_path: Optional[Path] = None,
+        debug: bool = False,
+        use_queue_logger: bool = False,
+    ):
+        self._validate_adaops_params(
+            epsilon_0,
+            xi,
+            delta,
+            min_particles,
+            max_particles,
+            zeta,
+            kld_confidence,
+            design_effect_threshold,
+            state_binner,
+            state_binner_id,
+        )
+        super().__init__(
+            environment=environment,
+            discount_factor=discount_factor,
+            depth=depth,
+            name=name,
+            n_scenarios=max_particles,
+            eta=xi,
+            max_reward=max_reward,
+            min_reward=min_reward,
+            rollout_depth=rollout_depth,
+            scenario_seed=random_seed,
+            use_determinized_scenarios=False,
+            time_out_in_seconds=time_out_in_seconds,
+            n_simulations=n_simulations,
+            reserve_capacity=reserve_capacity,
+            log_path=log_path,
+            debug=debug,
+            use_queue_logger=use_queue_logger,
+        )
+        self.epsilon_0 = float(epsilon_0)
+        self.xi = float(xi)
+        self.delta = float(delta)
+        self.min_particles = min_particles
+        self.max_particles = max_particles
+        self.zeta = float(zeta)
+        self.kld_confidence = float(kld_confidence)
+        self.design_effect_threshold = float(design_effect_threshold)
+        self._state_binner, persisted_binner = self._resolve_state_binner(
+            state_binner, state_binner_id
+        )
+        self.state_binner = persisted_binner
+        self.state_binner_id = persisted_binner
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+        self.random_seed = random_seed
+        self._particle_rng = np.random.default_rng(random_seed)
+        self._reset_adaops_counters()
+        self._last_snapshot: Optional[Dict[str, Any]] = None
+        self._stable_config_id = config_to_id(
+            {
+                "environment": environment.config_id,
+                "discount_factor": self.discount_factor,
+                "planner_class": type(self).__name__,
+                "name": self.name,
+                "depth": self.depth,
+                "algorithm": {
+                    "epsilon_0": self.epsilon_0,
+                    "xi": self.xi,
+                    "delta": self.delta,
+                    "min_particles": self.min_particles,
+                    "max_particles": self.max_particles,
+                    "zeta": self.zeta,
+                    "kld_confidence": self.kld_confidence,
+                    "design_effect_threshold": self.design_effect_threshold,
+                    "state_binner_id": self.state_binner_id,
+                    "lower_bound": self._callable_id(self.lower_bound),
+                    "upper_bound": self._callable_id(self.upper_bound),
+                    "max_reward": self.max_reward,
+                    "min_reward": self.min_reward,
+                    "rollout_depth": self.rollout_depth,
+                    "random_seed": self.random_seed,
+                },
+                "budget": {
+                    "n_simulations": self.n_simulations,
+                    "time_out_in_seconds": self.time_out_in_seconds,
+                },
+            }
+        )
+
+    @staticmethod
+    def _callable_id(value: Optional[BoundProvider]) -> Optional[str]:
+        if value is None:
+            return None
+        return f"{value.__module__}.{value.__qualname__}"
+
+    @staticmethod
+    def _resolve_state_binner(
+        value: Optional[Any], identifier: Optional[str]
+    ) -> Tuple[Optional[Callable[[Any], Any]], Optional[str]]:
+        if value is None:
+            return None, None
+        path = value if isinstance(value, str) else identifier
+        if not path or "." not in path:
+            raise ValueError("state_binner_id must be an importable 'module.function' path")
+        module_name, attribute = path.rsplit(".", 1)
+        imported = getattr(importlib.import_module(module_name), attribute)
+        if not callable(imported):
+            raise ValueError(f"state_binner_id does not name a callable: {path}")
+        if callable(value) and imported is not value:
+            raise ValueError(f"state_binner_id does not resolve to state_binner: {path}")
+        return imported, path
+
+    @property
+    def config_id(self) -> str:
+        """Stable constructor identity; search and mutable environment state are excluded."""
+        return self._stable_config_id
+
+    @staticmethod
+    def _validate_adaops_params(
+        epsilon_0: float,
+        xi: float,
+        delta: float,
+        minimum: int,
+        maximum: int,
+        zeta: float,
+        confidence: float,
+        threshold: float,
+        state_binner: Optional[Any],
+        state_binner_id: Optional[str],
+    ) -> None:
+        if epsilon_0 < 0.0:
+            raise ValueError("epsilon_0 must be non-negative")
+        if not 0.0 < xi < 1.0:
+            raise ValueError("xi must be strictly between 0 and 1")
+        if delta < 0.0 or delta > 2.0:
+            raise ValueError("delta must be between 0 and 2")
+        if minimum <= 0 or maximum < minimum:
+            raise ValueError("particle limits must satisfy 0 < min_particles <= max_particles")
+        if zeta <= 0.0:
+            raise ValueError("zeta must be positive")
+        if not 0.5 < confidence < 1.0:
+            raise ValueError("kld_confidence must be between 0.5 and 1")
+        if threshold < 1.0:
+            raise ValueError("design_effect_threshold must be at least 1")
+        if callable(state_binner) and not state_binner_id:
+            raise ValueError("state_binner_id is required when state_binner is provided")
+        if state_binner is None and state_binner_id is not None:
+            raise ValueError("state_binner_id requires state_binner")
+        if isinstance(state_binner, str) and state_binner_id not in (None, state_binner):
+            raise ValueError("saved state_binner and state_binner_id must match")
+
+    @classmethod
+    def get_space_info(cls) -> PolicySpaceInfo:
+        return PolicySpaceInfo(
+            action_space=SpaceType.DISCRETE, observation_space=SpaceType.CONTINUOUS
+        )
+
+    @classmethod
+    def get_info_variable_names(cls) -> List[str]:
+        return [metric.value for metric in TreeMetrics] + [metric.value for metric in AdaOPSMetrics]
+
+    def _reset_adaops_counters(self) -> None:
+        self._packed_branches = 0
+        self._merged_branches = 0
+        self._resample_count = 0
+        self._zero_weight_corrections = 0
+        self._stopped_by_timeout = False
+        self._stopped_by_trials = False
+        self._stopped_by_depth = False
+
+    def action(self, belief: Belief) -> Tuple[List[Any], PolicyRunData]:
+        if self._is_terminal_belief(belief=belief):
+            return [self._sample_random_action(belief=belief)], PolicyRunData(info_variables=[])
+        tree, root_id = self._learn_tree(belief)
+        self._last_tree, self._last_root_id = tree, root_id
+        chosen = (
+            self._sample_random_action(belief=belief)
+            if not tree.children_ids[root_id]
+            else self._action_of_best_lower_bound(tree, root_id)
+        )
+        metrics = compute_arena_tree_metrics(tree=tree, root_id=root_id)
+        metrics.extend(self._adaops_metrics(tree, root_id))
+        self._last_snapshot = copy.deepcopy(self._snapshot(tree, root_id, chosen))
+        if self._search_state_dump_dir is not None:
+            self._write_search_state_dump(tree, root_id)
+        return [chosen], PolicyRunData(info_variables=metrics)
+
+    def _learn_tree(self, belief: Belief) -> Tuple[Tree, int]:
+        tree = Tree()
+        capacity = self._effective_reserve_capacity()
+        if capacity > 0:
+            tree.reserve(capacity)
+        self._call_index += 1
+        self._particle_rng = np.random.default_rng(self.random_seed + self._call_index)
+        self._scenario_rng = self._particle_rng
+        self._streams = ScenarioRandomStreams(
+            n_scenarios=self.max_particles,
+            max_depth=max(self.depth, self.rollout_depth),
+            base_seed=self.random_seed + self._call_index,
+        )
+        self._n_trials = 0
+        self._max_trial_depth = 0
+        self._gap_closed = False
+        self._stalled = False
+        self._bound_clamps = 0
+        self._reset_adaops_counters()
+        particles, weights = self._root_particles(belief)
+        root_id = self._add_weighted_belief_node(
+            tree, particles, weights, 0, None, None, None, 1.0, list(range(len(particles)))
+        )
+        self._root_id = root_id
+        if self.n_simulations is not None:
+            for _ in range(self.n_simulations):
+                if self._should_stop(tree, root_id):
+                    break
+                self._simulate_path(tree, root_id, 0)
+            self._stopped_by_trials = not self._gap_closed and self._n_trials >= self.n_simulations
+        else:
+            if self.time_out_in_seconds is None:
+                raise ValueError("one search budget is required")
+            start = time.monotonic()
+            while time.monotonic() - start < self.time_out_in_seconds:
+                if self._should_stop(tree, root_id):
+                    break
+                self._simulate_path(tree, root_id, 0)
+            self._stopped_by_timeout = not self._gap_closed and not self._stalled
+        final_gap = tree.upper_confidence_bound[root_id] - tree.lower_confidence_bound[root_id]
+        if final_gap <= self.epsilon_0 + TINY:
+            self._gap_closed = True
+            self._stopped_by_trials = False
+            self._stopped_by_timeout = False
+        self._last_tree_size = len(tree)
+        return tree, root_id
+
+    def _root_particles(self, belief: Belief) -> Tuple[List[Any], np.ndarray]:
+        particles = getattr(belief, "particles", None)
+        if particles is None or len(particles) == 0:
+            particles = [belief.sample() for _ in range(self.max_particles)]
+            weights = np.full(len(particles), 1.0 / len(particles))
+        else:
+            particles = list(particles)
+            weights = self._particle_weights(belief, len(particles))
+        sampled, sampled_weights, _ = adaptive_resample(
+            particles,
+            weights,
+            self._particle_rng,
+            self.min_particles,
+            self.max_particles,
+            self.zeta,
+            self._state_binner,
+            self.kld_confidence,
+        )
+        self._resample_count += 1
+        return sampled, sampled_weights
+
+    def _maybe_resample(
+        self, particles: Sequence[Any], weights: Sequence[float]
+    ) -> Tuple[List[Any], np.ndarray, int, bool]:
+        normalized = normalize_weights(weights)
+        deff = design_effect(normalized)
+        if deff <= self.design_effect_threshold:
+            return list(particles), normalized, 0, False
+        sampled, sampled_weights, occupied = adaptive_resample(
+            particles,
+            normalized,
+            self._particle_rng,
+            self.min_particles,
+            self.max_particles,
+            self.zeta,
+            self._state_binner,
+            self.kld_confidence,
+        )
+        self._resample_count += 1
+        return sampled, sampled_weights, occupied, True
+
+    def _should_stop(self, tree: Tree, root_id: int) -> bool:
+        if self._stalled:
+            return True
+        gap = tree.upper_confidence_bound[root_id] - tree.lower_confidence_bound[root_id]
+        if gap <= self.epsilon_0 + TINY:
+            self._gap_closed = True
+            return True
+        return False
+
+    def _expand(self, tree: Tree, belief_id: int) -> None:
+        data: _AdaBeliefData = tree.data[belief_id]
+        particles = list(cast(WeightedParticleBelief, tree.get_belief(belief_id)).particles)
+        weights = data.weights
+        parent_mass = tree.weight[belief_id]
+        best_upper = -np.inf
+        best_action_id: Optional[int] = None
+        environment = cast(DiscreteActionsEnvironment, self.environment)
+        for action in environment.get_actions():
+            next_states: List[Any] = []
+            observations: List[Any] = []
+            rewards: List[float] = []
+            unique: Dict[Any, Any] = {}
+            generated_mass: Dict[Any, float] = {}
+            for state, weight in zip(particles, weights):
+                if self.environment.is_terminal(state=state):
+                    next_state, observation, reward = state, "<terminal>", 0.0
+                    key = "<terminal>"
+                else:
+                    next_state, observation, reward = self.environment.sample_next_step(
+                        state, action
+                    )
+                    key = self._observation_key(observation)
+                next_states.append(next_state)
+                observations.append(observation)
+                rewards.append(float(reward))
+                unique.setdefault(key, observation)
+                generated_mass[key] = generated_mass.get(key, 0.0) + float(weight)
+            action_id = tree.add_action_node(
+                action=action,
+                parent_id=belief_id,
+                action_key=self.environment.hash_action(action),
+            )
+            tree.set_immediate_reward(action_id, float(np.dot(weights, rewards)))
+            retained: List[Tuple[int, np.ndarray]] = []
+            for key, observation in unique.items():
+                if key == "<terminal>":
+                    posterior = normalize_weights(
+                        [
+                            weight if obs == "<terminal>" else 0.0
+                            for weight, obs in zip(weights, observations)
+                        ]
+                    )
+                else:
+                    log_likelihood = self.environment.observation_log_probability_per_state(
+                        next_states=next_states, action=action, observation=observation
+                    )
+                    likelihood = np.exp(np.asarray(log_likelihood) - np.max(log_likelihood))
+                    raw = weights * likelihood
+                    if not np.all(np.isfinite(raw)) or float(raw.sum()) <= 0.0:
+                        self._zero_weight_corrections += 1
+                        continue
+                    posterior = normalize_weights(raw)
+                merged_into: Optional[int] = None
+                for child_id, retained_weights in retained:
+                    if l1_weight_distance(posterior, retained_weights) <= self.delta + TINY:
+                        merged_into = child_id
+                        break
+                branch_probability = generated_mass[key]
+                if merged_into is not None:
+                    tree.weight[merged_into] += parent_mass * branch_probability
+                    tree.data[merged_into].observation_probability += branch_probability
+                    tree.data[merged_into].packed_observations.append(observation)
+                    tree.recompute_children_cdf(action_id)
+                    self._merged_branches += 1
+                    continue
+                child_particles, child_weights, occupied, resampled = self._maybe_resample(
+                    next_states, posterior
+                )
+                child_id = self._add_weighted_belief_node(
+                    tree,
+                    child_particles,
+                    child_weights,
+                    data.depth + 1,
+                    action_id,
+                    observation,
+                    key,
+                    parent_mass * branch_probability,
+                    list(range(len(child_particles))),
+                    branch_probability,
+                    occupied,
+                    resampled,
+                )
+                retained.append((child_id, posterior))
+                self._packed_branches += 1
+            self._update_action_bounds(tree, action_id)
+            upper = tree.upper_confidence_bound[action_id]
+            if upper > best_upper + TINY:
+                best_upper, best_action_id = upper, action_id
+        data.expanded = True
+        data.best_upper_action_id = best_action_id
+
+    def _add_weighted_belief_node(
+        self,
+        tree: Tree,
+        particles: Sequence[Any],
+        weights: Sequence[float],
+        depth: int,
+        parent_id: Optional[int],
+        observation: Any,
+        obs_key: Any,
+        mass: float,
+        scenario_ids: List[int],
+        observation_probability: float = 1.0,
+        occupied_bins: int = 0,
+        resampled: bool = False,
+    ) -> int:
+        normalized = normalize_weights(weights)
+        log_weights = np.log(np.maximum(normalized, 1e-300))
+        if not np.any(log_weights != 0.0):
+            # The repository belief class rejects an all-zero log vector even
+            # though it is the valid representation of a one-particle belief.
+            # A shared additive offset leaves normalized weights unchanged.
+            log_weights = log_weights - 1.0
+        belief = WeightedParticleBelief(particles=list(particles), log_weights=log_weights)
+        node_id = tree.add_belief_node(
+            belief=belief,
+            observation=observation,
+            weight=mass,
+            parent_id=parent_id,
+            obs_key=obs_key,
+        )
+        tree.sample[node_id] = list(scenario_ids)
+        terminal = all(self.environment.is_terminal(state=state) for state in particles)
+        lower, upper = self._weighted_initial_bounds(
+            particles, normalized, scenario_ids, depth, terminal
+        )
+        tree.lower_confidence_bound[node_id] = lower
+        tree.upper_confidence_bound[node_id] = upper
+        tree.v_value[node_id] = lower
+        tree.data[node_id] = _AdaBeliefData(
+            depth=depth,
+            weights=normalized,
+            default_value=lower,
+            terminal=terminal,
+            scenario_ids=scenario_ids,
+            observation_probability=observation_probability,
+            packed_observations=[observation] if observation is not None else [],
+            occupied_bins=occupied_bins,
+            resampled=resampled,
+        )
+        return node_id
+
+    def _weighted_initial_bounds(
+        self,
+        states: Sequence[Any],
+        weights: np.ndarray,
+        scenario_ids: Sequence[int],
+        depth: int,
+        terminal: bool,
+    ) -> Tuple[float, float]:
+        if terminal or depth >= self.depth:
+            self._stopped_by_depth = self._stopped_by_depth or depth >= self.depth
+            return 0.0, 0.0
+        if self.lower_bound is not None:
+            lower = float(self.lower_bound(states, weights.copy(), depth))
+        else:
+            actions = self._default_policy_actions(int(scenario_ids[0]), depth)
+            values = [
+                self._default_policy_value(int(sid), state, depth, actions)
+                for sid, state in zip(scenario_ids, states)
+            ]
+            lower = float(np.dot(weights, values))
+        if self.upper_bound is not None:
+            upper = float(self.upper_bound(states, weights.copy(), depth))
+        else:
+            remaining = self.depth - depth
+            values = [
+                0.0
+                if self.environment.is_terminal(state=state)
+                else self.max_reward * self._discount_sum(remaining)
+                for state in states
+            ]
+            upper = float(np.dot(weights, values))
+        if not np.isfinite(lower) or not np.isfinite(upper):
+            raise ValueError("bound providers must return finite values")
+        return lower, self._reconcile_bounds(lower, upper)
+
+    def _backup(self, tree: Tree, belief_id: int) -> None:
+        """Bellman backup: maximize each bound over all action children."""
+        action_ids = tree.get_children_ids(belief_id)
+        if not action_ids:
+            return
+        for action_id in action_ids:
+            self._update_action_bounds(tree, action_id)
+        best_upper = max(action_ids, key=lambda node: tree.upper_confidence_bound[node])
+        best_lower = max(action_ids, key=lambda node: tree.lower_confidence_bound[node])
+        lower = max(
+            tree.lower_confidence_bound[belief_id],
+            tree.lower_confidence_bound[best_lower],
+        )
+        upper = self._reconcile_bounds(lower, float(tree.upper_confidence_bound[best_upper]))
+        tree.lower_confidence_bound[belief_id] = lower
+        tree.upper_confidence_bound[belief_id] = upper
+        tree.v_value[belief_id] = lower
+        tree.data[belief_id].best_upper_action_id = best_upper
+
+    def _adaops_metrics(self, tree: Tree, root_id: int) -> List[PolicyInfoVariable]:
+        belief_ids = [node_id for node_id in range(len(tree)) if tree.kind[node_id] == BELIEF]
+        action_count = sum(tree.kind[node_id] == ACTION for node_id in range(len(tree)))
+        particle_counts = [
+            len(cast(WeightedParticleBelief, tree.get_belief(node_id)).particles)
+            for node_id in belief_ids
+        ]
+        ess_values = [effective_sample_size(tree.data[node_id].weights) for node_id in belief_ids]
+        design_values = [design_effect(tree.data[node_id].weights) for node_id in belief_ids]
+        lower = float(tree.lower_confidence_bound[root_id])
+        upper = float(tree.upper_confidence_bound[root_id])
+        values = {
+            AdaOPSMetrics.N_TRIALS: self._n_trials,
+            AdaOPSMetrics.ROOT_LOWER_BOUND: lower,
+            AdaOPSMetrics.ROOT_UPPER_BOUND: upper,
+            AdaOPSMetrics.ROOT_GAP: upper - lower,
+            AdaOPSMetrics.N_BELIEF_NODES: len(belief_ids),
+            AdaOPSMetrics.N_ACTION_NODES: action_count,
+            AdaOPSMetrics.PACKED_BRANCHES: self._packed_branches,
+            AdaOPSMetrics.MERGED_BRANCHES: self._merged_branches,
+            AdaOPSMetrics.RESAMPLE_COUNT: self._resample_count,
+            AdaOPSMetrics.MIN_PARTICLES: min(particle_counts),
+            AdaOPSMetrics.MAX_PARTICLES: max(particle_counts),
+            AdaOPSMetrics.MEAN_PARTICLES: float(np.mean(particle_counts)),
+            AdaOPSMetrics.MEAN_ESS: float(np.mean(ess_values)),
+            AdaOPSMetrics.MAX_DESIGN_EFFECT: max(design_values),
+            AdaOPSMetrics.BOUND_CORRECTIONS: self._bound_clamps,
+            AdaOPSMetrics.ZERO_WEIGHT_CORRECTIONS: self._zero_weight_corrections,
+            AdaOPSMetrics.STOPPED_BY_GAP: int(self._gap_closed),
+            AdaOPSMetrics.STOPPED_BY_TIMEOUT: int(self._stopped_by_timeout),
+            AdaOPSMetrics.STOPPED_BY_TRIALS: int(self._stopped_by_trials),
+            AdaOPSMetrics.STOPPED_BY_DEPTH: int(self._stopped_by_depth),
+            AdaOPSMetrics.STALLED: int(self._stalled),
+        }
+        return [
+            PolicyInfoVariable(name=metric.value, value=values[metric]) for metric in AdaOPSMetrics
+        ]
+
+    def get_last_search_state(self) -> Dict[str, Any]:
+        """Return an immutable deep copy of the last decision snapshot."""
+        if self._last_snapshot is None:
+            raise ValueError("no search state available; call action() first")
+        return copy.deepcopy(self._last_snapshot)
+
+    def export_search_state(
+        self, path: Path, tree: Optional[Tree] = None, root_id: Optional[int] = None
+    ) -> Path:
+        if tree is None or root_id is None:
+            if self._last_snapshot is None:
+                raise ValueError("no search state to export; call action() first")
+            payload = copy.deepcopy(self._last_snapshot)
+        else:
+            selected = (
+                self._action_of_best_lower_bound(tree, root_id)
+                if tree.children_ids[root_id]
+                else None
+            )
+            payload = self._snapshot(tree, root_id, selected)
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        return path
+
+    def _snapshot(self, tree: Tree, root_id: int, selected: Any) -> Dict[str, Any]:
+        nodes = []
+        for node_id in range(len(tree)):
+            common = {
+                "id": node_id,
+                "kind": "belief" if tree.kind[node_id] == BELIEF else "action",
+                "parent_id": tree.parent_id[node_id],
+                "children_ids": list(tree.children_ids[node_id]),
+                "depth": tree.data[node_id].depth if tree.kind[node_id] == BELIEF else None,
+                "probability_mass": tree.weight[node_id],
+                "lower_bound": tree.lower_confidence_bound[node_id],
+                "upper_bound": tree.upper_confidence_bound[node_id],
+                "visits": tree.visit_count[node_id],
+            }
+            if tree.kind[node_id] == BELIEF:
+                data: _AdaBeliefData = tree.data[node_id]
+                common.update(
+                    {
+                        "observation": repr(tree.observation[node_id]),
+                        "packed_observations": [repr(value) for value in data.packed_observations],
+                        "particles": [
+                            repr(value)
+                            for value in cast(
+                                WeightedParticleBelief, tree.get_belief(node_id)
+                            ).particles
+                        ],
+                        "weights": data.weights.tolist(),
+                        "effective_sample_size": effective_sample_size(data.weights),
+                        "design_effect": design_effect(data.weights),
+                        "occupied_bins": data.occupied_bins,
+                        "resampled": data.resampled,
+                    }
+                )
+            else:
+                common.update(
+                    {
+                        "action": repr(tree.action[node_id]),
+                        "immediate_reward": tree.immediate_reward[node_id],
+                    }
+                )
+            nodes.append(common)
+        return {
+            "planner": self.name,
+            "planner_class": type(self).__name__,
+            "config_id": self.config_id,
+            "selected_action": repr(selected),
+            "root_id": root_id,
+            "nodes": nodes,
+        }
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        # User callables are configuration, but many local functions are not
+        # pickleable. Require pickleable providers instead of silently losing them.
+        return state

--- a/POMDPPlanners/planners/scenario_tree_planners/adaptive_particles.py
+++ b/POMDPPlanners/planners/scenario_tree_planners/adaptive_particles.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: MIT
+
+"""Small, independently testable particle operations used by AdaOPS."""
+
+from statistics import NormalDist
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+
+def normalize_weights(weights: Sequence[float]) -> np.ndarray:
+    """Return finite non-negative weights summing to one."""
+    array = np.asarray(weights, dtype=np.float64).reshape(-1)
+    if array.size == 0:
+        raise ValueError("weights must not be empty")
+    if not np.all(np.isfinite(array)) or np.any(array < 0.0):
+        raise ValueError("weights must be finite and non-negative")
+    total = float(array.sum())
+    if total <= 0.0:
+        raise ValueError("weights must have positive total mass")
+    return array / total
+
+
+def effective_sample_size(weights: Sequence[float]) -> float:
+    """Equation (1) of Wu et al. (2021), in particles."""
+    normalized = normalize_weights(weights)
+    return float(1.0 / np.dot(normalized, normalized))
+
+
+def design_effect(weights: Sequence[float]) -> float:
+    """Particle count divided by effective sample size."""
+    normalized = normalize_weights(weights)
+    return float(normalized.size / effective_sample_size(normalized))
+
+
+def kld_sample_size(occupied_bins: int, zeta: float, confidence: float = 0.95) -> int:
+    """Fox's normal-quantile approximation used by AdaOPS (paper equation 2)."""
+    if occupied_bins <= 1:
+        return 1
+    if zeta <= 0.0:
+        raise ValueError("zeta must be positive")
+    if not 0.5 < confidence < 1.0:
+        raise ValueError("confidence must be between 0.5 and 1")
+    degrees = occupied_bins - 1
+    quantile = NormalDist().inv_cdf(confidence)
+    correction = 1.0 - 2.0 / (9.0 * degrees) + quantile * np.sqrt(2.0 / (9.0 * degrees))
+    return max(1, int(np.ceil(degrees * correction**3 / (2.0 * zeta))))
+
+
+def bounded_kld_sample_size(
+    occupied_bins: int,
+    zeta: float,
+    minimum: int,
+    maximum: int,
+    confidence: float = 0.95,
+) -> int:
+    """KLD size clamped to the configured particle limits."""
+    if minimum <= 0 or maximum < minimum:
+        raise ValueError("particle limits must satisfy 0 < minimum <= maximum")
+    return min(maximum, max(minimum, kld_sample_size(occupied_bins, zeta, confidence)))
+
+
+def l1_weight_distance(left: Sequence[float], right: Sequence[float]) -> float:
+    """L1 distance for sibling beliefs over one shared particle vector."""
+    left_array = normalize_weights(left)
+    right_array = normalize_weights(right)
+    if left_array.shape != right_array.shape:
+        raise ValueError("packed beliefs must share the same particle vector")
+    return float(np.abs(left_array - right_array).sum())
+
+
+def systematic_resample(
+    particles: Sequence[Any], weights: Sequence[float], count: int, rng: np.random.Generator
+) -> Tuple[List[Any], np.ndarray]:
+    """Low-variance resampling with uniform output weights."""
+    if count <= 0:
+        raise ValueError("count must be positive")
+    normalized = normalize_weights(weights)
+    if len(particles) != normalized.size:
+        raise ValueError("particles and weights must have the same length")
+    positions = (float(rng.random()) + np.arange(count, dtype=np.float64)) / count
+    indices = np.searchsorted(np.cumsum(normalized), positions, side="right")
+    indices = np.clip(indices, 0, normalized.size - 1)
+    return [particles[int(index)] for index in indices], np.full(count, 1.0 / count)
+
+
+def occupied_bin_count(particles: Iterable[Any], state_binner: Callable[[Any], Any]) -> int:
+    """Count explicit, hashable state bins; never infer a grid."""
+    bins = set()
+    for state in particles:
+        key = state_binner(state)
+        try:
+            hash(key)
+        except TypeError as error:
+            raise TypeError("state_binner must return hashable bin keys") from error
+        bins.add(key)
+    return len(bins)
+
+
+def adaptive_resample(
+    particles: Sequence[Any],
+    weights: Sequence[float],
+    rng: np.random.Generator,
+    minimum: int,
+    maximum: int,
+    zeta: float,
+    state_binner: Optional[Callable[[Any], Any]],
+    confidence: float = 0.95,
+) -> Tuple[List[Any], np.ndarray, int]:
+    """Resample to a KLD size, or to ``maximum`` when adaptation is disabled."""
+    occupied = occupied_bin_count(particles, state_binner) if state_binner is not None else 0
+    count = (
+        bounded_kld_sample_size(occupied, zeta, minimum, maximum, confidence)
+        if state_binner is not None
+        else maximum
+    )
+    sampled, sampled_weights = systematic_resample(particles, weights, count, rng)
+    return sampled, sampled_weights, occupied

--- a/POMDPPlanners/planners/scenario_tree_planners/despot.py
+++ b/POMDPPlanners/planners/scenario_tree_planners/despot.py
@@ -10,8 +10,8 @@ a running average of sampled returns. Search proceeds in *trials*: each trial
 walks from the root down the branch that currently looks best under the upper
 bound and least resolved under the gap between the bounds, expands the leaf it
 reaches, and then backs the bounds up along the path it came down. The search
-stops when the root's bounds have closed to within ``(1 - eta)`` of their
-current width, or when the budget runs out.
+stops when the root's residual excess uncertainty ``(1 - eta)(u - l)`` has
+fallen to numerical noise, or when the budget runs out.
 
 Why that is not MCTS: there is no exploration bonus, no visit-count-driven
 selection, and no averaging of returns. Branching is driven entirely by
@@ -125,6 +125,12 @@ class _TerminalObservation:
     them their own child -- with both bounds pinned to zero -- keeps
     ``sum_o w_o == w_b`` exactly, so the weighted averages in equation (2) stay
     correct instead of quietly renormalizing over the survivors.
+
+    Matched by object identity, never by value, so no real observation can
+    collide with it. That only holds if the singleton survives a round trip:
+    a search tree is deep-copied for a snapshot and pickled with the planner,
+    and without ``__reduce__`` each copy would be a *new* instance that fails
+    every ``is TERMINAL_OBSERVATION`` test afterwards.
     """
 
     __slots__ = ()
@@ -132,8 +138,23 @@ class _TerminalObservation:
     def __repr__(self) -> str:
         return "<terminal>"
 
+    def __reduce__(self):
+        return (_terminal_observation, ())
+
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        del memo
+        return self
+
 
 TERMINAL_OBSERVATION = _TerminalObservation()
+
+
+def _terminal_observation() -> "_TerminalObservation":
+    """Module-level factory so ``pickle`` restores the singleton, not a copy."""
+    return TERMINAL_OBSERVATION
 
 
 class DESPOTMetrics(Enum):
@@ -220,8 +241,16 @@ class DESPOT(ArenaPathSimulationPolicy):
             the planner optimises the ``D``-step discounted return.
         name: Unique identifier for this planner instance.
         n_scenarios: ``K``, the number of determinized scenarios per decision.
-        eta: Target-precision parameter in ``(0, 1)``. The search stops once the
-            root gap has shrunk to ``eta`` of its own width. ``eta = 1`` is
+        eta: Target-precision parameter ``xi`` in ``(0, 1)``, used in the
+            excess-uncertainty rule (5). It sets how much of the root gap a
+            node is allowed to keep before a trial stops descending into it:
+            a node at depth ``d`` is resolved once its width falls below
+            ``eta (u(root) - l(root)) gamma^(-d)``. At the root itself
+            (``d = 0``) that leaves the residual ``(1 - eta)(u - l)``, so the
+            search stops when the root gap reaches numerical noise scaled by
+            ``1 / (1 - eta)`` -- it is *not* a fraction of the gap's starting
+            width, and nothing here stores that starting width. Lower ``eta``
+            makes deep nodes get resolved more tightly. ``eta = 1`` is
             rejected: it makes the stopping test true before the first trial,
             so the planner would return without searching.
         pruning_constant: ``lambda`` in equation (8). ``0`` disables
@@ -572,8 +601,15 @@ class DESPOT(ArenaPathSimulationPolicy):
             return uniform
         return array / total
 
-    def _sample_from_belief_sampler(self, belief: Belief) -> List[Any]:
-        """``K`` draws from a belief that has no particle list of its own.
+    def _sample_from_belief_sampler(
+        self, belief: Belief, n_draws: Optional[int] = None
+    ) -> List[Any]:
+        """``n_draws`` draws from a belief that has no particle list of its own.
+
+        ``n_draws`` defaults to ``K``; subclasses that size their root set
+        differently (AdaOPS uses ``max_particles``) pass their own count so
+        they inherit the seed capture/restore below instead of reimplementing
+        the draw and leaking into the caller's global streams.
 
         The draw is seeded from the planner's private generator, so it is fresh
         on every call yet reproducible from ``scenario_seed``. Both global
@@ -589,7 +625,8 @@ class DESPOT(ArenaPathSimulationPolicy):
             seed = int(self._scenario_rng.integers(0, 2**32))
             np.random.seed(seed)
             random.seed(seed)
-            return [belief.sample() for _ in range(self.n_scenarios)]
+            count = self.n_scenarios if n_draws is None else int(n_draws)
+            return [belief.sample() for _ in range(count)]
         finally:
             ScenarioRandomStreams.restore_global_state(saved_state)
 

--- a/POMDPPlanners/planners/scenario_tree_planners/hyp_despot.py
+++ b/POMDPPlanners/planners/scenario_tree_planners/hyp_despot.py
@@ -574,9 +574,28 @@ class HypDESPOT(Policy):
         return copy.deepcopy(self._last_snapshot)
 
     def __getstate__(self):
+        """Drop the lock and the tree; keep an explicit model override.
+
+        ``_model`` itself is re-resolved on unpickling rather than stored,
+        which avoids a second reference to the same object -- the environment
+        is in the state and already carries it. An explicit ``model=``
+        argument is different: it is the only record of which model this
+        planner was built with, so it has to travel, or the restored planner
+        silently binds to whatever the environment happens to expose. The one
+        exception is the case where the two are the same object, where storing
+        it would pickle the model twice and break the ``is`` relationship on
+        the way back.
+        """
         state = self.__dict__.copy()
-        for key in ("_tree_lock", "_nodes", "_model", "_model_override", "_last_snapshot"):
+        for key in ("_tree_lock", "_nodes", "_model", "_last_snapshot"):
             state.pop(key, None)
+        if state.get("_model_override") is not None and state["_model_override"] is getattr(
+            self.environment, "hyp_despot_cuda_model", None
+        ):
+            state["_model_override"] = None
+            state["_model_override_from_environment"] = True
+        else:
+            state["_model_override_from_environment"] = False
         return state
 
     def __setstate__(self, state):
@@ -584,11 +603,19 @@ class HypDESPOT(Policy):
             setattr(self, key, value)
         self._tree_lock = threading.RLock()
         self._last_snapshot = None
-        resolved_model = getattr(self.environment, "hyp_despot_cuda_model", None)
+        from_environment = getattr(self, "_model_override_from_environment", False)
+        override = getattr(self, "_model_override", None)
+        resolved_model = (
+            override
+            if override is not None
+            else getattr(self.environment, "hyp_despot_cuda_model", None)
+        )
         if resolved_model is None:
             raise HypDESPOTCompatibilityError(
                 "unpickled environment must expose hyp_despot_cuda_model"
             )
+        if from_environment:
+            self._model_override = resolved_model
         self._model = cast(HypDESPOTCUDAmodel, resolved_model)
         validate_cuda_contract(self._model, self._actions, torch.device(self.device))
         self._reset_transient()

--- a/POMDPPlanners/planners/scenario_tree_planners/hyp_despot.py
+++ b/POMDPPlanners/planners/scenario_tree_planners/hyp_despot.py
@@ -1,0 +1,604 @@
+# SPDX-License-Identifier: MIT
+"""HyP-DESPOT: shared CPU search with batched CUDA leaf expansion.
+
+This is a clean implementation from HyP-DESPOT (Cai et al., RSS 2018,
+arXiv:1802.06215).  It does not copy the unlicensed author C++/CUDA source.
+CPU workers traverse one scenario tree using scenario-weighted PO-UCT and
+temporary observation-branch virtual loss.  A queue combines discovered
+leaves; transition, reward, observation grouping, terminal masking, and leaf
+bounds then execute over the leaf/action/scenario Cartesian batch on CUDA.
+Final choice uses backed-up lower values, never the exploration score.
+"""
+# pylint: disable=too-many-instance-attributes,too-many-arguments
+import copy
+import json
+import math
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, cast
+import torch
+from torch import Tensor
+from POMDPPlanners.core.environment import SpaceType
+from POMDPPlanners.core.environment.hyp_despot_cuda_model import HypDESPOTCUDAmodel
+from POMDPPlanners.core.policy import Policy, PolicyInfoVariable, PolicyRunData, PolicySpaceInfo
+from POMDPPlanners.planners.scenario_tree_planners.hyp_despot_cuda import (
+    CUDAExpansionResult,
+    HypDESPOTCompatibilityError,
+    expand_cuda_leaves,
+    validate_cuda_contract,
+)
+
+
+class HypDESPOTMetrics(Enum):
+    TRAVERSALS = "hyp_despot_traversals"
+    CUDA_BATCHES = "hyp_despot_cuda_batches"
+    CUDA_LEAVES = "hyp_despot_cuda_leaves"
+    CUDA_SCENARIOS = "hyp_despot_cuda_scenarios"
+    CUDA_ACTIONS = "hyp_despot_cuda_actions"
+    MEAN_BATCH_SIZE = "hyp_despot_mean_batch_size"
+    MAX_BATCH_SIZE = "hyp_despot_max_batch_size"
+    QUEUE_TIME = "hyp_despot_queue_time_seconds"
+    KERNEL_TIME = "hyp_despot_kernel_time_seconds"
+    TRANSFER_TIME = "hyp_despot_transfer_time_seconds"
+    TRAVERSAL_TIME = "hyp_despot_traversal_time_seconds"
+    BACKUP_TIME = "hyp_despot_backup_time_seconds"
+    TOTAL_TIME = "hyp_despot_total_time_seconds"
+    VIRTUAL_LOSS = "hyp_despot_virtual_loss_applications"
+    LOCK_CONTENTION = "hyp_despot_lock_contention_seconds"
+    ROOT_LOWER = "hyp_despot_root_lower_bound"
+    ROOT_UPPER = "hyp_despot_root_upper_bound"
+    ROOT_GAP = "hyp_despot_root_gap"
+    GPU_DEVICE = "hyp_despot_gpu_device"
+    PEAK_MEMORY = "hyp_despot_peak_memory_bytes"
+
+
+@dataclass
+class ObservationBranch:
+    key: int
+    child: int
+    weight: float
+    virtual_loss: float = 0.0
+
+
+@dataclass
+class ActionBranch:
+    action_index: int
+    visits: float = 0.0
+    lower: float = 0.0
+    upper: float = 0.0
+    immediate_reward: float = 0.0
+    observations: Dict[int, ObservationBranch] = field(default_factory=dict)
+
+
+@dataclass
+class BeliefNode:
+    node_id: int
+    parent_action: Optional[Tuple[int, int]]
+    depth: int
+    states: Tensor
+    scenario_ids: Tensor
+    weights: Tensor
+    visits: float = 0.0
+    lower: float = 0.0
+    upper: float = 0.0
+    expanded: bool = False
+    terminal: bool = False
+    actions: Dict[int, ActionBranch] = field(default_factory=dict)
+
+
+class HypDESPOT(Policy):
+    """Hybrid parallel DESPOT requiring a deterministic CUDA scenario model.
+
+    The environment must expose ``hyp_despot_cuda_model`` after JSON reload.
+    ``expansion_actions`` is an explicit finite list; its indices are passed to
+    CUDA. ``n_traversals`` is a deterministic work budget.
+    """
+
+    def __init__(
+        self,
+        environment: Any,
+        discount_factor: float,
+        depth: int,
+        name: str,
+        n_scenarios: int = 64,
+        n_traversals: int = 64,
+        n_workers: int = 4,
+        cuda_batch_size: int = 8,
+        exploration_constant: float = 1.0,
+        virtual_loss: float = 1.0,
+        scenario_seed: int = 0,
+        expansion_actions: Optional[Sequence[Any]] = None,
+        device: str = "cuda:0",
+        search_state_dump_dir: Optional[Path] = None,
+        log_path: Optional[Path] = None,
+        debug: bool = False,
+        use_queue_logger: bool = False,
+        model: Any = None,
+    ):
+        if (
+            depth <= 0
+            or n_scenarios <= 0
+            or n_traversals <= 0
+            or n_workers <= 0
+            or cuda_batch_size <= 0
+        ):
+            raise ValueError(
+                "depth, scenarios, traversals, workers, and CUDA batch size must be positive"
+            )
+        if not 0.0 < discount_factor <= 1.0:
+            raise ValueError("discount_factor must be in (0, 1]")
+        if exploration_constant < 0 or virtual_loss < 0:
+            raise ValueError("exploration_constant and virtual_loss must be non-negative")
+        self.depth = depth
+        self.n_scenarios = n_scenarios
+        self.n_traversals = n_traversals
+        self.n_workers = n_workers
+        self.cuda_batch_size = cuda_batch_size
+        self.exploration_constant = float(exploration_constant)
+        self.virtual_loss = float(virtual_loss)
+        self.scenario_seed = scenario_seed
+        self.expansion_actions = list(expansion_actions) if expansion_actions is not None else None
+        self.device = device
+        self.search_state_dump_dir = Path(search_state_dump_dir) if search_state_dump_dir else None
+        self._model_override = model
+        self._tree_lock = threading.RLock()
+        self._last_snapshot = None
+        super().__init__(environment, discount_factor, name, log_path, debug, use_queue_logger)
+        self._actions = self.expansion_actions or self._resolve_actions(environment)
+        self.expansion_actions = list(self._actions)
+        resolved_model = (
+            model if model is not None else getattr(environment, "hyp_despot_cuda_model", None)
+        )
+        if resolved_model is None:
+            raise HypDESPOTCompatibilityError(
+                "environment must expose hyp_despot_cuda_model or model must be supplied"
+            )
+        self._model: HypDESPOTCUDAmodel = cast(HypDESPOTCUDAmodel, resolved_model)
+        validate_cuda_contract(self._model, self._actions, torch.device(device))
+        self._reset_transient()
+
+    @staticmethod
+    def _resolve_actions(environment: Any) -> List[Any]:
+        getter = getattr(environment, "get_actions", None)
+        if not callable(getter):
+            raise HypDESPOTCompatibilityError(
+                "continuous actions require an explicit finite expansion_actions set"
+            )
+        actions = list(cast(Iterable[Any], getter()))
+        if not actions:
+            raise HypDESPOTCompatibilityError("finite expansion action set must not be empty")
+        return actions
+
+    @classmethod
+    def get_space_info(cls) -> PolicySpaceInfo:
+        # Continuous environments are legal only when the caller supplies a
+        # finite representative expansion set; constructor validation enforces
+        # that condition more precisely than the generic compatibility check.
+        return PolicySpaceInfo(SpaceType.MIXED, SpaceType.MIXED)
+
+    @classmethod
+    def get_info_variable_names(cls) -> List[str]:
+        return [x.value for x in HypDESPOTMetrics]
+
+    def _reset_transient(self) -> None:
+        self._nodes: Dict[int, BeliefNode] = {}
+        self._next_node_id = 0
+        self._counts = {metric: 0.0 for metric in HypDESPOTMetrics}
+        self._batch_sizes = []
+
+    @staticmethod
+    def scenario_po_uct(
+        action_visits: float,
+        parent_visits: float,
+        scenario_weight: float,
+        value: float,
+        exploration_constant: float,
+        virtual_loss: float = 0.0,
+    ) -> float:
+        """Paper PO-UCT: value plus exploration scaled by scenario mass."""
+        if action_visits <= 0:
+            return math.inf
+        bonus = exploration_constant * math.sqrt(
+            max(0.0, scenario_weight) * math.log(max(1.0, parent_visits)) / action_visits
+        )
+        return value + bonus - virtual_loss
+
+    def _acquire(self) -> float:
+        start = time.perf_counter()
+        self._tree_lock.acquire()
+        waited = time.perf_counter() - start
+        self._counts[HypDESPOTMetrics.LOCK_CONTENTION] += waited
+        return waited
+
+    def _new_node(
+        self,
+        states: Tensor,
+        ids: Tensor,
+        weights: Tensor,
+        depth: int,
+        parent: Optional[Tuple[int, int]],
+    ) -> int:
+        node_id = self._next_node_id
+        self._next_node_id += 1
+        self._nodes[node_id] = BeliefNode(node_id, parent, depth, states, ids, weights)
+        return node_id
+
+    def _root_particles(self, belief: Any) -> Tuple[Tensor, Tensor, Tensor]:
+        particles = getattr(belief, "particles", belief)
+        if not isinstance(particles, Tensor):
+            raise HypDESPOTCompatibilityError(
+                "HypDESPOT belief particles must be a CUDA torch.Tensor; scalar Python models are unsupported"
+            )
+        device = torch.device(self.device)
+        if particles.device != device:
+            raise HypDESPOTCompatibilityError(
+                f"belief particles must already be on {device}; hidden copies are forbidden"
+            )
+        if particles.dim() != 2 or not particles.dtype.is_floating_point:
+            raise HypDESPOTCompatibilityError(
+                "belief particles must be floating [scenario, state] tensors"
+            )
+        if particles.shape[0] < self.n_scenarios:
+            raise HypDESPOTCompatibilityError("belief has fewer particles than n_scenarios")
+        states = particles[: self.n_scenarios]
+        ids = torch.arange(self.n_scenarios, device=device, dtype=torch.int64)
+        raw = getattr(belief, "weights", None)
+        if raw is None:
+            weights = torch.full(
+                (self.n_scenarios,), 1 / self.n_scenarios, device=device, dtype=states.dtype
+            )
+        else:
+            if (
+                not isinstance(raw, Tensor)
+                or raw.device != device
+                or raw.shape[0] < self.n_scenarios
+            ):
+                raise HypDESPOTCompatibilityError(
+                    "belief weights must be a same-device tensor aligned with particles"
+                )
+            weights = raw[: self.n_scenarios]
+            total = weights.sum()
+            if (
+                not bool(torch.isfinite(weights).all())
+                or bool((weights < 0).any())
+                or float(total) <= 0
+            ):
+                raise HypDESPOTCompatibilityError(
+                    "belief weights must be finite, non-negative, and have positive mass"
+                )
+            weights = weights / total
+        return states, ids, weights
+
+    def _select_leaf(self, root: int) -> Tuple[int, List[Tuple[int, int, int]]]:
+        path: List[Tuple[int, int, int]] = []
+        self._acquire()
+        try:
+            node = self._nodes[root]
+            while node.expanded and node.depth < self.depth and node.actions:
+                parent = max(1.0, node.visits)
+                total_weight = float(node.weights.sum())
+                action = max(
+                    node.actions.values(),
+                    key=lambda a: self.scenario_po_uct(
+                        a.visits,
+                        parent,
+                        total_weight,
+                        a.upper,
+                        self.exploration_constant,
+                        sum(o.virtual_loss for o in a.observations.values()),
+                    ),
+                )
+                if not action.observations:
+                    break
+                obs = max(action.observations.values(), key=lambda o: o.weight - o.virtual_loss)
+                obs.virtual_loss += self.virtual_loss
+                self._counts[HypDESPOTMetrics.VIRTUAL_LOSS] += 1
+                path.append((node.node_id, action.action_index, obs.key))
+                node = self._nodes[obs.child]
+            return node.node_id, path
+        except Exception:
+            for node_id, action, key in path:
+                branch = self._nodes[node_id].actions[action].observations[key]
+                branch.virtual_loss = max(0.0, branch.virtual_loss - self.virtual_loss)
+            raise
+        finally:
+            self._tree_lock.release()
+
+    def _release_virtual_loss(self, path: List[Tuple[int, int, int]]) -> None:
+        self._acquire()
+        try:
+            for node_id, action, key in path:
+                branch = self._nodes[node_id].actions[action].observations[key]
+                branch.virtual_loss = max(0.0, branch.virtual_loss - self.virtual_loss)
+        finally:
+            self._tree_lock.release()
+
+    def _integrate(self, leaf_ids: List[int], result: CUDAExpansionResult) -> None:
+        start = time.perf_counter()
+        self._acquire()
+        try:
+            for local_leaf, node_id in enumerate(leaf_ids):
+                node = self._nodes[node_id]
+                if node.expanded:
+                    continue
+                rows = result.leaf_indices == local_leaf
+                for action_index in range(len(self._actions)):
+                    mask = rows & (result.action_indices == action_index)
+                    rewards = result.rewards[mask]
+                    terminal = result.terminal[mask]
+                    source_indices = result.scenario_indices[mask]
+                    row_weights = node.weights[source_indices]
+                    normalized_weights = row_weights / row_weights.sum()
+                    lower = torch.where(
+                        terminal, torch.zeros_like(result.lower[mask]), result.lower[mask]
+                    )
+                    upper = torch.where(
+                        terminal, torch.zeros_like(result.upper[mask]), result.upper[mask]
+                    )
+                    branch = ActionBranch(
+                        action_index,
+                        visits=self._host_float(node.weights.sum()),
+                        immediate_reward=self._host_float((rewards * normalized_weights).sum()),
+                    )
+                    branch.lower = (
+                        branch.immediate_reward
+                        + self.discount_factor
+                        * self._host_float((lower * normalized_weights).sum())
+                    )
+                    branch.upper = (
+                        branch.immediate_reward
+                        + self.discount_factor
+                        * self._host_float((upper * normalized_weights).sum())
+                    )
+                    keys = result.observation_keys[mask]
+                    next_states = result.next_states[mask]
+                    for key_tensor in torch.unique(keys):
+                        key = int(key_tensor.item())
+                        group = keys == key_tensor
+                        indices = source_indices[group]
+                        child_weights = node.weights[indices]
+                        mass = self._host_float(child_weights.sum())
+                        child_normalized = child_weights / child_weights.sum()
+                        child = self._new_node(
+                            next_states[group],
+                            node.scenario_ids[indices],
+                            child_weights,
+                            node.depth + 1,
+                            (node_id, action_index),
+                        )
+                        self._nodes[child].lower = self._host_float(
+                            (lower[group] * child_normalized).sum()
+                        )
+                        self._nodes[child].upper = self._host_float(
+                            (upper[group] * child_normalized).sum()
+                        )
+                        self._nodes[child].terminal = bool(terminal[group].all())
+                        branch.observations[key] = ObservationBranch(key, child, mass)
+                    node.actions[action_index] = branch
+                node.expanded = True
+                self._backup_node(node)
+        finally:
+            self._tree_lock.release()
+            self._counts[HypDESPOTMetrics.BACKUP_TIME] += time.perf_counter() - start
+
+    def _host_float(self, value: Tensor) -> float:
+        """Copy one scalar needed by the CPU tree and account for that transfer."""
+        start = time.perf_counter()
+        result = float(value.item())
+        self._counts[HypDESPOTMetrics.TRANSFER_TIME] += time.perf_counter() - start
+        return result
+
+    def _backup_node(self, node: BeliefNode) -> None:
+        if not node.actions:
+            return
+        node.lower = max(a.lower for a in node.actions.values())
+        node.upper = max(a.upper for a in node.actions.values())
+
+    @staticmethod
+    def _select_final_action(node: BeliefNode) -> int:
+        """Choose only from backed-up lower values, excluding PO-UCT bonuses."""
+        if not node.actions:
+            raise RuntimeError("HyP-DESPOT root has no backed-up actions")
+        return max(node.actions.values(), key=lambda action: action.lower).action_index
+
+    def _backup_path(self, path: List[Tuple[int, int, int]]) -> None:
+        start = time.perf_counter()
+        self._acquire()
+        try:
+            for node_id, action_index, _ in reversed(path):
+                node = self._nodes[node_id]
+                action = node.actions[action_index]
+                action.visits += float(node.weights.sum())
+                node.visits += float(node.weights.sum())
+                if action.observations:
+                    mass = sum(o.weight for o in action.observations.values()) or 1.0
+                    action.lower = (
+                        action.immediate_reward
+                        + self.discount_factor
+                        * sum(
+                            o.weight * self._nodes[o.child].lower
+                            for o in action.observations.values()
+                        )
+                        / mass
+                    )
+                    action.upper = (
+                        action.immediate_reward
+                        + self.discount_factor
+                        * sum(
+                            o.weight * self._nodes[o.child].upper
+                            for o in action.observations.values()
+                        )
+                        / mass
+                    )
+                self._backup_node(node)
+        finally:
+            self._tree_lock.release()
+            self._counts[HypDESPOTMetrics.BACKUP_TIME] += time.perf_counter() - start
+
+    def action(self, belief: Any) -> Tuple[List[Any], PolicyRunData]:
+        validate_cuda_contract(self._model, self._actions, torch.device(self.device))
+        self._reset_transient()
+        torch.cuda.reset_peak_memory_stats(torch.device(self.device))
+        total_start = time.perf_counter()
+        states, ids, weights = self._root_particles(belief)
+        root = self._new_node(states, ids, weights, 0, None)
+        remaining = self.n_traversals
+        while remaining:
+            count = min(self.cuda_batch_size, remaining)
+            traverse_start = time.perf_counter()
+            with ThreadPoolExecutor(max_workers=self.n_workers) as pool:
+                selected = list(pool.map(lambda _: self._select_leaf(root), range(count)))
+            self._counts[HypDESPOTMetrics.TRAVERSAL_TIME] += time.perf_counter() - traverse_start
+            queue_start = time.perf_counter()
+            try:
+                unique = []
+                for leaf, _ in selected:
+                    candidate = self._nodes[leaf]
+                    if (
+                        leaf not in unique
+                        and not candidate.expanded
+                        and not candidate.terminal
+                        and candidate.depth < self.depth
+                    ):
+                        unique.append(leaf)
+                if unique:
+                    batch_depth = self._nodes[unique[0]].depth
+                    # A model call has one deterministic scenario depth.
+                    unique = [leaf for leaf in unique if self._nodes[leaf].depth == batch_depth]
+                self._counts[HypDESPOTMetrics.QUEUE_TIME] += time.perf_counter() - queue_start
+                if unique:
+                    kernel_start = time.perf_counter()
+                    result = expand_cuda_leaves(
+                        self._model,
+                        [self._nodes[x].states for x in unique],
+                        [self._nodes[x].scenario_ids for x in unique],
+                        len(self._actions),
+                        batch_depth,
+                        self.depth,
+                        self.scenario_seed,
+                    )
+                    torch.cuda.synchronize(torch.device(self.device))
+                    self._counts[HypDESPOTMetrics.KERNEL_TIME] += time.perf_counter() - kernel_start
+                    self._integrate(unique, result)
+                    self._counts[HypDESPOTMetrics.CUDA_BATCHES] += 1
+                    self._counts[HypDESPOTMetrics.CUDA_LEAVES] += len(unique)
+                    self._batch_sizes.append(len(unique))
+                    self._counts[HypDESPOTMetrics.CUDA_SCENARIOS] += result.rewards.numel() / len(
+                        self._actions
+                    )
+                    self._counts[HypDESPOTMetrics.CUDA_ACTIONS] += result.rewards.numel()
+                    self._counts[HypDESPOTMetrics.GPU_DEVICE] = result.kernel_device_index
+                for _, path in selected:
+                    self._backup_path(path)
+            finally:
+                for _, path in selected:
+                    self._release_virtual_loss(path)
+            self._counts[HypDESPOTMetrics.TRAVERSALS] += count
+            remaining -= count
+        root_node = self._nodes[root]
+        if not root_node.actions:
+            raise RuntimeError("HyP-DESPOT completed no CUDA leaf expansion")
+        chosen = self._select_final_action(root_node)
+        self._counts[HypDESPOTMetrics.ROOT_LOWER] = root_node.lower
+        self._counts[HypDESPOTMetrics.ROOT_UPPER] = root_node.upper
+        self._counts[HypDESPOTMetrics.ROOT_GAP] = root_node.upper - root_node.lower
+        self._counts[HypDESPOTMetrics.MEAN_BATCH_SIZE] = sum(self._batch_sizes) / len(
+            self._batch_sizes
+        )
+        self._counts[HypDESPOTMetrics.MAX_BATCH_SIZE] = max(self._batch_sizes)
+        self._counts[HypDESPOTMetrics.PEAK_MEMORY] = torch.cuda.max_memory_allocated(
+            torch.device(self.device)
+        )
+        self._counts[HypDESPOTMetrics.TOTAL_TIME] = time.perf_counter() - total_start
+        self._last_snapshot = self._snapshot(root, chosen)
+        if self.search_state_dump_dir:
+            self.search_state_dump_dir.mkdir(parents=True, exist_ok=True)
+            path = self.search_state_dump_dir / f"hyp_despot_{time.time_ns()}.json"
+            path.write_text(json.dumps(self._last_snapshot, indent=2), encoding="utf-8")
+        info = [
+            PolicyInfoVariable(metric.value, float(self._counts[metric]))
+            for metric in HypDESPOTMetrics
+        ]
+        return [self._actions[chosen]], PolicyRunData(info)
+
+    def _snapshot(self, root: int, chosen: int) -> dict:
+        nodes = []
+        for node in self._nodes.values():
+            nodes.append(
+                {
+                    "id": node.node_id,
+                    "parent_action": node.parent_action,
+                    "depth": node.depth,
+                    "scenario_ids": node.scenario_ids.detach().cpu().tolist(),
+                    "scenario_weights": node.weights.detach().cpu().tolist(),
+                    "visits": node.visits,
+                    "lower": node.lower,
+                    "upper": node.upper,
+                    "expanded": node.expanded,
+                    "terminal": node.terminal,
+                    "actions": [
+                        {
+                            "action_index": a.action_index,
+                            "visits": a.visits,
+                            "lower": a.lower,
+                            "upper": a.upper,
+                            "immediate_reward": a.immediate_reward,
+                            "observations": [
+                                {
+                                    "key": o.key,
+                                    "child": o.child,
+                                    "weight": o.weight,
+                                    "virtual_loss": o.virtual_loss,
+                                }
+                                for o in a.observations.values()
+                            ],
+                        }
+                        for a in node.actions.values()
+                    ],
+                }
+            )
+        return {
+            "root": root,
+            "selected_action_index": chosen,
+            "nodes": nodes,
+            "worker_count": self.n_workers,
+            "cuda_batch_sizes": list(self._batch_sizes),
+            "metrics": {m.value: float(v) for m, v in self._counts.items()},
+        }
+
+    def get_search_snapshot(self) -> Optional[dict]:
+        return copy.deepcopy(self._last_snapshot)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        for key in ("_tree_lock", "_nodes", "_model", "_model_override", "_last_snapshot"):
+            state.pop(key, None)
+        return state
+
+    def __setstate__(self, state):
+        for key, value in dict(state).items():
+            setattr(self, key, value)
+        self._tree_lock = threading.RLock()
+        self._last_snapshot = None
+        resolved_model = getattr(self.environment, "hyp_despot_cuda_model", None)
+        if resolved_model is None:
+            raise HypDESPOTCompatibilityError(
+                "unpickled environment must expose hyp_despot_cuda_model"
+            )
+        self._model = cast(HypDESPOTCUDAmodel, resolved_model)
+        validate_cuda_contract(self._model, self._actions, torch.device(self.device))
+        self._reset_transient()
+
+
+__all__ = [
+    "HypDESPOT",
+    "HypDESPOTMetrics",
+    "HypDESPOTCompatibilityError",
+    "BeliefNode",
+    "ActionBranch",
+    "ObservationBranch",
+]

--- a/POMDPPlanners/planners/scenario_tree_planners/hyp_despot_cuda.py
+++ b/POMDPPlanners/planners/scenario_tree_planners/hyp_despot_cuda.py
@@ -25,9 +25,35 @@ class CUDAExpansionResult:
     kernel_device_index: int
 
 
+def normalize_cuda_device(device: torch.device | str) -> torch.device:
+    """Give a CUDA device an explicit index so ``==`` compares like for like.
+
+    ``torch.device("cuda")`` carries index ``None`` while every tensor's
+    ``.device`` carries an explicit ``0``; the two name the same GPU but are
+    not equal in PyTorch. Normalizing once at the boundary keeps the contract
+    checks from rejecting a valid configuration.
+
+    A bare ``cuda`` resolves to the process's *current* device, not to ``0``,
+    so that is what is filled in. Hard-coding ``0`` would let a planner on a
+    box where ``torch.cuda.set_device(1)`` has run slip past the single-GPU
+    guard below and then fail much later with a message naming the wrong GPU.
+    """
+    resolved: torch.device = device if isinstance(device, torch.device) else torch.device(device)
+    if resolved.type == "cuda" and resolved.index is None:
+        try:
+            index = int(torch.cuda.current_device())
+        except (RuntimeError, AssertionError):
+            # No usable CUDA runtime. The availability check rejects this
+            # anyway; assume 0 so the comparison stays well defined.
+            index = 0
+        return torch.device("cuda", index)
+    return resolved
+
+
 def validate_cuda_contract(
     model: HypDESPOTCUDAmodel, actions: Sequence[object], device: torch.device
 ) -> None:
+    device = normalize_cuda_device(device)
     if not torch.cuda.is_available():
         raise HypDESPOTCompatibilityError("HypDESPOT requires CUDA PyTorch and an NVIDIA GPU")
     if torch.version.cuda is None:
@@ -38,7 +64,8 @@ def validate_cuda_contract(
         raise HypDESPOTCompatibilityError("HypDESPOT model.device must be a CUDA device")
     if device.index not in (None, 0):
         raise HypDESPOTCompatibilityError("HypDESPOT supports one GPU only (cuda:0)")
-    if getattr(model, "device", None) != device:
+    model_device = getattr(model, "device", None)
+    if model_device is None or normalize_cuda_device(model_device) != device:
         raise HypDESPOTCompatibilityError("model.device must exactly match the planner CUDA device")
     if not actions:
         raise HypDESPOTCompatibilityError(
@@ -70,7 +97,8 @@ def _tensor(
             f"{name} must be a torch.Tensor; host values are forbidden"
         )
     tensor: Tensor = value
-    if tensor.device != device:
+    device = normalize_cuda_device(device)
+    if normalize_cuda_device(tensor.device) != device:
         raise HypDESPOTCompatibilityError(
             f"{name} must remain on {device}; hidden host/device copies are forbidden"
         )
@@ -95,7 +123,7 @@ def expand_cuda_leaves(
     """Evaluate all Cartesian leaf/action/scenario rows in one device batch."""
     if not leaf_states:
         raise ValueError("leaf_states must not be empty")
-    device, width = model.device, leaf_states[0].shape[1]
+    device, width = normalize_cuda_device(model.device), leaf_states[0].shape[1]
     states_parts, id_parts, leaf_parts, action_parts, scenario_parts = [], [], [], [], []
     for leaf_index, (states, ids) in enumerate(zip(leaf_states, leaf_scenario_ids)):
         _tensor(states, "leaf states", device, states.shape[0])
@@ -184,5 +212,6 @@ __all__ = [
     "CUDAExpansionResult",
     "HypDESPOTCompatibilityError",
     "expand_cuda_leaves",
+    "normalize_cuda_device",
     "validate_cuda_contract",
 ]

--- a/POMDPPlanners/planners/scenario_tree_planners/hyp_despot_cuda.py
+++ b/POMDPPlanners/planners/scenario_tree_planners/hyp_despot_cuda.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: MIT
+"""Contract checks and leaf/action/scenario CUDA batching for HyP-DESPOT."""
+from dataclasses import dataclass
+from typing import List, Sequence
+import torch
+from torch import Tensor
+from POMDPPlanners.core.environment.hyp_despot_cuda_model import HypDESPOTCUDAmodel
+
+
+class HypDESPOTCompatibilityError(ValueError):
+    """The supplied model cannot perform required HyP-DESPOT CUDA work."""
+
+
+@dataclass(frozen=True)
+class CUDAExpansionResult:
+    next_states: Tensor
+    observation_keys: Tensor
+    rewards: Tensor
+    terminal: Tensor
+    lower: Tensor
+    upper: Tensor
+    leaf_indices: Tensor
+    action_indices: Tensor
+    scenario_indices: Tensor
+    kernel_device_index: int
+
+
+def validate_cuda_contract(
+    model: HypDESPOTCUDAmodel, actions: Sequence[object], device: torch.device
+) -> None:
+    if not torch.cuda.is_available():
+        raise HypDESPOTCompatibilityError("HypDESPOT requires CUDA PyTorch and an NVIDIA GPU")
+    if torch.version.cuda is None:
+        raise HypDESPOTCompatibilityError("PyTorch was built without a supported CUDA runtime")
+    if device.type == "mps":
+        raise HypDESPOTCompatibilityError("HypDESPOT does not support Apple MPS")
+    if device.type != "cuda":
+        raise HypDESPOTCompatibilityError("HypDESPOT model.device must be a CUDA device")
+    if device.index not in (None, 0):
+        raise HypDESPOTCompatibilityError("HypDESPOT supports one GPU only (cuda:0)")
+    if getattr(model, "device", None) != device:
+        raise HypDESPOTCompatibilityError("model.device must exactly match the planner CUDA device")
+    if not actions:
+        raise HypDESPOTCompatibilityError(
+            "HypDESPOT needs an explicit non-empty finite expansion action set"
+        )
+    if getattr(model, "supports_factored_step", False):
+        raise HypDESPOTCompatibilityError(
+            "HyP-DESPOT does not support within-step factored CUDA kernels"
+        )
+    required = (
+        "scenario_randomness",
+        "sample_next_states",
+        "sample_observations",
+        "rewards",
+        "terminal_mask",
+        "observation_keys",
+        "leaf_bounds",
+    )
+    missing = [name for name in required if not callable(getattr(model, name, None))]
+    if missing:
+        raise HypDESPOTCompatibilityError("HypDESPOT CUDA model is missing: " + ", ".join(missing))
+
+
+def _tensor(
+    value: object, name: str, device: torch.device, rows: int, dtype: torch.dtype | None = None
+) -> Tensor:
+    if not isinstance(value, Tensor):
+        raise HypDESPOTCompatibilityError(
+            f"{name} must be a torch.Tensor; host values are forbidden"
+        )
+    tensor: Tensor = value
+    if tensor.device != device:
+        raise HypDESPOTCompatibilityError(
+            f"{name} must remain on {device}; hidden host/device copies are forbidden"
+        )
+    if tensor.shape[0] != rows:
+        raise HypDESPOTCompatibilityError(
+            f"{name} first dimension must be {rows}, got {tuple(tensor.shape)}"
+        )
+    if dtype is not None and tensor.dtype != dtype:
+        raise HypDESPOTCompatibilityError(f"{name} must have dtype {dtype}, got {tensor.dtype}")
+    return tensor
+
+
+def expand_cuda_leaves(
+    model: HypDESPOTCUDAmodel,
+    leaf_states: List[Tensor],
+    leaf_scenario_ids: List[Tensor],
+    num_actions: int,
+    depth: int,
+    horizon: int,
+    scenario_seed: int,
+) -> CUDAExpansionResult:
+    """Evaluate all Cartesian leaf/action/scenario rows in one device batch."""
+    if not leaf_states:
+        raise ValueError("leaf_states must not be empty")
+    device, width = model.device, leaf_states[0].shape[1]
+    states_parts, id_parts, leaf_parts, action_parts, scenario_parts = [], [], [], [], []
+    for leaf_index, (states, ids) in enumerate(zip(leaf_states, leaf_scenario_ids)):
+        _tensor(states, "leaf states", device, states.shape[0])
+        _tensor(ids, "scenario ids", device, states.shape[0], torch.int64)
+        if states.dim() != 2 or states.shape[1] != width:
+            raise HypDESPOTCompatibilityError(
+                "leaf states must share a 2-D [scenario, state] shape"
+            )
+        count = states.shape[0]
+        states_parts.append(states.repeat_interleave(num_actions, 0))
+        id_parts.append(ids.repeat_interleave(num_actions))
+        leaf_parts.append(
+            torch.full((count * num_actions,), leaf_index, device=device, dtype=torch.int64)
+        )
+        action_parts.append(torch.arange(num_actions, device=device).repeat(count))
+        scenario_parts.append(torch.arange(count, device=device).repeat_interleave(num_actions))
+    states, ids = torch.cat(states_parts), torch.cat(id_parts)
+    leaves, actions, scenarios = (
+        torch.cat(leaf_parts),
+        torch.cat(action_parts),
+        torch.cat(scenario_parts),
+    )
+    rows = states.shape[0]
+    random_values = _tensor(
+        model.scenario_randomness(ids, depth, scenario_seed), "scenario randomness", device, rows
+    )
+    repeated_randomness = _tensor(
+        model.scenario_randomness(ids, depth, scenario_seed), "scenario randomness", device, rows
+    )
+    if not torch.equal(random_values, repeated_randomness):
+        raise HypDESPOTCompatibilityError(
+            "scenario_randomness must be deterministic for the same ids, depth, and seed"
+        )
+    next_states = _tensor(
+        model.sample_next_states(states, actions, random_values), "next states", device, rows
+    )
+    observations = _tensor(
+        model.sample_observations(next_states, actions, random_values), "observations", device, rows
+    )
+    rewards = _tensor(model.rewards(states, actions, next_states), "rewards", device, rows)
+    terminal = _tensor(model.terminal_mask(next_states), "terminal mask", device, rows, torch.bool)
+    keys = _tensor(
+        model.observation_keys(observations), "observation keys", device, rows, torch.int64
+    )
+    repeated_keys = _tensor(
+        model.observation_keys(observations), "observation keys", device, rows, torch.int64
+    )
+    if not torch.equal(keys, repeated_keys):
+        raise HypDESPOTCompatibilityError(
+            "observation_keys must be stable for identical observation tensors"
+        )
+    if keys.dim() != 1:
+        raise HypDESPOTCompatibilityError("observation keys must be a groupable 1-D int64 tensor")
+    lower, upper = model.leaf_bounds(next_states, max(0, horizon - depth - 1))
+    lower, upper = _tensor(lower, "leaf lower bounds", device, rows), _tensor(
+        upper, "leaf upper bounds", device, rows
+    )
+    for name, value in (
+        ("rewards", rewards),
+        ("leaf lower bounds", lower),
+        ("leaf upper bounds", upper),
+    ):
+        if (
+            value.dim() != 1
+            or not value.dtype.is_floating_point
+            or not bool(torch.isfinite(value).all())
+        ):
+            raise HypDESPOTCompatibilityError(f"{name} must be finite 1-D floating CUDA values")
+    if bool((lower > upper).any()):
+        raise HypDESPOTCompatibilityError("CUDA leaf lower bounds must not exceed upper bounds")
+    return CUDAExpansionResult(
+        next_states,
+        keys,
+        rewards,
+        terminal,
+        lower,
+        upper,
+        leaves,
+        actions,
+        scenarios,
+        next_states.device.index or 0,
+    )
+
+
+__all__ = [
+    "CUDAExpansionResult",
+    "HypDESPOTCompatibilityError",
+    "expand_cuda_leaves",
+    "validate_cuda_contract",
+]

--- a/POMDPPlanners/tests/test_planners/test_scenario_tree_planners/test_adaops.py
+++ b/POMDPPlanners/tests/test_planners/test_scenario_tree_planners/test_adaops.py
@@ -12,11 +12,19 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from typing import cast
 
 from POMDPPlanners.core.tree.arena import ACTION, BELIEF
 from POMDPPlanners.planners import POLICY_REGISTRY, AdaOPS
 from POMDPPlanners.planners.scenario_tree_planners.adaops import AdaOPSMetrics
-from POMDPPlanners.tests.test_planners.planner_fixtures import ROOT, ChainEnv, chain_belief
+from POMDPPlanners.core.belief import WeightedParticleBelief
+from POMDPPlanners.tests.test_planners.planner_fixtures import (
+    END,
+    NEXT,
+    ROOT,
+    ChainEnv,
+    chain_belief,
+)
 from POMDPPlanners.tests.test_planners.test_scenario_tree_planners.test_despot_correctness import (
     CoinEnv,
 )
@@ -53,7 +61,7 @@ def test_registration_metrics_and_alternating_topology_are_exercised():
     actions, run_data = planner.action(chain_belief(ROOT))
     tree = planner._last_tree
     assert POLICY_REGISTRY["AdaOPS"] is AdaOPS
-    assert actions[0] in planner.environment.get_actions()
+    assert actions[0] in cast(ChainEnv, planner.environment).get_actions()
     assert tree is not None and len(tree) > 3
     assert any(
         tree.kind[node] == BELIEF and tree.parent_id[node] is not None for node in range(len(tree))
@@ -96,7 +104,7 @@ def test_root_kld_sampling_obeys_particle_caps_even_for_uniform_input():
     belief = chain_belief(ROOT)
     belief.particles = [ROOT] * 20
     tree, root = planner._learn_tree(belief)
-    assert len(tree.get_belief(root).particles) == 5
+    assert len(cast(WeightedParticleBelief, tree.get_belief(root)).particles) == 5
     assert tree.data[root].weights.tolist() == pytest.approx([0.2] * 5)
 
 
@@ -158,7 +166,9 @@ def test_configuration_identity_reset_pickle_and_snapshot_immutability(tmp_path:
     planner.save(config_path)
     loaded = AdaOPS.load(config_path)
     assert loaded.config_id == planner.config_id
-    assert loaded.action(chain_belief(ROOT))[0][0] in loaded.environment.get_actions()
+    assert (
+        loaded.action(chain_belief(ROOT))[0][0] in cast(ChainEnv, loaded.environment).get_actions()
+    )
 
     binned = _planner(
         state_binner=state_bin,
@@ -170,7 +180,7 @@ def test_configuration_identity_reset_pickle_and_snapshot_immutability(tmp_path:
     binned.save(binned_path)
     loaded_binned = AdaOPS.load(binned_path)
     assert loaded_binned.config_id == binned.config_id
-    assert loaded_binned._state_binner(ROOT) == ROOT
+    assert cast(AdaOPS, loaded_binned)._state_binner(ROOT) == ROOT
 
     path = tmp_path / "search.json"
     planner.export_search_state(path)
@@ -183,7 +193,7 @@ def test_configuration_identity_reset_pickle_and_snapshot_immutability(tmp_path:
 def test_budget_boundaries_and_metrics_reset_between_calls():
     zero = _planner(n_simulations=0)
     actions, run_data = zero.action(chain_belief(ROOT))
-    assert actions[0] in zero.environment.get_actions()
+    assert actions[0] in cast(ChainEnv, zero.environment).get_actions()
     metrics = {item.name: item.value for item in run_data.info_variables}
     assert metrics[AdaOPSMetrics.N_TRIALS.value] == 0
     assert metrics[AdaOPSMetrics.STOPPED_BY_TRIALS.value] == 1
@@ -209,3 +219,128 @@ def test_metrics_survive_the_simulation_history_record_shape():
     persisted = {item.name: item.value for item in restored.policy_run_data[0].info_variables}
     assert persisted == original
     assert set(persisted) == set(AdaOPS.get_info_variable_names())
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the 2026-09-08 review findings
+# ---------------------------------------------------------------------------
+
+
+class _SamplerOnlyBelief:
+    """A belief that can only be sampled from -- no ``particles`` list.
+
+    This is the branch ``_root_particles`` falls back to, and the one no
+    existing fixture reached, which is how the global-RNG leak stayed hidden.
+    """
+
+    particles = None
+
+    def __init__(self, state=ROOT):
+        self._state = state
+        self.samples = 0
+
+    def sample(self, n_samples: int = 1):
+        del n_samples
+        self.samples += 1
+        # The particle carries the uniform it was drawn with, so a test can see
+        # which random stream the draw actually ran on.
+        return (self._state, round(float(np.random.random()), 12))
+
+
+def test_particle_less_belief_does_not_leak_into_the_global_rng():
+    """Sampling a belief with no particle list must restore global state."""
+    np.random.seed(1234)
+    import random as _random
+
+    _random.seed(1234)
+    expected_np = np.random.get_state()[1].copy()
+    expected_pos = np.random.get_state()[2]
+    expected_py = _random.getstate()
+    untouched_next_draw = float(np.random.random())
+    np.random.seed(1234)
+    _random.seed(1234)
+
+    planner = _planner()
+    planner._call_index = 0
+    planner._particle_rng = np.random.default_rng(planner.random_seed)
+    planner._scenario_rng = planner._particle_rng
+    belief = _SamplerOnlyBelief()
+    particles, weights = planner._root_particles(belief)
+
+    assert belief.samples == planner.max_particles
+    assert len(particles) == len(weights) >= planner.min_particles
+    # Compare the whole Mersenne state, position included: a restore that put
+    # back the key but not the position would pass a prefix-only check.
+    assert np.random.get_state()[1].tolist() == expected_np.tolist()
+    assert np.random.get_state()[2] == expected_pos
+    assert _random.getstate() == expected_py, "python random stream was perturbed"
+    # The decisive check: the caller's next draw is the one it would have got
+    # had the planner never run.
+    np.random.seed(1234)
+    _random.seed(1234)
+    assert float(np.random.random()) == pytest.approx(untouched_next_draw)
+
+
+def test_particle_less_root_depends_on_the_planner_seed_not_the_caller_stream():
+    """The root draw must come from the planner's own generator.
+
+    The two calls below differ only in the caller's global numpy seed. If the
+    draw still ran on the unseeded global stream the particles would track that
+    caller seed instead of ``random_seed``.
+    """
+
+    def draw(planner_seed, caller_seed):
+        planner = _planner(random_seed=planner_seed)
+        planner._call_index = 0
+        planner._particle_rng = np.random.default_rng(planner_seed)
+        planner._scenario_rng = planner._particle_rng
+        np.random.seed(caller_seed)
+        return planner._root_particles(_SamplerOnlyBelief())[0]
+
+    assert draw(11, 999) == draw(11, 4242), "root particles tracked the caller's RNG"
+    assert draw(11, 999) != draw(31, 999), "root particles ignored the planner seed"
+
+
+class _TerminalStringObsEnv(ChainEnv):
+    """A ChainEnv whose real observation for ``next`` is the text ``<terminal>``.
+
+    ``END`` is terminal, so one particle takes AdaOPS's terminal branch while
+    the other emits an observation whose *string* value used to be the terminal
+    bucket's key. The two must stay separate branches.
+    """
+
+    TEXT = "<terminal>"
+
+    def sample_observation(self, next_state, action, n_samples: int = 1):
+        del action
+        observation = self.TEXT if next_state == END else next_state
+        return observation if n_samples == 1 else [observation] * n_samples
+
+    def observation_log_probability(self, next_state, action, observations):
+        del action
+        expected = self.TEXT if next_state == END else next_state
+        return np.array(
+            [0.0 if obs == expected else -50.0 for obs in observations], dtype=np.float64
+        )
+
+
+def test_terminal_bucket_does_not_swallow_a_matching_string_observation():
+    """A real ``"<terminal>"`` observation must not merge into the terminal
+    bucket (review finding 6)."""
+    from POMDPPlanners.planners.scenario_tree_planners.despot import TERMINAL_OBSERVATION
+
+    environment = _TerminalStringObsEnv(discount_factor=0.5, terminal_states=(END,))
+    planner = _planner(environment=environment, n_simulations=1)
+    # One terminal particle and one live particle whose observation is the text.
+    belief = WeightedParticleBelief(particles=[END, NEXT], log_weights=np.array([-1.0, -1.0]))
+    tree, root = planner._learn_tree(belief)
+
+    action_ids = [node for node in tree.children_ids[root]]
+    assert action_ids
+    for action_id in action_ids:
+        keys = [key for (parent, key) in tree.obs_child_lookup if parent == action_id]
+        assert TERMINAL_OBSERVATION in keys, "terminal scenarios lost their own branch"
+        assert (
+            _TerminalStringObsEnv.TEXT in keys
+        ), "the real string observation was merged into the terminal bucket"
+        assert len(set(keys)) == 2

--- a/POMDPPlanners/tests/test_planners/test_scenario_tree_planners/test_adaops.py
+++ b/POMDPPlanners/tests/test_planners/test_scenario_tree_planners/test_adaops.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: MIT
+
+"""AdaOPS public contract and search-equation tests."""
+
+# pylint: disable=protected-access
+
+import copy
+import json
+import math
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.tree.arena import ACTION, BELIEF
+from POMDPPlanners.planners import POLICY_REGISTRY, AdaOPS
+from POMDPPlanners.planners.scenario_tree_planners.adaops import AdaOPSMetrics
+from POMDPPlanners.tests.test_planners.planner_fixtures import ROOT, ChainEnv, chain_belief
+from POMDPPlanners.tests.test_planners.test_scenario_tree_planners.test_despot_correctness import (
+    CoinEnv,
+)
+from POMDPPlanners.tests.test_simulations.test_planner_metrics_persistence import (
+    _history_with_metrics,
+)
+from POMDPPlanners.core.simulation.history import History
+from POMDPPlanners.utils.tree_statistics import TreeMetrics
+
+
+def state_bin(state):
+    """Importable bin function used by the JSON round-trip test."""
+    return state
+
+
+def _planner(environment=None, **overrides):
+    environment = environment or ChainEnv(discount_factor=0.5)
+    params = dict(
+        environment=environment,
+        discount_factor=environment.discount_factor,
+        depth=3,
+        name="AdaOPS_test",
+        min_particles=2,
+        max_particles=8,
+        n_simulations=4,
+        random_seed=7,
+    )
+    params.update(overrides)
+    return AdaOPS(**params)
+
+
+def test_registration_metrics_and_alternating_topology_are_exercised():
+    planner = _planner()
+    actions, run_data = planner.action(chain_belief(ROOT))
+    tree = planner._last_tree
+    assert POLICY_REGISTRY["AdaOPS"] is AdaOPS
+    assert actions[0] in planner.environment.get_actions()
+    assert tree is not None and len(tree) > 3
+    assert any(
+        tree.kind[node] == BELIEF and tree.parent_id[node] is not None for node in range(len(tree))
+    )
+    assert any(tree.kind[node] == ACTION for node in range(len(tree)))
+    for node in range(len(tree)):
+        parent = tree.parent_id[node]
+        if parent is not None:
+            assert tree.kind[parent] != tree.kind[node], f"node {node} does not alternate kind"
+            assert node in tree.children_ids[parent]
+    names = [item.name for item in run_data.info_variables]
+    assert len(names) == len(set(names))
+    assert set(names) == set(AdaOPS.get_info_variable_names())
+    assert {metric.value for metric in TreeMetrics} <= set(names)
+    assert {metric.value for metric in AdaOPSMetrics} <= set(names)
+    assert all(
+        isinstance(item.value, (int, float)) and math.isfinite(item.value)
+        for item in run_data.info_variables
+    )
+
+
+def test_bounds_backup_discount_and_final_choice_use_lower_bound():
+    planner = _planner(n_simulations=1)
+    tree, root = planner._learn_tree(chain_belief(ROOT))
+    action_ids = tree.children_ids[root]
+    assert len(action_ids) == 2
+    for action_id in action_ids:
+        # Chain reward is 2 now and 4 next; gamma=.5, so Q=4.
+        assert tree.lower_confidence_bound[action_id] == pytest.approx(4.0, abs=1e-12)
+        assert tree.upper_confidence_bound[action_id] >= tree.lower_confidence_bound[action_id]
+    tree.lower_confidence_bound[action_ids[0]] = 1.0
+    tree.upper_confidence_bound[action_ids[0]] = 100.0
+    tree.lower_confidence_bound[action_ids[1]] = 2.0
+    tree.upper_confidence_bound[action_ids[1]] = 3.0
+    assert planner._action_of_best_lower_bound(tree, root) == tree.action[action_ids[1]]
+
+
+def test_root_kld_sampling_obeys_particle_caps_even_for_uniform_input():
+    planner = _planner(min_particles=2, max_particles=5, n_simulations=0)
+    belief = chain_belief(ROOT)
+    belief.particles = [ROOT] * 20
+    tree, root = planner._learn_tree(belief)
+    assert len(tree.get_belief(root).particles) == 5
+    assert tree.data[root].weights.tolist() == pytest.approx([0.2] * 5)
+
+
+def test_excess_uncertainty_weights_probability_and_discount():
+    planner = _planner(n_simulations=1, xi=0.5)
+    tree, root = planner._learn_tree(chain_belief(ROOT))
+    action_id = tree.children_ids[root][0]
+    child = tree.children_ids[action_id][0]
+    tree.lower_confidence_bound[root] = 0.0
+    tree.upper_confidence_bound[root] = 4.0
+    tree.lower_confidence_bound[child] = 0.0
+    tree.upper_confidence_bound[child] = 10.0
+    selected, value = planner._best_excess_uncertainty_child(tree, action_id)
+    expected = (tree.weight[child] / tree.weight[root]) * (10.0 - 0.5 * 4.0 / 0.5)
+    assert selected == child
+    assert value == pytest.approx(expected, abs=1e-12)
+
+
+def test_packing_merges_at_delta_and_preserves_action_probability_mass():
+    env = CoinEnv(discount_factor=0.5)
+    planner = _planner(env, delta=2.0, min_particles=4, max_particles=4, n_simulations=1)
+    belief = chain_belief(("start", 0))
+    # Use four particles so both generated observations are overwhelmingly likely.
+    belief.particles = [("start", 0)] * 4
+    tree, root = planner._learn_tree(belief)
+    exercised = 0
+    for action_id in tree.children_ids[root]:
+        children = tree.children_ids[action_id]
+        if planner._merged_branches:
+            exercised += 1
+            assert len(children) == 1
+            assert tree.weight[children[0]] == pytest.approx(tree.weight[root], abs=1e-12)
+            assert tree.data[children[0]].observation_probability == pytest.approx(1.0, abs=1e-12)
+    assert exercised > 0, "seed did not exercise a packed multi-observation action"
+
+
+def test_configuration_identity_reset_pickle_and_snapshot_immutability(tmp_path: Path):
+    planner = _planner()
+    same = _planner()
+    changed = _planner(delta=0.2)
+    assert planner.config_id == same.config_id
+    assert planner.config_id != changed.config_id
+    with pytest.raises(ValueError, match="state_binner_id"):
+        _planner(state_binner=lambda state: state)
+
+    planner.action(chain_belief(ROOT))
+    first = planner.get_last_search_state()
+    frozen = copy.deepcopy(first)
+    planner.action(chain_belief(ROOT))
+    assert first == frozen
+    first["nodes"][0]["weights"][0] = -1.0
+    assert planner.get_last_search_state()["nodes"][0]["weights"][0] >= 0.0
+
+    restored = pickle.loads(pickle.dumps(planner))
+    assert restored.config_id == planner.config_id
+    assert restored.action(chain_belief(ROOT))[0][0] in restored.environment.get_actions()
+
+    config_path = tmp_path / "planner.json"
+    planner.save(config_path)
+    loaded = AdaOPS.load(config_path)
+    assert loaded.config_id == planner.config_id
+    assert loaded.action(chain_belief(ROOT))[0][0] in loaded.environment.get_actions()
+
+    binned = _planner(
+        state_binner=state_bin,
+        state_binner_id=(
+            "POMDPPlanners.tests.test_planners.test_scenario_tree_planners." "test_adaops.state_bin"
+        ),
+    )
+    binned_path = tmp_path / "binned.json"
+    binned.save(binned_path)
+    loaded_binned = AdaOPS.load(binned_path)
+    assert loaded_binned.config_id == binned.config_id
+    assert loaded_binned._state_binner(ROOT) == ROOT
+
+    path = tmp_path / "search.json"
+    planner.export_search_state(path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["selected_action"]
+    assert all("lower_bound" in node and "upper_bound" in node for node in payload["nodes"])
+    assert any("particles" in node and "weights" in node for node in payload["nodes"])
+
+
+def test_budget_boundaries_and_metrics_reset_between_calls():
+    zero = _planner(n_simulations=0)
+    actions, run_data = zero.action(chain_belief(ROOT))
+    assert actions[0] in zero.environment.get_actions()
+    metrics = {item.name: item.value for item in run_data.info_variables}
+    assert metrics[AdaOPSMetrics.N_TRIALS.value] == 0
+    assert metrics[AdaOPSMetrics.STOPPED_BY_TRIALS.value] == 1
+
+    planner = _planner(n_simulations=2)
+    _, first = planner.action(chain_belief(ROOT))
+    _, second = planner.action(chain_belief(ROOT))
+    first_metrics = {item.name: item.value for item in first.info_variables}
+    second_metrics = {item.name: item.value for item in second.info_variables}
+    assert first_metrics[AdaOPSMetrics.N_TRIALS.value] <= 2
+    assert second_metrics[AdaOPSMetrics.N_TRIALS.value] <= 2
+    assert (
+        second_metrics[AdaOPSMetrics.N_TRIALS.value]
+        != first_metrics[AdaOPSMetrics.N_TRIALS.value] + 2
+    )
+
+
+def test_metrics_survive_the_simulation_history_record_shape():
+    planner = _planner(n_simulations=2)
+    _, run_data = planner.action(chain_belief(ROOT))
+    restored = History.from_dict(_history_with_metrics(policy_run_data=[run_data]).to_dict())
+    original = {item.name: item.value for item in run_data.info_variables}
+    persisted = {item.name: item.value for item in restored.policy_run_data[0].info_variables}
+    assert persisted == original
+    assert set(persisted) == set(AdaOPS.get_info_variable_names())

--- a/POMDPPlanners/tests/test_planners/test_scenario_tree_planners/test_adaptive_particles.py
+++ b/POMDPPlanners/tests/test_planners/test_scenario_tree_planners/test_adaptive_particles.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT
+
+"""Hand-calculated tests for AdaOPS particle operations."""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.planners.scenario_tree_planners.adaptive_particles import (
+    adaptive_resample,
+    bounded_kld_sample_size,
+    design_effect,
+    effective_sample_size,
+    kld_sample_size,
+    l1_weight_distance,
+    systematic_resample,
+)
+
+
+def test_effective_sample_size_and_design_effect_are_independent_calculations():
+    weights = [0.9, 0.1]
+    assert effective_sample_size(weights) == pytest.approx(1.0 / 0.82, abs=1e-12)
+    assert design_effect(weights) == pytest.approx(2.0 * 0.82, abs=1e-12)
+
+
+def test_kld_formula_and_particle_caps_cover_both_boundaries():
+    expected = int(
+        np.ceil((1.0 / 0.1) * (1.0 - 2.0 / 9.0 + 1.644853626951 * np.sqrt(2.0 / 9.0)) ** 3)
+    )
+    assert kld_sample_size(2, 0.05) == expected
+    assert bounded_kld_sample_size(1, 0.05, 5, 20) == 5
+    assert bounded_kld_sample_size(100, 0.05, 5, 20) == 20
+
+
+def test_systematic_resampling_preserves_count_and_resets_weights():
+    particles, weights = systematic_resample(
+        ["rare", "common"], [0.1, 0.9], 10, np.random.default_rng(3)
+    )
+    assert len(particles) == 10
+    assert particles.count("common") == 9
+    assert weights.tolist() == pytest.approx([0.1] * 10)
+
+
+def test_adaptive_resampling_requires_explicit_bins_or_uses_the_documented_cap():
+    particles, weights, occupied = adaptive_resample(
+        [0, 1], [0.5, 0.5], np.random.default_rng(1), 2, 6, 0.05, None
+    )
+    assert len(particles) == 6
+    assert occupied == 0
+    assert weights.sum() == pytest.approx(1.0)
+
+    particles, _, occupied = adaptive_resample(
+        [0, 1], [0.5, 0.5], np.random.default_rng(1), 2, 6, 0.05, lambda s: s
+    )
+    assert occupied == 2
+    assert 2 <= len(particles) <= 6
+
+
+@pytest.mark.parametrize(
+    ("right", "expected"),
+    [([0.55, 0.45], 0.1), ([0.5, 0.5], 0.0), ([1.0, 0.0], 1.0)],
+)
+def test_l1_distance_has_exact_packing_boundary(right, expected):
+    assert l1_weight_distance([0.5, 0.5], right) == pytest.approx(expected)

--- a/POMDPPlanners/tests/test_planners/test_scenario_tree_planners/test_despot.py
+++ b/POMDPPlanners/tests/test_planners/test_scenario_tree_planners/test_despot.py
@@ -692,3 +692,102 @@ def test_exporting_before_any_search_is_an_error_not_an_empty_file():
     with tempfile.TemporaryDirectory() as tmpdir:
         with pytest.raises(ValueError, match="no search state"):
             planner.export_search_state(Path(tmpdir) / "dump.json")
+
+
+def test_eta_is_an_excess_uncertainty_parameter_not_a_fraction_of_the_initial_gap():
+    """Pin what ``eta`` actually does, because the docstring once said otherwise.
+
+    Purpose: The stopping test is the paper's excess uncertainty at the root,
+        ``E(b0) = (u - l) - eta (u - l) = (1 - eta)(u - l)``. Nothing stores the
+        gap's *starting* width, so a search does not stop when the gap has
+        halved at ``eta = 0.5``; it stops when the residual reaches numerical
+        noise. A reader who believes the old wording would pick ``eta`` wrongly.
+
+    Given: A planner with ``eta = 0.5`` and a hand-set root interval.
+    When: ``_should_stop`` is asked at gaps of 1.0, 0.5 and ``TINY``.
+    Then: Only the last stops, and ``eta`` scales the absolute threshold.
+
+    Test type: unit
+    """
+    from POMDPPlanners.planners.scenario_tree_planners.despot import TINY
+
+    environment = ChainEnv(discount_factor=0.5)
+    planner = _planner(environment, discount_factor=0.5, eta=0.5, n_simulations=1)
+    tree, root = planner._learn_tree(chain_belief(ROOT))
+    planner._gap_closed = False
+    planner._stalled = False
+
+    def gap_stops(gap: float) -> bool:
+        tree.lower_confidence_bound[root] = 0.0
+        tree.upper_confidence_bound[root] = gap
+        planner._gap_closed = False
+        return planner._should_stop(tree=tree, root_id=root)
+
+    assert not gap_stops(1.0)
+    # Half of the starting width: the old docstring implied this stops. It does not.
+    assert not gap_stops(0.5)
+    # The real threshold is TINY / (1 - eta).
+    assert gap_stops(TINY / (1.0 - planner.eta) * 0.999)
+    assert not gap_stops(TINY / (1.0 - planner.eta) * 1.001)
+
+
+def test_eta_scales_the_per_depth_weighted_excess_uncertainty_target():
+    """``eta`` is not inert: it sets the WEU target every branch is judged by.
+
+    Purpose: Rejecting the review's claim that ``eta`` "barely changes"
+        anything needs the other half of equation (5) pinned -- the
+        ``eta * root_gap * gamma^(-d)`` target used to pick an observation
+        branch.
+
+    Given: Two planners identical but for ``eta``.
+    When: The same action node's branch score is computed.
+    Then: The larger ``eta`` yields the smaller (more forgiving) score.
+
+    Test type: unit
+    """
+    environment = ChainEnv(discount_factor=0.5)
+    planner = _planner(environment, discount_factor=0.5, eta=0.1, n_simulations=2)
+    tree, root = planner._learn_tree(chain_belief(ROOT))
+    action_id = tree.children_ids[root][0]
+    tree.lower_confidence_bound[root] = 0.0
+    tree.upper_confidence_bound[root] = 10.0
+
+    # One tree, one node, only ``eta`` changed, so nothing else can explain a
+    # difference in the score.
+    scores = {}
+    for eta in (0.1, 0.9):
+        planner.eta = eta
+        scores[eta] = planner._best_excess_uncertainty_child(tree, action_id)[1]
+
+    child_id = tree.children_ids[action_id][0]
+    width = tree.upper_confidence_bound[child_id] - tree.lower_confidence_bound[child_id]
+    weight = tree.weight[child_id] / tree.weight[action_id]
+    gamma = planner.discount_factor
+    depth = tree.data[child_id].depth
+    for eta, score in scores.items():
+        expected = weight * (width - eta * 10.0 * gamma ** (-depth))
+        assert score == pytest.approx(expected), f"WEU at eta={eta} is not equation (5)"
+    assert scores[0.9] < scores[0.1], "eta does not move the branch-selection target"
+
+
+def test_the_terminal_observation_sentinel_survives_copy_and_pickle():
+    """Identity matching only works if the singleton stays a singleton.
+
+    Purpose: AdaOPS and DESPOT both key their terminal branch on ``is``. A
+        planner is pickled into worker processes and its tree is deep-copied
+        for a search-state snapshot, so a sentinel that copies into a new
+        instance would silently stop matching and terminal scenarios would be
+        treated as a real observation named ``<terminal>``.
+
+    Test type: unit
+    """
+    import copy as copy_module
+    import pickle as pickle_module
+
+    from POMDPPlanners.planners.scenario_tree_planners.despot import TERMINAL_OBSERVATION
+
+    assert copy_module.copy(TERMINAL_OBSERVATION) is TERMINAL_OBSERVATION
+    assert copy_module.deepcopy(TERMINAL_OBSERVATION) is TERMINAL_OBSERVATION
+    assert pickle_module.loads(pickle_module.dumps(TERMINAL_OBSERVATION)) is TERMINAL_OBSERVATION
+    nested = pickle_module.loads(pickle_module.dumps({"o": [TERMINAL_OBSERVATION]}))
+    assert nested["o"][0] is TERMINAL_OBSERVATION

--- a/POMDPPlanners/tests/test_planners/test_scenario_tree_planners/test_hyp_despot.py
+++ b/POMDPPlanners/tests/test_planners/test_scenario_tree_planners/test_hyp_despot.py
@@ -103,7 +103,7 @@ def test_contract_rejects_empty_actions_missing_bounds_and_factored(monkeypatch)
     with pytest.raises(HypDESPOTCompatibilityError, match="factored"):
         validate_cuda_contract(model, [0], torch.device("cuda:0"))
     model.supports_factored_step = False
-    model.leaf_bounds = None
+    model.leaf_bounds = None  # type: ignore[assignment]
     with pytest.raises(HypDESPOTCompatibilityError, match="leaf_bounds"):
         validate_cuda_contract(model, [0], torch.device("cuda:0"))
 
@@ -256,3 +256,111 @@ def test_cuda_batch_has_real_leaf_action_scenario_work_and_masks():
     expected = states[0][0, 0] + 0 + (0 + 7) * 0.01
     assert result.rewards[0].item() == pytest.approx(expected.item(), abs=1e-6)
     assert bool(result.terminal.any())
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the 2026-09-08 review findings
+# ---------------------------------------------------------------------------
+
+
+class _EnvironmentWithoutModel(_Environment):
+    """Environment that carries no ``hyp_despot_cuda_model`` of its own.
+
+    The documented way to plan on such an environment is the explicit
+    ``model=`` argument, so this is the fixture that exposes whether the
+    planner survives a pickle round trip on that path.
+    """
+
+    def __init__(self):  # pylint: disable=super-init-not-called
+        pass
+
+
+class _ForeignModel(_Model):
+    """A second, distinguishable model, to catch a silent substitution."""
+
+
+def test_normalize_cuda_device_matches_indexed_and_bare_cuda():
+    """``cuda`` and ``cuda:0`` name the same GPU (review finding 4)."""
+    from POMDPPlanners.planners.scenario_tree_planners.hyp_despot_cuda import (
+        normalize_cuda_device,
+    )
+
+    assert normalize_cuda_device(torch.device("cuda")) == torch.device("cuda", 0)
+    assert normalize_cuda_device("cuda") == normalize_cuda_device(torch.device("cuda:0"))
+    # Non-CUDA devices are returned untouched, so the CPU/MPS rejections stand.
+    assert normalize_cuda_device(torch.device("cpu")) == torch.device("cpu")
+    assert normalize_cuda_device(torch.device("cuda:1")) == torch.device("cuda", 1)
+
+
+def test_contract_accepts_bare_cuda_planner_device_against_indexed_model(monkeypatch):
+    """A ``device="cuda"`` planner and a ``cuda:0`` model are a valid pair."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.version, "cuda", "12.1")
+    validate_cuda_contract(_Model("cuda:0"), [0], torch.device("cuda"))
+    validate_cuda_contract(_Model("cuda"), [0], torch.device("cuda:0"))
+
+
+def test_pickle_keeps_the_explicit_model_when_the_environment_has_none(monkeypatch):
+    """An explicit ``model=`` must survive pickling (review finding 3)."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.version, "cuda", "12.1")
+    model = _Model("cuda:0")
+    planner = HypDESPOT(
+        _EnvironmentWithoutModel(), 0.9, 3, "hyp", n_scenarios=2, n_traversals=2, model=model
+    )
+    restored = pickle.loads(pickle.dumps(planner))
+    assert isinstance(restored._model, _Model)
+    assert restored._model_override is not None
+
+
+def test_pickle_does_not_swap_an_explicit_model_for_an_unrelated_environment_one(monkeypatch):
+    """The environment's model must not silently replace an explicit one."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.version, "cuda", "12.1")
+    environment = _Environment()  # carries its own, different, model
+    explicit = _ForeignModel("cuda:0")
+    planner = HypDESPOT(environment, 0.9, 3, "hyp", n_scenarios=2, n_traversals=2, model=explicit)
+    assert planner._model is explicit
+    restored = pickle.loads(pickle.dumps(planner))
+    assert isinstance(restored._model, _ForeignModel), "explicit model was swapped on unpickle"
+
+
+def test_pickle_still_re_resolves_the_environment_supplied_model(monkeypatch):
+    """When the model came from the environment it is re-resolved, not copied."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.version, "cuda", "12.1")
+    environment = _Environment()
+    planner = HypDESPOT(
+        environment,
+        0.9,
+        3,
+        "hyp",
+        n_scenarios=2,
+        n_traversals=2,
+        model=environment.hyp_despot_cuda_model,
+    )
+    state = planner.__getstate__()
+    assert state["_model_override"] is None, "environment-owned model should not travel"
+    restored = pickle.loads(pickle.dumps(planner))
+    assert restored._model is restored.environment.hyp_despot_cuda_model
+
+
+def test_bare_cuda_resolves_to_the_process_current_device_not_hard_coded_zero(monkeypatch):
+    """A bare ``cuda`` names the current device, so the one-GPU guard still bites.
+
+    On a box where ``torch.cuda.set_device(1)`` has run, ``torch.device("cuda")``
+    means ``cuda:1``. Filling in ``0`` regardless would let that configuration
+    pass the "one GPU only" check and then fail later against tensors on the
+    other GPU, with a message naming the wrong device.
+    """
+    from POMDPPlanners.planners.scenario_tree_planners.hyp_despot_cuda import (
+        normalize_cuda_device,
+    )
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 1)
+    assert normalize_cuda_device(torch.device("cuda")) == torch.device("cuda", 1)
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.version, "cuda", "12.1")
+    with pytest.raises(HypDESPOTCompatibilityError, match="one GPU"):
+        validate_cuda_contract(_Model("cuda:1"), [0], torch.device("cuda"))

--- a/POMDPPlanners/tests/test_planners/test_scenario_tree_planners/test_hyp_despot.py
+++ b/POMDPPlanners/tests/test_planners/test_scenario_tree_planners/test_hyp_despot.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: MIT
+"""Deterministic CPU and CUDA correctness checks for HyP-DESPOT."""
+import pickle
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+import pytest
+import torch
+from POMDPPlanners.core.environment import SpaceInfo, SpaceType
+from POMDPPlanners.planners.scenario_tree_planners.hyp_despot import (
+    ActionBranch,
+    BeliefNode,
+    HypDESPOT,
+    ObservationBranch,
+)
+from POMDPPlanners.planners.scenario_tree_planners.hyp_despot_cuda import (
+    CUDAExpansionResult,
+    HypDESPOTCompatibilityError,
+    expand_cuda_leaves,
+    validate_cuda_contract,
+)
+
+
+class _Model:
+    supports_factored_step = False
+
+    def __init__(self, device):
+        self.device = torch.device(device)
+        self.calls = []
+
+    def scenario_randomness(self, ids, depth, seed):
+        self.calls.append("random")
+        return (ids + depth + seed).to(torch.float32).unsqueeze(1)
+
+    def sample_next_states(self, states, actions, random_values):
+        self.calls.append("transition")
+        return states + actions.unsqueeze(1) + random_values * 0.01
+
+    def sample_observations(self, next_states, actions, random_values):
+        self.calls.append("observation")
+        return next_states[:, :1].floor()
+
+    def rewards(self, states, actions, next_states):
+        self.calls.append("reward")
+        return next_states[:, 0]
+
+    def terminal_mask(self, states):
+        self.calls.append("terminal")
+        return states[:, 0] >= 9
+
+    def observation_keys(self, observations):
+        self.calls.append("keys")
+        return observations[:, 0].to(torch.int64)
+
+    def leaf_bounds(self, states, remaining_depth):
+        self.calls.append("bounds")
+        lower = states[:, 0] * remaining_depth
+        return lower, lower + 1
+
+
+class _Environment:
+    name = "cuda-test"
+    config_id = "cuda-test-config"
+    space_info = SpaceInfo(SpaceType.DISCRETE, SpaceType.DISCRETE)
+
+    def __init__(self):
+        self.hyp_despot_cuda_model = _Model("cuda:0")
+
+    def get_actions(self):
+        return ["left", "right"]
+
+
+def test_scenario_po_uct_uses_scenario_weight_and_differs_from_uct():
+    weighted = HypDESPOT.scenario_po_uct(2, 16, 0.01, 3, 2)
+    ordinary = 3 + 2 * (torch.log(torch.tensor(16.0)) / 2).sqrt().item()
+    assert weighted < ordinary
+    assert HypDESPOT.scenario_po_uct(0, 16, 1, 0, 1) == float("inf")
+
+
+@pytest.mark.parametrize(
+    "device,message", [("cpu", "CUDA device"), ("mps", "Apple MPS"), ("cuda:1", "one GPU")]
+)
+def test_contract_rejects_wrong_devices(monkeypatch, device, message):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.version, "cuda", "12.1")
+    with pytest.raises(HypDESPOTCompatibilityError, match=message):
+        validate_cuda_contract(_Model(device), [0], torch.device(device))
+
+
+def test_contract_rejects_unavailable_cuda(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    with pytest.raises(HypDESPOTCompatibilityError, match="requires CUDA PyTorch"):
+        validate_cuda_contract(_Model("cpu"), [0], torch.device("cpu"))
+
+
+def test_contract_rejects_empty_actions_missing_bounds_and_factored(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.version, "cuda", "12.1")
+    model = _Model("cuda:0")
+    with pytest.raises(HypDESPOTCompatibilityError, match="finite expansion"):
+        validate_cuda_contract(model, [], torch.device("cuda:0"))
+    model.supports_factored_step = True
+    with pytest.raises(HypDESPOTCompatibilityError, match="factored"):
+        validate_cuda_contract(model, [0], torch.device("cuda:0"))
+    model.supports_factored_step = False
+    model.leaf_bounds = None
+    with pytest.raises(HypDESPOTCompatibilityError, match="leaf_bounds"):
+        validate_cuda_contract(model, [0], torch.device("cuda:0"))
+
+
+def test_configuration_identity_pickle_and_transient_reset(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.version, "cuda", "12.1")
+    first = HypDESPOT(_Environment(), 0.9, 3, "hyp", n_scenarios=2, n_traversals=2)
+    same = HypDESPOT(_Environment(), 0.9, 3, "hyp", n_scenarios=2, n_traversals=2)
+    changed = HypDESPOT(_Environment(), 0.9, 4, "hyp", n_scenarios=2, n_traversals=2)
+    first._nodes[9] = object()
+    restored = pickle.loads(pickle.dumps(first))
+    assert first.config_id == same.config_id != changed.config_id
+    assert restored.config_id == first.config_id
+    assert restored._nodes == {} and restored.get_search_snapshot() is None
+
+
+def _bare_planner():
+    planner = HypDESPOT.__new__(HypDESPOT)
+    planner.virtual_loss = 2
+    planner.exploration_constant = 1
+    planner.depth = 3
+    planner._tree_lock = threading.RLock()
+    from POMDPPlanners.planners.scenario_tree_planners.hyp_despot import HypDESPOTMetrics
+
+    planner._counts = {metric: 0.0 for metric in HypDESPOTMetrics}
+    states = torch.zeros(1, 1)
+    ids = torch.zeros(1, dtype=torch.int64)
+    weights = torch.ones(1)
+    child = BeliefNode(1, (0, 0), 1, states, ids, weights)
+    action = ActionBranch(0, 1, 0, 1, 0, {4: ObservationBranch(4, 1, 1)})
+    root = BeliefNode(0, None, 0, states, ids, weights, 1, 0, 1, True, False, {0: action})
+    planner._nodes = {0: root, 1: child}
+    return planner
+
+
+def test_virtual_loss_is_applied_and_released():
+    planner = _bare_planner()
+    leaf, path = planner._select_leaf(0)
+    assert leaf == 1 and planner._nodes[0].actions[0].observations[4].virtual_loss == 2
+    planner._release_virtual_loss(path)
+    assert planner._nodes[0].actions[0].observations[4].virtual_loss == 0
+
+
+def test_virtual_loss_makes_workers_choose_different_action_branches():
+    planner = _bare_planner()
+    second = BeliefNode(
+        2, (0, 1), 1, torch.zeros(1, 1), torch.zeros(1, dtype=torch.int64), torch.ones(1)
+    )
+    planner._nodes[2] = second
+    planner._nodes[0].actions[1] = ActionBranch(1, 1, 0, 1, 0, {5: ObservationBranch(5, 2, 1)})
+    _, first_path = planner._select_leaf(0)
+    _, second_path = planner._select_leaf(0)
+    assert first_path[0][1] != second_path[0][1]
+    planner._release_virtual_loss(first_path)
+    planner._release_virtual_loss(second_path)
+
+
+def test_virtual_loss_is_released_when_selection_raises(monkeypatch):
+    planner = _bare_planner()
+
+    class Broken(dict):
+        def values(self):
+            raise RuntimeError("boom")
+
+    # Fail after a virtual loss by making the selected child expansion access fail.
+    original = planner._nodes
+
+    class Nodes(dict):
+        def __getitem__(self, key):
+            if key == 1:
+                raise RuntimeError("boom")
+            return super().__getitem__(key)
+
+    planner._nodes = Nodes(original)
+    with pytest.raises(RuntimeError, match="boom"):
+        planner._select_leaf(0)
+    assert original[0].actions[0].observations[4].virtual_loss == 0
+
+
+def test_locked_backup_is_thread_safe_and_final_choice_ignores_exploration():
+    planner = _bare_planner()
+    planner.discount_factor = 0.5
+    planner._nodes[1].lower = 4
+    planner._nodes[1].upper = 6
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        list(pool.map(lambda _: planner._backup_path([(0, 0, 4)]), range(20)))
+    action = planner._nodes[0].actions[0]
+    assert action.visits == 21 and action.lower == 2 and action.upper == 3
+
+
+def test_final_choice_uses_backed_up_value_not_exploration_score():
+    planner = _bare_planner()
+    root = planner._nodes[0]
+    root.actions[0].lower = 1
+    root.actions[0].visits = 100
+    root.actions[1] = ActionBranch(1, visits=0, lower=0, upper=100)
+    assert HypDESPOT.scenario_po_uct(0, 100, 1, 0, 1) == float("inf")
+    assert HypDESPOT._select_final_action(root) == 0
+
+
+def test_concurrent_leaf_expansion_is_exactly_once_and_weighted():
+    planner = _bare_planner()
+    planner._actions = [0, 1]
+    planner.discount_factor = 0.5
+    planner._nodes = {}
+    planner._next_node_id = 0
+    root = planner._new_node(
+        torch.tensor([[0.0], [0.0]]),
+        torch.tensor([0, 1]),
+        torch.tensor([0.75, 0.25]),
+        0,
+        None,
+    )
+    result = CUDAExpansionResult(
+        next_states=torch.tensor([[1.0], [2.0], [3.0], [4.0]]),
+        observation_keys=torch.tensor([7, 8, 7, 8]),
+        rewards=torch.tensor([2.0, 10.0, 6.0, 14.0]),
+        terminal=torch.tensor([False, False, False, False]),
+        lower=torch.tensor([4.0, 8.0, 12.0, 16.0]),
+        upper=torch.tensor([6.0, 10.0, 14.0, 18.0]),
+        leaf_indices=torch.zeros(4, dtype=torch.int64),
+        action_indices=torch.tensor([0, 1, 0, 1]),
+        scenario_indices=torch.tensor([0, 0, 1, 1]),
+        kernel_device_index=0,
+    )
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        list(pool.map(lambda _: planner._integrate([root], result), range(8)))
+    assert len(planner._nodes) == 3
+    assert len(planner._nodes[root].actions) == 2
+    # Action 0 reward = .75*2 + .25*6; lower adds .5*(.75*4 + .25*12).
+    assert planner._nodes[root].actions[0].lower == pytest.approx(6.0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires NVIDIA CUDA")
+def test_cuda_batch_has_real_leaf_action_scenario_work_and_masks():
+    device = torch.device("cuda:0")
+    model = _Model(device)
+    states = [
+        torch.tensor([[1.0], [9.0]], device=device),
+        torch.tensor([[2.0], [3.0]], device=device),
+    ]
+    ids = [torch.tensor([0, 1], device=device), torch.tensor([2, 3], device=device)]
+    result = expand_cuda_leaves(model, states, ids, 3, 0, 3, 7)
+    assert result.rewards.shape == (12,)
+    assert set(result.leaf_indices.cpu().tolist()) == {0, 1}
+    assert set(result.action_indices.cpu().tolist()) == {0, 1, 2}
+    assert result.next_states.is_cuda
+    assert {"transition", "reward", "bounds"}.issubset(model.calls)
+    expected = states[0][0, 0] + 0 + (0 + 7) * 0.01
+    assert result.rewards[0].item() == pytest.approx(expected.item(), abs=1e-6)
+    assert bool(result.terminal.any())

--- a/POMDPPlanners/tests/test_utils/test_hyperparameter_tuning_and_eval.py
+++ b/POMDPPlanners/tests/test_utils/test_hyperparameter_tuning_and_eval.py
@@ -3163,3 +3163,32 @@ class TestHyperParamRunnerUseCases:
             assert optimization_results[0].environment == env
             assert optimization_results[0].environment.name == "RealTiger"
             assert results["summary"]["environment_name"] == "RealTiger"
+
+
+def test_compatible_planner_docstring_matches_the_live_registry():
+    """The pinned example list must equal what the function really returns.
+
+    Purpose: The docstring's example is executed as a doctest in CI, but only
+        inside Docker. Every new planner that is Tiger-compatible silently
+        invalidates it -- that is how ``AdaOPS`` and ``HypDESPOT`` were left
+        out. This test fails in the plain local suite the moment the two drift.
+
+    Test type: unit
+    """
+    import re
+
+    from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP
+    from POMDPPlanners.utils.hyperparameter_tuning_and_eval import (
+        get_benchmark_hyperparameter_planners,
+    )
+
+    docstring = get_benchmark_hyperparameter_planners.__doc__ or ""
+    match = re.search(r"Compatible planners: (\[[^\]]*\])", docstring)
+    assert match, "the docstring no longer pins an example planner list"
+    documented = [name.strip().strip("'\"") for name in match.group(1)[1:-1].split(",")]
+
+    actual = [
+        planner.__name__
+        for planner in get_benchmark_hyperparameter_planners(TigerPOMDP(discount_factor=0.95))
+    ]
+    assert documented == actual

--- a/POMDPPlanners/utils/hyperparameter_tuning_and_eval.py
+++ b/POMDPPlanners/utils/hyperparameter_tuning_and_eval.py
@@ -1977,7 +1977,7 @@ def get_benchmark_hyperparameter_planners(
             >>> env = TigerPOMDP(discount_factor=0.95)
             >>> compatible_planners = get_benchmark_hyperparameter_planners(env)
             >>> print(f"Compatible planners: {[p.__name__ for p in compatible_planners]}")
-            Compatible planners: ['POMCP', 'SparseSamplingDiscreteActionsPlanner', 'SparsePFT', 'POMCPOW', 'PFT_DPW', 'POMCP_DPW', 'DiscreteActionSequencesPlanner', 'BetaZero', 'ConstrainedZero', 'ICVaR_PFT_DPW', 'ICVaR_POMCPOW', 'ICVaRSparseSampling', 'DESPOT', 'ARDESPOT']
+            Compatible planners: ['POMCP', 'SparseSamplingDiscreteActionsPlanner', 'SparsePFT', 'POMCPOW', 'PFT_DPW', 'POMCP_DPW', 'DiscreteActionSequencesPlanner', 'BetaZero', 'ConstrainedZero', 'ICVaR_PFT_DPW', 'ICVaR_POMCPOW', 'ICVaRSparseSampling', 'DESPOT', 'ARDESPOT', 'AdaOPS', 'HypDESPOT']
     """
     if debug:
         logger.debug("Finding compatible planners for environment: %s", env.name)

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Self-contained Jupyter notebooks with executable end-to-end examples live in
 | iCVaR POMCPOW / iCVaR PFT-DPW / iCVaR Sparse Sampling | Risk-averse planning with iterated CVaR objectives |
 | DESPOT / AR-DESPOT | Scenario-tree search with lower and upper value bounds |
 | AdaOPS | Adaptive weighted-particle search with L1 belief packing |
+| HyP-DESPOT | Shared CPU scenario tree with batched CUDA leaf evaluation |
 | VOPP | Fully GPU-vectorized online POMDP planning (Hoerger et al., 2025) |
 | Discrete Action Sequences | Open-loop baseline planner |
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Self-contained Jupyter notebooks with executable end-to-end examples live in
 | ConstrainedZero | Safety-constrained variant of BetaZero |
 | Constrained POMCPOW / Constrained PFT-DPW | Cost-constrained online planning |
 | iCVaR POMCPOW / iCVaR PFT-DPW / iCVaR Sparse Sampling | Risk-averse planning with iterated CVaR objectives |
+| DESPOT / AR-DESPOT | Scenario-tree search with lower and upper value bounds |
+| AdaOPS | Adaptive weighted-particle search with L1 belief packing |
 | VOPP | Fully GPU-vectorized online POMDP planning (Hoerger et al., 2025) |
 | Discrete Action Sequences | Open-loop baseline planner |
 

--- a/docs/core/planners.rst
+++ b/docs/core/planners.rst
@@ -15,6 +15,15 @@ Planning Algorithm Categories
    POMDPPlanners.planners.mcts_planners.pft_dpw.PFT_DPW
    POMDPPlanners.planners.mcts_planners.sparse_pft.SparsePFT
 
+**Bounded Belief-Tree Search**
+
+.. autosummary::
+   :toctree: ../api/
+
+   POMDPPlanners.planners.scenario_tree_planners.despot.DESPOT
+   POMDPPlanners.planners.scenario_tree_planners.ardespot.ARDESPOT
+   POMDPPlanners.planners.scenario_tree_planners.adaops.AdaOPS
+
 **Sparse Sampling**
 
 .. autosummary::

--- a/docs/core/planners.rst
+++ b/docs/core/planners.rst
@@ -23,6 +23,7 @@ Planning Algorithm Categories
    POMDPPlanners.planners.scenario_tree_planners.despot.DESPOT
    POMDPPlanners.planners.scenario_tree_planners.ardespot.ARDESPOT
    POMDPPlanners.planners.scenario_tree_planners.adaops.AdaOPS
+   POMDPPlanners.planners.scenario_tree_planners.hyp_despot.HypDESPOT
 
 **Sparse Sampling**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,6 +100,7 @@ What is in the package
    :hidden:
 
    core/planners
+   planners/adaops/index
    core/beliefs
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,6 +101,7 @@ What is in the package
 
    core/planners
    planners/adaops/index
+   planners/hyp_despot/index
    core/beliefs
 
 .. toctree::

--- a/docs/planners/adaops/adaops-tree.svg
+++ b/docs/planners/adaops/adaops-tree.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="280" viewBox="0 0 760 280">
+  <style>.t{font:14px sans-serif}.h{font:bold 16px sans-serif}.b{fill:#dbeafe;stroke:#2563eb;stroke-width:2}.a{fill:#fef3c7;stroke:#d97706;stroke-width:2}.m{fill:#dcfce7;stroke:#16a34a;stroke-width:2}.e{stroke:#475569;stroke-width:2}.dash{stroke:#16a34a;stroke-width:2;stroke-dasharray:6 4}</style>
+  <text x="70" y="25" class="h">Unpacked observations</text><text x="475" y="25" class="h">AdaOPS packing</text>
+  <circle cx="165" cy="65" r="28" class="b"/><text x="145" y="70" class="t">b, w</text>
+  <rect x="137" y="112" width="56" height="36" rx="6" class="a"/><text x="157" y="136" class="t">a</text>
+  <line x1="165" y1="93" x2="165" y2="112" class="e"/>
+  <line x1="145" y1="148" x2="90" y2="195" class="e"/><line x1="165" y1="148" x2="165" y2="195" class="e"/><line x1="185" y1="148" x2="240" y2="195" class="e"/>
+  <circle cx="80" cy="220" r="25" class="b"/><circle cx="165" cy="220" r="25" class="b"/><circle cx="250" cy="220" r="25" class="b"/>
+  <text x="55" y="260" class="t">o1: w1</text><text x="140" y="260" class="t">o2: w2</text><text x="225" y="260" class="t">o3: w3</text>
+  <circle cx="555" cy="65" r="28" class="b"/><text x="535" y="70" class="t">b, w</text>
+  <rect x="527" y="112" width="56" height="36" rx="6" class="a"/><text x="547" y="136" class="t">a</text><line x1="555" y1="93" x2="555" y2="112" class="e"/>
+  <line x1="540" y1="148" x2="500" y2="195" class="e"/><line x1="570" y1="148" x2="620" y2="195" class="e"/>
+  <circle cx="490" cy="220" r="28" class="m"/><circle cx="630" cy="220" r="28" class="b"/>
+  <text x="445" y="260" class="t">o1+o2: p1+p2</text><text x="600" y="260" class="t">o3: p3</text>
+  <path d="M 565 220 Q 555 175 515 215" fill="none" class="dash"/><text x="525" y="190" class="t">L1 ≤ delta</text>
+  <text x="415" y="105" class="t">shared particles; different weights</text>
+</svg>

--- a/docs/planners/adaops/index.rst
+++ b/docs/planners/adaops/index.rst
@@ -1,0 +1,65 @@
+AdaOPS
+======
+
+Which problem does it solve?
+----------------------------
+
+AdaOPS is an online planner for partially observed problems with a generative
+model and scoreable observations. Fixed-particle searches can lose accuracy as
+weights collapse, while expanding every sampled observation makes the tree too
+wide. AdaOPS changes both parts: it resamples only when weight disparity is
+high, chooses the resample count with KLD sampling, and merges nearby sibling
+beliefs. The paper proves high-probability convergence under its stated
+assumptions; this implementation has correctness tests but no episode QA yet.
+
+What does its value function mean?
+----------------------------------
+
+The objective is the finite-horizon discounted expected reward
+
+.. math:: V_D(b)=\max_\pi\mathbb{E}_{s_0\sim b,\pi}\left[\sum_{t=0}^{D-1}\gamma^t R(s_t,a_t)\right].
+
+Here ``b`` is the current state belief, ``D`` is the number of remaining
+rewards, ``pi`` is a policy, ``gamma`` is the discount factor, and ``R`` is the
+one-step reward. Larger values are better. Each tree node stores lower and
+upper bounds on this value. Action bounds use the weighted immediate reward
+plus ``gamma`` times the packed children. Search follows the largest upper
+bound; the returned action has the largest lower bound.
+
+What search structure does it build?
+------------------------------------
+
+.. image:: adaops-tree.svg
+   :alt: Comparison of an unpacked observation tree and AdaOPS packed weighted-belief tree
+   :width: 760px
+
+The figure shows the defining change. Several sampled observations create
+posterior weight vectors over shared successor particles. A posterior within
+``delta`` L1 distance of an earlier sibling contributes its probability mass
+to that sibling instead of creating another value-evaluation branch. A node
+whose particle-count-to-effective-sample-size ratio crosses the configured
+threshold is resampled.
+
+Core benefits and limitations
+-----------------------------
+
+Adaptive particles spend more samples on dispersed beliefs, while packing
+trades a bounded local bias for fewer observation branches. Both mechanisms
+need model support: observations must have stable keys and likelihoods, and
+KLD adaptation requires a user-supplied state-to-bin function plus a stable
+identifier. No bins are inferred. Bounds must be valid for the configured
+horizon. Search snapshots and numeric metrics are implemented and tested;
+ten-episode planner QA is deliberately pending.
+
+When to use it
+--------------
+
+Use AdaOPS when actions are discrete, observation likelihoods are available,
+and ordinary particle trees either collapse weights or branch on too many
+observations. Choose another planner when state bins have no defensible meaning,
+the model cannot score observations, or packing bias is unacceptable. Expect
+more belief bookkeeping in exchange for a narrower, better allocated search.
+
+Revision note: Wu et al., NeurIPS 2021; author code ``JuliaPOMDP/AdaOPS.jl``
+``main`` inspected 2026-09-08 under the MIT license. Local planner QA is not
+part of this implementation job.

--- a/docs/planners/hyp_despot/hyp-despot-tree.svg
+++ b/docs/planners/hyp_despot/hyp-despot-tree.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="390" viewBox="0 0 900 390">
+  <style>
+    text{font:14px sans-serif;fill:#172033}.title{font-size:18px;font-weight:bold}
+    .belief{fill:#dbeafe;stroke:#2563eb;stroke-width:2}.action{fill:#dcfce7;stroke:#16a34a;stroke-width:2}
+    .gpu{fill:#fef3c7;stroke:#d97706;stroke-width:2}.edge{stroke:#64748b;stroke-width:2}.worker{stroke:#7c3aed;stroke-width:3;stroke-dasharray:6 4}
+  </style>
+  <text x="120" y="28" class="title">DESPOT: serial leaf work</text>
+  <circle cx="220" cy="75" r="28" class="belief"/><text x="204" y="80">b₀</text>
+  <line x1="205" y1="100" x2="155" y2="145" class="edge"/><line x1="235" y1="100" x2="285" y2="145" class="edge"/>
+  <rect x="125" y="145" width="60" height="34" rx="5" class="action"/><text x="140" y="167">a₀</text>
+  <rect x="255" y="145" width="60" height="34" rx="5" class="action"/><text x="270" y="167">a₁</text>
+  <line x1="155" y1="179" x2="155" y2="225" class="edge"/><line x1="285" y1="179" x2="285" y2="225" class="edge"/>
+  <circle cx="155" cy="252" r="27" class="belief"/><circle cx="285" cy="252" r="27" class="belief"/>
+  <text x="137" y="257">b(o₄)</text><text x="267" y="257">b(o₇)</text>
+  <rect x="115" y="315" width="210" height="42" rx="7" class="gpu"/><text x="139" y="341">one leaf evaluated at a time</text>
+  <line x1="155" y1="279" x2="185" y2="315" class="edge"/>
+
+  <text x="555" y="28" class="title">HyP-DESPOT: shared tree + CUDA batch</text>
+  <circle cx="660" cy="75" r="28" class="belief"/><text x="644" y="80">b₀</text>
+  <line x1="645" y1="100" x2="595" y2="145" class="edge"/><line x1="675" y1="100" x2="725" y2="145" class="edge"/>
+  <rect x="565" y="145" width="60" height="34" rx="5" class="action"/><text x="580" y="167">a₀</text>
+  <rect x="695" y="145" width="60" height="34" rx="5" class="action"/><text x="710" y="167">a₁</text>
+  <line x1="595" y1="179" x2="595" y2="225" class="edge"/><line x1="725" y1="179" x2="725" y2="225" class="edge"/>
+  <circle cx="595" cy="252" r="27" class="belief"/><circle cx="725" cy="252" r="27" class="belief"/>
+  <text x="577" y="257">b(o₄)</text><text x="707" y="257">b(o₇)</text>
+  <path d="M500 85 C535 90 545 175 580 224" fill="none" class="worker"/><text x="462" y="78">worker 1</text>
+  <path d="M820 85 C785 90 775 175 740 224" fill="none" class="worker"/><text x="796" y="78">worker 2</text>
+  <rect x="535" y="315" width="250" height="42" rx="7" class="gpu"/><text x="552" y="341">CUDA: leaves × actions × scenarios</text>
+  <line x1="595" y1="279" x2="625" y2="315" class="edge"/><line x1="725" y1="279" x2="695" y2="315" class="edge"/>
+  <text x="370" y="382">Blue circles: weighted scenario beliefs · green boxes: actions · dashed purple: CPU traversal · gold: leaf kernels</text>
+</svg>

--- a/docs/planners/hyp_despot/index.rst
+++ b/docs/planners/hyp_despot/index.rst
@@ -1,0 +1,105 @@
+HyP-DESPOT
+==========
+
+1. Which problem does it solve?
+--------------------------------
+
+HyP-DESPOT plans online in a partially observed problem by fixing deterministic
+scenarios and searching one sparse belief tree. DESPOT performs leaf work and
+tree traversal serially. HyP-DESPOT keeps the shared tree on the CPU while it
+batches expensive leaf transition, reward, observation, terminal, and bound
+work on an NVIDIA GPU. CPU workers use scenario-aware PO-UCT and temporary
+virtual loss so simultaneous traversals spread over useful branches. [Cai2018]_
+
+2. What does its value function mean?
+--------------------------------------
+
+The implementation maximizes the finite-horizon discounted return
+
+.. math:: V_D(b)=\max_\pi\;\mathbb{E}_{s_0\sim b,\,\phi}
+          [\sum_{t=0}^{D-1}\gamma^t r(s_t,\pi(h_t),s_{t+1})].
+
+``b`` is the current belief, ``D`` is the number of remaining rewards,
+``pi`` maps an action-observation history ``h_t`` to an action, ``phi`` is the
+explicit deterministic scenario-randomness stream, ``gamma`` is the discount,
+and ``r`` is immediate reward. Larger values are better. Each action stores
+lower and upper return bounds. PO-UCT adds a scenario-mass-weighted exploration
+term only during traversal. The returned action has the largest backed-up lower
+bound, so the exploration score cannot determine the final choice.
+
+3. What search structure does it build?
+----------------------------------------
+
+.. image:: hyp-despot-tree.svg
+   :alt: Serial DESPOT leaf evaluation compared with HyP-DESPOT CPU workers and a CUDA leaf batch
+   :width: 100%
+
+All CPU workers share this topology. A worker marks its chosen observation
+edge with virtual loss before it leaves the lock. The CUDA queue combines
+several discovered beliefs, expands the leaf/action/scenario Cartesian axes,
+then the CPU integrates each result exactly once and backs bounds toward the
+root. The two sides use the same belief-action-observation topology; the marked
+difference is parallel traversal and batched leaf evaluation, not a new tree.
+
+4. Core benefits and limitations
+---------------------------------
+
+The GPU batch shares launch overhead across leaves, actions, and scenarios,
+while CPU workers keep tree control flow off the device. Deterministic random
+tensors make repeated scenario transitions reproducible. Numeric metrics and
+opt-in JSON snapshots expose worker, batch, bound, virtual-loss, and topology
+evidence.
+
+The model must supply floating CUDA states, explicit scenario randomness,
+integer observation keys, terminal masks, and CUDA leaf bounds. Only one GPU
+(``cuda:0``) is supported. Continuous action environments need an explicit
+finite expansion set. Within-step factored kernels are unsupported. CPU, MPS,
+implicit model randomness, Python scalar states, and hidden device copies raise
+``HypDESPOTCompatibilityError``. Local CPU contract tests pass; CUDA behavior
+awaits the routed GPU QA job, so there is no episode-performance claim yet.
+
+5. When to use it
+------------------
+
+Use HyP-DESPOT when model evaluation dominates planning cost, the model already
+has deterministic batched CUDA kernels, and several scenarios and actions can
+fill each batch. Choose DESPOT for scalar models or CPU-only machines. Choose a
+continuous-action planner when no defensible finite action set exists. Expect
+higher setup cost and GPU memory use in exchange for parallel leaf evaluation.
+
+Configuration and evidence
+--------------------------
+
+``n_scenarios`` fixes root scenario count. ``n_traversals`` is the deterministic
+work budget. ``n_workers`` controls CPU traversal threads and
+``cuda_batch_size`` caps queued leaves. ``exploration_constant`` weights PO-UCT;
+``virtual_loss`` spreads workers. ``scenario_seed`` identifies deterministic
+random tensors. Set ``search_state_dump_dir`` to write immutable JSON snapshots.
+
+Metrics cover traversals; CUDA batches, leaves, scenarios, and action rows;
+mean/max batch size; queue, kernel, transfer, traversal, backup, and total time;
+virtual-loss applications; lock wait; root bounds/gap; device index; and peak
+allocated memory. Each value resets for every decision.
+
+.. code-block:: python
+
+   planner = HypDESPOT(
+       environment=env,
+       discount_factor=0.95,
+       depth=8,
+       name="gpu-search",
+       n_scenarios=128,
+       n_traversals=64,
+       n_workers=4,
+       cuda_batch_size=8,
+       expansion_actions=env.get_actions(),
+   )
+
+Revision note: clean implementation from Cai et al., RSS 2018,
+arXiv:1802.06215. Author code ``AdaCompNUS/hyp-despot`` was consulted by the
+prior design job on 2026-09-08, but no license was found and no source was
+copied. The exact upstream revision was unavailable because GitHub access was
+blocked.
+
+.. [Cai2018] Cai, P., Luo, Y., Hsu, D., and Lee, W. S. “HyP-DESPOT: A Hybrid
+   Parallel Algorithm for Online Planning under Uncertainty.” RSS 2018.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -397,3 +397,6 @@ Next Steps
 **API Reference**
 
 Browse the complete API documentation: :doc:`api/modules`
+
+HyP-DESPOT is available only for environments that expose a deterministic
+``hyp_despot_cuda_model`` on ``cuda:0``. It never falls back to CPU DESPOT.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -8,6 +8,11 @@ Your First POMDP Solution
 
 Let's solve the classic Tiger POMDP problem using POMCP:
 
+AdaOPS is also available for discrete-action models whose observation
+likelihood can be scored. It needs explicit state bins to enable KLD particle
+sizing; passing no ``state_binner`` disables adaptation and uses
+``max_particles`` during resampling. See :doc:`planners/adaops/index`.
+
 .. code-block:: python
 
    from POMDPPlanners.environments.tiger_pomdp import TigerPOMDP


### PR DESCRIPTION
Adds the AdaOPS and HyP-DESPOT planners, then fixes the six defects a review of
the branch found. The first two commits are the planners as written; the third
is the review response, kept separate so the fixes are readable on their own.

## The six findings

| # | Defect | Disposition |
|---|---|---|
| 1 | `get_benchmark_hyperparameter_planners`'s pinned Tiger planner list stopped at ARDESPOT, but AdaOPS and HypDESPOT are both compatible, so the CI doctest would fail | Fixed |
| 2 | DESPOT's `eta` docstring described a stopping rule the code does not implement | Docstring fixed; **code deliberately unchanged** |
| 3 | `HypDESPOT.__getstate__` dropped an explicit `model=`, so unpickling raised or bound to the wrong model | Fixed |
| 4 | `validate_cuda_contract` compared `torch.device` with `!=`, rejecting `cuda` against `cuda:0` | Fixed |
| 5 | AdaOPS's particle-less root sampled off the global RNG, breaking `random_seed` reproducibility | Fixed |
| 6 | AdaOPS keyed its terminal bucket on the string `"<terminal>"`, which a real observation can equal | Fixed |

### On finding 2

The reviewer read the docstring, not the paper. `_should_stop` computes
`(1 - eta) * gap <= TINY`, which is exactly the excess uncertainty
`E(b) = (u - l) - eta (u(root) - l(root)) gamma^(-d)` evaluated at the root
(`d = 0`). `eta` is not inert either: `_best_excess_uncertainty_child` uses the
same quantity at depth to choose which observation branch a trial follows. So
the code is the reference algorithm and the docstring was the bug. Two tests now
pin both halves, including the exact value equation (5) gives.

### Beyond the review

A second-opinion pass turned up three more, all fixed here:

- `normalize_cuda_device` originally filled a bare `cuda` in as `cuda:0`. PyTorch
  resolves it to the process's *current* device, so on a box where
  `torch.cuda.set_device(1)` has run that would have slipped past the single-GPU
  guard and failed later naming the wrong device.
- `TERMINAL_OBSERVATION` is matched by identity, but it had no `__reduce__` or
  `__deepcopy__`, so the sentinel stopped being a singleton across a snapshot
  deep-copy or a pickle into a worker. Finding 6's fix depends on that identity
  holding, so the sentinel now returns itself.
- The RNG-leak and WEU tests were weaker than they looked; both were tightened.

## Testing

Full local suite, pyright, black, and doctests; then Black, Pyright and the
non-slow pytest suite again inside the `linux/amd64` CI image. Every new test was
checked against the pre-fix code and fails there.

**Not covered:** no NVIDIA GPU was reachable, so the real-CUDA HypDESPOT tests
are skipped, as they are on any CPU-only machine. Only the contract checks and
CPU-side search logic are exercised.
