### PR TITLE
Add a vectorized whole-map belief for OccupancyGridMapping

### DIFF
--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/__init__.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/__init__.py
@@ -7,6 +7,10 @@ Exports:
     OccupancyGridAction: Its three action indices.
     OccupancyGridMappingVisualizer: Episode renderer.
     OccupancyGridInitialStateDistribution: The per-episode map prior.
+    OccupancyGridMappingBelief: The scalar conditional whole-map filter.
+    OccupancyGridMappingVectorizedBelief: Its batched twin.
+    OccupancyGridMappingVectorizedUpdater: The batched kernels behind it.
+    create_occupancy_grid_mapping_belief: Factory choosing between the two filters.
 """
 
 from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_pomdp import (
@@ -40,6 +44,9 @@ from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sens
 
 __all__ = [
     "OccupancyGridMappingBelief",
+    "OccupancyGridMappingVectorizedBelief",
+    "OccupancyGridMappingVectorizedUpdater",
+    "create_occupancy_grid_mapping_belief",
     "COL_INDEX",
     "HEADING_INDEX",
     "HEADING_LABELS",
@@ -65,3 +72,8 @@ __all__ = [
 ]
 
 from .occupancy_grid_mapping_belief import OccupancyGridMappingBelief
+from .occupancy_grid_mapping_beliefs import (
+    OccupancyGridMappingVectorizedBelief,
+    OccupancyGridMappingVectorizedUpdater,
+    create_occupancy_grid_mapping_belief,
+)

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/__init__.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+
+"""Batched belief implementations for the occupancy-grid mapping POMDP."""
+
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_beliefs.occupancy_grid_mapping_vectorized_updater import (
+    OccupancyGridMappingVectorizedUpdater,
+)
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_beliefs.occupancy_grid_mapping_vectorized_belief import (
+    OccupancyGridMappingVectorizedBelief,
+)
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_beliefs.occupancy_grid_mapping_belief_factory import (
+    create_occupancy_grid_mapping_belief,
+)
+
+__all__ = [
+    "OccupancyGridMappingVectorizedBelief",
+    "OccupancyGridMappingVectorizedUpdater",
+    "create_occupancy_grid_mapping_belief",
+]

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/occupancy_grid_mapping_belief_factory.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/occupancy_grid_mapping_belief_factory.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+
+"""Belief factory for the occupancy-grid mapping POMDP.
+
+Both belief types this factory returns are the environment's own conditional
+whole-map filters. The generic bootstrap filter from ``get_initial_belief``
+is deliberately not offered: it draws a fresh scan per particle and compares
+it to the observed one, which has zero support for a continuous scan.
+
+Functions:
+    create_occupancy_grid_mapping_belief: Factory producing a configured belief.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_belief import (
+    OccupancyGridMappingBelief,
+)
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_beliefs.occupancy_grid_mapping_vectorized_belief import (
+    OccupancyGridMappingVectorizedBelief,
+)
+from POMDPPlanners.utils.belief_factory import BeliefType
+
+if TYPE_CHECKING:
+    from POMDPPlanners.core.belief.base_belief import Belief
+    from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_pomdp import (
+        OccupancyGridMappingPOMDP,
+    )
+
+_SUPPORTED_TYPES = {BeliefType.PARTICLE, BeliefType.VECTORIZED_PARTICLE}
+_DEFAULT_TYPE = BeliefType.VECTORIZED_PARTICLE
+
+
+def create_occupancy_grid_mapping_belief(
+    env: "OccupancyGridMappingPOMDP",
+    belief_type: BeliefType = _DEFAULT_TYPE,
+    n_particles: int = 30,
+) -> "Belief":
+    """Create a ready-to-use whole-map filter for the occupancy-grid mapping POMDP.
+
+    Args:
+        env: The environment instance.
+        belief_type: ``PARTICLE`` for the scalar filter, ``VECTORIZED_PARTICLE``
+            for the batched one. Defaults to ``VECTORIZED_PARTICLE``.
+        n_particles: Number of map hypotheses. Defaults to 30, the QA choice.
+
+    Returns:
+        A configured filter over fresh prior maps.
+
+    Raises:
+        ValueError: If ``belief_type`` is not one of the two particle types.
+    """
+    if belief_type not in _SUPPORTED_TYPES:
+        raise ValueError(
+            f"OccupancyGridMappingPOMDP does not support {belief_type}. "
+            f"Supported: {_SUPPORTED_TYPES}"
+        )
+    if belief_type == BeliefType.PARTICLE:
+        return OccupancyGridMappingBelief.initial(env, n_particles=n_particles)
+    return OccupancyGridMappingVectorizedBelief.initial(env, n_particles=n_particles)

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/occupancy_grid_mapping_vectorized_belief.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/occupancy_grid_mapping_vectorized_belief.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: MIT
+
+"""Vectorized whole-map filter for the occupancy-grid mapping POMDP.
+
+This is the batched twin of
+:class:`~POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_belief.OccupancyGridMappingBelief`.
+It keeps that filter's semantics exactly -- condition every particle on the
+observed scan, weight by the predictive density times the motion probability,
+no epsilon floor, no routine resampling, bounded prior replay on zero support
+-- and replaces its per-particle loops with the batched kernels of
+:class:`~.occupancy_grid_mapping_vectorized_updater.OccupancyGridMappingVectorizedUpdater`.
+
+The shared :class:`VectorizedWeightedParticleBelief` update runs predict then
+reweight. That cannot work here: a freshly drawn scan equals the observed
+one with probability zero, so every weight would be ``-inf``. ``update`` is
+therefore overridden to run the conditional cycle instead.
+
+Classes:
+    OccupancyGridMappingVectorizedBelief: Batched conditional whole-map filter.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any, Optional, cast
+
+import numpy as np
+
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.core.environment import Environment
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_beliefs.occupancy_grid_mapping_vectorized_updater import (
+    OccupancyGridMappingVectorizedUpdater,
+)
+from POMDPPlanners.utils.config_to_id import config_to_id
+
+if TYPE_CHECKING:
+    from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_pomdp import (
+        OccupancyGridMappingPOMDP,
+    )
+
+#: Fresh prior maps tested per replay attempt, and the number of attempts.
+#: Together they give the 4096-proposal bound the scalar filter documents.
+_REPLAY_BATCH = 512
+_REPLAY_ATTEMPTS = 8
+
+
+class OccupancyGridMappingVectorizedBelief(VectorizedWeightedParticleBelief):
+    """Weighted whole maps, conditioned on each observed scan in one batched call.
+
+    Same contract as the scalar ``OccupancyGridMappingBelief``: identical
+    particles, weights, history and restart count for the same seed. Routine
+    resampling is refused because it would drop the low-weight motion
+    hypotheses the filter exists to keep.
+
+    Attributes:
+        history: Every ``(action, observation)`` conditioned on so far, kept
+            for prior replay.
+        support_restarts: How many times support collapsed and was rebuilt.
+        pre_resample_ess: Effective sample size of the weights after the update.
+        update_seconds: Wall-clock time of the last update.
+        replay_proposals: Prior maps tested by the last update's replay, or 0.
+        updater: The batched kernels for the environment.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(0)
+        >>> from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
+        ...     OccupancyGridMappingPOMDP,
+        ... )
+        >>> env = OccupancyGridMappingPOMDP()
+        >>> belief = OccupancyGridMappingVectorizedBelief.initial(env, n_particles=8)
+        >>> _, observation, _ = env.sample_next_step(belief.sample(), 0)
+        >>> updated = belief.update(0, observation, env)
+        >>> updated.particles.shape
+        (8, 228)
+        >>> len(updated.history)
+        1
+    """
+
+    updater: OccupancyGridMappingVectorizedUpdater
+
+    # pylint: disable-next=too-many-arguments
+    def __init__(
+        self,
+        particles: Any,
+        log_weights: Any,
+        updater: OccupancyGridMappingVectorizedUpdater,
+        resampling: bool = False,
+        ess_factor: float = 0.5,
+        history: Any = (),
+        support_restarts: int = 0,
+    ):
+        """Initialize the filter.
+
+        Args:
+            particles: State array or list of shape ``(N, state_size)``.
+            log_weights: Log-weights of shape ``(N,)``. ``-inf`` is allowed;
+                at least one entry must be finite.
+            updater: The batched kernels for the environment.
+            resampling: Must be ``False``.
+            ess_factor: Kept for interface compatibility; resampling is off.
+            history: ``(action, observation)`` pairs already conditioned on.
+            support_restarts: Replay count carried over from earlier updates.
+
+        Raises:
+            ValueError: If resampling is requested or the weights have no
+                finite support.
+        """
+        if resampling:
+            raise ValueError(
+                "occupancy filter preserves support; routine resampling is unsupported"
+            )
+        weights = np.asarray(log_weights, dtype=np.float64)
+        if (
+            np.any(np.isnan(weights))
+            or np.any(np.isposinf(weights))
+            or not np.any(np.isfinite(weights))
+        ):
+            raise ValueError("weights need finite support and no NaN or positive infinity")
+        super().__init__(
+            np.asarray(particles, dtype=np.float64),
+            weights.copy(),
+            updater,
+            False,
+            ess_factor,
+        )
+        self.history = tuple((int(a), np.asarray(o, dtype=np.float64)) for a, o in history)
+        self.support_restarts = int(support_restarts)
+        self.pre_resample_ess = float(1.0 / np.sum(self.normalized_weights**2))
+        self.update_seconds = 0.0
+        self.replay_proposals = 0
+
+    @classmethod
+    def initial(
+        cls, environment: "OccupancyGridMappingPOMDP", n_particles: int = 30
+    ) -> "OccupancyGridMappingVectorizedBelief":
+        """Sample the whole-map prior without reading the true state.
+
+        Args:
+            environment: The environment whose prior and sensor to use.
+            n_particles: Number of map hypotheses. Defaults to 30.
+
+        Returns:
+            A uniformly weighted filter over fresh prior maps.
+        """
+        return cls(
+            np.asarray(environment.initial_state_dist().sample(int(n_particles))),
+            np.full(int(n_particles), -np.log(int(n_particles))),
+            OccupancyGridMappingVectorizedUpdater.from_environment(environment),
+        )
+
+    def to_dict(self) -> dict:
+        """Serialize everything but the updater, which is rebuilt from the environment."""
+        return {
+            "particles": self.particles.tolist(),
+            "log_weights": self.log_weights.tolist(),
+            "resampling": self.resampling,
+            "ess_factor": self.ess_factor,
+            "history": [(a, o.tolist()) for a, o in self.history],
+            "support_restarts": self.support_restarts,
+        }
+
+    @property
+    def config_id(self) -> str:
+        """Include the updater and replay history in cache identity."""
+        return config_to_id(
+            {
+                "type": type(self).__name__,
+                "version": 2,
+                "base": super().config_id,
+                "history": [(a, o.tolist()) for a, o in self.history],
+            }
+        )
+
+    def update(
+        self,
+        action: Any,
+        observation: Any,
+        pomdp: Optional[Environment] = None,
+        state: Optional[Any] = None,
+    ) -> "OccupancyGridMappingVectorizedBelief":
+        """Condition every particle on the observed scan; the true state is ignored.
+
+        Args:
+            action: The action taken.
+            observation: ``[row, col, heading, ranges...]``.
+            pomdp: The environment. Needed only when support collapses and
+                fresh prior maps must be drawn.
+            state: Ignored.
+
+        Returns:
+            The conditioned filter.
+
+        Raises:
+            RuntimeError: If support collapses and ``pomdp`` is not given, or
+                the bounded replay finds no map consistent with the history.
+        """
+        del state
+        started = time.perf_counter()
+        observation = np.asarray(observation, dtype=np.float64)
+        weights = self.log_weights + self.updater.batch_predictive_log_likelihood(
+            self.particles, action, observation
+        )
+        history = self.history + ((int(action), observation.copy()),)
+        restarts = self.support_restarts
+        replay_ess = None
+        proposals = 0
+        if not np.any(np.isfinite(weights)):
+            if pomdp is None:
+                raise RuntimeError(
+                    "occupancy whole-map particle support exhausted and no environment "
+                    "was given to draw fresh prior maps from"
+                )
+            particles, weights, replay_ess, proposals = self._replay_prior(
+                cast("OccupancyGridMappingPOMDP", pomdp), history
+            )
+            restarts += 1
+        else:
+            particles = self.updater.batch_state_from_observation(self.particles, observation)
+        result = type(self)(
+            particles,
+            weights,
+            self.updater,
+            False,
+            self.ess_factor,
+            history,
+            restarts,
+        )
+        if replay_ess is not None:
+            result.pre_resample_ess = replay_ess
+        result.update_seconds = time.perf_counter() - started
+        result.replay_proposals = proposals
+        return result
+
+    def _replay_prior(self, pomdp: "OccupancyGridMappingPOMDP", history):
+        """Restore support from the original prior; never change a hidden map to fit.
+
+        Draws the same candidates from the same global stream as the scalar
+        filter, so a seeded run gives the same replayed particles.
+        """
+        for attempt in range(_REPLAY_ATTEMPTS):
+            candidates = np.asarray(pomdp.initial_state_dist().sample(_REPLAY_BATCH))
+            weights = np.zeros(len(candidates))
+            for action, observation in history:
+                alive = np.flatnonzero(np.isfinite(weights))
+                if alive.size == 0:
+                    break
+                scores = self.updater.batch_predictive_log_likelihood(
+                    candidates[alive], action, observation
+                )
+                weights[alive] += scores
+                survivors = alive[np.isfinite(scores)]
+                if survivors.size:
+                    candidates[survivors] = self.updater.batch_state_from_observation(
+                        candidates[survivors], observation
+                    )
+            finite = np.isfinite(weights)
+            if np.any(finite):
+                probabilities = np.exp(weights - np.max(weights))
+                probabilities /= probabilities.sum()
+                indices = np.random.choice(len(candidates), len(self.particles), p=probabilities)
+                return (
+                    candidates[indices],
+                    np.full(len(indices), -np.log(len(indices))),
+                    float(1.0 / np.sum(probabilities**2)),
+                    (attempt + 1) * _REPLAY_BATCH,
+                )
+        raise RuntimeError(
+            "occupancy whole-map particle support exhausted after "
+            f"{_REPLAY_ATTEMPTS * _REPLAY_BATCH} prior proposals"
+        )

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/occupancy_grid_mapping_vectorized_updater.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/occupancy_grid_mapping_vectorized_updater.py
@@ -1,0 +1,626 @@
+# SPDX-License-Identifier: MIT
+
+"""Vectorized particle belief updater for the occupancy-grid mapping POMDP.
+
+The scalar filter in :mod:`..occupancy_grid_mapping_belief` calls the
+environment once per particle for the predictive score and once per particle
+for the map update. Both loops are pure array work over whole-map particles,
+so this module does them for all particles in one call:
+
+* :meth:`OccupancyGridMappingVectorizedUpdater.batch_predictive_log_likelihood`
+  casts one batched scan over every hidden map and scores the observed ranges
+  under the Gaussian range law and the exact motion probability. It is the
+  batched form of ``predictive_observation_log_probability``.
+* :meth:`OccupancyGridMappingVectorizedUpdater.batch_state_from_observation`
+  installs the observed pose and scan and applies the inverse sensor update.
+  The inverse-sensor delta depends only on the observation and the observed
+  pose, never on the hidden map, so it is computed once and added to every
+  particle. It is the batched form of ``state_from_observation``.
+
+The two methods of the shared updater interface are also implemented, as the
+batched forms of ``sample_next_state`` and ``observation_log_probability``:
+a generative transition that draws motion and a fresh Gaussian scan, and the
+point-mass likelihood on the stored scan. They make the updater a faithful
+batched copy of the environment's generative model, which is what the shared
+equivalence tests check. The conditional filter does not use them, because a
+freshly drawn scan matches the observed one with probability zero.
+
+Classes:
+    OccupancyGridMappingVectorizedUpdater: Batched updater for the environment.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, List, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
+    VectorizedParticleBeliefUpdater,
+)
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sensor import (
+    HEADING_STEPS,
+    NUM_HEADINGS,
+    build_ray_templates,
+    observed_scan_log_odds_delta,
+)
+from POMDPPlanners.utils.config_to_id import config_to_id
+
+if TYPE_CHECKING:
+    from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_pomdp import (
+        OccupancyGridMappingPOMDP,
+    )
+
+# State layout, duplicated from the environment module rather than imported
+# from it so this module does not import the environment at load time.
+_STEP_INDEX = 0
+_ROW_INDEX = 1
+_COL_INDEX = 2
+_HEADING_INDEX = 3
+_POSE_WIDTH = 4
+_FORWARD = 0
+_TURN_LEFT = 1
+_TURN_RIGHT = 2
+
+_HEADING_STEPS = np.asarray(HEADING_STEPS, dtype=np.int64)
+
+
+class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
+    """Batched motion, ray casting and inverse-sensor mapping over map particles.
+
+    Attributes:
+        num_rows: Grid rows.
+        num_cols: Grid columns.
+        num_beams: Beams per scan.
+        max_range_cells: Sensor range in cell widths.
+        range_noise_std_cells: Per-beam Gaussian range noise.
+        move_failure_probability: Chance an otherwise-valid forward move fails.
+
+    Example:
+        >>> import numpy as np
+        >>> np.random.seed(0)
+        >>> from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
+        ...     OccupancyGridMappingPOMDP,
+        ... )
+        >>> env = OccupancyGridMappingPOMDP()
+        >>> updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        >>> particles = np.asarray(env.initial_state_dist().sample(8))
+        >>> successor = env.sample_next_state(particles[0], 0)
+        >>> observation = env.sample_observation(successor, 0)
+        >>> updater.batch_predictive_log_likelihood(particles, 0, observation).shape
+        (8,)
+        >>> updater.batch_state_from_observation(particles, observation).shape
+        (8, 228)
+    """
+
+    # pylint: disable-next=too-many-arguments
+    def __init__(
+        self,
+        num_rows: int,
+        num_cols: int,
+        num_beams: int,
+        field_of_view_degrees: float,
+        max_range_cells: float,
+        range_noise_std_cells: float,
+        free_log_odds: float,
+        occupied_log_odds: float,
+        log_odds_clamp: float,
+        move_failure_probability: float,
+        sensor_contract_version: int = 2,
+    ):
+        """Initialize the updater from the environment's sensor and motion settings.
+
+        Args:
+            num_rows: Grid rows.
+            num_cols: Grid columns.
+            num_beams: Beams per scan.
+            field_of_view_degrees: Angular width of the fan, centred on the heading.
+            max_range_cells: Sensor range in cell widths.
+            range_noise_std_cells: Per-beam Gaussian range noise. Must be positive.
+            free_log_odds: Increment for a cell a beam passes through. Negative.
+            occupied_log_odds: Increment for the cell a beam stops in. Positive.
+            log_odds_clamp: Symmetric bound on accumulated log-odds.
+            move_failure_probability: Chance an otherwise-valid forward move fails.
+            sensor_contract_version: The environment's sensor contract version,
+                carried into the identifier so a contract change invalidates caches.
+
+        Raises:
+            ValueError: If ``range_noise_std_cells`` is not positive.
+        """
+        if range_noise_std_cells <= 0.0:
+            raise ValueError(f"range_noise_std_cells must be positive, got {range_noise_std_cells}")
+        self.num_rows = int(num_rows)
+        self.num_cols = int(num_cols)
+        self.num_beams = int(num_beams)
+        self.field_of_view_degrees = float(field_of_view_degrees)
+        self.max_range_cells = float(max_range_cells)
+        self.range_noise_std_cells = float(range_noise_std_cells)
+        self.free_log_odds = float(free_log_odds)
+        self.occupied_log_odds = float(occupied_log_odds)
+        self.log_odds_clamp = float(log_odds_clamp)
+        self.move_failure_probability = float(move_failure_probability)
+        self.sensor_contract_version = int(sensor_contract_version)
+
+        self.num_cells = self.num_rows * self.num_cols
+        self.map_offset = _POSE_WIDTH
+        self.log_odds_offset = _POSE_WIDTH + self.num_cells
+        self.scan_offset = _POSE_WIDTH + 2 * self.num_cells
+        self.state_size = self.scan_offset + self.num_beams
+        self._log_norm = -self.num_beams * np.log(self.range_noise_std_cells * np.sqrt(2 * np.pi))
+        self._ray_templates = build_ray_templates(
+            num_beams=self.num_beams,
+            field_of_view_degrees=self.field_of_view_degrees,
+            max_range_cells=self.max_range_cells,
+        )
+
+    @classmethod
+    def from_environment(
+        cls, env: "OccupancyGridMappingPOMDP"
+    ) -> "OccupancyGridMappingVectorizedUpdater":
+        """Construct an updater that matches ``env``'s sensor and motion model.
+
+        Args:
+            env: The environment to copy the settings from.
+
+        Returns:
+            A new updater.
+        """
+        return cls(
+            num_rows=env.num_rows,
+            num_cols=env.num_cols,
+            num_beams=env.num_beams,
+            field_of_view_degrees=env.field_of_view_degrees,
+            max_range_cells=env.max_range_cells,
+            range_noise_std_cells=env.range_noise_std_cells,
+            free_log_odds=env.free_log_odds,
+            occupied_log_odds=env.occupied_log_odds,
+            log_odds_clamp=env.log_odds_clamp,
+            move_failure_probability=env.move_failure_probability,
+            sensor_contract_version=env.sensor_contract_version,
+        )
+
+    # ------------------------------------------------------------------
+    # Conditional filter kernels
+    # ------------------------------------------------------------------
+
+    def batch_predictive_log_likelihood(
+        self, particles: np.ndarray, action: int, observation: np.ndarray
+    ) -> np.ndarray:
+        """Score ``p(observation | particle, action)`` for every particle.
+
+        Integrates the discrete motion outcomes and scores the observed ranges
+        under the Gaussian range law of each particle's hidden map, before the
+        observation is stored. Matches the environment's scalar
+        ``predictive_observation_log_probability`` particle by particle.
+
+        Args:
+            particles: State array of shape ``(N, state_size)``.
+            action: The action taken.
+            observation: ``[row, col, heading, ranges...]``.
+
+        Returns:
+            Log-scores of shape ``(N,)``. ``-inf`` where the observed pose is
+            unreachable from the particle, or for a malformed observation.
+        """
+        particles = np.asarray(particles, dtype=np.float64)
+        observation = np.asarray(observation, dtype=np.float64)
+        count = particles.shape[0]
+        if observation.shape != (3 + self.num_beams,) or not np.all(np.isfinite(observation)):
+            return np.full(count, -np.inf)
+        maps = self._maps(particles)
+        scores = np.full(count, -np.inf)
+        for rows, cols, headings, probabilities in self._motion_outcomes(particles, action):
+            matched = (
+                (probabilities > 0.0)
+                & (rows.astype(np.float64) == observation[0])
+                & (cols.astype(np.float64) == observation[1])
+                & (headings.astype(np.float64) == observation[2])
+            )
+            if not np.any(matched):
+                continue
+            index = np.flatnonzero(matched)
+            nominal = self._nominal_scans(maps[index], rows[index], cols[index], headings[index])
+            residual = (observation[3:][None, :] - nominal) / self.range_noise_std_cells
+            log_density = -0.5 * np.sum(residual**2, axis=1) + self._log_norm
+            scores[index] = np.logaddexp(scores[index], np.log(probabilities[index]) + log_density)
+        return scores
+
+    def batch_state_from_observation(
+        self, particles: np.ndarray, observation: np.ndarray
+    ) -> np.ndarray:
+        """Install the observed pose and scan and apply the map update to every particle.
+
+        Matches the environment's scalar ``state_from_observation`` particle by
+        particle, including its validation.
+
+        Args:
+            particles: State array of shape ``(N, state_size)``.
+            observation: ``[row, col, heading, ranges...]``.
+
+        Returns:
+            Successor array of shape ``(N, state_size)``.
+
+        Raises:
+            ValueError: If the observation is malformed or its pose is not an
+                in-grid integer pose.
+        """
+        particles = np.asarray(particles, dtype=np.float64)
+        observation = np.asarray(observation, dtype=np.float64)
+        if observation.shape != (3 + self.num_beams,) or not np.all(np.isfinite(observation)):
+            raise ValueError("observation must contain finite pose and ranges")
+        row, col, heading = observation[:3]
+        if (
+            not np.array_equal(observation[:3], np.round(observation[:3]))
+            or not 0 <= row < self.num_rows
+            or not 0 <= col < self.num_cols
+            or not 0 <= heading < NUM_HEADINGS
+        ):
+            raise ValueError("observation pose must be an in-grid integer pose")
+        row, col, heading = int(row), int(col), int(heading)
+        delta = observed_scan_log_odds_delta(
+            observation[3:],
+            self._ray_templates[heading],
+            row,
+            col,
+            self.num_rows,
+            self.num_cols,
+            self.max_range_cells,
+            self.free_log_odds,
+            self.occupied_log_odds,
+        )
+        delta[row * self.num_cols + col] += self.free_log_odds
+        return self._install(
+            particles, observation[None, :3], observation[None, 3:], delta[None, :]
+        )
+
+    def batch_expected_reward(
+        self,
+        particles: np.ndarray,
+        action: int,
+        noise_points: np.ndarray,
+        step_cost: float,
+    ) -> np.ndarray:
+        """Expected entropy reduction of one step from every particle, minus the step cost.
+
+        The batched form of the environment's ``reward`` without a successor:
+        for each motion outcome and each fixed noise point, install the noisy
+        nominal scan and measure the map entropy afterwards, then average.
+        Every hypothetical scan of every particle goes through one batched
+        inverse-sensor call, so the cost is a handful of array operations
+        rather than ``N * len(noise_points)`` environment calls.
+
+        Args:
+            particles: State array of shape ``(N, state_size)``.
+            action: The action taken.
+            noise_points: ``(K, num_beams)`` unit-variance integration points.
+            step_cost: Constant charge per step.
+
+        Returns:
+            Expected rewards of shape ``(N,)``.
+        """
+        particles = np.asarray(particles, dtype=np.float64)
+        noise_points = np.asarray(noise_points, dtype=np.float64)
+        count = particles.shape[0]
+        num_points = noise_points.shape[0]
+        end = self.log_odds_offset + self.num_cells
+        log_odds = particles[:, self.log_odds_offset : end]
+        before = self.entropy_bits_rows(log_odds)
+        maps = self._maps(particles)
+        after = np.zeros(count)
+        for rows, cols, headings, probabilities in self._motion_outcomes(particles, action):
+            live = np.flatnonzero(probabilities > 0.0)
+            if live.size == 0:
+                continue
+            nominal = self._nominal_scans(maps[live], rows[live], cols[live], headings[live])
+            # Lay the K noisy scans of each particle out as K * n independent
+            # particles, so one inverse-sensor call covers all of them.
+            ranges = (
+                nominal[None, :, :] + self.range_noise_std_cells * noise_points[:, None, :]
+            ).reshape(num_points * len(live), self.num_beams)
+            deltas = self._scan_deltas(
+                ranges,
+                np.tile(rows[live], num_points),
+                np.tile(cols[live], num_points),
+                np.tile(headings[live], num_points),
+            )
+            updated = np.clip(
+                np.tile(log_odds[live], (num_points, 1)) + deltas,
+                -self.log_odds_clamp,
+                self.log_odds_clamp,
+            )
+            entropies = self.entropy_bits_rows(updated).reshape(num_points, len(live))
+            after[live] += probabilities[live] * entropies.sum(axis=0)
+        return before - after / num_points - float(step_cost)
+
+    @staticmethod
+    def entropy_bits_rows(log_odds: np.ndarray) -> np.ndarray:
+        """Summed binary entropy of each row of log-odds, in bits.
+
+        Same numerics as the scalar ``grid_entropy_bits``: stable sigmoid,
+        probabilities clipped away from 0 and 1, base-2 logs.
+        """
+        values = np.asarray(log_odds, dtype=np.float64)
+        positive = values >= 0.0
+        exp_negative_abs = np.exp(-np.abs(values))
+        probability = np.where(
+            positive, 1.0 / (1.0 + exp_negative_abs), exp_negative_abs / (1.0 + exp_negative_abs)
+        )
+        clipped = np.clip(probability, 1e-12, 1.0 - 1e-12)
+        per_cell = -(clipped * np.log2(clipped) + (1.0 - clipped) * np.log2(1.0 - clipped))
+        return per_cell.sum(axis=-1)
+
+    # ------------------------------------------------------------------
+    # VectorizedParticleBeliefUpdater interface (generative model)
+    # ------------------------------------------------------------------
+
+    def batch_transition(self, particles: np.ndarray, action: Any) -> np.ndarray:
+        """Draw motion and a fresh Gaussian scan for every particle, then map it.
+
+        The batched form of the environment's ``sample_next_state``. Draws from
+        the global NumPy stream: one uniform per particle that has two motion
+        outcomes, then ``(N, num_beams)`` normals.
+
+        Args:
+            particles: State array of shape ``(N, state_size)``.
+            action: The action taken, as an int or a 0-d array.
+
+        Returns:
+            Successor array of shape ``(N, state_size)``.
+        """
+        particles = np.asarray(particles, dtype=np.float64)
+        count = particles.shape[0]
+        outcomes = self._motion_outcomes(particles, action)
+        rows, cols, headings, _ = outcomes[0]
+        if len(outcomes) == 2:
+            stay_rows, stay_cols, stay_headings, stay_probabilities = outcomes[1]
+            uncertain = stay_probabilities > 0.0
+            if np.any(uncertain):
+                draws = np.random.random(int(np.count_nonzero(uncertain)))
+                stay = np.zeros(count, dtype=bool)
+                stay[uncertain] = draws >= 1.0 - stay_probabilities[uncertain]
+                rows = np.where(stay, stay_rows, rows)
+                cols = np.where(stay, stay_cols, cols)
+                headings = np.where(stay, stay_headings, headings)
+        nominal = self._nominal_scans(self._maps(particles), rows, cols, headings)
+        ranges = nominal + np.random.normal(
+            0.0, self.range_noise_std_cells, (count, self.num_beams)
+        )
+        poses = np.stack([rows, cols, headings], axis=1).astype(np.float64)
+        delta = self._scan_deltas(ranges, rows, cols, headings)
+        return self._install(particles, poses, ranges, delta)
+
+    def batch_observation_log_likelihood(
+        self, next_particles: np.ndarray, action: Any, observation: np.ndarray
+    ) -> np.ndarray:
+        """Point mass on each particle's exact pose and stored scan.
+
+        The batched form of the environment's ``observation_log_probability``.
+
+        Args:
+            next_particles: Successor array of shape ``(N, state_size)``.
+            action: Unused; the observation depends only on the successor.
+            observation: ``[row, col, heading, ranges...]``.
+
+        Returns:
+            ``0.0`` where the observation equals the particle's revealed
+            reading, ``-inf`` elsewhere. Shape ``(N,)``.
+        """
+        del action
+        next_particles = np.asarray(next_particles, dtype=np.float64)
+        observation = np.asarray(observation, dtype=np.float64)
+        count = next_particles.shape[0]
+        if observation.shape != (3 + self.num_beams,):
+            return np.full(count, -np.inf)
+        rows, cols, headings = self._poses(next_particles)
+        expected = np.concatenate(
+            [
+                np.stack([rows, cols, headings], axis=1).astype(np.float64),
+                next_particles[:, self.scan_offset :],
+            ],
+            axis=1,
+        )
+        return np.where(np.all(expected == observation[None, :], axis=1), 0.0, -np.inf)
+
+    @property
+    def config_id(self) -> str:
+        """Deterministic identifier of the sensor and motion settings."""
+        return config_to_id(
+            {
+                "class": type(self).__name__,
+                "num_rows": self.num_rows,
+                "num_cols": self.num_cols,
+                "num_beams": self.num_beams,
+                "field_of_view_degrees": self.field_of_view_degrees,
+                "max_range_cells": self.max_range_cells,
+                "range_noise_std_cells": self.range_noise_std_cells,
+                "free_log_odds": self.free_log_odds,
+                "occupied_log_odds": self.occupied_log_odds,
+                "log_odds_clamp": self.log_odds_clamp,
+                "move_failure_probability": self.move_failure_probability,
+                "sensor_contract_version": self.sensor_contract_version,
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Batched geometry
+    # ------------------------------------------------------------------
+
+    def _maps(self, particles: np.ndarray) -> np.ndarray:
+        """The hidden true maps as an ``(N, num_rows, num_cols)`` view."""
+        return particles[:, self.map_offset : self.map_offset + self.num_cells].reshape(
+            particles.shape[0], self.num_rows, self.num_cols
+        )
+
+    @staticmethod
+    def _poses(particles: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Integer ``(rows, cols, headings)`` of every particle, rounded like ``pose``."""
+        rows = np.rint(particles[:, _ROW_INDEX]).astype(np.int64)
+        cols = np.rint(particles[:, _COL_INDEX]).astype(np.int64)
+        headings = np.rint(particles[:, _HEADING_INDEX]).astype(np.int64) % NUM_HEADINGS
+        return rows, cols, headings
+
+    def _next_poses(
+        self,
+        rows: np.ndarray,
+        cols: np.ndarray,
+        headings: np.ndarray,
+        action: int,
+        maps: np.ndarray,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Where each particle's robot ends up, and whether a forward move was blocked."""
+        action = int(action)
+        count = rows.shape[0]
+        if action == _TURN_LEFT:
+            return rows, cols, (headings - 1) % NUM_HEADINGS, np.zeros(count, dtype=bool)
+        if action == _TURN_RIGHT:
+            return rows, cols, (headings + 1) % NUM_HEADINGS, np.zeros(count, dtype=bool)
+        steps = _HEADING_STEPS[headings]
+        target_rows = rows + steps[:, 0]
+        target_cols = cols + steps[:, 1]
+        inside = (
+            (target_rows >= 0)
+            & (target_rows < self.num_rows)
+            & (target_cols >= 0)
+            & (target_cols < self.num_cols)
+        )
+        safe_rows = np.where(inside, target_rows, 0)
+        safe_cols = np.where(inside, target_cols, 0)
+        occupied = maps[np.arange(count), safe_rows, safe_cols] != 0
+        blocked = ~inside | occupied
+        return (
+            np.where(blocked, rows, target_rows),
+            np.where(blocked, cols, target_cols),
+            headings,
+            blocked,
+        )
+
+    def _motion_outcomes(
+        self, particles: np.ndarray, action: int
+    ) -> List[Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]]:
+        """Per-particle motion outcomes as ``(rows, cols, headings, probabilities)``.
+
+        The first entry is the attempted pose; a second entry, present only when
+        moves can fail, is the pose the robot keeps on failure. A particle whose
+        robot did not move has probability 1 on the first entry and 0 on the
+        second, which matches the scalar environment's single-outcome case.
+        """
+        rows, cols, headings = self._poses(particles)
+        next_rows, next_cols, next_headings, _ = self._next_poses(
+            rows, cols, headings, action, self._maps(particles)
+        )
+        if self.move_failure_probability <= 0.0:
+            return [(next_rows, next_cols, next_headings, np.ones(rows.shape[0]))]
+        moved = (next_rows != rows) | (next_cols != cols)
+        failure = np.where(moved, self.move_failure_probability, 0.0)
+        return [
+            (next_rows, next_cols, next_headings, 1.0 - failure),
+            (rows, cols, headings, failure),
+        ]
+
+    def _nominal_scans(
+        self, maps: np.ndarray, rows: np.ndarray, cols: np.ndarray, headings: np.ndarray
+    ) -> np.ndarray:
+        """Noise-free ranges from each particle's pose against its own map.
+
+        The batched form of ``cast_scan``, grouped by heading because each
+        heading has its own ray template.
+        """
+        count = maps.shape[0]
+        ranges = np.full((count, self.num_beams), self.max_range_cells, dtype=np.float64)
+        for heading in np.unique(headings):
+            index = np.flatnonzero(headings == heading)
+            offsets, template_ranges = self._ray_templates[int(heading)]
+            length = offsets.shape[1]
+            ray_rows = offsets[None, :, :, 0] + rows[index, None, None]
+            ray_cols = offsets[None, :, :, 1] + cols[index, None, None]
+            inside = (
+                (ray_rows >= 0)
+                & (ray_rows < self.num_rows)
+                & (ray_cols >= 0)
+                & (ray_cols < self.num_cols)
+            )
+            safe_rows = np.where(inside, ray_rows, 0)
+            safe_cols = np.where(inside, ray_cols, 0)
+            occupied = (maps[index[:, None, None], safe_rows, safe_cols] != 0) & inside
+            stops = occupied | ~inside
+            any_stop = stops.any(axis=2)
+            stop_slot = np.where(any_stop, np.argmax(stops, axis=2), length)
+            clipped = np.minimum(stop_slot, length - 1)
+            hit = any_stop & np.take_along_axis(occupied, clipped[:, :, None], axis=2)[:, :, 0]
+            hit_ranges = np.take_along_axis(
+                np.broadcast_to(template_ranges[None], (len(index), self.num_beams, length)),
+                clipped[:, :, None],
+                axis=2,
+            )[:, :, 0]
+            ranges[index] = np.where(hit, hit_ranges, self.max_range_cells)
+        return ranges
+
+    def _scan_deltas(
+        self, observed_ranges: np.ndarray, rows: np.ndarray, cols: np.ndarray, headings: np.ndarray
+    ) -> np.ndarray:
+        """Per-particle inverse-sensor increments for per-particle readings.
+
+        The batched form of ``observed_scan_log_odds_delta`` plus the free
+        evidence on the robot's own cell, used by the generative transition
+        where every particle has its own scan.
+        """
+        count = observed_ranges.shape[0]
+        deltas = np.zeros((count, self.num_cells), dtype=np.float64)
+        slot_offsets = np.arange(count) * self.num_cells
+        for heading in np.unique(headings):
+            index = np.flatnonzero(headings == heading)
+            offsets, distances = self._ray_templates[int(heading)]
+            length = distances.shape[1]
+            ray_rows = offsets[None, :, :, 0] + rows[index, None, None]
+            ray_cols = offsets[None, :, :, 1] + cols[index, None, None]
+            valid = (
+                (ray_rows >= 0)
+                & (ray_rows < self.num_rows)
+                & (ray_cols >= 0)
+                & (ray_cols < self.num_cols)
+                & np.isfinite(distances)[None]
+            )
+            valid = np.logical_and.accumulate(valid, axis=2)
+            has_cell = valid.any(axis=2)
+            gaps = np.abs(distances[None] - observed_ranges[index][:, :, None])
+            nearest = np.argmin(np.where(valid, gaps, np.inf), axis=2)
+            hit = (observed_ranges[index] < self.max_range_cells) & has_cell
+            slots = np.arange(length)[None, None, :]
+            free = valid & ((slots < nearest[:, :, None]) | ~hit[:, :, None])
+            occupied = valid & (slots == nearest[:, :, None]) & hit[:, :, None]
+            flat = ray_rows * self.num_cols + ray_cols + slot_offsets[index][:, None, None]
+            deltas += (
+                np.bincount(flat[free], minlength=count * self.num_cells).reshape(
+                    count, self.num_cells
+                )
+                * self.free_log_odds
+            )
+            deltas += (
+                np.bincount(flat[occupied], minlength=count * self.num_cells).reshape(
+                    count, self.num_cells
+                )
+                * self.occupied_log_odds
+            )
+        deltas[np.arange(count), rows * self.num_cols + cols] += self.free_log_odds
+        return deltas
+
+    def _install(
+        self, particles: np.ndarray, poses: np.ndarray, ranges: np.ndarray, deltas: np.ndarray
+    ) -> np.ndarray:
+        """Advance the step, write pose and scan, and accumulate clamped log-odds.
+
+        ``poses``, ``ranges`` and ``deltas`` broadcast over the particle axis,
+        so one observation shared by every particle and one per particle both
+        go through here.
+        """
+        successors = particles.copy()
+        successors[:, _STEP_INDEX] += 1
+        successors[:, _ROW_INDEX : _ROW_INDEX + 3] = poses
+        successors[:, self.scan_offset :] = ranges
+        end = self.log_odds_offset + self.num_cells
+        successors[:, self.log_odds_offset : end] = np.clip(
+            successors[:, self.log_odds_offset : end] + deltas,
+            -self.log_odds_clamp,
+            self.log_odds_clamp,
+        )
+        return successors

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_pomdp.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_pomdp.py
@@ -18,7 +18,8 @@ The map is an approximate independent-cell inverse estimate. Its entropy is
 not the entropy of the posterior over whole maps. Realised reward and completion use the observed inverse map. Planning
 without a successor uses fixed Gaussian integration of its expected reduction. Repeated correlated beams can create false
 confidence. The separate whole-map particle belief predicts scans and motion.
-Use OccupancyGridMappingBelief to condition the augmented state correctly.
+Use OccupancyGridMappingBelief, or its batched twin in the
+occupancy_grid_mapping_beliefs package, to condition the augmented state correctly.
 
 Integer pose and three actions are a chosen simplification. Particle-based
 MCTS also supports continuous states; it does not require this discretization.
@@ -657,6 +658,69 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
                 )
         return self.entropy_bits(state) - after / len(self._reward_noise) - self.step_cost
 
+    def reward_batch(self, states, action, next_states=None):
+        """Batched :meth:`reward`: one array pass instead of one call per state.
+
+        A belief-space planner asks for the expected reward of every particle
+        at every node it expands, and without a successor each scalar call
+        integrates eight hypothetical scans. Doing all particles and all
+        integration points in one batched inverse-sensor call is what makes
+        the planner's decision time drop; the values are the scalar ones.
+
+        Args:
+            states: Sequence of ``N`` states.
+            action: Action executed from each state.
+            next_states: Optional realised successors, length ``N``.
+
+        Returns:
+            Rewards of shape ``(N,)``.
+        """
+        states = np.asarray(states, dtype=np.float64).reshape(-1, self.state_size)
+        kernels = self._batched_kernels
+        if next_states is not None:
+            successors = np.asarray(next_states, dtype=np.float64).reshape(-1, self.state_size)
+            end = self.log_odds_offset + self.num_cells
+            return (
+                kernels.entropy_bits_rows(states[:, self.log_odds_offset : end])
+                - kernels.entropy_bits_rows(successors[:, self.log_odds_offset : end])
+                - self.step_cost
+            )
+        return kernels.batch_expected_reward(states, action, self._reward_noise, self.step_cost)
+
+    @property
+    def _batched_kernels(self):
+        """The batched sensor and motion kernels, built on first use.
+
+        Underscored and lazily built for the same reason as the ray templates:
+        a pure function of settings already in the identity, and not worth
+        shipping to every worker.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_beliefs.occupancy_grid_mapping_vectorized_updater import (  # noqa: E501
+            OccupancyGridMappingVectorizedUpdater,
+        )
+
+        # Keyed on the settings so a test that edits one after construction
+        # gets kernels that match, not a stale copy.
+        key = (
+            self.num_rows,
+            self.num_cols,
+            self.num_beams,
+            self.field_of_view_degrees,
+            self.max_range_cells,
+            self.range_noise_std_cells,
+            self.free_log_odds,
+            self.occupied_log_odds,
+            self.log_odds_clamp,
+            self.move_failure_probability,
+            self.sensor_contract_version,
+        )
+        cached = vars(self).get("_batched_kernels_cache")
+        if cached is None or cached[0] != key:
+            cached = (key, OccupancyGridMappingVectorizedUpdater.from_environment(self))
+            vars(self)["_batched_kernels_cache"] = cached
+        return cached[1]
+
     # -- terminal / initial ---------------------------------------------
 
     def is_terminal(self, state: OccupancyGridState) -> bool:
@@ -834,13 +898,14 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
     # -- pickling -------------------------------------------------------
 
     def __getstate__(self) -> Dict[str, Any]:
-        """Drop the ray templates before pickling.
+        """Drop the ray templates and the batched kernels before pickling.
 
-        They are a derived read-only artifact rebuilt in milliseconds, and this
+        Both are derived read-only artifacts rebuilt in milliseconds, and this
         environment is shipped to every parallel worker once per task.
         """
         state = self.__dict__.copy()
         state["_ray_templates"] = None
+        state.pop("_batched_kernels_cache", None)
         return state
 
     def __setstate__(self, state: Dict[str, Any]) -> None:

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/__init__.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the occupancy-grid mapping belief implementations."""

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/benchmark_occupancy_grid_mapping_vectorized_belief.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/benchmark_occupancy_grid_mapping_vectorized_belief.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: MIT
+
+"""Benchmark: PFT-DPW on occupancy-grid mapping with the scalar vs the vectorized filter.
+
+Two comparisons, both run through ``LocalSimulationsAPI`` so the cache, the
+per-episode records and the seeding are the production ones:
+
+* **Fixed work.** PFT-DPW with a fixed simulation count per decision. The
+  decision time and the belief-update time are read from each episode's
+  history; their ratio is the speed-up.
+* **Fixed time.** PFT-DPW with the QA time budget per decision. The number of
+  simulations a decision completes (``root_visit_count``) is the throughput;
+  return and completion say whether the extra search bought anything.
+
+Episodes are seeded from the environment name, the policy name and the
+episode index, so both filters face the same worlds. The search itself still
+draws its own randomness, so trajectories differ.
+
+Run manually, for example::
+
+    python -m POMDPPlanners.tests.test_environments.test_occupancy_grid_mapping_pomdp\
+.test_occupancy_grid_mapping_beliefs.benchmark_occupancy_grid_mapping_vectorized_belief \
+        --episodes 5 --n-simulations 200 --time-out 1
+
+Results go under ``results/`` and are never committed.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+
+from POMDPPlanners.core.simulation import EnvironmentRunParams
+from POMDPPlanners.core.simulation.history import history_to_discounted_return_value
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
+    OccupancyGridMappingPOMDP,
+)
+from POMDPPlanners.planners.mcts_planners.pft_dpw import PFT_DPW
+from POMDPPlanners.simulations.simulation_apis.local_simulations_api import (
+    LocalSimulationsAPI,
+)
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    occupancy_grid_mapping_pinned_kwargs,
+)
+from POMDPPlanners.tests.test_utils.env_qa_planner_configs import (
+    occupancy_grid_mapping_qa_belief_particles,
+    occupancy_grid_mapping_qa_pft_dpw_kwargs,
+)
+from POMDPPlanners.utils.action_samplers import DiscreteActionSampler
+from POMDPPlanners.utils.belief_factory import BeliefType, create_environment_belief
+from POMDPPlanners.utils.tree_statistics import TreeMetrics
+
+BELIEF_TYPES = {
+    "scalar": BeliefType.PARTICLE,
+    "vectorized": BeliefType.VECTORIZED_PARTICLE,
+}
+
+
+def _planner(env: OccupancyGridMappingPOMDP, **overrides) -> PFT_DPW:
+    kwargs = occupancy_grid_mapping_qa_pft_dpw_kwargs(**overrides)
+    return PFT_DPW(
+        environment=env,
+        discount_factor=env.discount_factor,
+        name="PFT_DPW",
+        action_sampler=DiscreteActionSampler(env.get_actions()),
+        **kwargs,
+    )
+
+
+def _summarize(histories) -> Dict[str, float]:
+    """Per-episode means of the timing, throughput and outcome fields."""
+    visits: List[float] = []
+    for history in histories:
+        for run_data in history.policy_run_data:
+            for variable in run_data.info_variables:
+                if variable.name == TreeMetrics.ROOT_VISIT_COUNT.value:
+                    visits.append(float(variable.value))
+    return {
+        "decision_s": float(np.mean([h.average_action_time for h in histories])),
+        "belief_update_s": float(np.mean([h.average_belief_update_time for h in histories])),
+        "reward_s": float(np.mean([h.average_reward_time for h in histories])),
+        "simulations_per_decision": float(np.mean(visits)) if visits else float("nan"),
+        "steps": float(np.mean([h.actual_num_steps for h in histories])),
+        "discounted_return": float(
+            np.mean([history_to_discounted_return_value(h) for h in histories])
+        ),
+    }
+
+
+def _run(
+    label: str,
+    belief_type: BeliefType,
+    episodes: int,
+    n_jobs: int,
+    results_dir: Path,
+    **planner_overrides,
+) -> Dict[str, float]:
+    env = OccupancyGridMappingPOMDP(discount_factor=0.95, **occupancy_grid_mapping_pinned_kwargs())
+    np.random.seed(0)
+    belief = create_environment_belief(
+        env, belief_type, n_particles=occupancy_grid_mapping_qa_belief_particles()
+    )
+    params = EnvironmentRunParams(
+        environment=env,
+        belief=belief,
+        policies=[_planner(env, **planner_overrides)],
+        num_episodes=episodes,
+        num_steps=env.max_steps,
+    )
+    results, _ = LocalSimulationsAPI().run_multiple_environments_and_policies(
+        environment_run_params=[params],
+        alpha=0.05,
+        confidence_interval_level=0.95,
+        experiment_name=f"occupancy_belief_benchmark_{label}",
+        n_jobs=n_jobs,
+        cache_dir_path=results_dir / label,
+    )
+    histories = [h for policies in results.values() for hs in policies.values() for h in hs]
+    return _summarize(histories)
+
+
+def _print_table(title: str, rows: Dict[str, Dict[str, float]]) -> None:
+    keys = list(next(iter(rows.values())).keys())
+    print(f"\n--- {title} ---")
+    print(f"{'belief':>12} | " + " | ".join(f"{k:>24}" for k in keys))
+    for label, values in rows.items():
+        print(f"{label:>12} | " + " | ".join(f"{values[k]:>24.4f}" for k in keys))
+    if {"scalar", "vectorized"} <= rows.keys():
+        scalar, vectorized = rows["scalar"], rows["vectorized"]
+        print(
+            f"speed-up: decision x{scalar['decision_s'] / vectorized['decision_s']:.2f}, "
+            f"belief update x{scalar['belief_update_s'] / vectorized['belief_update_s']:.2f}, "
+            f"simulations per decision x"
+            f"{vectorized['simulations_per_decision'] / scalar['simulations_per_decision']:.2f}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--episodes", type=int, default=5)
+    parser.add_argument("--n-simulations", type=int, default=200)
+    parser.add_argument("--time-out", type=int, default=1)
+    parser.add_argument("--n-jobs", type=int, default=1)
+    parser.add_argument(
+        "--results-dir", type=Path, default=Path("results") / "occupancy_belief_benchmark"
+    )
+    parser.add_argument(
+        "--skip-fixed-time", action="store_true", help="Run only the fixed-work comparison."
+    )
+    args = parser.parse_args()
+
+    fixed_work = {
+        label: _run(
+            f"fixed_work_{label}",
+            belief_type,
+            args.episodes,
+            args.n_jobs,
+            args.results_dir,
+            n_simulations=args.n_simulations,
+            time_out_in_seconds=None,
+        )
+        for label, belief_type in BELIEF_TYPES.items()
+    }
+    _print_table(f"fixed work: {args.n_simulations} simulations per decision", fixed_work)
+
+    if not args.skip_fixed_time:
+        fixed_time = {
+            label: _run(
+                f"fixed_time_{label}",
+                belief_type,
+                args.episodes,
+                args.n_jobs,
+                args.results_dir,
+                time_out_in_seconds=args.time_out,
+            )
+            for label, belief_type in BELIEF_TYPES.items()
+        }
+        _print_table(f"fixed time: {args.time_out}s per decision", fixed_time)
+
+
+if __name__ == "__main__":
+    main()

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/benchmark_occupancy_grid_mapping_vectorized_belief.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/benchmark_occupancy_grid_mapping_vectorized_belief.py
@@ -90,19 +90,18 @@ def _summarize(histories) -> Dict[str, float]:
     }
 
 
