### PR TITLE
ci: run Docker Tests daily at 02:17 UTC on develop

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,12 @@ on:
     branches: [ "master", "develop" ]
   pull_request:
     branches: [ "master", "develop" ]
+  schedule:
+    # Daily at 02:17 UTC. GitHub only loads this file from the default
+    # branch, so the schedule stays defined here but the job checks out
+    # develop below.
+    - cron: "17 2 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,6 +22,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Scheduled runs are dispatched from the default branch; check out
+        # develop so the nightly suite tests the active branch. An empty
+        # ref keeps the default checkout for every other event.
+        ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
 
     - name: Free up disk space
       run: |
@@ -86,9 +97,10 @@ jobs:
     - name: Run unit tests inside Docker
       # Run the full suite (slow tests included) on direct pushes to or PRs
       # targeting master/develop, so regressions in slow integration tests
-      # are caught at PR time rather than by the weekly cron.
+      # are caught at PR time rather than only by the nightly run.
       run: |
-        if [ "${{ github.ref }}" = "refs/heads/master" ] \
+        if [ "${{ github.event_name }}" = "schedule" ] \
+          || [ "${{ github.ref }}" = "refs/heads/master" ] \
           || [ "${{ github.ref }}" = "refs/heads/develop" ] \
           || [ "${{ github.base_ref }}" = "master" ] \
           || [ "${{ github.base_ref }}" = "develop" ]; then


### PR DESCRIPTION
GitHub only reads workflow files from the default branch (master), so a schedule
defined only on develop never fires. This defines the cron in the workflow and
checks out develop for scheduled runs, leaving every other event on its default
checkout. It also adds `workflow_dispatch` so the same suite can be triggered by
hand, and makes the full (slow) suite explicit for scheduled runs instead of
relying on the default branch's name.

Diff is workflow-only: `.github/workflows/tests.yml`, +14/-2.

The companion change on master is #273 — the schedule cannot fire until that
merges, since GitHub reads schedules from the default branch.

## Test evidence

Full Docker CI gate run at 55cf838d on **ubuntu64** (native linux/amd64, 16
cores, Docker 29.1.3). Serial — the gate script exposes no worker/parallelism
option, so no `-n` was added and test selection is unchanged.

| Stage | Result |
| --- | --- |
| pylint (`--exit-zero`, reporting only) | 9.97/10 |
| black --check | exit 0, but matched no files (see below) |
| pyright | 0 errors, 296 warnings |
| pytest, non-slow | 6720 passed, 64 skipped, 141 deselected, 12 xfailed, 629s, 93% coverage |
| notebook smoke (optional in CI) | 3 passed, 6 deselected |
| doctests | 197 passed |
| sphinx html (optional in CI) | exit 0 |

CI image `sha256:20ca2dcc40e93aa9be256423ca65cc0b12cb91ad14bbdc1c4da7b90cd7c2df6c`.

**Pre-existing issue, not fixed here:** `black --check` reports "No Python files
are present to be formatted" and passes vacuously. `pyproject.toml` has
`include = '\\.(py|pyi)$'`; in a TOML basic string the doubled backslash yields
the regex `\\.(py|pyi)$` — a literal backslash followed by any character — which
matches no filename. GitHub CI reads the same pyproject, so formatting is
unchecked there too. Out of scope for this workflow change; worth a separate fix.