### PR TITLE
ci: run Docker Tests daily at 02:17 UTC on develop

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,12 @@ on:
     branches: [ "master", "develop" ]
   pull_request:
     branches: [ "master", "develop" ]
+  schedule:
+    # Daily at 02:17 UTC. GitHub only loads this file from the default
+    # branch, so the schedule stays defined here but the job checks out
+    # develop below.
+    - cron: "17 2 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,6 +22,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Scheduled runs are dispatched from the default branch; check out
+        # develop so the nightly suite tests the active branch. An empty
+        # ref keeps the default checkout for every other event.
+        ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
 
     - name: Free up disk space
       run: |
@@ -86,9 +97,10 @@ jobs:
     - name: Run unit tests inside Docker
       # Run the full suite (slow tests included) on direct pushes to or PRs
       # targeting master/develop, so regressions in slow integration tests
-      # are caught at PR time rather than by the weekly cron.
+      # are caught at PR time rather than only by the nightly run.
       run: |
-        if [ "${{ github.ref }}" = "refs/heads/master" ] \
+        if [ "${{ github.event_name }}" = "schedule" ] \
+          || [ "${{ github.ref }}" = "refs/heads/master" ] \
           || [ "${{ github.ref }}" = "refs/heads/develop" ] \
           || [ "${{ github.base_ref }}" = "master" ] \
           || [ "${{ github.base_ref }}" = "develop" ]; then


### PR DESCRIPTION
## What

Adds a nightly schedule to the Docker Tests workflow.

- `schedule: cron "17 2 * * *"` — daily at 02:17 UTC.
- `workflow_dispatch` — lets the workflow be triggered by hand.
- On a `schedule` event, checkout uses `ref: develop`. GitHub only reads
  workflow schedules from the default branch, so the cron has to live on
  `master`, but the branch we actually want tested nightly is `develop`.
- Scheduled runs execute the full suite (slow tests included), same as
  pushes to and PRs against `master`/`develop`.

## Why this targets master

GitHub loads `schedule` triggers only from the default branch. Until this
lands on `master`, the nightly run does not exist. A matching PR against
`develop` keeps the two branches from diverging on this file.

## Scope

Only `.github/workflows/tests.yml`. Existing push and pull_request triggers
are unchanged. No package code, dependencies, or build settings touched.

## Tests

Workflow-only change; the repo test gate was waived for this patch by the
requester. The develop-targeting counterpart is gated on a Linux AMD64
Docker run.