-def _run(
+def _run(  # pylint: disable=too-many-arguments
     label: str,
     belief_type: BeliefType,
     episodes: int,
     n_jobs: int,
     results_dir: Path,
+    n_particles: int,
     **planner_overrides,
 ) -> Dict[str, float]:
     env = OccupancyGridMappingPOMDP(discount_factor=0.95, **occupancy_grid_mapping_pinned_kwargs())
     np.random.seed(0)
-    belief = create_environment_belief(
-        env, belief_type, n_particles=occupancy_grid_mapping_qa_belief_particles()
-    )
+    belief = create_environment_belief(env, belief_type, n_particles=n_particles)
     params = EnvironmentRunParams(
         environment=env,
         belief=belief,
@@ -145,6 +144,12 @@ def main() -> None:
     parser.add_argument("--time-out", type=int, default=1)
     parser.add_argument("--n-jobs", type=int, default=1)
     parser.add_argument(
+        "--particles",
+        type=int,
+        default=occupancy_grid_mapping_qa_belief_particles(),
+        help="Map particles per belief. Defaults to the QA setting.",
+    )
+    parser.add_argument(
         "--results-dir", type=Path, default=Path("results") / "occupancy_belief_benchmark"
     )
     parser.add_argument(
@@ -154,31 +159,38 @@ def main() -> None:
 
     fixed_work = {
         label: _run(
-            f"fixed_work_{label}",
+            f"fixed_work_{label}_{args.particles}p",
             belief_type,
             args.episodes,
             args.n_jobs,
             args.results_dir,
+            args.particles,
             n_simulations=args.n_simulations,
             time_out_in_seconds=None,
         )
         for label, belief_type in BELIEF_TYPES.items()
     }
-    _print_table(f"fixed work: {args.n_simulations} simulations per decision", fixed_work)
+    _print_table(
+        f"fixed work: {args.n_simulations} simulations per decision, {args.particles} particles",
+        fixed_work,
+    )
 
     if not args.skip_fixed_time:
         fixed_time = {
             label: _run(
-                f"fixed_time_{label}",
+                f"fixed_time_{label}_{args.particles}p",
                 belief_type,
                 args.episodes,
                 args.n_jobs,
                 args.results_dir,
+                args.particles,
                 time_out_in_seconds=args.time_out,
             )
             for label, belief_type in BELIEF_TYPES.items()
         }
-        _print_table(f"fixed time: {args.time_out}s per decision", fixed_time)
+        _print_table(
+            f"fixed time: {args.time_out}s per decision, {args.particles} particles", fixed_time
+        )
 
 
 if __name__ == "__main__":

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_belief_factory.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_belief_factory.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the occupancy-grid mapping belief factory and its registry entry."""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
+    OccupancyGridMappingBelief,
+    OccupancyGridMappingPOMDP,
+    OccupancyGridMappingVectorizedBelief,
+    create_occupancy_grid_mapping_belief,
+)
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    occupancy_grid_mapping_pinned_kwargs,
+)
+from POMDPPlanners.utils.belief_factory import BeliefType, create_environment_belief
+
+
+@pytest.fixture
+def env():
+    return OccupancyGridMappingPOMDP(
+        discount_factor=0.95, **occupancy_grid_mapping_pinned_kwargs(num_rows=8, num_cols=8)
+    )
+
+
+class TestEnvironmentFactory:
+    def test_default_is_the_vectorized_filter(self, env):
+        """Purpose: the batched filter is the one runs should get without asking.
+
+        Test type: unit
+        """
+        belief = create_occupancy_grid_mapping_belief(env, n_particles=6)
+        assert isinstance(belief, OccupancyGridMappingVectorizedBelief)
+        assert belief.n_particles == 6
+        assert belief.particles.shape == (6, env.state_size)
+
+    def test_particle_is_the_scalar_whole_map_filter(self, env):
+        """Purpose: ``PARTICLE`` must give the environment's own conditional
+        filter, never the generic bootstrap filter, which cannot condition on
+        a stored continuous scan.
+
+        Test type: unit
+        """
+        belief = create_occupancy_grid_mapping_belief(env, BeliefType.PARTICLE, n_particles=6)
+        assert isinstance(belief, OccupancyGridMappingBelief)
+        assert len(belief.particles) == 6
+
+    @pytest.mark.parametrize("belief_type", [BeliefType.GAUSSIAN, BeliefType.GAUSSIAN_MIXTURE])
+    def test_other_types_are_rejected(self, env, belief_type):
+        """Purpose: a whole-map prior has no Gaussian form to offer.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="does not support"):
+            create_occupancy_grid_mapping_belief(env, belief_type)
+
+    def test_both_filters_start_from_the_same_prior(self, env):
+        """Purpose: the choice of filter must not change the maps an episode starts with.
+
+        Test type: unit
+        """
+        np.random.seed(8)
+        scalar = create_occupancy_grid_mapping_belief(env, BeliefType.PARTICLE, n_particles=5)
+        np.random.seed(8)
+        vectorized = create_occupancy_grid_mapping_belief(env, n_particles=5)
+        assert isinstance(scalar, OccupancyGridMappingBelief)
+        assert isinstance(vectorized, OccupancyGridMappingVectorizedBelief)
+        np.testing.assert_array_equal(np.asarray(scalar.particles), vectorized.particles)
+
+
+class TestTopLevelRegistry:
+    def test_top_level_factory_routes_to_the_environment_factory(self, env):
+        """Purpose: runs pick their belief through the top-level factory, so the
+        environment must be registered there with the vectorized default.
+
+        Test type: unit
+        """
+        assert isinstance(
+            create_environment_belief(env, n_particles=4), OccupancyGridMappingVectorizedBelief
+        )
+        assert isinstance(
+            create_environment_belief(env, BeliefType.PARTICLE, n_particles=4),
+            OccupancyGridMappingBelief,
+        )
+        with pytest.raises(ValueError, match="does not support"):
+            create_environment_belief(env, BeliefType.GAUSSIAN)

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_reward_batch.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_reward_batch.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the batched reward of the occupancy-grid mapping POMDP.
+
+``reward_batch`` is what a belief-space planner calls for the expected reward
+of every particle, so it must return the scalar ``reward`` values, with and
+without a realised successor.
+"""
+
+import pickle
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.tests.test_environments.test_occupancy_grid_mapping_pomdp.test_occupancy_grid_mapping_beliefs.test_occupancy_grid_mapping_vectorized_updater import (  # noqa: E501
+    ACTIONS,
+    diverse_particles,
+    make_env,
+)
+
+
+@pytest.mark.parametrize("move_failure_probability", [0.0, 0.25])
+@pytest.mark.parametrize("action", ACTIONS)
+def test_expected_reward_matches_scalar_reward(action, move_failure_probability):
+    """Purpose: the planner's expected reward must not change with the batching.
+
+    Given: Particles at mixed poses with partly resolved maps.
+    When: ``reward_batch`` without successors and the scalar ``reward`` are
+        evaluated for the same action.
+    Then: They agree to floating-point precision for every particle.
+
+    Test type: unit
+    """
+    env = make_env(move_failure_probability=move_failure_probability, step_cost=0.1)
+    particles = diverse_particles(env)
+    batched = env.reward_batch(particles, action)
+    scalar = np.array([env.reward(particle, action) for particle in particles])
+    np.testing.assert_allclose(batched, scalar, rtol=1e-12, atol=1e-9)
+    assert batched.shape == (len(particles),)
+
+
+def test_realised_reward_matches_scalar_reward():
+    """Purpose: the runner's realised reward path must batch to the same values.
+
+    Test type: unit
+    """
+    env = make_env(step_cost=0.1)
+    particles = diverse_particles(env)
+    successors = np.asarray([env.sample_next_state(particle, 0) for particle in particles])
+    batched = env.reward_batch(particles, 0, successors)
+    scalar = np.array(
+        [env.reward(particle, 0, successor) for particle, successor in zip(particles, successors)]
+    )
+    np.testing.assert_allclose(batched, scalar, rtol=1e-12, atol=1e-9)
+
+
+def test_reward_batch_accepts_a_list_of_states():
+    """Purpose: the scalar filter hands a list of particles, not an array.
+
+    Test type: unit
+    """
+    env = make_env()
+    particles = list(diverse_particles(env, n_particles=5))
+    np.testing.assert_allclose(
+        env.reward_batch(particles, 1), [env.reward(particle, 1) for particle in particles]
+    )
+
+
+def test_batched_kernels_follow_setting_changes_and_survive_pickling():
+    """Purpose: a setting edited after construction must not leave stale
+    kernels behind, and a worker's unpickled copy must rebuild them.
+
+    Test type: unit
+    """
+    env = make_env()
+    particles = diverse_particles(env, n_particles=4)
+    before = env.reward_batch(particles, 0)
+    env.step_cost = 0.5
+    np.testing.assert_allclose(env.reward_batch(particles, 0), before - 0.5)
+    env.move_failure_probability = 0.5
+    np.testing.assert_allclose(
+        env.reward_batch(particles, 0), [env.reward(particle, 0) for particle in particles]
+    )
+    restored = pickle.loads(pickle.dumps(env))
+    assert "_batched_kernels_cache" not in restored.__dict__
+    np.testing.assert_allclose(restored.reward_batch(particles, 0), env.reward_batch(particles, 0))

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_vectorized_belief.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_vectorized_belief.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for OccupancyGridMappingVectorizedBelief.
+
+The vectorized filter promises the scalar filter's results, not merely the
+same distribution, so every test here drives both from the same seed and
+compares particles, weights, history and restart counts directly.
+"""
+
+import pickle
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.belief.vectorized_weighted_particle_belief import (
+    VectorizedWeightedParticleBelief,
+)
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
+    OccupancyGridMappingBelief,
+    OccupancyGridMappingPOMDP,
+    OccupancyGridMappingVectorizedBelief,
+    OccupancyGridMappingVectorizedUpdater,
+    create_occupancy_grid_state,
+)
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    occupancy_grid_mapping_pinned_kwargs,
+)
+
+
+def make_env(**overrides):
+    kwargs = occupancy_grid_mapping_pinned_kwargs(
+        num_rows=8, num_cols=8, num_beams=12, start_row=4, start_col=4, **overrides
+    )
+    return OccupancyGridMappingPOMDP(discount_factor=0.95, **kwargs)
+
+
+def one_beam_world():
+    """The observation-contract world: one east-facing beam, empty 7x7 grid."""
+    env = OccupancyGridMappingPOMDP(
+        num_rows=7,
+        num_cols=7,
+        num_beams=1,
+        field_of_view_degrees=1,
+        max_range_cells=2,
+        has_boundary_wall=False,
+        num_obstacles=0,
+    )
+    empty = np.zeros((7, 7))
+    hit = empty.copy()
+    hit[3, 5] = 1
+    return env, create_occupancy_grid_state(env, empty), create_occupancy_grid_state(env, hit)
+
+
+def paired_filters(env, n_particles=20, seed=3):
+    """The scalar and the vectorized filter over the same prior draw."""
+    np.random.seed(seed)
+    scalar = OccupancyGridMappingBelief.initial(env, n_particles=n_particles)
+    np.random.seed(seed)
+    vectorized = OccupancyGridMappingVectorizedBelief.initial(env, n_particles=n_particles)
+    return scalar, vectorized
+
+
+def assert_same_filter_state(scalar, vectorized):
+    np.testing.assert_array_equal(vectorized.particles, np.asarray(scalar.particles))
+    np.testing.assert_array_equal(vectorized.log_weights, scalar.log_weights)
+    np.testing.assert_allclose(vectorized.normalized_weights, scalar.normalized_weights)
+    assert vectorized.support_restarts == scalar.support_restarts
+    assert len(vectorized.history) == len(scalar.history)
+    for (action_a, obs_a), (action_b, obs_b) in zip(vectorized.history, scalar.history):
+        assert action_a == action_b
+        np.testing.assert_array_equal(obs_a, obs_b)
+    assert vectorized.pre_resample_ess == pytest.approx(scalar.pre_resample_ess)
+
+
+class TestConstruction:
+    def test_initial_draws_the_same_prior_as_the_scalar_filter(self):
+        """Purpose: both filters must start from the same maps under one seed.
+
+        Test type: unit
+        """
+        scalar, vectorized = paired_filters(make_env())
+        assert isinstance(vectorized, VectorizedWeightedParticleBelief)
+        assert_same_filter_state(scalar, vectorized)
+        assert vectorized.n_particles == 20
+        assert vectorized.replay_proposals == 0
+        assert vectorized.update_seconds == 0.0
+
+    def test_resampling_is_refused(self):
+        """Purpose: routine resampling would drop the low-weight motion
+        hypotheses the filter exists to keep.
+
+        Test type: unit
+        """
+        env = make_env()
+        updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        particles = np.asarray(env.initial_state_dist().sample(2))
+        with pytest.raises(ValueError, match="resampling"):
+            OccupancyGridMappingVectorizedBelief(
+                particles, np.log([0.5, 0.5]), updater, resampling=True
+            )
+
+    def test_weights_need_finite_support(self):
+        """Purpose: a filter with no live particle cannot be sampled from.
+
+        Test type: unit
+        """
+        env = make_env()
+        updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        particles = np.asarray(env.initial_state_dist().sample(2))
+        for weights in ([-np.inf, -np.inf], [0.0, np.nan], [0.0, np.inf]):
+            with pytest.raises(ValueError, match="finite support"):
+                OccupancyGridMappingVectorizedBelief(particles, weights, updater)
+        kept = OccupancyGridMappingVectorizedBelief(particles, [0.0, -np.inf], updater)
+        np.testing.assert_array_equal(kept.log_weights, [0.0, -np.inf])
+        np.testing.assert_array_equal(kept.normalized_weights, [1.0, 0.0])
+
+
+class TestUpdate:
+    @pytest.mark.parametrize("move_failure_probability", [0.0, 0.25])
+    def test_chained_updates_match_the_scalar_filter(self, move_failure_probability):
+        """Purpose: the vectorized filter is a drop-in replacement, so an
+        episode's worth of conditioning must give identical particles and
+        weights, not just the same distribution.
+
+        Given: Both filters over the same 20 prior maps and a true world.
+        When: Twelve observed steps are conditioned on, in the same order.
+        Then: After every step, particles, weights, history and restart
+            counts are identical.
+
+        Test type: integration
+        """
+        env = make_env(move_failure_probability=move_failure_probability)
+        scalar, vectorized = paired_filters(env)
+        np.random.seed(17)
+        true_state = env.initial_state_dist().sample()[0]
+        for action in [0, 0, 1, 0, 0, 2, 0, 1, 1, 0, 0, 2]:
+            true_state, observation, _ = env.sample_next_step(true_state, action)
+            np.random.seed(action + 100)
+            scalar = scalar.update(action, observation, env)
+            np.random.seed(action + 100)
+            vectorized = vectorized.update(action, observation, env)
+            assert isinstance(vectorized, OccupancyGridMappingVectorizedBelief)
+            assert_same_filter_state(scalar, vectorized)
+        assert len(vectorized.history) == 12
+        assert vectorized.update_seconds > 0.0
+
+    def test_bayes_weights_on_two_maps(self):
+        """Purpose: posterior odds equal prior odds times the Gaussian
+        likelihood ratio, as in the scalar observation-contract test.
+
+        Test type: unit
+        """
+        env, empty, hit = one_beam_world()
+        env.true_map(hit)[3, 4] = 1
+        updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        belief = OccupancyGridMappingVectorizedBelief([empty, hit], np.log([0.4, 0.6]), updater)
+        observation = np.array([3, 3, 1, 1.2])
+        result = belief.update(2, observation, env, state=hit)
+        scores = np.array(
+            [env.predictive_observation_log_probability(s, 2, observation) for s in [empty, hit]]
+        ) + np.log([0.4, 0.6])
+        weights = np.exp(scores - np.max(scores))
+        weights /= weights.sum()
+        np.testing.assert_allclose(result.normalized_weights, weights)
+        np.testing.assert_array_equal(
+            env.log_odds(result.particles[0]), env.log_odds(result.particles[1])
+        )
+        assert result.support_restarts == 0
+
+    def test_replay_matches_the_scalar_filter(self):
+        """Purpose: on zero support both filters draw the same fresh maps from
+        the same stream and must resample the same survivors.
+
+        Given: Two copies of a map that blocks the observed move.
+        When: The impossible observation is conditioned on under one seed.
+        Then: Both filters restart once, test the same number of proposals,
+            and hold identical particles, all consistent with the move.
+
+        Test type: unit
+        """
+        env, empty, _ = one_beam_world()
+        blocked = empty.copy()
+        env.true_map(blocked)[2, 3] = 1
+        updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        np.random.seed(5)
+        scalar = OccupancyGridMappingBelief([blocked, blocked.copy()], np.log([0.5, 0.5])).update(
+            0, [2, 3, 0, 2], env
+        )
+        np.random.seed(5)
+        vectorized = OccupancyGridMappingVectorizedBelief(
+            [blocked, blocked.copy()], np.log([0.5, 0.5]), updater
+        ).update(0, [2, 3, 0, 2], env)
+        assert vectorized.support_restarts == 1
+        assert vectorized.replay_proposals == scalar.replay_proposals == 512
+        assert_same_filter_state(scalar, vectorized)
+        assert all(env.true_map(p)[2, 3] == 0 for p in vectorized.particles)
+        assert all(env.pose(p) == (2, 3, 0) for p in vectorized.particles)
+
+    def test_replay_needs_the_environment(self):
+        """Purpose: fresh prior maps can only come from the environment, so a
+        collapse without one must fail loudly rather than return an empty filter.
+
+        Test type: unit
+        """
+        env, empty, _ = one_beam_world()
+        blocked = empty.copy()
+        env.true_map(blocked)[2, 3] = 1
+        updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        belief = OccupancyGridMappingVectorizedBelief([blocked], np.log([1.0]), updater)
+        with pytest.raises(RuntimeError, match="no environment"):
+            belief.update(0, [2, 3, 0, 2])
+        # With support, the environment is not needed.
+        assert belief.update(2, [3, 3, 1, 2]).support_restarts == 0
+
+
+class TestSerialization:
+    def test_to_dict_and_pickle_round_trip(self):
+        """Purpose: restored filters must keep the history that prior replay needs.
+
+        Given: A filter after one update that left one particle at ``-inf``.
+        When: It is rebuilt from ``to_dict`` and from a pickle.
+        Then: Identity, weights and history survive, and a further update works.
+
+        Test type: unit
+        """
+        env, empty, hit = one_beam_world()
+        env.true_map(hit)[2, 3] = 1
+        updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        belief = OccupancyGridMappingVectorizedBelief([empty, hit], np.log([0.5, 0.5]), updater)
+        result = belief.update(0, [2, 3, 0, 2], env)
+        assert result.log_weights[1] == -np.inf
+        serialized = result.to_dict()
+        assert "updater" not in serialized
+        for restored in [
+            OccupancyGridMappingVectorizedBelief(updater=updater, **serialized),
+            pickle.loads(pickle.dumps(result)),
+        ]:
+            assert restored.config_id == result.config_id
+            assert len(restored.history) == 1
+            np.testing.assert_array_equal(restored.normalized_weights, result.normalized_weights)
+            assert len(restored.update(2, [2, 3, 1, 2], env).history) == 2
+
+    def test_config_id_changes_with_history_and_particles(self):
+        """Purpose: two filters that would condition differently must not share a cache key.
+
+        Test type: unit
+        """
+        env = make_env()
+        _, belief = paired_filters(env, n_particles=4)
+        _, same = paired_filters(env, n_particles=4)
+        assert belief.config_id == same.config_id
+        _, observation, _ = env.sample_next_step(belief.sample(), 0)
+        assert belief.update(0, observation, env).config_id != belief.config_id
+        _, other = paired_filters(env, n_particles=4, seed=4)
+        assert other.config_id != belief.config_id

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_vectorized_updater.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for OccupancyGridMappingVectorizedUpdater.
+
+Every batched kernel is checked against the scalar environment method it
+replaces, particle by particle. The generative transition draws from the global
+NumPy stream in the same order as the scalar loop when moves cannot fail, so
+that case is compared bit for bit under a shared seed; with move failure the
+two paths interleave their draws differently and only the motion statistics
+are compared.
+"""
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
+    OccupancyGridAction,
+    OccupancyGridMappingPOMDP,
+    OccupancyGridMappingVectorizedUpdater,
+)
+from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
+    assert_batch_obs_log_likelihood_matches_loop,
+    assert_batch_transition_matches_loop,
+)
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
+    occupancy_grid_mapping_pinned_kwargs,
+)
+
+ACTIONS = [int(action) for action in OccupancyGridAction]
+
+
+def make_env(**overrides):
+    """A small pinned world so a test runs in well under a second."""
+    kwargs = occupancy_grid_mapping_pinned_kwargs(
+        num_rows=8, num_cols=8, num_beams=12, start_row=4, start_col=4, **overrides
+    )
+    return OccupancyGridMappingPOMDP(discount_factor=0.95, **kwargs)
+
+
+def diverse_particles(env, n_particles=24, seed=11):
+    """Prior maps whose robots have been driven to different poses.
+
+    Fresh prior particles all share the start pose, which would leave the
+    per-particle pose handling untested. Driving disjoint subsets through
+    different action strings spreads the poses, headings and step counts.
+    """
+    np.random.seed(seed)
+    particles = np.asarray(env.initial_state_dist().sample(n_particles))
+    scripts = ([0, 0], [1, 0], [2, 0, 0], [0, 1, 0], [])
+    for index, script in enumerate(scripts):
+        rows = np.arange(index, n_particles, len(scripts))
+        for action in script:
+            particles[rows] = np.asarray(
+                [env.sample_next_state(particle, action) for particle in particles[rows]]
+            )
+    return particles
+
+
+def observation_from(env, particle, action):
+    successor = env.sample_next_state(particle, action)
+    return env.sample_observation(successor, action)
+
+
+@pytest.fixture
+def env():
+    return make_env()
+
+
+@pytest.fixture
+def updater(env):
+    return OccupancyGridMappingVectorizedUpdater.from_environment(env)
+
+
+@pytest.fixture
+def particles(env):
+    return diverse_particles(env)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_from_environment_copies_sensor_and_motion_settings(self, env, updater):
+        """Purpose: the updater must describe the same world as the environment.
+
+        Given: An environment with pinned settings.
+        When: An updater is built from it.
+        Then: Grid, beam, range, noise, log-odds and motion settings all match,
+            and the derived state layout matches the environment's.
+
+        Test type: unit
+        """
+        assert (updater.num_rows, updater.num_cols) == (env.num_rows, env.num_cols)
+        assert updater.num_beams == env.num_beams
+        assert updater.max_range_cells == env.max_range_cells
+        assert updater.range_noise_std_cells == env.range_noise_std_cells
+        assert updater.free_log_odds == env.free_log_odds
+        assert updater.occupied_log_odds == env.occupied_log_odds
+        assert updater.log_odds_clamp == env.log_odds_clamp
+        assert updater.move_failure_probability == env.move_failure_probability
+        assert updater.state_size == env.state_size
+        assert updater.scan_offset == env.scan_offset
+        assert updater.log_odds_offset == env.log_odds_offset
+
+    def test_zero_noise_is_rejected(self):
+        """Purpose: a zero-width Gaussian has no density to weight with.
+
+        Test type: unit
+        """
+        with pytest.raises(ValueError, match="range_noise_std_cells"):
+            OccupancyGridMappingVectorizedUpdater(
+                num_rows=5,
+                num_cols=5,
+                num_beams=4,
+                field_of_view_degrees=360.0,
+                max_range_cells=2.0,
+                range_noise_std_cells=0.0,
+                free_log_odds=-1.0,
+                occupied_log_odds=1.0,
+                log_odds_clamp=6.0,
+                move_failure_probability=0.0,
+            )
+
+    def test_config_id_tracks_every_setting(self, env, updater):
+        """Purpose: two updaters that would score differently must cache differently.
+
+        Given: An updater built from the environment.
+        When: One sensor setting changes, and separately the contract version.
+        Then: Each change gives a new identifier; an identical build gives the same.
+
+        Test type: unit
+        """
+        same = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        assert same.config_id == updater.config_id
+        noisier = OccupancyGridMappingVectorizedUpdater.from_environment(
+            make_env(range_noise_std_cells=0.5)
+        )
+        assert noisier.config_id != updater.config_id
+        env.sensor_contract_version += 1
+        assert OccupancyGridMappingVectorizedUpdater.from_environment(env).config_id != (
+            updater.config_id
+        )
+
+
+# ---------------------------------------------------------------------------
+# Conditional kernels
+# ---------------------------------------------------------------------------
+
+
+class TestPredictiveLogLikelihood:
+    @pytest.mark.parametrize("move_failure_probability", [0.0, 0.25])
+    @pytest.mark.parametrize("action", ACTIONS)
+    def test_matches_scalar_predictive_density(self, action, move_failure_probability):
+        """Purpose: the batched score is the filter's importance weight; it must
+        equal the scalar one for every particle, including the ``-inf`` entries
+        for particles whose robot cannot have reached the observed pose.
+
+        Given: Twenty-four particles at mixed poses, and an observation drawn
+            from one of them.
+        When: The batched and the scalar predictive scores are computed.
+        Then: They agree to floating-point precision, and at least one particle
+            has finite score (the one the observation was drawn from).
+
+        Test type: unit
+        """
+        env = make_env(move_failure_probability=move_failure_probability)
+        updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        particles = diverse_particles(env)
+        observation = observation_from(env, particles[7], action)
+
+        batched = updater.batch_predictive_log_likelihood(particles, action, observation)
+        scalar = np.array(
+            [
+                env.predictive_observation_log_probability(particle, action, observation)
+                for particle in particles
+            ]
+        )
+        np.testing.assert_allclose(batched, scalar, rtol=1e-12, atol=1e-12)
+        assert np.isfinite(batched[7])
+
+    def test_motion_failure_weight_matches_scalar_ratio(self):
+        """Purpose: a failed move must carry ``p_fail`` and a successful one
+        ``1 - p_fail``, exactly as the scalar model integrates them.
+
+        Given: The observation-contract world -- one east-facing beam over an
+            empty 7x7 grid, so the nominal scan is the same at both poses --
+            with move failure 0.25.
+        When: The observed pose is the moved cell, then the start cell.
+        Then: The score ratio is 3 for every particle, as in the scalar test.
+
+        Test type: unit
+        """
+        env = OccupancyGridMappingPOMDP(
+            num_rows=7,
+            num_cols=7,
+            num_beams=1,
+            field_of_view_degrees=1,
+            max_range_cells=2,
+            has_boundary_wall=False,
+            num_obstacles=0,
+            move_failure_probability=0.25,
+        )
+        updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        particles = np.asarray(env.initial_state_dist().sample(3))
+        ratio = np.exp(
+            updater.batch_predictive_log_likelihood(particles, 0, np.array([2, 3, 0, 2]))
+            - updater.batch_predictive_log_likelihood(particles, 0, np.array([3, 3, 0, 2]))
+        )
+        np.testing.assert_allclose(ratio, 3.0)
+
+    def test_unreachable_pose_and_malformed_observation_have_no_support(
+        self, env, updater, particles
+    ):
+        """Purpose: no epsilon floor may sneak in through the batched path.
+
+        Given: A valid observation.
+        When: Its pose is shifted by a fraction, moved two cells away, or a
+            range is made non-finite, or the vector has the wrong length.
+        Then: Every particle scores ``-inf``.
+
+        Test type: unit
+        """
+        observation = observation_from(env, particles[0], 0)
+        fractional = observation.copy()
+        fractional[0] += 0.1
+        far = observation.copy()
+        far[0] += 2
+        non_finite = observation.copy()
+        non_finite[5] = np.nan
+        for bad in (fractional, far, non_finite, observation[:-1]):
+            assert np.all(np.isneginf(updater.batch_predictive_log_likelihood(particles, 0, bad)))
+
+
+class TestStateFromObservation:
+    @pytest.mark.parametrize("action", ACTIONS)
+    def test_matches_scalar_map_update(self, env, updater, particles, action):
+        """Purpose: the shared inverse-sensor delta must produce exactly the
+        scalar successor for every particle, whatever map it carries.
+
+        Given: Particles at mixed poses and an observation from one of them.
+        When: Both paths install the observation.
+        Then: Step, pose, hidden map, log-odds and stored scan are identical.
+
+        Test type: unit
+        """
+        observation = observation_from(env, particles[3], action)
+        batched = updater.batch_state_from_observation(particles, observation)
+        scalar = np.asarray(
+            [env.state_from_observation(particle, observation) for particle in particles]
+        )
+        np.testing.assert_array_equal(batched, scalar)
+        assert np.all(batched[:, 0] == particles[:, 0] + 1)
+        assert np.all(
+            np.abs(batched[:, env.log_odds_offset : env.scan_offset]) <= env.log_odds_clamp
+        )
+
+    def test_clamp_is_applied_after_accumulation(self, env, updater, particles):
+        """Purpose: repeated evidence must saturate at the clamp, not grow past it.
+
+        Given: The same observation installed twenty times over.
+        When: The log-odds are read back.
+        Then: No cell exceeds the clamp in magnitude, and the scalar path agrees.
+
+        Test type: unit
+        """
+        observation = observation_from(env, particles[0], 0)
+        batched = particles
+        scalar = list(particles)
+        for _ in range(20):
+            batched = updater.batch_state_from_observation(batched, observation)
+            scalar = [env.state_from_observation(particle, observation) for particle in scalar]
+        np.testing.assert_array_equal(batched, np.asarray(scalar))
+        assert np.max(np.abs(batched[:, env.log_odds_offset : env.scan_offset])) == pytest.approx(
+            env.log_odds_clamp
+        )
+
+    def test_rejects_the_same_observations_the_scalar_path_rejects(self, env, updater, particles):
+        """Purpose: validation must not be looser in the batched path.
+
+        Test type: unit
+        """
+        observation = observation_from(env, particles[0], 0)
+        fractional = observation.copy()
+        fractional[2] += 0.5
+        outside = observation.copy()
+        outside[0] = env.num_rows
+        with pytest.raises(ValueError, match="integer"):
+            updater.batch_state_from_observation(particles, fractional)
+        with pytest.raises(ValueError, match="in-grid"):
+            updater.batch_state_from_observation(particles, outside)
+        with pytest.raises(ValueError, match="finite"):
+            updater.batch_state_from_observation(particles, observation[:-1])
+
+
+# ---------------------------------------------------------------------------
+# Shared updater interface (generative model)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerativeInterface:
+    @pytest.mark.parametrize("action", ACTIONS)
+    def test_batch_transition_matches_scalar_under_shared_seed(
+        self, env, updater, particles, action
+    ):
+        """Purpose: with no move failure both paths consume the Gaussian stream
+        in the same order, so the successors must be bit-identical.
+
+        Given: Particles at mixed poses, no move failure.
+        When: Both paths transition from the same seed.
+        Then: The successor arrays are equal.
+
+        Test type: unit
+        """
+        assert_batch_transition_matches_loop(
+            updater,
+            particles,
+            action,
+            env.sample_next_state,
+            atol=0.0,
+            seed=5,
+        )
+
+    def test_batch_transition_motion_failure_rate(self):
+        """Purpose: a failed move keeps the robot in place with ``p_fail``.
+
+        Given: 4000 copies of one free-space map, move failure 0.4.
+        When: All move forward once.
+        Then: The fraction that stayed is 0.4 within sampling error, the rest
+            are one cell north, and every scan differs (fresh noise per particle).
+
+        Test type: unit
+        """
+        env = make_env(move_failure_probability=0.4, num_obstacles=0)
+        updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        np.random.seed(2)
+        particles = np.tile(env.initial_state_dist().sample(1)[0], (4000, 1))
+        successors = updater.batch_transition(particles, 0)
+        stayed = successors[:, 1] == 4
+        assert np.mean(stayed) == pytest.approx(0.4, abs=0.03)
+        assert np.all(successors[~stayed, 1] == 3)
+        assert len(np.unique(successors[:, env.scan_offset :], axis=0)) == 4000
+
+    @pytest.mark.parametrize("action", ACTIONS)
+    def test_batch_observation_log_likelihood_is_a_point_mass(
+        self, env, updater, particles, action
+    ):
+        """Purpose: the augmented observation kernel is a point mass on the
+        stored scan; the batched form must say 0 for the matching successor
+        and ``-inf`` for every other one.
+
+        Test type: unit
+        """
+        np.random.seed(3)
+        successors = updater.batch_transition(particles, action)
+        observation = env.sample_observation(successors[5], action)
+        assert_batch_obs_log_likelihood_matches_loop(
+            updater,
+            successors,
+            action,
+            observation,
+            lambda particle, act, obs: env.observation_log_probability(particle, act, obs)[0],
+            atol=0.0,
+        )
+        scores = updater.batch_observation_log_likelihood(successors, action, observation)
+        assert scores[5] == 0.0
+        assert np.count_nonzero(np.isfinite(scores)) == 1

--- a/POMDPPlanners/utils/belief_factory.py
+++ b/POMDPPlanners/utils/belief_factory.py
@@ -125,6 +125,11 @@ _ENV_FACTORY_REGISTRY: dict[str, tuple[str, str, BeliefType]] = {
         "create_rocksample_belief",
         BeliefType.VECTORIZED_PARTICLE,
     ),
+    "OccupancyGridMappingPOMDP": (
+        "POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_beliefs",
+        "create_occupancy_grid_mapping_belief",
+        BeliefType.VECTORIZED_PARTICLE,
+    ),
 }
 
 

--- a/docs/environments/occupancy_grid_mapping.rst
+++ b/docs/environments/occupancy_grid_mapping.rst
@@ -11,11 +11,12 @@ continuous states.
 .. code-block:: python
 
    from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
-       OccupancyGridMappingPOMDP, OccupancyGridMappingBelief,
+       OccupancyGridMappingPOMDP,
    )
+   from POMDPPlanners.utils.belief_factory import create_environment_belief
 
    env = OccupancyGridMappingPOMDP()
-   belief = OccupancyGridMappingBelief.initial(env, n_particles=30)
+   belief = create_environment_belief(env, n_particles=30)
 
 State and observation contract
 ------------------------------
@@ -75,17 +76,35 @@ use the inverse estimate; neither substitutes the true occupancy grid.
 Filtering and limits
 --------------------
 
-Use ``OccupancyGridMappingBelief`` with PFT_DPW. Ordinary
+Use one of the environment's two whole-map filters with PFT_DPW. Ordinary
 ``get_initial_belief`` returns a bootstrap filter which cannot condition this
 stored continuous scan correctly. No core planner changes are needed.
 
-The custom filter installs the observed scan and its map update in every
-particle. It weights whole-map hypotheses by the predictive Gaussian density
+Both filters install the observed scan and its map update in every
+particle. They weight whole-map hypotheses by the predictive Gaussian density
 and exact motion probability, with no epsilon floor for impossible poses.
 Routine resampling is disabled to retain low-weight hypotheses. If every
 particle contradicts observed motion, bounded prior replay tests up to 4096
 fresh maps against the entire observation history and resamples surviving
 weighted maps. It raises if that search finds no support.
+
+``OccupancyGridMappingVectorizedBelief`` is the default from
+``create_environment_belief`` and from ``BeliefType.VECTORIZED_PARTICLE``. It
+scores all particles with one batched ray cast and applies one shared
+inverse-sensor delta to all of them, so an update costs a few array
+operations rather than two environment calls per particle. It gives the same
+particles, weights, history and restart count as the scalar filter for the
+same seed. ``OccupancyGridMappingBelief`` is the scalar reference, available
+as ``BeliefType.PARTICLE``. Its updater also exposes the batched generative
+transition and point-mass observation likelihood that the shared vectorized
+updater interface expects, but the filter does not use them: a freshly drawn
+scan matches the observed one with probability zero.
+
+The environment's ``reward_batch`` uses the same kernels. A belief-space
+planner asks for the expected reward of every particle at every node it
+expands, and without a successor each scalar call integrates eight
+hypothetical scans; batching those is where most of PFT_DPW's decision time
+goes, so it is what makes the planner faster with either filter.
 
 Thirty particles is a QA resource choice, not a guarantee against degeneracy.
 Reweighting cannot create missing maps. Prior replay is finite importance
@@ -113,5 +132,5 @@ hidden true map for review. Panels depict the state before the captioned action;
 the caption's reward is the realised inverse-map entropy reduction.
 
 There is no torch vectorized or C++ model. VOPP is unsupported. Scalar PFT_DPW
-uses the environment and custom belief shown above. Sensor contract version 2
+uses the environment and the whole-map filters shown above. Sensor contract version 2
 changes cache identity; old results and GIFs describe the earlier behavior.


### PR DESCRIPTION
## Why

PFT-DPW on OccupancyGridMapping spent most of a decision in Python loops over
whole-map particles. The scalar filter called the environment twice per
particle on every update, and the belief-expected reward called it eight times
per particle on every node the tree expanded. A profile of one 100-simulation
decision put 80% of the time in the reward loop and most of the rest in the
update. Both loops are array work, so they now run batched.

## What changed

- **Vectorized updater** in `occupancy_grid_mapping_beliefs/`. Batched forms
  of the predictive score (one ray cast over all hidden maps) and of the map
  update (one inverse-sensor delta shared by every particle, because it
  depends only on the observation and the observed pose). It also implements
  the shared updater interface, the generative transition and the point-mass
  observation likelihood, so the repo's equivalence helpers apply.
- **Vectorized whole-map filter.** Same contract as the scalar
  `OccupancyGridMappingBelief`: identical particles, weights, history and
  restart count under a shared seed. Routine resampling is refused, prior
  replay on zero support is batched, `to_dict` and pickling round-trip.
- **Factory and registry.** `create_environment_belief(env)` returns the
  vectorized filter by default and the scalar whole-map filter for
  `BeliefType.PARTICLE`. Before, the environment fell through to the generic
  bootstrap filter, which cannot condition on a stored continuous scan.
- **Batched reward on the environment.** `reward_batch` uses the same
  kernels, so the belief-expected reward is one call. This goes beyond the
  belief itself, and it is what the speed-up rests on: the belief update was
  under a fifth of a decision, so batching it alone gave about 1.1x. The
  scalar filter benefits too.
- **Tests.** Updater equivalence (bit-exact generative transition under a
  shared seed when moves cannot fail, motion statistics otherwise), predictive
  scores including the `-inf` cases, map update and its validation, chained
  filter equivalence with the scalar filter, replay, serialization,
  `reward_batch` with and without successors, factory routing.
- **Benchmark script** that runs PFT-DPW with each filter through
  `LocalSimulationsAPI`, on the same seeded worlds, and prints decision time,
  belief-update time and simulations per decision.
- **Docs** page updated.

## Acceleration in PFT-DPW: scalar vs vectorized belief

Measured on ubuntu64 (i9-11900K, one core, python 3.12.3, numpy 2.2.6), 8
episodes per row, the QA PFT-DPW settings, 30 map particles, the default 10x10
world, both rows on this branch. Results are not committed.

Fixed work, 200 simulations per decision:

| belief | decision (s) | belief update per step (s) | discounted return |
| --- | --- | --- | --- |
| scalar | 0.965 | 0.0025 | 57.5 |
| vectorized | 0.513 | 0.0003 | 57.4 |

Decisions are 1.88x faster and the belief update 8.9x faster, at the same
return.

Fixed time, the QA budget of 1 s per decision:

| belief | simulations per decision | discounted return |
| --- | --- | --- |
| scalar | 685 | 56.0 |
| vectorized | 939 | 55.2 |

1.37x more search per decision for the same budget.

### 200 particles

Same host and settings, 4 episodes per row, `--particles 200`.

Fixed work, 200 simulations per decision:

| belief | decision (s) | belief update per step (s) | discounted return |
| --- | --- | --- | --- |
| scalar | 4.72 | 0.0162 | 58.3 |
| vectorized | 1.43 | 0.0006 | 57.4 |

Decisions 3.3x faster, belief update 28x faster.

Fixed time, 1 s per decision:

| belief | simulations per decision | discounted return |
| --- | --- | --- |
| scalar | 48 | 56.0 |
| vectorized | 680 | 57.4 |

14x more search per decision. The gap widens with particles because the
scalar cost grows linearly in the count while the batched cost grows much
more slowly: a 200-particle vectorized decision costs about what a
30-particle scalar one does. Under a time budget the per-simulation cost
falls as the tree fills, since later simulations mostly revisit existing
nodes with no belief update or reward call, which is why the fixed-time
throughput exceeds the fixed-work rate in every row but the slowest.

A local profile of one 100-simulation decision (MacBook, not the benchmark
host) shows the two pieces separately: 1.29 s on develop, 0.34 s on this
branch with the scalar filter (the batched reward alone), 0.19 s with the
vectorized filter.

## Review

Own review plus a Codex second opinion of the branch diff against develop: no
defects found. Locally, 128 tests in the environment and belief-factory suites
pass; black, pylint (10/10) and pyright are clean on the changed files.
Docker CI gate (linux/amd64 image, run from a clean worktree): the runner
aborted in its whole-package pyright stage with exit 245 and no diagnostics.
Docker Desktop here emulates amd64 with 6 GB, so I take that as a resource
crash and ran the remaining stages in the same image by hand. Pyright on the
changed packages: 0 errors. Doctests: 199 passed. Full non-slow suite: 5159
passed, 1 failed. The failure, `test_minimal_cost_clamp_preserves_real_vectors`
in the constrained PFT-DPW tests, fails identically on origin/develop and is
not touched by this change. GitHub CI is the authority for the full gate.

https://claude.ai/code/session_01MCJKbgioXLR23wMBYukt7h
