### PR TITLE
Redesign recorded Racetrack visualization

### DIFF
--- a/POMDPPlanners/environments/racetrack_pomdp/racetrack_pomdp.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/racetrack_pomdp.py
@@ -641,15 +641,19 @@ class RacetrackPOMDP(Environment):
             return None
         return self._session.render_frame()
 
-    def cache_visualization(
-        self, history: List[Any], output_dir: Path, episode_index: int
-    ) -> None:
+    def cache_visualization(self, history: List[Any], output_dir: Path, episode_index: int) -> None:
         """Save a recorded episode without querying or advancing the live simulator."""
         from POMDPPlanners.environments.racetrack_pomdp.racetrack_visualizer import (
             RacetrackVisualizer,
         )
 
-        RacetrackVisualizer(self.max_tracked_agents).save(
+        from POMDPPlanners.environments.racetrack_pomdp.racetrack_visualizer_track import (
+            reference_track_lanes,
+        )
+
+        # racetrack-v0's layout is fixed. Unknown scenarios must not inherit its road.
+        lanes = reference_track_lanes() if self.env_id == DEFAULT_ENV_ID else None
+        RacetrackVisualizer(self.max_tracked_agents, self.action_presets, lanes).save(
             history, output_dir / f"agent_path_{episode_index}.gif"
         )
 

--- a/POMDPPlanners/environments/racetrack_pomdp/racetrack_visualizer.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/racetrack_visualizer.py
@@ -1,158 +1,347 @@
 # SPDX-License-Identifier: MIT
+"""Offline Racetrack artwork. Only recorded poses define vehicle movement.
 
-"""Deterministic Pillow renderer for recorded Racetrack episode states."""
+The standard road is a reference map of highway-env 1.12.1's exact lane
+parameters. Custom scenarios can supply lane polygons or omit the map. It is
+never reconstructed from the planner's approximate curvature profile.
+"""
 
+from functools import lru_cache
 from pathlib import Path
-from typing import List, Sequence
+from typing import Any, List, Sequence
 
 import numpy as np
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, ImageFont
 
 from POMDPPlanners.core.simulation.history import StepData
 from POMDPPlanners.environments.racetrack_pomdp.racetrack_schema import (
     AGENT_PRESENT,
     AGENT_REL_X,
     AGENT_REL_Y,
+    AGENT_SLOT_WIDTH,
+    DEFAULT_ACTION_PRESETS,
     EGO_HEADING,
+    EGO_SPEED,
     EGO_STATE_WIDTH,
     EGO_X,
     EGO_Y,
     state_agent_rows,
 )
 
-_SIZE = 640
-_MARGIN = 48
-_FRAME_DURATION_MS = 125
-_BACKGROUND = (244, 246, 248)
-_TRACK = (87, 96, 106)
-_TRAIL = (42, 116, 181)
-_EGO = (22, 101, 52)
-_OPPONENT = (194, 55, 45)
+WIDTH, HEIGHT = 1100, 760
+INK = "#203744"
+MUTED = "#617581"
+PAPER = "#f6f5ef"
+GRASS = "#e3e8dc"
+ROAD = "#384953"
+EDGE = "#f8f5df"
+BLUE = "#287fba"
+TRAIL = "#81cde0"
+AMBER = "#e2a233"
+CORAL = "#c3634d"
+
+
+@lru_cache(maxsize=16)
+def _font(size: int):
+    return ImageFont.load_default(size=size)
 
 
 def _recorded_states(history: Sequence[StepData]) -> List[np.ndarray]:
-    """Return each recorded state once, including a non-retired final successor."""
+    """Keep every row and append only an explicitly recorded final successor."""
     if not history:
         raise ValueError("history must contain at least one recorded step")
-
     states = [np.asarray(step.state, dtype=float) for step in history]
-    final_successor = history[-1].next_state
-    if final_successor is not None:
-        states.append(np.asarray(final_successor, dtype=float))
+    if history[-1].next_state is not None:
+        states.append(np.asarray(history[-1].next_state, dtype=float))
     return states
 
 
-class RacetrackVisualizer:
-    """Render saved episodes from history without touching the live simulator."""
+def _world_points(state: np.ndarray, rows: np.ndarray) -> np.ndarray:
+    """Rotate body-relative positions with this record's own ego heading."""
+    angle = float(state[EGO_HEADING])
+    rotation = np.array([[np.cos(angle), -np.sin(angle)], [np.sin(angle), np.cos(angle)]])
+    return rows[:, [AGENT_REL_X, AGENT_REL_Y]] @ rotation.T + state[[EGO_X, EGO_Y]]
 
-    def __init__(self, max_tracked_agents: int) -> None:
+
+def _number(value: Any) -> str:
+    return "unavailable" if value is None else f"{float(value):+.3g}"
+
+
+class RacetrackVisualizer:
+    """One 500 ms frame per record, with a 1500 ms hold on the final frame.
+
+    Cars show the true pre-action pose. Amber dots project the stored belief
+    onto ego and opponent position; larger rings indicate greater particle weight.
+    Heading/speed uncertainty is omitted from this spatial projection. Observations
+    and rewards belong to the displayed action's successor, not its initial pose.
+    """
+
+    def __init__(
+        self,
+        max_tracked_agents: int,
+        action_presets: Sequence[tuple[float, float]] = DEFAULT_ACTION_PRESETS,
+        track_lanes: Sequence[dict] | None = None,
+    ) -> None:
         self.max_tracked_agents = max_tracked_agents
+        self.action_presets = action_presets
+        # No map is the safe default for arbitrary supplied histories.
+        self.track_lanes = list(track_lanes) if track_lanes is not None else []
+
+    def _opponents(self, state: np.ndarray) -> np.ndarray:
+        if state.size < EGO_STATE_WIDTH + AGENT_SLOT_WIDTH * self.max_tracked_agents:
+            return np.empty((0, 2))
+        rows = state_agent_rows(state, self.max_tracked_agents)
+        return _world_points(state, rows[rows[:, AGENT_PRESENT] > 0.5])
+
+    def _belief_points(self, belief: Any) -> tuple[np.ndarray, np.ndarray]:
+        particles = getattr(belief, "particles", None)
+        if particles is None:
+            return np.empty((0, 2)), np.empty(0)
+        particles = np.asarray(particles, dtype=float)
+        if particles.ndim != 2 or particles.shape[1] < EGO_STATE_WIDTH or not len(particles):
+            return np.empty((0, 2)), np.empty(0)
+        weights = np.asarray(
+            getattr(belief, "normalized_weights", np.ones(len(particles))), dtype=float
+        )
+        if weights.shape != (len(particles),) or not np.all(np.isfinite(weights)):
+            return np.empty((0, 2)), np.empty(0)
+        points, masses = [], []
+        for particle, weight in zip(particles, weights):
+            if weight <= 0 or not np.all(np.isfinite(particle)):
+                continue
+            positions = np.vstack([particle[[EGO_X, EGO_Y]], self._opponents(particle)])
+            points.extend(positions)
+            masses.extend([weight] * len(positions))
+        return np.asarray(points).reshape(-1, 2), np.asarray(masses)
 
     def _bounds(self, states: Sequence[np.ndarray]) -> tuple[float, float, float, float]:
-        # pylint: disable=too-many-locals
-        """Return fixed world bounds that contain every recorded vehicle."""
         points = []
         for state in states:
-            ego_x, ego_y = float(state[EGO_X]), float(state[EGO_Y])
-            points.append((ego_x, ego_y))
-            if state.size < EGO_STATE_WIDTH + 5 * self.max_tracked_agents:
-                continue
-            heading = float(state[EGO_HEADING])
-            cosine, sine = float(np.cos(heading)), float(np.sin(heading))
-            rows = state_agent_rows(state, self.max_tracked_agents)
-            for row in rows[rows[:, AGENT_PRESENT] > 0.5]:
-                rel_x, rel_y = float(row[AGENT_REL_X]), float(row[AGENT_REL_Y])
-                points.append(
-                    (
-                        ego_x + cosine * rel_x - sine * rel_y,
-                        ego_y + sine * rel_x + cosine * rel_y,
-                    )
-                )
-        points = np.asarray(points, dtype=float)
-        low = points.min(axis=0)
-        high = points.max(axis=0)
-        centre = (low + high) / 2.0
-        span = max(float(np.max(high - low)), 20.0) * 1.2
+            points.append(state[[EGO_X, EGO_Y]])
+            points.extend(self._opponents(state))
+        for lane in self.track_lanes:
+            points.extend(lane["polygon"])
+        array = np.asarray(points)
+        low, high = array.min(axis=0), array.max(axis=0)
+        span = np.maximum(high - low, 20.0)
         return (
-            float(centre[0] - span / 2.0),
-            float(centre[1] - span / 2.0),
-            float(centre[0] + span / 2.0),
-            float(centre[1] + span / 2.0),
+            float(low[0] - 0.08 * span[0]),
+            float(low[1] - 0.12 * span[1]),
+            float(high[0] + 0.08 * span[0]),
+            float(high[1] + 0.12 * span[1]),
         )
 
     @staticmethod
-    def _project(
-        x: float, y: float, bounds: tuple[float, float, float, float]
-    ) -> tuple[int, int]:
+    def _project(x: float, y: float, bounds) -> tuple[float, float]:
         left, bottom, right, top = bounds
-        scale = (_SIZE - 2 * _MARGIN) / max(right - left, top - bottom)
-        return (
-            round(_MARGIN + (x - left) * scale),
-            round(_SIZE - _MARGIN - (y - bottom) * scale),
+        scale = min(980 / (right - left), 414 / (top - bottom))
+        return (550 + (x - (left + right) / 2) * scale, 338 - (y - (bottom + top) / 2) * scale)
+
+    @staticmethod
+    def _text(draw, xy, text, size=17, fill=INK, anchor=None):
+        draw.text(xy, text, font=_font(size), fill=fill, anchor=anchor)
+
+    def _background(self, bounds) -> Image.Image:
+        image = Image.new("RGB", (WIDTH, HEIGHT), PAPER)
+        draw = ImageDraw.Draw(image)
+        self._text(draw, (40, 24), "RACETRACK", 30)
+        self._text(draw, (40, 66), "Recorded driving  /  observer view", 17, MUTED)
+        draw.rounded_rectangle((30, 108, 1070, 568), radius=18, fill=GRASS)
+        project = lambda points: [self._project(float(x), float(y), bounds) for x, y in points]
+        # Paint all surfaces before boundaries, so adjacent lanes have no false seams.
+        for lane in self.track_lanes:
+            draw.polygon(project(lane["polygon"]), fill=ROAD)
+        for lane in self.track_lanes:
+            for line in lane["lines"]:
+                points = project(line["points"])
+                if line["type"] == 1:  # highway-env STRIPED
+                    for start in range(0, len(points) - 1, 10):
+                        draw.line(points[start : start + 5], fill="#aebbb9", width=1)
+                elif line["type"] in (2, 3):
+                    draw.line(points, fill=EDGE, width=2)
+        note = (
+            "Reference road: racetrack-v0 / highway-env 1.12.1"
+            if self.track_lanes
+            else "Road geometry unavailable"
         )
+        self._text(draw, (50, 124), note, 13, MUTED)
+        # Metric scale shares the pose transform; decorative borders are never road edges.
+        x, y = self._project(bounds[0], bounds[1], bounds)
+        p1 = self._project(bounds[0] + 10, bounds[1], bounds)
+        bar = p1[0] - x
+        draw.line((58, 540, 58 + bar, 540), fill=MUTED, width=2)
+        draw.line((58, 536, 58, 544), fill=MUTED, width=2)
+        draw.line((58 + bar, 536, 58 + bar, 544), fill=MUTED, width=2)
+        self._text(draw, (58, 515), "10 m", 13, MUTED)
+        return image
+
+    def _car(self, draw, position, heading: float, bounds) -> None:
+        # A 5 x 2 m footprint centred on the exact recorded pose. Artwork is
+        # illustrative, not a new collision shape. Front windshield marks heading.
+        cx, cy = position
+        cosine, sine = np.cos(heading), np.sin(heading)
+
+        def polygon(vertices, color):
+            points = [
+                self._project(cx + cosine * x - sine * y, cy + sine * x + cosine * y, bounds)
+                for x, y in vertices
+            ]
+            draw.polygon(points, fill=color)
+
+        polygon([(-2.5, -1), (1.9, -1), (2.5, -0.65), (2.5, 0.65), (1.9, 1), (-2.5, 1)], "#173f59")
+        polygon(
+            [(-2.2, -0.82), (1.9, -0.82), (2.2, -0.5), (2.2, 0.5), (1.9, 0.82), (-2.2, 0.82)], BLUE
+        )
+        polygon([(0.1, -0.75), (1.05, -0.62), (1.05, 0.62), (0.1, 0.75)], "#c3e5e9")
+        polygon([(-1.8, -0.65), (-1.1, -0.65), (-1.1, 0.65), (-1.8, 0.65)], "#173f59")
+        polygon([(1.8, -0.75), (2.15, -0.7), (2.15, -0.4), (1.8, -0.4)], "#fff2ca")
+        polygon([(1.8, 0.4), (2.15, 0.4), (2.15, 0.7), (1.8, 0.75)], "#fff2ca")
+
+    def _action(self, action: Any) -> str:
+        if action is None:
+            return "none"
+        if isinstance(action, (int, np.integer)) and 0 <= int(action) < len(self.action_presets):
+            accel, steer = self.action_presets[int(action)]
+            return f"{int(action)}   accel {accel:+g} / steer {steer:+g}"
+        return str(action)
+
+    @staticmethod
+    def _observation(observation: Any) -> str:
+        if observation is None:
+            return "unavailable"
+        if hasattr(observation, "detections"):
+            rows = np.asarray(observation.detections)
+            count = int(np.sum(rows[:, 0] > 0.5))
+            speed = float(np.asarray(observation.ego_speed).flat[0])
+            return f"{count} detections / speed {speed:.2f} m/s"
+        table = np.asarray(observation)
+        if table.ndim == 2 and table.shape[1] == 5:
+            return f"kinematics / {int(np.sum(table[:, 0] > .5))} present rows"
+        return "recorded (not projected)"
 
     def render_frames(self, history: Sequence[StepData]) -> List[Image.Image]:
-        # pylint: disable=too-many-locals
-        """Draw one frame for each state in a normalized recorded history."""
+        """Render history without sampling, stepping, or modifying any record."""
         states = _recorded_states(history)
         bounds = self._bounds(states)
+        background = self._background(bounds)
         trail = [self._project(float(s[EGO_X]), float(s[EGO_Y]), bounds) for s in states]
-        frames: List[Image.Image] = []
-
+        frames = []
+        total = 0.0
         for index, state in enumerate(states):
-            image = Image.new("RGB", (_SIZE, _SIZE), _BACKGROUND)
+            step = history[index] if index < len(history) else None
+            image = background.copy()
             draw = ImageDraw.Draw(image)
-            draw.rectangle(
-                (_MARGIN, _MARGIN, _SIZE - _MARGIN, _SIZE - _MARGIN),
-                outline=_TRACK,
-                width=2,
-            )
             if index:
-                draw.line(trail[: index + 1], fill=_TRAIL, width=5)
-
-            ego_x, ego_y = float(state[EGO_X]), float(state[EGO_Y])
-            ego_point = self._project(ego_x, ego_y, bounds)
-            heading = float(state[EGO_HEADING])
-            direction = (np.cos(heading), np.sin(heading))
-            nose = self._project(ego_x + 2.0 * direction[0], ego_y + 2.0 * direction[1], bounds)
-            draw.line((ego_point, nose), fill=_EGO, width=6)
-            draw.ellipse(
-                (ego_point[0] - 7, ego_point[1] - 7, ego_point[0] + 7, ego_point[1] + 7),
-                fill=_EGO,
+                # Connect only actual adjacent transitions, not gaps in supplied history.
+                for j in range(index):
+                    successor = history[j].next_state
+                    if successor is not None and np.array_equal(successor, states[j + 1]):
+                        draw.line((trail[j], trail[j + 1]), fill=TRAIL, width=3)
+                for point in trail[:index]:
+                    draw.ellipse(
+                        (point[0] - 2, point[1] - 2, point[0] + 2, point[1] + 2), fill=TRAIL
+                    )
+            particles, masses = self._belief_points(step.belief if step else None)
+            hidden = 0
+            for point, mass in zip(particles, masses):
+                px, py = self._project(float(point[0]), float(point[1]), bounds)
+                if not (35 < px < 1065 and 150 < py < 558):
+                    hidden += 1
+                    continue
+                radius = 1.5 + 3 * float(np.sqrt(mass / masses.max()))
+                draw.ellipse(
+                    (px - radius, py - radius, px + radius, py + radius), outline=AMBER, width=1
+                )
+            for point in self._opponents(state):
+                px, py = self._project(float(point[0]), float(point[1]), bounds)
+                # Opponent heading is absent from state. A round marker does not invent it.
+                draw.ellipse((px - 6, py - 6, px + 6, py + 6), fill=CORAL, outline=PAPER, width=2)
+            self._car(draw, state[[EGO_X, EGO_Y]], float(state[EGO_HEADING]), bounds)
+            self._text(draw, (1060, 32), f"{index + 1:02d} / {len(states):02d}", 23, anchor="ra")
+            phase = (
+                "Pre-action state"
+                if step is not None and step.action is not None
+                else "Final recorded state"
             )
-
-            if state.size >= EGO_STATE_WIDTH + 5 * self.max_tracked_agents:
-                rows = state_agent_rows(state, self.max_tracked_agents)
-                cosine, sine = float(np.cos(heading)), float(np.sin(heading))
-                for row in rows[rows[:, AGENT_PRESENT] > 0.5]:
-                    rel_x, rel_y = float(row[AGENT_REL_X]), float(row[AGENT_REL_Y])
-                    world_x = ego_x + cosine * rel_x - sine * rel_y
-                    world_y = ego_y + sine * rel_x + cosine * rel_y
-                    px, py = self._project(world_x, world_y, bounds)
-                    draw.rectangle((px - 6, py - 4, px + 6, py + 4), fill=_OPPONENT)
-
-            draw.text((16, 16), f"Recorded frame {index + 1}/{len(states)}", fill=_TRACK)
+            self._text(draw, (1060, 69), phase, 15, MUTED, "ra")
+            self._text(draw, (42, 590), "STATE", 13, MUTED)
+            self._text(draw, (42, 613), f"{state[EGO_SPEED]:.2f} m/s", 26)
+            self._text(draw, (42, 649), f"x {state[EGO_X]:.2f}   y {state[EGO_Y]:.2f} m", 15, MUTED)
+            self._text(draw, (300, 590), "SELECTED CONTROL (NORMALISED)", 13, MUTED)
+            self._text(draw, (300, 617), self._action(step.action if step else None), 17)
+            self._text(draw, (300, 649), f"heading {state[EGO_HEADING]:+.3f} rad", 15, MUTED)
+            self._text(draw, (730, 590), "RECORDED RESULT OF THIS ACTION", 13, MUTED)
+            reward = step.reward if step else None
+            if reward is not None:
+                total += float(reward)
+            self._text(draw, (730, 617), f"Reward {_number(reward)}   /   total {total:+.3g}", 17)
+            self._text(
+                draw, (730, 649), self._observation(step.observation if step else None), 15, MUTED
+            )
+            draw.line((40, 682, 1060, 682), fill="#d7dfd8", width=1)
+            labels = [
+                (42, BLUE, "ego"),
+                (130, CORAL, "other vehicle"),
+                (305, TRAIL, "recorded path"),
+            ]
+            for x, color, label in labels:
+                draw.ellipse((x, 704, x + 10, 714), fill=color)
+                self._text(draw, (x + 19, 700), label, 15, MUTED)
+            belief_note = "belief unavailable"
+            if len(particles):
+                belief_note = (
+                    f"belief: position projection ({hidden} outside view)"
+                    if hidden
+                    else "belief: position projection / larger = more weight"
+                )
+            draw.ellipse((495, 703, 507, 715), outline=AMBER, width=2)
+            self._text(draw, (517, 700), belief_note, 15, MUTED)
+            info = step.info if step else history[-1].info
+            if step is not None and step.action is None and index > 0:
+                previous = history[index - 1]
+                if previous.next_state is not None and np.array_equal(previous.next_state, state):
+                    info = previous.info
+            if info:
+                events = [
+                    label
+                    for key, label in [
+                        ("crashed", "collision"),
+                        ("off_road", "off road"),
+                        ("time_limit", "time limit"),
+                    ]
+                    if info.get(key, 0)
+                ]
+                if events:
+                    self._text(
+                        draw, (1050, 538), "Recorded result: " + ", ".join(events), 16, CORAL, "ra"
+                    )
             frames.append(image)
         return frames
 
     def save(self, history: Sequence[StepData], path: Path) -> None:
-        """Save one recorded frame as PNG or all recorded frames as GIF."""
+        """Save the final state as PNG, or every recorded frame as GIF."""
         if not isinstance(path, Path):
             raise TypeError("path must be a pathlib.Path")
-        suffix = path.suffix.lower()
-        if suffix not in {".gif", ".png"}:
+        if path.suffix.lower() not in {".gif", ".png"}:
             raise ValueError("path must end in .gif or .png")
-
         frames = self.render_frames(history)
         path.parent.mkdir(parents=True, exist_ok=True)
-        if suffix == ".png":
-            frames[-1].save(path)
-            return
-        frames[0].save(
-            path,
-            save_all=True,
-            append_images=frames[1:],
-            duration=_FRAME_DURATION_MS,
-            loop=0,
-            optimize=False,
-        )
+        # A shared palette makes PNG and decoded GIF pixels agree exactly.
+        sample = frames[0].copy()
+        swatches = ImageDraw.Draw(sample)
+        for index, color in enumerate((TRAIL, CORAL, AMBER, BLUE)):
+            swatches.rectangle((index * 30, 0, index * 30 + 29, 29), fill=color)
+        palette = sample.quantize(colors=128, method=Image.Quantize.MEDIANCUT)
+        indexed = [frame.quantize(palette=palette, dither=Image.Dither.NONE) for frame in frames]
+        if path.suffix.lower() == ".png":
+            indexed[-1].convert("RGB").save(path)
+        else:
+            indexed[0].save(
+                path,
+                save_all=True,
+                append_images=indexed[1:],
+                duration=[500] * (len(frames) - 1) + [1500],
+                loop=0,
+                optimize=False,
+                disposal=2,
+            )

--- a/POMDPPlanners/environments/racetrack_pomdp/racetrack_visualizer_track.py
+++ b/POMDPPlanners/environments/racetrack_pomdp/racetrack_visualizer_track.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MIT
+"""Reference artwork geometry copied from highway-env 1.12.1 lane parameters.
+
+These are world coordinates, not the planner's re-integrated curvature map.
+The regression test compares every sampled edge with the actual simulator.
+This module is rendering-only and never participates in transitions/collisions.
+"""
+
+import numpy as np
+
+# Straight: start, end, width, line types. Arc: centre, radius, start/end
+# phase (radians), clockwise, width, line types. Preserve source seam overlaps.
+_LANES = [
+    ("straight", [42, 0], [100, 0], 5, [2, 1]),
+    ("straight", [42, 5], [100, 5], 5, [1, 2]),
+    ("arc", [100, -20], 20, 1.5707963267948966, -0.017453292519943295, False, 5, [2, 0]),
+    ("arc", [100, -20], 25, 1.5707963267948966, -0.017453292519943295, False, 5, [1, 2]),
+    ("straight", [120, -20], [120, -30], 5, [2, 0]),
+    ("straight", [125, -20], [125, -30], 5, [1, 2]),
+    ("arc", [105, -30], 15, 0.0, -3.1590459461097367, False, 5, [2, 0]),
+    ("arc", [105, -30], 20, 0.0, -3.1590459461097367, False, 5, [1, 2]),
+    ("arc", [70, -30], 20, 0.0, 2.3736477827122884, True, 5, [2, 1]),
+    ("arc", [70, -30], 15, 0.0, 2.3911010752322315, True, 5, [0, 2]),
+    ("straight", [55.7, -15.7], [35.7, -35.7], 5, [2, 0]),
+    ("straight", [59.3934, -19.2], [39.3934, -39.2], 5, [1, 2]),
+    ("arc", [18.1, -18.1], 25, 5.497787143782138, 2.9670597283903604, False, 5, [2, 0]),
+    ("arc", [18.1, -18.1], 30, 5.497787143782138, 2.8797932657906435, False, 5, [1, 2]),
+    ("arc", [18.1, -18.1], 25, 2.9670597283903604, 0.9773843811168246, False, 5, [2, 0]),
+    ("arc", [18.1, -18.1], 30, 2.9670597283903604, 1.0122909661567112, False, 5, [1, 2]),
+    ("arc", [43.2, 23.4], 23.5, 4.1887902047863905, 4.71238898038469, True, 5, [2, 1]),
+    ("arc", [43.2, 23.4], 18.5, 4.153883619746504, 4.6774823953448035, True, 5, [0, 2]),
+]
+
+
+def reference_track_lanes() -> list[dict]:
+    """Sample each exact lane edge at at most 0.25 m intervals for drawing."""
+    lanes = []
+    for spec in _LANES:
+        width, line_types = spec[-2:]
+        if spec[0] == "straight":
+            start, end = np.asarray(spec[1], dtype=float), np.asarray(spec[2], dtype=float)
+            length = float(np.linalg.norm(end - start))
+            direction = (end - start) / length
+            normal = np.array([-direction[1], direction[0]])
+            distance = np.linspace(0, length, int(np.ceil(length / 0.25)) + 1)
+            centre = start + distance[:, None] * direction
+            edges = [centre + lateral * normal for lateral in (-width / 2, width / 2)]
+        else:
+            _, centre, radius, start, end, clockwise, _, _ = spec
+            direction = 1 if clockwise else -1
+            length = radius * (end - start) * direction
+            phase = np.linspace(start, end, int(np.ceil(length / 0.25)) + 1)
+            vectors = np.column_stack((np.cos(phase), np.sin(phase)))
+            edges = [
+                np.asarray(centre) + (radius - lateral * direction) * vectors
+                for lateral in (-width / 2, width / 2)
+            ]
+        lanes.append(
+            {
+                "polygon": np.vstack((edges[0], edges[1][::-1])),
+                "lines": [{"points": edge, "type": kind} for edge, kind in zip(edges, line_types)],
+            }
+        )
+    return lanes

--- a/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_visualizer.py
+++ b/POMDPPlanners/tests/test_environments/test_racetrack_pomdp/test_racetrack_visualizer.py
@@ -54,7 +54,7 @@ def test_normal_history_adds_last_successor_and_can_save_still(tmp_path):
         decoded.seek(2)
         final_animation = decoded.convert("RGB")
     with Image.open(still) as decoded_still:
-        assert decoded_still.size == (640, 640)
+        assert decoded_still.size == (1100, 760)
         assert decoded_still.convert("RGB").tobytes() == final_animation.tobytes()
 
 
@@ -81,3 +81,149 @@ def test_live_render_frame_contract_is_preserved():
 
     assert env.render_frame() is expected
     session.render_frame.assert_called_once_with()
+
+
+def test_reference_map_matches_simulator_edges():
+    """Check the displayed road against world geometry, not the planner model."""
+    pytest.importorskip("highway_env")
+    from highway_env.envs.racetrack_env import RacetrackEnv
+    from POMDPPlanners.environments.racetrack_pomdp.racetrack_visualizer_track import (
+        reference_track_lanes,
+    )
+
+    world = RacetrackEnv()
+    try:
+        lanes = [
+            lane
+            for ends in world.road.network.graph.values()
+            for parts in ends.values()
+            for lane in parts
+        ]
+        rendered = reference_track_lanes()
+        assert len(lanes) == len(rendered) == 18
+        for lane, painted in zip(lanes, rendered):
+            for side, edge in enumerate(painted["lines"]):
+                distances = np.linspace(0, lane.length, len(edge["points"]))
+                expected = np.array(
+                    [lane.position(s, (side - 0.5) * lane.width_at(s)) for s in distances]
+                )
+                np.testing.assert_allclose(edge["points"], expected, atol=1e-12)
+                assert edge["type"] == lane.line_types[side]
+            np.testing.assert_array_equal(
+                painted["polygon"],
+                np.vstack([painted["lines"][0]["points"], painted["lines"][1]["points"][::-1]]),
+            )
+    finally:
+        world.close()
+
+
+def test_particle_projection_uses_each_particle_pose_and_preserves_weights():
+    from POMDPPlanners.core.belief import WeightedParticleBelief
+
+    first, second = _state(0, True), _state(10, True)
+    first[:3] = [1, 2, 0]
+    second[:3] = [10, 20, np.pi / 2]
+    belief = WeightedParticleBelief([first, second], np.log([0.2, 0.8]))
+    points, weights = RacetrackVisualizer(1)._belief_points(belief)
+    np.testing.assert_allclose(points, [[1, 2], [6, 4], [10, 20], [8, 25]])
+    np.testing.assert_allclose(weights, [0.2, 0.2, 0.8, 0.8])
+    np.testing.assert_allclose(belief.normalized_weights, [0.2, 0.8])
+
+
+def test_frames_preserve_poses_and_never_sample_belief():
+    from unittest.mock import patch
+    from POMDPPlanners.core.belief import WeightedParticleBelief
+
+    first, final = _state(0), _state(4)
+    belief = WeightedParticleBelief([first.copy(), final.copy()], np.log([0.3, 0.7]))
+    belief.sample = Mock(side_effect=AssertionError("renderer sampled belief"))
+    history = [StepData(first, 1, final, None, 0.25, belief)]
+    original = np.stack([first.copy(), final.copy()])
+    visualizer = RacetrackVisualizer(1)
+    with patch.object(visualizer, "_car", wraps=visualizer._car) as car:
+        frames = visualizer.render_frames(history)
+    assert len(frames) == 2
+    for call, state in zip(car.call_args_list, [first, final]):
+        np.testing.assert_array_equal(call.args[1], state[:2])
+        assert call.args[2] == state[2]
+    np.testing.assert_array_equal(np.stack([first, final]), original)
+    belief.sample.assert_not_called()
+
+
+def test_gif_is_deterministic_with_readable_timing(tmp_path):
+    import hashlib
+
+    history = [_step(_state(0), _state(0)), _step(_state(0), _state(0))]
+    visualizer = RacetrackVisualizer(1)
+    one, two = tmp_path / "one.gif", tmp_path / "two.gif"
+    visualizer.save(history, one)
+    visualizer.save(history, two)
+    assert hashlib.sha256(one.read_bytes()).digest() == hashlib.sha256(two.read_bytes()).digest()
+    with Image.open(one) as gif:
+        assert getattr(gif, "n_frames") == 3
+        durations = []
+        for index in range(3):
+            gif.seek(index)
+            durations.append(gif.info["duration"])
+        assert durations == [500, 500, 1500]
+
+
+def test_missing_map_and_terminal_metadata_are_explicit():
+    from unittest.mock import patch
+
+    history = [_step(_state(0), None, None)]
+    visualizer = RacetrackVisualizer(1)
+    with patch.object(visualizer, "_text", wraps=visualizer._text) as text:
+        visualizer.render_frames(history)
+    strings = [call.args[2] for call in text.call_args_list]
+    assert "Road geometry unavailable" in strings
+    assert "belief unavailable" in strings
+    assert "Final recorded state" in strings
+    assert any("Reward unavailable" in value for value in strings)
+
+
+def test_history_gap_is_not_drawn_as_movement():
+    from PIL import ImageColor
+    from POMDPPlanners.environments.racetrack_pomdp.racetrack_visualizer import TRAIL
+
+    first, successor, disconnected = _state(0), _state(1), _state(10)
+    history = [_step(first, successor), _step(disconnected, None, None)]
+    visualizer = RacetrackVisualizer(1)
+    frames = visualizer.render_frames(history)
+    bounds = visualizer._bounds([first, disconnected])
+    point = visualizer._project(5, 2.5, bounds)
+    assert frames[-1].getpixel((round(point[0]), round(point[1]))) != ImageColor.getrgb(TRAIL)
+
+
+def test_custom_scenario_omits_reference_map(tmp_path):
+    from unittest.mock import patch
+
+    env = RacetrackPOMDP(discount_factor=0.95, env_id="custom-track")
+    with patch.object(RacetrackVisualizer, "save") as save:
+        env.cache_visualization([_step(_state(0), None, None)], tmp_path, 0)
+    save.assert_called_once()
+    # The standard hook must work with no backend or optional simulator installed.
+    assert env._session is None
+
+
+def test_custom_controls_are_displayed_verbatim():
+    visualizer = RacetrackVisualizer(1, action_presets=[(0.25, -0.125)])
+    assert visualizer._action(0) == "0   accel +0.25 / steer -0.125"
+    assert visualizer._action(None) == "none"
+
+
+def test_terminal_frame_preserves_last_transition_event():
+    from unittest.mock import patch
+
+    first, final = _state(0), _state(4)
+    history = [
+        _step(first, final, 1)._replace(reward=0.25, info={"off_road": 1.0}),
+        _step(final, None, None),
+    ]
+    visualizer = RacetrackVisualizer(1)
+    with patch.object(visualizer, "_text", wraps=visualizer._text) as text:
+        visualizer.render_frames(history)
+    events = [
+        call.args[2] for call in text.call_args_list if call.args[2] == "Recorded result: off road"
+    ]
+    assert len(events) == 2


### PR DESCRIPTION
Recorded Racetrack episodes now show the approved 1100×760 circuit scene with a shaped ego car, stored trajectory, particle positions and weights, readable controls/rewards, and terminal events that survive the final bookkeeping frame. The same seed-0 recording previously rendered as a 640×640 dot view.

The standard map uses highway-env 1.12.1 lane geometry. Custom tracks omit that map. Rendering reads recorded history without starting or advancing the simulator. The visual design is approved. The renderer, map and hook match the approved source exactly; two test-only type corrections were needed on develop.

Validation on macOS against cached develop 0d46c864 (includes PR268/270):

- 384 Racetrack tests passed, 41 upstream deprecation warnings.
- Black 23.12.1: four files pass. Pyright: zero errors/warnings. Diff whitespace check passes.
- Offline wheel built and installed outside the checkout. Its rendering is byte-identical to the approved GIF with simulator imports blocked and no live session.
- Own review and independent Claude review completed. Claude confirmed all 384 tests pass and found no lost behavior or incorrect image. Its two measured performance findings remain pre-merge work: avoid retaining RGB and quantized frame lists together, and use equivalent GIF frame encoding to reduce file size. Its 301-frame probe measured about 1.9 GB peak memory and a 7 MB GIF; both can be reduced without changing decoded images.

Linux CI remains pending. Fresh develop was verified unchanged at 0d46c864 outside the sandbox. Keep this PR draft until the performance findings are addressed and relevant Linux checks pass.
