### PR TITLE
Add a lower-truncated normal range noise option to OccupancyGridMapping

### DIFF
--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/__init__.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/__init__.py
@@ -11,6 +11,7 @@ Exports:
     OccupancyGridMappingVectorizedBelief: Its batched twin.
     OccupancyGridMappingVectorizedUpdater: The batched kernels behind it.
     create_occupancy_grid_mapping_belief: Factory choosing between the two filters.
+    RangeNoiseModel: The selectable per-beam range noise laws.
 """
 
 from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_pomdp import (
@@ -35,6 +36,7 @@ from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sens
     HEADING_LABELS,
     HEADING_STEPS,
     NUM_HEADINGS,
+    RangeNoiseModel,
     build_ray_templates,
     cast_scan,
     grid_entropy_bits,
@@ -62,6 +64,7 @@ __all__ = [
     "OccupancyGridMappingPOMDP",
     "OccupancyGridState",
     "OccupancyGridStepChannel",
+    "RangeNoiseModel",
     "build_ray_templates",
     "cast_scan",
     "create_occupancy_grid_state",

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_belief.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_belief.py
@@ -3,7 +3,8 @@
 
 The proposal installs the observed scan rather than drawing an independent
 scan that would match it with probability zero. Importance weights are the
-predictive Gaussian density times the exact motion probability. No epsilon
+predictive range density, under the environment's selected range law, times
+the exact motion probability. No epsilon
 floor admits impossible poses. Whole-map support can still collapse; a bounded
 prior replay then reweights fresh map hypotheses against the complete history.
 """

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/occupancy_grid_mapping_vectorized_updater.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/occupancy_grid_mapping_vectorized_updater.py
@@ -9,8 +9,11 @@ so this module does them for all particles in one call:
 
 * :meth:`OccupancyGridMappingVectorizedUpdater.batch_predictive_log_likelihood`
   casts one batched scan over every hidden map and scores the observed ranges
-  under the Gaussian range law and the exact motion probability. It is the
-  batched form of ``predictive_observation_log_probability``.
+  under the environment's range law and the exact motion probability. It is
+  the batched form of ``predictive_observation_log_probability``. The range
+  law is selected by ``range_noise_model``: the unbounded Gaussian, or the
+  normal truncated to ``[0, +inf)`` whose normaliser depends on each beam's
+  nominal range and is therefore scored per beam and per particle.
 * :meth:`OccupancyGridMappingVectorizedUpdater.batch_state_from_observation`
   installs the observed pose and scan and applies the inverse sensor update.
   The inverse-sensor delta depends only on the observation and the observed
@@ -19,7 +22,7 @@ so this module does them for all particles in one call:
 
 The two methods of the shared updater interface are also implemented, as the
 batched forms of ``sample_next_state`` and ``observation_log_probability``:
-a generative transition that draws motion and a fresh Gaussian scan, and the
+a generative transition that draws motion and a fresh noisy scan, and the
 point-mass likelihood on the stored scan. They make the updater a faithful
 batched copy of the environment's generative model, which is what the shared
 equivalence tests check. The conditional filter does not use them, because a
@@ -31,7 +34,7 @@ Classes:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, Tuple
+from typing import TYPE_CHECKING, Any, List, Tuple, Union
 
 import numpy as np
 
@@ -41,8 +44,13 @@ from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
 from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sensor import (
     HEADING_STEPS,
     NUM_HEADINGS,
+    RangeNoiseModel,
     build_ray_templates,
     observed_scan_log_odds_delta,
+    quadrature_ranges,
+    resolve_range_noise_model,
+    sample_ranges,
+    scan_log_density,
 )
 from POMDPPlanners.utils.config_to_id import config_to_id
 
@@ -73,7 +81,8 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
         num_cols: Grid columns.
         num_beams: Beams per scan.
         max_range_cells: Sensor range in cell widths.
-        range_noise_std_cells: Per-beam Gaussian range noise.
+        range_noise_std_cells: Per-beam range noise standard deviation.
+        range_noise_model: Which per-beam range law that deviation parametrises.
         move_failure_probability: Chance an otherwise-valid forward move fails.
 
     Example:
@@ -107,6 +116,7 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
         log_odds_clamp: float,
         move_failure_probability: float,
         sensor_contract_version: int = 2,
+        range_noise_model: Union[RangeNoiseModel, str] = RangeNoiseModel.GAUSSIAN,
     ):
         """Initialize the updater from the environment's sensor and motion settings.
 
@@ -116,19 +126,26 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
             num_beams: Beams per scan.
             field_of_view_degrees: Angular width of the fan, centred on the heading.
             max_range_cells: Sensor range in cell widths.
-            range_noise_std_cells: Per-beam Gaussian range noise. Must be positive.
+            range_noise_std_cells: Per-beam range noise standard deviation. Must
+                be positive.
             free_log_odds: Increment for a cell a beam passes through. Negative.
             occupied_log_odds: Increment for the cell a beam stops in. Positive.
             log_odds_clamp: Symmetric bound on accumulated log-odds.
             move_failure_probability: Chance an otherwise-valid forward move fails.
             sensor_contract_version: The environment's sensor contract version,
                 carried into the identifier so a contract change invalidates caches.
+            range_noise_model: Which per-beam range law ``range_noise_std_cells``
+                parametrises. Defaults to the unbounded Gaussian, the law every
+                updater built before the option existed used. Accepts the
+                member or its string value.
 
         Raises:
-            ValueError: If ``range_noise_std_cells`` is not positive.
+            ValueError: If ``range_noise_std_cells`` is not positive, or
+                ``range_noise_model`` names no known law.
         """
         if range_noise_std_cells <= 0.0:
             raise ValueError(f"range_noise_std_cells must be positive, got {range_noise_std_cells}")
+        self.range_noise_model = resolve_range_noise_model(range_noise_model)
         self.num_rows = int(num_rows)
         self.num_cols = int(num_cols)
         self.num_beams = int(num_beams)
@@ -146,7 +163,6 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
         self.log_odds_offset = _POSE_WIDTH + self.num_cells
         self.scan_offset = _POSE_WIDTH + 2 * self.num_cells
         self.state_size = self.scan_offset + self.num_beams
-        self._log_norm = -self.num_beams * np.log(self.range_noise_std_cells * np.sqrt(2 * np.pi))
         self._ray_templates = build_ray_templates(
             num_beams=self.num_beams,
             field_of_view_degrees=self.field_of_view_degrees,
@@ -177,6 +193,7 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
             log_odds_clamp=env.log_odds_clamp,
             move_failure_probability=env.move_failure_probability,
             sensor_contract_version=env.sensor_contract_version,
+            range_noise_model=env.range_noise_model,
         )
 
     # ------------------------------------------------------------------
@@ -189,8 +206,8 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
         """Score ``p(observation | particle, action)`` for every particle.
 
         Integrates the discrete motion outcomes and scores the observed ranges
-        under the Gaussian range law of each particle's hidden map, before the
-        observation is stored. Matches the environment's scalar
+        under the selected range law against each particle's hidden map,
+        before the observation is stored. Matches the environment's scalar
         ``predictive_observation_log_probability`` particle by particle.
 
         Args:
@@ -220,8 +237,15 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
                 continue
             index = np.flatnonzero(matched)
             nominal = self._nominal_scans(maps[index], rows[index], cols[index], headings[index])
-            residual = (observation[3:][None, :] - nominal) / self.range_noise_std_cells
-            log_density = -0.5 * np.sum(residual**2, axis=1) + self._log_norm
+            # Under truncation the normaliser is a function of each beam's
+            # nominal range, so it differs across particles and cannot be
+            # hoisted into one constant; the helper handles both laws.
+            log_density = scan_log_density(
+                observation[3:][None, :],
+                nominal,
+                self.range_noise_std_cells,
+                self.range_noise_model,
+            )
             scores[index] = np.logaddexp(scores[index], np.log(probabilities[index]) + log_density)
         return scores
 
@@ -313,9 +337,14 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
                 continue
             nominal = self._nominal_scans(maps[live], rows[live], cols[live], headings[live])
             # Lay the K noisy scans of each particle out as K * n independent
-            # particles, so one inverse-sensor call covers all of them.
-            ranges = (
-                nominal[None, :, :] + self.range_noise_std_cells * noise_points[:, None, :]
+            # particles, so one inverse-sensor call covers all of them. The
+            # unit-normal points are mapped through the selected law, so under
+            # truncation the integral averages over scans that law can produce.
+            ranges = quadrature_ranges(
+                nominal[None, :, :],
+                noise_points[:, None, :],
+                self.range_noise_std_cells,
+                self.range_noise_model,
             ).reshape(num_points * len(live), self.num_beams)
             deltas = self._scan_deltas(
                 ranges,
@@ -354,11 +383,11 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
     # ------------------------------------------------------------------
 
     def batch_transition(self, particles: np.ndarray, action: Any) -> np.ndarray:
-        """Draw motion and a fresh Gaussian scan for every particle, then map it.
+        """Draw motion and a fresh noisy scan for every particle, then map it.
 
         The batched form of the environment's ``sample_next_state``. Draws from
         the global NumPy stream: one uniform per particle that has two motion
-        outcomes, then ``(N, num_beams)`` normals.
+        outcomes, then ``(N, num_beams)`` range draws under the selected law.
 
         Args:
             particles: State array of shape ``(N, state_size)``.
@@ -382,9 +411,7 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
                 cols = np.where(stay, stay_cols, cols)
                 headings = np.where(stay, stay_headings, headings)
         nominal = self._nominal_scans(self._maps(particles), rows, cols, headings)
-        ranges = nominal + np.random.normal(
-            0.0, self.range_noise_std_cells, (count, self.num_beams)
-        )
+        ranges = sample_ranges(nominal, self.range_noise_std_cells, self.range_noise_model)
         poses = np.stack([rows, cols, headings], axis=1).astype(np.float64)
         delta = self._scan_deltas(ranges, rows, cols, headings)
         return self._install(particles, poses, ranges, delta)
@@ -433,6 +460,7 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
                 "field_of_view_degrees": self.field_of_view_degrees,
                 "max_range_cells": self.max_range_cells,
                 "range_noise_std_cells": self.range_noise_std_cells,
+                "range_noise_model": self.range_noise_model.value,
                 "free_log_odds": self.free_log_odds,
                 "occupied_log_odds": self.occupied_log_odds,
                 "log_odds_clamp": self.log_odds_clamp,

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_pomdp.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_pomdp.py
@@ -3,10 +3,17 @@
 """Occupancy-grid exploration with known integer pose and noisy range scans.
 
 State: [step, row, col, heading, hidden occupancy(C), inverse-map log-odds(C),
-last noisy ranges(B)]. The transition samples motion and an unbounded Gaussian
-scan, stores that scan and applies its inverse sensor update. Observation
-reveals the exact pose and stored ranges. Hidden occupancy is used only by the
-forward motion/sensor model, never by the inverse map update.
+last noisy ranges(B)]. The transition samples motion and a noisy scan, stores
+that scan and applies its inverse sensor update. Observation reveals the exact
+pose and stored ranges. Hidden occupancy is used only by the forward
+motion/sensor model, never by the inverse map update.
+
+The per-beam range law is selected by ``range_noise_model``: the unbounded
+Gaussian (the default, and the law every earlier result used), or the same
+normal truncated to ``[0, +inf)`` so that no reading can be negative. The
+truncated law is a renormalised density, not a clamp, and its normaliser
+depends on each beam's nominal range, so it enters every likelihood per beam.
+Neither law truncates above the maximum range.
 
 A range at or above the maximum is interpreted as a miss. A shorter range
 selects the nearest ray cell (negative readings select the first cell). Thus a
@@ -16,8 +23,8 @@ hit flag is supplied to the robot.
 
 The map is an approximate independent-cell inverse estimate. Its entropy is
 not the entropy of the posterior over whole maps. Realised reward and completion use the observed inverse map. Planning
-without a successor uses fixed Gaussian integration of its expected reduction. Repeated correlated beams can create false
-confidence. The separate whole-map particle belief predicts scans and motion.
+without a successor uses a fixed antithetic quadrature, mapped through the selected range law, of its expected
+reduction. Repeated correlated beams can create false confidence. The separate whole-map particle belief predicts scans and motion.
 Use OccupancyGridMappingBelief, or its batched twin in the
 occupancy_grid_mapping_beliefs package, to condition the augmented state correctly.
 
@@ -54,11 +61,16 @@ from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_maps
 from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sensor import (
     HEADING_STEPS,
     NUM_HEADINGS,
+    RangeNoiseModel,
     build_ray_templates,
     cast_scan,
     grid_entropy_bits,
     log_odds_from_probability,
     observed_scan_log_odds_delta,
+    quadrature_ranges,
+    resolve_range_noise_model,
+    sample_ranges,
+    scan_log_density,
 )
 
 
@@ -142,6 +154,7 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
         field_of_view_degrees: float = 360.0,
         max_range_cells: float = 3.5,
         range_noise_std_cells: float = 0.35,
+        range_noise_model: Union[RangeNoiseModel, str] = RangeNoiseModel.GAUSSIAN,
         hit_probability: float = 0.85,
         miss_probability: float = 0.15,
         log_odds_clamp: float = 6.0,
@@ -183,6 +196,16 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
                 finish the map rather than resolving it from the start cell.
             range_noise_std_cells: Per-beam Gaussian range noise. Defaults to
                 0.35 cells -- a tenth of the sensor's range, used by the forward sensor model. Finite map particles can still collapse.
+            range_noise_model: Which per-beam range law that standard deviation
+                parametrises. Defaults to ``RangeNoiseModel.GAUSSIAN``, the
+                unbounded normal, which is what every result before this option
+                existed was produced under. ``RangeNoiseModel.TRUNCATED_NORMAL``
+                truncates it to ``[0, +inf)`` and renormalises, so no beam can
+                report a negative distance -- a reading a real range finder
+                cannot produce, and one the untruncated law assigns real
+                probability to whenever a nominal range is within a few standard
+                deviations of zero. Accepts the member or its string value.
+                Readings above the maximum range are not truncated either way.
             hit_probability: Inverse sensor model probability for the cell a
                 beam stops in. Defaults to 0.85.
             miss_probability: Inverse sensor model probability for a cell a beam
@@ -235,6 +258,9 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
                 "range_noise_std_cells must be positive: a zero-width Gaussian has no "
                 f"density for the particle filter to weight with, got {range_noise_std_cells}"
             )
+        # Raises on an unknown name, so a typo in a config file fails at
+        # construction rather than silently selecting the default law.
+        range_noise_model = resolve_range_noise_model(range_noise_model)
         if max_steps < 1:
             raise ValueError(f"max_steps must be at least 1, got {max_steps}")
         if not 0.0 <= entropy_threshold_fraction <= 1.0:
@@ -279,6 +305,7 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
         self.field_of_view_degrees = float(field_of_view_degrees)
         self.max_range_cells = float(max_range_cells)
         self.range_noise_std_cells = float(range_noise_std_cells)
+        self.range_noise_model = range_noise_model
         self.hit_probability = float(hit_probability)
         self.miss_probability = float(miss_probability)
         self.log_odds_clamp = float(log_odds_clamp)
@@ -309,8 +336,13 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
         self.num_cells = num_cells
         self.scan_offset = POSE_WIDTH + 2 * num_cells
         self.state_size = self.scan_offset + self.num_beams
-        self.sensor_contract_version = 2
+        # Bumped from 2 when range_noise_model was added: the range law is part
+        # of the sensor contract, so a cached episode from before the option
+        # existed must not be reused for one after it.
+        self.sensor_contract_version = 3
         # Fixed antithetic integration points leave the simulation RNG untouched.
+        # They are unit normals; ``quadrature_ranges`` maps them into the
+        # selected range law at use time.
         points = np.random.RandomState(0).normal(size=(4, self.num_beams))
         self._reward_noise = np.concatenate([points, -points])
         self.map_offset = POSE_WIDTH
@@ -521,7 +553,7 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
         )
 
     def sample_next_state(self, state, action, n_samples=1):
-        """Sample motion and Gaussian ranges, then apply the observed scan."""
+        """Sample motion and noisy ranges, then apply the observed scan."""
         successors, probabilities = self._motion_outcomes(state, action)
         samples = []
         for _ in range(int(n_samples)):
@@ -529,8 +561,8 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
                 0 if len(successors) == 1 else np.random.choice(len(successors), p=probabilities)
             )
             moved = successors[index]
-            ranges = self.nominal_scan(moved) + np.random.normal(
-                0.0, self.range_noise_std_cells, self.num_beams
+            ranges = sample_ranges(
+                self.nominal_scan(moved), self.range_noise_std_cells, self.range_noise_model
             )
             samples.append(self.state_from_observation(state, np.r_[moved[1:4], ranges]))
         return samples[0] if n_samples == 1 else np.asarray(samples)
@@ -549,9 +581,16 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
         for moved, probability in zip(successors, probabilities):
             if probability <= 0 or not np.array_equal(moved[1:4], observation[:3]):
                 continue
-            residual = (observation[3:] - self.nominal_scan(moved)) / self.range_noise_std_cells
-            log_density = -0.5 * np.sum(residual**2) - self.num_beams * np.log(
-                self.range_noise_std_cells * np.sqrt(2 * np.pi)
+            # Under truncation the normaliser is Phi(nominal / sigma), which
+            # differs from beam to beam and from particle to particle, so the
+            # helper scores the scan under whichever law is selected.
+            log_density = float(
+                scan_log_density(
+                    observation[3:],
+                    self.nominal_scan(moved),
+                    self.range_noise_std_cells,
+                    self.range_noise_model,
+                )
             )
             score = np.logaddexp(score, np.log(probability) + log_density)
         return float(score)
@@ -641,9 +680,11 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
 
         Simulation supplies next_state and receives the observed inverse-map
         entropy difference. PFT_DPW's belief reward calls without a successor;
-        that explicit fallback uses eight fixed antithetic Gaussian samples.
-        The numerical expectation is approximate and uses no global randomness.
-        Neither quantity is posterior whole-map information gain.
+        that explicit fallback uses eight fixed antithetic unit-normal points
+        mapped through the selected range law, so under truncation it never
+        integrates over a scan the law cannot produce. The numerical
+        expectation is approximate and uses no global randomness. Neither
+        quantity is posterior whole-map information gain.
         """
         if next_state is not None:
             return self.entropy_bits(state) - self.entropy_bits(next_state) - self.step_cost
@@ -652,7 +693,12 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
         for moved, probability in zip(successors, probabilities):
             nominal = self.nominal_scan(moved)
             for noise in self._reward_noise:
-                observation = np.r_[moved[1:4], nominal + self.range_noise_std_cells * noise]
+                observation = np.r_[
+                    moved[1:4],
+                    quadrature_ranges(
+                        nominal, noise, self.range_noise_std_cells, self.range_noise_model
+                    ),
+                ]
                 after += probability * self.entropy_bits(
                     self.state_from_observation(state, observation)
                 )
@@ -709,6 +755,7 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
             self.field_of_view_degrees,
             self.max_range_cells,
             self.range_noise_std_cells,
+            self.range_noise_model,
             self.free_log_odds,
             self.occupied_log_odds,
             self.log_odds_clamp,

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_visualizer.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_visualizer.py
@@ -561,8 +561,9 @@ class OccupancyGridMappingVisualizer:
         endpoints: List[Tuple[float, float]] = []
         hits: List[bool] = []
         for (delta_row, delta_col), measured in zip(directions, np.asarray(ranges, dtype=float)):
-            # The noise is unclipped, so a reading can land past the sensor's
-            # range or below zero. Both are drawn clamped, because that is what
+            # The noise is unclipped above the range, and below zero too in
+            # Gaussian mode, so a reading can land past the sensor's range or
+            # below zero. Both are drawn clamped, because that is what
             # the inverse model does with them: it treats anything at or beyond
             # max_range_cells as a miss that frees the whole ray, and the beam
             # is drawn to the range with no end spark to say exactly that.

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_sensor.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_sensor.py
@@ -15,8 +15,11 @@ each can be tested on its own:
   evidence, the cell it stops in gets occupied evidence, and cells behind that
   one are left untouched because the beam never saw them.
 
-The forward ray cast is noise-free. The transition adds Gaussian noise before
-``observed_scan_log_odds_delta`` interprets the measured ranges. The legacy
+The forward ray cast is noise-free. The transition adds per-beam range noise
+before ``observed_scan_log_odds_delta`` interprets the measured ranges. Two
+noise laws live here, selected by the environment's ``range_noise_model``: the
+original unbounded Gaussian, and a normal truncated to ``[0, +inf)`` for callers
+who need a range law that cannot produce a negative reading. The legacy
 ``scan_log_odds_delta`` helper operates on explicit hit/slot arrays and is used
 only by geometry tests; the environment never uses hidden hits for mapping.
 
@@ -37,12 +40,31 @@ Functions:
     scan_log_odds_delta: Inverse sensor model for one scan.
     log_odds_from_probability: Convert a probability to log-odds.
     grid_entropy_bits: Binary entropy of an occupancy grid, in bits.
+    gaussian_log_density: Per-beam log density of the unbounded range law.
+    truncated_normal_log_norm: Per-beam log normaliser of the truncated law.
+    truncated_normal_log_density: Per-beam log density of the truncated law.
+    truncated_normal_from_upper_tail: Quantile function of the truncated law.
+    sample_truncated_normal_ranges: Draw truncated-normal ranges.
+    resolve_range_noise_model: Coerce a string or member to a range noise model.
+    range_log_density: Per-beam log density under the selected range law.
+    scan_log_density: Whole-scan log density under the selected range law.
+    sample_ranges: Draw noisy ranges under the selected range law.
+    quadrature_ranges: Transform fixed quadrature points under the selected law.
+
+Classes:
+    RangeNoiseModel: Which per-beam range noise law the sensor uses.
 """
 
 import math
-from typing import List, Tuple
+from enum import Enum
+from typing import List, Tuple, Union
 
 import numpy as np
+from numpy.typing import ArrayLike
+
+# The normal CDF, its inverse and its log are compiled ufuncs that pylint
+# cannot see inside scipy.special, as with the native extensions elsewhere.
+from scipy.special import log_ndtr, ndtr, ndtri  # pylint: disable=no-name-in-module
 
 
 #: Number of headings. North, east, south, west, in that order.
@@ -380,3 +402,303 @@ def observed_scan_log_odds_delta(
         np.bincount(flat[free], minlength=num_rows * num_cols) * free_log_odds
         + np.bincount(flat[occupied], minlength=num_rows * num_cols) * occupied_log_odds
     )
+
+
+def gaussian_log_density(values: ArrayLike, nominal: ArrayLike, std: float) -> np.ndarray:
+    """Per-beam log density of ``values`` under ``N(nominal, std^2)``.
+
+    The untruncated range law, kept here beside its truncated twin so the two
+    branches of the sensor read as one pair rather than as an addition bolted
+    onto the environment.
+
+    Args:
+        values: Measured ranges, any shape broadcastable against ``nominal``.
+        nominal: Noise-free ranges of the same broadcast shape.
+        std: Range noise standard deviation. Positive.
+
+    Returns:
+        Log densities, of the broadcast shape.
+    """
+    residual = (np.asarray(values, dtype=np.float64) - np.asarray(nominal, dtype=np.float64)) / std
+    return -0.5 * residual**2 - math.log(std * math.sqrt(2.0 * math.pi))
+
+
+def truncated_normal_log_norm(nominal: ArrayLike, std: float) -> np.ndarray:
+    """``log Phi(nominal / std)``: the truncation normaliser, per beam.
+
+    This is the mass the untruncated normal would have put below zero, divided
+    out. It depends on ``nominal``, so it is a per-beam and per-state quantity,
+    not a constant that can be hoisted out of a particle loop: two map particles
+    that predict different ranges for the same beam are normalised differently,
+    and dropping that difference would quietly bias every importance weight.
+
+    Computed with ``log_ndtr`` rather than ``log(ndtr(x))``: once ``nominal``
+    is more than about eight standard deviations above zero, ``ndtr`` rounds to
+    exactly 1 and the log to exactly 0, whereas ``log_ndtr`` still returns the
+    true ``-Phi(-x)`` tail. The difference is far below anything a particle
+    weight can feel, but there is no reason to throw it away.
+
+    Args:
+        nominal: Noise-free ranges, non-negative, any shape.
+        std: Range noise standard deviation. Positive.
+
+    Returns:
+        The log normaliser, of ``nominal``'s shape. Always non-positive, and
+        effectively ``0.0`` once ``nominal`` is several ``std`` above zero.
+    """
+    return log_ndtr(np.asarray(nominal, dtype=np.float64) / std)
+
+
+def truncated_normal_log_density(
+    values: ArrayLike, nominal: ArrayLike, std: float
+) -> np.ndarray:
+    """Per-beam log density of a normal truncated to ``[0, +inf)``.
+
+    ``f(z | rho, sigma) = phi((z - rho)/sigma) / (sigma * Phi(rho/sigma))`` for
+    ``z >= 0``, and zero below. A negative reading is impossible under this law,
+    so it scores ``-inf`` rather than the small-but-finite score the untruncated
+    normal would give it -- that is the whole point of the option.
+
+    Args:
+        values: Measured ranges, any shape broadcastable against ``nominal``.
+        nominal: Noise-free ranges, non-negative, of the same broadcast shape.
+        std: Range noise standard deviation. Positive.
+
+    Returns:
+        Log densities of the broadcast shape, ``-inf`` where ``values < 0``.
+    """
+    values = np.asarray(values, dtype=np.float64)
+    density = gaussian_log_density(values, nominal, std) - truncated_normal_log_norm(nominal, std)
+    return np.where(values >= 0.0, density, -np.inf)
+
+
+def truncated_normal_from_upper_tail(
+    upper_tail: ArrayLike, nominal: ArrayLike, std: float
+) -> np.ndarray:
+    """Quantile function of the ``[0, +inf)``-truncated normal, by upper tail.
+
+    Returns the ``z >= 0`` whose upper-tail probability under the truncated law
+    is ``upper_tail``. Written in the upper tail rather than the lower one
+    because that is the numerically safe direction here: the factor
+    ``Phi(nominal/std)`` is the one close to 1, and
+
+        z = nominal - std * Phi^-1(upper_tail * Phi(nominal / std))
+
+    then degenerates gracefully. At the environment's defaults a beam at full
+    range sits ten standard deviations above zero, ``Phi(10) == 1.0`` in double
+    precision, and the expression reduces exactly to the untruncated quantile --
+    so turning truncation on costs nothing where truncation does not bite.
+
+    Exact inversion, so it is equally usable for drawing samples (feed uniforms)
+    and for transforming a fixed quadrature rule (feed ``Phi(-point)``). Neither
+    use rejects, loops, or drops a tail.
+
+    Args:
+        upper_tail: Upper-tail probabilities in ``(0, 1]``, any shape
+            broadcastable against ``nominal``. A value of exactly ``0`` would
+            map to ``+inf``; callers drawing uniforms must exclude it.
+        nominal: Noise-free ranges, non-negative, of the same broadcast shape.
+        std: Range noise standard deviation. Positive.
+
+    Returns:
+        Ranges of the broadcast shape, all ``>= 0``.
+    """
+    nominal = np.asarray(nominal, dtype=np.float64)
+    upper_tail = np.asarray(upper_tail, dtype=np.float64)
+    values = nominal - std * ndtri(upper_tail * ndtr(nominal / std))
+    # Only a floating-point guard on the boundary itself: ``upper_tail == 1``
+    # is the lower end of the support, an exact zero analytically, and
+    # ``ndtri(ndtr(x))`` returns it a few ulps off on either side. It is not a
+    # clamp -- no interior probability mass is moved onto zero, because no
+    # interior tail value reaches it.
+    return np.where(upper_tail >= 1.0, 0.0, np.maximum(values, 0.0))
+
+
+def sample_truncated_normal_ranges(nominal: ArrayLike, std: float) -> np.ndarray:
+    """Draw one truncated-normal range per entry of ``nominal``.
+
+    Draws from the global NumPy stream, like every other generative path in this
+    environment, consuming exactly one uniform per beam.
+
+    Args:
+        nominal: Noise-free ranges, non-negative, any shape.
+        std: Range noise standard deviation. Positive.
+
+    Returns:
+        Sampled ranges of ``nominal``'s shape, all ``>= 0``.
+    """
+    nominal = np.asarray(nominal, dtype=np.float64)
+    # ``random_sample`` yields [0, 1); the complement moves that to (0, 1] so an
+    # exact zero -- which the quantile maps to +inf -- can never be drawn.
+    upper_tail = 1.0 - np.random.random_sample(nominal.shape)
+    return truncated_normal_from_upper_tail(upper_tail, nominal, std)
+
+
+class RangeNoiseModel(Enum):
+    """Which per-beam range noise law the sensor draws from and scores with.
+
+    Attributes:
+        GAUSSIAN: Unbounded ``N(rho, sigma^2)``. The original law, and the
+            default, so existing results stay reproducible.
+        TRUNCATED_NORMAL: The same normal truncated to ``[0, +inf)`` and
+            renormalised, for callers who need a range law that cannot report a
+            negative distance. Readings above the nominal maximum range are
+            untouched; only the impossible side is cut off.
+    """
+
+    GAUSSIAN = "gaussian"
+    TRUNCATED_NORMAL = "truncated_normal"
+
+
+def resolve_range_noise_model(value: Union[RangeNoiseModel, str]) -> RangeNoiseModel:
+    """Coerce a member or its string value to a :class:`RangeNoiseModel`.
+
+    Strings are accepted so an environment can be configured from a YAML file
+    without importing the enum.
+
+    Args:
+        value: A :class:`RangeNoiseModel`, or one of its string values.
+
+    Returns:
+        The matching member.
+
+    Raises:
+        ValueError: If ``value`` names no member. The message lists the valid
+            names, because a silently accepted typo here would fall through to
+            whichever branch is written first and look like a modelling result.
+    """
+    if isinstance(value, RangeNoiseModel):
+        return value
+    try:
+        return RangeNoiseModel(value)
+    except ValueError as error:
+        valid = ", ".join(repr(member.value) for member in RangeNoiseModel)
+        raise ValueError(
+            f"range_noise_model must be one of {valid} or a RangeNoiseModel, got {value!r}"
+        ) from error
+
+
+def range_log_density(
+    values: ArrayLike, nominal: ArrayLike, std: float, model: RangeNoiseModel
+) -> np.ndarray:
+    """Per-beam log density of measured ranges under the selected law.
+
+    Args:
+        values: Measured ranges, any shape broadcastable against ``nominal``.
+        nominal: Noise-free ranges of the same broadcast shape.
+        std: Range noise standard deviation. Positive.
+        model: Which range law to score under.
+
+    Returns:
+        Log densities of the broadcast shape. Sum over the beam axis for a
+        scan's log density -- note the truncated law's normaliser varies per
+        beam, so that sum is not the constant it is under the Gaussian law.
+
+    Raises:
+        ValueError: If ``model`` is not a known range noise model.
+    """
+    if model is RangeNoiseModel.GAUSSIAN:
+        return gaussian_log_density(values, nominal, std)
+    if model is RangeNoiseModel.TRUNCATED_NORMAL:
+        return truncated_normal_log_density(values, nominal, std)
+    raise ValueError(f"unknown range noise model: {model}")
+
+
+def scan_log_density(
+    values: ArrayLike, nominal: ArrayLike, std: float, model: RangeNoiseModel
+) -> np.ndarray:
+    """Log density of whole scans: the per-beam densities summed over the last axis.
+
+    Under the Gaussian law the normaliser is one constant for the whole scan,
+    and it is applied once, after the sum, in the arithmetic the environment
+    used before the truncated law existed. Summing ``range_log_density`` per
+    beam instead would give the same value up to rounding -- and that rounding
+    is enough to move a particle filter's weights by a few ulps, which is a
+    silent change to every seeded Gaussian result, including the golden
+    visualization. Under the truncated law the normaliser is per beam, so
+    there the per-beam sum is the only correct form.
+
+    Args:
+        values: Measured ranges, shape ``(..., num_beams)``, broadcastable
+            against ``nominal``.
+        nominal: Noise-free ranges of the same broadcast shape.
+        std: Range noise standard deviation. Positive.
+        model: Which range law to score under.
+
+    Returns:
+        Log densities of the broadcast shape with the last axis removed.
+
+    Raises:
+        ValueError: If ``model`` is not a known range noise model.
+    """
+    values = np.asarray(values, dtype=np.float64)
+    nominal = np.asarray(nominal, dtype=np.float64)
+    if model is RangeNoiseModel.GAUSSIAN:
+        residual = (values - nominal) / std
+        num_beams = np.broadcast_shapes(values.shape, nominal.shape)[-1]
+        return -0.5 * np.sum(residual**2, axis=-1) - num_beams * np.log(std * np.sqrt(2 * np.pi))
+    if model is RangeNoiseModel.TRUNCATED_NORMAL:
+        return np.sum(truncated_normal_log_density(values, nominal, std), axis=-1)
+    raise ValueError(f"unknown range noise model: {model}")
+
+
+def sample_ranges(nominal: ArrayLike, std: float, model: RangeNoiseModel) -> np.ndarray:
+    """Draw one noisy range per entry of ``nominal`` under the selected law.
+
+    Draws from the global NumPy stream. The Gaussian branch keeps its original
+    ``np.random.normal`` call, and therefore its exact seeded output, so a run
+    that does not select truncation reproduces bit for bit.
+
+    Args:
+        nominal: Noise-free ranges, non-negative, any shape.
+        std: Range noise standard deviation. Positive.
+        model: Which range law to draw from.
+
+    Returns:
+        Sampled ranges of ``nominal``'s shape.
+
+    Raises:
+        ValueError: If ``model`` is not a known range noise model.
+    """
+    nominal = np.asarray(nominal, dtype=np.float64)
+    if model is RangeNoiseModel.GAUSSIAN:
+        return nominal + np.random.normal(0.0, std, nominal.shape)
+    if model is RangeNoiseModel.TRUNCATED_NORMAL:
+        return sample_truncated_normal_ranges(nominal, std)
+    raise ValueError(f"unknown range noise model: {model}")
+
+
+def quadrature_ranges(
+    nominal: ArrayLike, standard_points: ArrayLike, std: float, model: RangeNoiseModel
+) -> np.ndarray:
+    """Map fixed unit-normal quadrature points to ranges under the selected law.
+
+    The expected-reward integral uses a fixed antithetic set of unit normals so
+    it consumes no global randomness. Under truncation those points must be
+    pushed through the truncated quantile function rather than scaled and
+    shifted, or the integral would average over scans the model cannot produce
+    -- including negative ones, which is exactly what the option exists to
+    prevent. Transforming by upper-tail probability keeps the points antithetic,
+    because ``Phi(-x)`` and ``Phi(x)`` sum to one.
+
+    Args:
+        nominal: Noise-free ranges, non-negative, broadcastable against
+            ``standard_points``.
+        standard_points: Unit-variance integration points of the same broadcast
+            shape.
+        std: Range noise standard deviation. Positive.
+        model: Which range law the points are integrating over.
+
+    Returns:
+        Ranges of the broadcast shape.
+
+    Raises:
+        ValueError: If ``model`` is not a known range noise model.
+    """
+    nominal = np.asarray(nominal, dtype=np.float64)
+    standard_points = np.asarray(standard_points, dtype=np.float64)
+    if model is RangeNoiseModel.GAUSSIAN:
+        return nominal + std * standard_points
+    if model is RangeNoiseModel.TRUNCATED_NORMAL:
+        return truncated_normal_from_upper_tail(ndtr(-standard_points), nominal, std)
+    raise ValueError(f"unknown range noise model: {model}")

--- a/POMDPPlanners/tests/test_environments/test_env_api_conformance.py
+++ b/POMDPPlanners/tests/test_environments/test_env_api_conformance.py
@@ -164,8 +164,18 @@ def _build_battleship() -> BattleshipPOMDP:
 
 
 def _build_occupancy_grid_mapping() -> OccupancyGridMappingPOMDP:
+    return OccupancyGridMappingPOMDP(discount_factor=0.95, **occupancy_grid_mapping_pinned_kwargs())
+
+
+def _build_occupancy_grid_mapping_truncated_normal() -> OccupancyGridMappingPOMDP:
+    # The second range law is a different observation model on the same
+    # class, so it gets its own registry entry; the wider noise is what makes
+    # the truncation actually bite on the pinned world.
     return OccupancyGridMappingPOMDP(
-        discount_factor=0.95, **occupancy_grid_mapping_pinned_kwargs()
+        discount_factor=0.95,
+        **occupancy_grid_mapping_pinned_kwargs(
+            range_noise_model="truncated_normal", range_noise_std_cells=1.0
+        ),
     )
 
 
@@ -245,6 +255,7 @@ ENV_BUILDERS: List[Tuple[str, EnvBuilder]] = [
     ("ContinuousMazePOMDP", _build_continuous_maze),
     ("BattleshipPOMDP", _build_battleship),
     ("OccupancyGridMappingPOMDP", _build_occupancy_grid_mapping),
+    ("OccupancyGridMappingPOMDP[truncated_normal]", _build_occupancy_grid_mapping_truncated_normal),
 ]
 
 
@@ -772,8 +783,7 @@ def test_reward_batch_agrees_with_looped_reward(env_builder: EnvBuilder) -> None
     looped = np.array([float(env.reward(state, action)) for state in states])
 
     assert np.allclose(batched, looped), (
-        f"{type(env).__name__}.reward_batch disagrees with looped reward: "
-        f"{batched} vs {looped}"
+        f"{type(env).__name__}.reward_batch disagrees with looped reward: " f"{batched} vs {looped}"
     )
 
 
@@ -1081,8 +1091,7 @@ def test_inequality_survives_a_changed_discount_factor(env_builder: EnvBuilder) 
     second.discount_factor = first.discount_factor / 2.0
 
     assert first != second, (
-        f"{type(first).__name__} compares equal to an env with a different "
-        "discount factor"
+        f"{type(first).__name__} compares equal to an env with a different " "discount factor"
     )
     assert first.config_id != second.config_id
 
@@ -1291,9 +1300,9 @@ def test_step_info_tolerates_terminal_bookkeeping_step(env_builder: EnvBuilder) 
         "bookkeeping step; the contract is a flat name -> scalar mapping"
     )
     for channel, value in info.items():
-        assert isinstance(channel, str), (
-            f"{type(env).__name__}.step_info used a non-string channel name {channel!r}"
-        )
+        assert isinstance(
+            channel, str
+        ), f"{type(env).__name__}.step_info used a non-string channel name {channel!r}"
         assert isinstance(value, (int, float)) and not isinstance(value, bool), (
             f"{type(env).__name__}.step_info reported {channel!r} as "
             f"{type(value).__name__}; values must be plain picklable scalars"
@@ -1454,6 +1463,5 @@ def test_same_seed_reproduces_trajectory(env_builder: EnvBuilder) -> None:
     second = _rollout(env_builder(), seed=1234)
     assert first, "rollout produced no steps; the determinism check would be vacuous"
     assert first == second, (
-        f"{type(env_builder()).__name__} produced two different trajectories from the "
-        "same seed"
+        f"{type(env_builder()).__name__} produced two different trajectories from the " "same seed"
     )

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_observation_contract.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_observation_contract.py
@@ -3,15 +3,18 @@
 
 import numpy as np
 import pytest
+from scipy.special import log_ndtr  # pylint: disable=no-name-in-module
+from scipy.stats import truncnorm
 
 from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
     OccupancyGridMappingPOMDP,
     OccupancyGridMappingBelief,
+    RangeNoiseModel,
     create_occupancy_grid_state,
 )
 
 
-def scenario(noise=0.35):
+def scenario(noise=0.35, range_noise_model=RangeNoiseModel.GAUSSIAN):
     """One east-facing beam whose endpoint is two cells from the robot."""
     env = OccupancyGridMappingPOMDP(
         num_rows=7,
@@ -22,6 +25,7 @@ def scenario(noise=0.35):
         has_boundary_wall=False,
         num_obstacles=0,
         range_noise_std_cells=noise,
+        range_noise_model=range_noise_model,
     )
     empty = np.zeros((7, 7))
     hit = empty.copy()
@@ -207,3 +211,99 @@ def test_realised_reward_uses_the_same_observation_as_reported_mapping():
     successor, observation, reward = env.sample_next_step(state, 2)
     reconstructed = env.state_from_observation(state, observation)
     assert reward == pytest.approx(env.entropy_bits(state) - env.entropy_bits(reconstructed))
+
+
+# -- truncated-normal range law ---------------------------------------------
+
+TRUNCATED = RangeNoiseModel.TRUNCATED_NORMAL
+
+
+def test_truncated_normal_is_sampled_once_nonnegative_and_scored_with_its_normaliser():
+    """The truncated law follows the same one-draw contract with a proper density.
+
+    With ``sigma = 1.5`` and a nominal range of 2 the Gaussian would put about
+    nine percent of its mass below zero, so the truncation is doing real work.
+    """
+    env, state, _ = scenario(noise=1.5, range_noise_model=TRUNCATED)
+    np.random.seed(4)
+    samples = env.sample_next_state(state, 2, 4000)
+    ranges = samples[:, env.scan_offset]
+    reference = truncnorm(a=-2 / 1.5, b=np.inf, loc=2, scale=1.5)
+    assert ranges.min() >= 0
+    assert ranges.mean() == pytest.approx(reference.mean(), abs=0.06)
+    assert ranges.std() == pytest.approx(reference.std(), abs=0.06)
+    observation = env.sample_observation(samples[0], 2)
+    # The stored scan and the revealed observation are the same numbers.
+    np.testing.assert_array_equal(observation[3:], samples[0, env.scan_offset :])
+    np.testing.assert_array_equal(env.sample_observation(samples[0], 2, 3), [observation] * 3)
+    assert env.observation_log_probability(samples[0], 2, observation)[0] == 0
+    expected = (
+        -0.5 * ((observation[-1] - 2) / 1.5) ** 2
+        - np.log(1.5 * np.sqrt(2 * np.pi))
+        - log_ndtr(2 / 1.5)
+    )
+    assert env.predictive_observation_log_probability(state, 2, observation) == pytest.approx(
+        expected
+    )
+    assert env.transition_log_probability(state, 2, samples[:1])[0] == pytest.approx(expected)
+    np.testing.assert_array_equal(env.state_from_observation(state, observation), samples[0])
+
+
+def test_a_negative_reading_has_no_support_under_the_truncated_law_only():
+    """The truncated law scores an impossible reading ``-inf``; the Gaussian does not."""
+    truncated, state, _ = scenario(noise=1.5, range_noise_model=TRUNCATED)
+    gaussian, _, _ = scenario(noise=1.5)
+    negative = np.array([3, 3, 1, -0.2])
+    assert truncated.predictive_observation_log_probability(state, 2, negative) == -np.inf
+    assert np.isfinite(gaussian.predictive_observation_log_probability(state, 2, negative))
+    forged = truncated.state_from_observation(state, negative)
+    assert truncated.transition_log_probability(state, 2, [forged])[0] == -np.inf
+    assert np.isfinite(gaussian.transition_log_probability(state, 2, [forged])[0])
+    assert truncated.predictive_observation_log_probability(
+        state, 2, np.array([3, 3, 1, 0.0])
+    ) > -np.inf
+
+
+def test_truncated_filter_weights_carry_each_particle_normaliser():
+    """Posterior odds include the per-particle ``Phi(rho / sigma)``, and the
+    correction favours the nearer hypothesis relative to the Gaussian."""
+    env, empty, hit = scenario(noise=1.5, range_noise_model=TRUNCATED)
+    env.true_map(hit)[3, 4] = 1  # nominal 1 for ``hit``, 2 for ``empty``
+    belief = OccupancyGridMappingBelief([empty, hit], np.log([0.5, 0.5]))
+    observation = np.array([3, 3, 1, 1.5])
+    result = belief.update(2, observation, env, state=hit)
+    gaussian_ratio = np.exp(
+        -0.5 * ((1.5 - 1) / 1.5) ** 2 + 0.5 * ((1.5 - 2) / 1.5) ** 2
+    )
+    truncated_ratio = gaussian_ratio * np.exp(log_ndtr(2 / 1.5) - log_ndtr(1 / 1.5))
+    weights = result.normalized_weights
+    assert weights[1] / weights[0] == pytest.approx(truncated_ratio)
+    assert truncated_ratio > gaussian_ratio
+    scores = np.array(
+        [env.predictive_observation_log_probability(s, 2, observation) for s in [empty, hit]]
+    )
+    assert scores[1] - scores[0] == pytest.approx(np.log(truncated_ratio))
+    np.testing.assert_array_equal(
+        env.log_odds(result.particles[0]), env.log_odds(result.particles[1])
+    )
+
+
+def test_truncated_expected_reward_is_deterministic_and_matches_gaussian_far_from_zero():
+    """The quadrature represents the selected law without touching the RNG."""
+    truncated, state, _ = scenario(noise=1.5, range_noise_model=TRUNCATED)
+    gaussian, same_state, _ = scenario(noise=1.5)
+    np.random.seed(9)
+    expected_next_random = np.random.random()
+    np.random.seed(9)
+    reward = truncated.reward(state, 2)
+    assert np.random.random() == expected_next_random
+    assert truncated.reward(state, 2) == reward
+    assert truncated.reward_range[0] <= reward <= truncated.reward_range[1]
+    assert reward != pytest.approx(gaussian.reward(same_state, 2))
+    # At the default noise the beam sits about six deviations above zero and
+    # the two laws integrate over the same scans.
+    narrow_truncated, narrow_state, _ = scenario(range_noise_model=TRUNCATED)
+    narrow_gaussian, _, _ = scenario()
+    assert narrow_truncated.reward(narrow_state, 2) == pytest.approx(
+        narrow_gaussian.reward(narrow_state, 2), abs=1e-6
+    )

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_reward_batch.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_reward_batch.py
@@ -12,26 +12,35 @@ import pickle
 import numpy as np
 import pytest
 
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import RangeNoiseModel
 from POMDPPlanners.tests.test_environments.test_occupancy_grid_mapping_pomdp.test_occupancy_grid_mapping_beliefs.test_occupancy_grid_mapping_vectorized_updater import (  # noqa: E501
     ACTIONS,
+    RANGE_NOISE_MODELS,
     diverse_particles,
     make_env,
 )
 
 
+@pytest.mark.parametrize("range_noise_model", RANGE_NOISE_MODELS)
 @pytest.mark.parametrize("move_failure_probability", [0.0, 0.25])
 @pytest.mark.parametrize("action", ACTIONS)
-def test_expected_reward_matches_scalar_reward(action, move_failure_probability):
+def test_expected_reward_matches_scalar_reward(action, move_failure_probability, range_noise_model):
     """Purpose: the planner's expected reward must not change with the batching.
 
-    Given: Particles at mixed poses with partly resolved maps.
+    Given: Particles at mixed poses with partly resolved maps, under each
+        range law with noise wide enough for the truncation to matter.
     When: ``reward_batch`` without successors and the scalar ``reward`` are
         evaluated for the same action.
     Then: They agree to floating-point precision for every particle.
 
     Test type: unit
     """
-    env = make_env(move_failure_probability=move_failure_probability, step_cost=0.1)
+    env = make_env(
+        move_failure_probability=move_failure_probability,
+        step_cost=0.1,
+        range_noise_std_cells=1.0,
+        range_noise_model=range_noise_model,
+    )
     particles = diverse_particles(env)
     batched = env.reward_batch(particles, action)
     scalar = np.array([env.reward(particle, action) for particle in particles])
@@ -81,6 +90,12 @@ def test_batched_kernels_follow_setting_changes_and_survive_pickling():
     np.testing.assert_allclose(
         env.reward_batch(particles, 0), [env.reward(particle, 0) for particle in particles]
     )
+    env.range_noise_std_cells = 1.0
+    gaussian = env.reward_batch(particles, 0)
+    env.range_noise_model = RangeNoiseModel.TRUNCATED_NORMAL
+    truncated = env.reward_batch(particles, 0)
+    np.testing.assert_allclose(truncated, [env.reward(particle, 0) for particle in particles])
+    assert not np.allclose(truncated, gaussian)
     restored = pickle.loads(pickle.dumps(env))
     assert "_batched_kernels_cache" not in restored.__dict__
     np.testing.assert_allclose(restored.reward_batch(particles, 0), env.reward_batch(particles, 0))

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_vectorized_belief.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_vectorized_belief.py
@@ -116,11 +116,21 @@ class TestConstruction:
 
 
 class TestUpdate:
-    @pytest.mark.parametrize("move_failure_probability", [0.0, 0.25])
-    def test_chained_updates_match_the_scalar_filter(self, move_failure_probability):
+    @pytest.mark.parametrize(
+        ("move_failure_probability", "range_noise_model", "range_noise_std_cells"),
+        [
+            (0.0, "gaussian", 0.35),
+            (0.25, "gaussian", 0.35),
+            (0.0, "truncated_normal", 1.0),
+            (0.25, "truncated_normal", 1.0),
+        ],
+    )
+    def test_chained_updates_match_the_scalar_filter(
+        self, move_failure_probability, range_noise_model, range_noise_std_cells
+    ):
         """Purpose: the vectorized filter is a drop-in replacement, so an
         episode's worth of conditioning must give identical particles and
-        weights, not just the same distribution.
+        weights, not just the same distribution -- under either range law.
 
         Given: Both filters over the same 20 prior maps and a true world.
         When: Twelve observed steps are conditioned on, in the same order.
@@ -129,7 +139,11 @@ class TestUpdate:
 
         Test type: integration
         """
-        env = make_env(move_failure_probability=move_failure_probability)
+        env = make_env(
+            move_failure_probability=move_failure_probability,
+            range_noise_model=range_noise_model,
+            range_noise_std_cells=range_noise_std_cells,
+        )
         scalar, vectorized = paired_filters(env)
         np.random.seed(17)
         true_state = env.initial_state_dist().sample()[0]

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_vectorized_updater.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_beliefs/test_occupancy_grid_mapping_vectorized_updater.py
@@ -17,6 +17,7 @@ from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
     OccupancyGridAction,
     OccupancyGridMappingPOMDP,
     OccupancyGridMappingVectorizedUpdater,
+    RangeNoiseModel,
 )
 from POMDPPlanners.tests.test_core.test_belief.vectorized_updater_test_utils import (
     assert_batch_obs_log_likelihood_matches_loop,
@@ -27,6 +28,7 @@ from POMDPPlanners.tests.test_utils.env_pinned_kwargs import (
 )
 
 ACTIONS = [int(action) for action in OccupancyGridAction]
+RANGE_NOISE_MODELS = list(RangeNoiseModel)
 
 
 def make_env(**overrides):
@@ -366,3 +368,124 @@ class TestGenerativeInterface:
         scores = updater.batch_observation_log_likelihood(successors, action, observation)
         assert scores[5] == 0.0
         assert np.count_nonzero(np.isfinite(scores)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Truncated-normal range law
+# ---------------------------------------------------------------------------
+
+
+def truncated_env(**overrides):
+    """The pinned world under the truncated law, noisy enough for it to bite.
+
+    At ``sigma = 1.0`` a beam stopping one cell away sits one standard
+    deviation above zero, so the per-particle normaliser is far from one and
+    a batched path that hoisted it into a constant would fail every parity
+    check below.
+    """
+    return make_env(
+        range_noise_std_cells=1.0, range_noise_model=RangeNoiseModel.TRUNCATED_NORMAL, **overrides
+    )
+
+
+class TestTruncatedNormalMode:
+    def test_from_environment_copies_the_law_and_the_identity_tracks_it(self, updater):
+        """Purpose: the updater must score under the environment's law, and
+        two updaters under different laws must cache differently.
+
+        Test type: unit
+        """
+        assert updater.range_noise_model is RangeNoiseModel.GAUSSIAN
+        truncated = OccupancyGridMappingVectorizedUpdater.from_environment(
+            make_env(range_noise_model="truncated_normal")
+        )
+        assert truncated.range_noise_model is RangeNoiseModel.TRUNCATED_NORMAL
+        assert truncated.config_id != updater.config_id
+        with pytest.raises(ValueError, match="range_noise_model"):
+            OccupancyGridMappingVectorizedUpdater(
+                num_rows=5,
+                num_cols=5,
+                num_beams=4,
+                field_of_view_degrees=360.0,
+                max_range_cells=2.0,
+                range_noise_std_cells=0.5,
+                free_log_odds=-1.0,
+                occupied_log_odds=1.0,
+                log_odds_clamp=6.0,
+                move_failure_probability=0.0,
+                range_noise_model="clipped",
+            )
+
+    @pytest.mark.parametrize("move_failure_probability", [0.0, 0.25])
+    @pytest.mark.parametrize("action", ACTIONS)
+    def test_predictive_density_matches_scalar_with_per_particle_normalisers(
+        self, action, move_failure_probability
+    ):
+        """Purpose: the batched importance weight must carry each particle's
+        own ``Phi(rho / sigma)`` per beam, exactly as the scalar path does.
+
+        Given: Particles at mixed poses with maps that put obstacles at
+            different distances, under the truncated law with wide noise.
+        When: Both paths score an observation drawn from one particle.
+        Then: They agree to floating-point precision, the drawn-from particle
+            is finite, and the scores are not what the Gaussian law gives.
+
+        Test type: unit
+        """
+        env = truncated_env(move_failure_probability=move_failure_probability)
+        updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        particles = diverse_particles(env)
+        observation = observation_from(env, particles[7], action)
+        batched = updater.batch_predictive_log_likelihood(particles, action, observation)
+        scalar = np.array(
+            [
+                env.predictive_observation_log_probability(particle, action, observation)
+                for particle in particles
+            ]
+        )
+        np.testing.assert_allclose(batched, scalar, rtol=1e-12, atol=1e-12)
+        assert np.isfinite(batched[7])
+        gaussian = OccupancyGridMappingVectorizedUpdater.from_environment(
+            make_env(
+                range_noise_std_cells=1.0, move_failure_probability=move_failure_probability
+            )
+        ).batch_predictive_log_likelihood(particles, action, observation)
+        finite = np.isfinite(batched)
+        assert np.array_equal(finite, np.isfinite(gaussian))
+        assert np.all(batched[finite] > gaussian[finite])
+
+    def test_a_negative_reading_has_no_support_in_the_batched_path(self):
+        """Test type: unit"""
+        env = truncated_env()
+        updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        particles = diverse_particles(env)
+        observation = observation_from(env, particles[0], 0)
+        observation[5] = -0.01
+        assert np.all(np.isneginf(updater.batch_predictive_log_likelihood(particles, 0, observation)))
+        observation[5] = 0.0
+        assert np.isfinite(updater.batch_predictive_log_likelihood(particles, 0, observation)[0])
+
+    @pytest.mark.parametrize("action", ACTIONS)
+    def test_batch_transition_matches_scalar_under_shared_seed_and_stays_nonnegative(
+        self, action
+    ):
+        """Purpose: the truncated sampler consumes one uniform per beam in the
+        same order on both paths, so the successors must be bit-identical, and
+        no stored range may be negative.
+
+        Test type: unit
+        """
+        env = truncated_env()
+        updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+        particles = diverse_particles(env)
+        assert_batch_transition_matches_loop(
+            updater, particles, action, env.sample_next_state, atol=0.0, seed=5
+        )
+        np.random.seed(5)
+        successors = updater.batch_transition(particles, action)
+        assert successors[:, env.scan_offset :].min() >= 0.0
+        np.random.seed(5)
+        gaussian = OccupancyGridMappingVectorizedUpdater.from_environment(
+            make_env(range_noise_std_cells=1.0)
+        ).batch_transition(particles, action)
+        assert gaussian[:, env.scan_offset :].min() < 0.0

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_mapping_pomdp.py
@@ -19,6 +19,7 @@ from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
     OccupancyGridMappingMetrics,
     OccupancyGridMappingPOMDP,
     OccupancyGridStepChannel,
+    RangeNoiseModel,
     create_occupancy_grid_state,
     grid_entropy_bits,
 )
@@ -442,3 +443,117 @@ def test_config_id_is_unchanged_by_using_the_environment(env):
         state, _, _ = env.sample_next_step(state, int(np.random.randint(3)))
     assert env.config_id == before
     assert env.config_id == OccupancyGridMappingPOMDP().config_id
+
+
+# -- range noise model configuration ---------------------------------------
+
+
+def test_range_noise_model_accepts_its_string_name_and_rejects_unknown_ones():
+    """A YAML config can name the law; a typo fails at construction.
+
+    Test type: unit
+    """
+    env = OccupancyGridMappingPOMDP(range_noise_model="truncated_normal")
+    assert env.range_noise_model is RangeNoiseModel.TRUNCATED_NORMAL
+    assert OccupancyGridMappingPOMDP().range_noise_model is RangeNoiseModel.GAUSSIAN
+    with pytest.raises(ValueError, match="range_noise_model"):
+        OccupancyGridMappingPOMDP(range_noise_model="clipped")
+    with pytest.raises(ValueError, match="range_noise_std_cells"):
+        OccupancyGridMappingPOMDP(range_noise_model="truncated_normal", range_noise_std_cells=0.0)
+
+
+def test_the_two_range_laws_have_distinct_identities_that_survive_serialization():
+    """A truncated-normal run must never read a Gaussian cache, or vice versa.
+
+    Purpose: ``config_id`` keys the result cache and the belief identities
+        hang off the updater's. If the mode were not in them, the two laws
+        would silently share cached episodes.
+
+    Given: Two otherwise identical environments, one per law
+    When: Their ids are compared, and the truncated one is round-tripped
+        through ``to_dict`` / ``from_dict`` and through pickle
+    Then: The ids differ, the rebuilt environments keep the enum member and
+        the id, and the sensor contract version is 3
+
+    Test type: unit
+    """
+    import pickle  # pylint: disable=import-outside-toplevel
+
+    gaussian = OccupancyGridMappingPOMDP()
+    truncated = OccupancyGridMappingPOMDP(range_noise_model=RangeNoiseModel.TRUNCATED_NORMAL)
+    assert gaussian.config_id != truncated.config_id
+    assert gaussian != truncated
+    assert gaussian.sensor_contract_version == truncated.sensor_contract_version == 3
+    assert truncated.to_dict()["params"]["range_noise_model"]["value"] == "truncated_normal"
+    for rebuilt in (
+        OccupancyGridMappingPOMDP.from_dict(truncated.to_dict()),
+        pickle.loads(pickle.dumps(truncated)),
+    ):
+        assert isinstance(rebuilt, OccupancyGridMappingPOMDP)
+        assert rebuilt.range_noise_model is RangeNoiseModel.TRUNCATED_NORMAL
+        assert rebuilt.config_id == truncated.config_id
+        assert rebuilt == truncated
+    updaters = {
+        env.range_noise_model: env._batched_kernels  # pylint: disable=protected-access
+        for env in (gaussian, truncated)
+    }
+    assert (
+        updaters[RangeNoiseModel.GAUSSIAN].config_id
+        != updaters[RangeNoiseModel.TRUNCATED_NORMAL].config_id
+    )
+
+
+def test_gaussian_mode_reproduces_the_original_seeded_scan(open_room_env):
+    """The default law draws exactly what the environment drew before the option.
+
+    Purpose: This is the regression guard for "no silent behaviour change":
+        the pre-option transition was ``nominal + normal(0, sigma)`` from the
+        global stream, and a seeded run must still produce those numbers.
+
+    Test type: unit
+    """
+    env = open_room_env
+    state = create_occupancy_grid_state(env, _empty_room(env))
+    moved = env.sample_next_state(state, int(OccupancyGridAction.TURN_LEFT))
+    np.random.seed(3)
+    successor = env.sample_next_state(state, int(OccupancyGridAction.TURN_LEFT))
+    np.random.seed(3)
+    expected = env.nominal_scan(moved) + np.random.normal(
+        0.0, env.range_noise_std_cells, env.num_beams
+    )
+    np.testing.assert_array_equal(successor[env.scan_offset :], expected)
+    observation = env.sample_observation(successor, int(OccupancyGridAction.TURN_LEFT))
+    residual = (observation[3:] - env.nominal_scan(moved)) / env.range_noise_std_cells
+    pooled = -0.5 * np.sum(residual**2) - env.num_beams * np.log(
+        env.range_noise_std_cells * np.sqrt(2 * np.pi)
+    )
+    assert env.predictive_observation_log_probability(
+        state, int(OccupancyGridAction.TURN_LEFT), observation
+    ) == pytest.approx(pooled)
+
+
+def test_truncated_mode_never_stores_or_reveals_a_negative_range():
+    """A long noisy rollout keeps every stored scan and observation non-negative.
+
+    Purpose: The map update and the returned observation read the same stored
+        scan, so one check on the state covers both; the noise is set high
+        enough that the Gaussian law would go negative many times.
+
+    Test type: integration
+    """
+    env = OccupancyGridMappingPOMDP(
+        num_rows=7,
+        num_cols=7,
+        max_range_cells=2.5,
+        num_obstacles=2,
+        range_noise_std_cells=1.5,
+        range_noise_model="truncated_normal",
+        max_steps=200,
+    )
+    np.random.seed(5)
+    state = env.initial_state_dist().sample()[0]
+    for _ in range(120):
+        action = int(np.random.randint(3))
+        state, observation, _ = env.sample_next_step(state, action)
+        assert observation[3:].min() >= 0.0
+        np.testing.assert_array_equal(observation[3:], state[env.scan_offset :])

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_sensor.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_grid_sensor.py
@@ -10,17 +10,30 @@ would still pass every shared contract while quietly measuring the wrong thing.
 """
 
 import math
+from typing import Any
 
 import numpy as np
 import pytest
+from scipy.integrate import quad
+from scipy.special import log_ndtr  # pylint: disable=no-name-in-module
+from scipy.stats import kstest, truncnorm
 
 from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sensor import (
     NUM_HEADINGS,
+    RangeNoiseModel,
     build_ray_templates,
     cast_scan,
+    gaussian_log_density,
     grid_entropy_bits,
     log_odds_from_probability,
+    quadrature_ranges,
+    range_log_density,
+    resolve_range_noise_model,
+    sample_ranges,
+    scan_log_density,
     scan_log_odds_delta,
+    truncated_normal_from_upper_tail,
+    truncated_normal_log_density,
 )
 
 
@@ -359,3 +372,283 @@ def test_certain_evidence_is_rejected(probability):
     """
     with pytest.raises(ValueError):
         log_odds_from_probability(probability)
+
+
+# -- range noise laws -----------------------------------------------------
+
+
+def _reference(nominal, std) -> Any:
+    """SciPy's truncated normal on ``[0, +inf)`` with the same parameters."""
+    return truncnorm(a=-nominal / std, b=np.inf, loc=nominal, scale=std)
+
+
+def test_truncated_samples_are_nonnegative_where_gaussian_samples_are_not():
+    """The truncated law never produces a negative range; the Gaussian does.
+
+    Purpose: The option exists to prevent negative readings. Checking the
+        Gaussian side too proves the mode switch does something, rather than
+        the nominal range merely being far from zero.
+
+    Given: A nominal range half a standard deviation above zero
+    When: Twenty thousand ranges are drawn under each law
+    Then: Every truncated draw is ``>= 0`` and some Gaussian draw is ``< 0``
+
+    Test type: unit
+    """
+    nominal = np.full(20000, 0.5)
+    np.random.seed(0)
+    truncated = sample_ranges(nominal, 1.0, RangeNoiseModel.TRUNCATED_NORMAL)
+    np.random.seed(0)
+    gaussian = sample_ranges(nominal, 1.0, RangeNoiseModel.GAUSSIAN)
+    assert truncated.min() >= 0.0
+    assert gaussian.min() < 0.0
+    assert truncated.shape == gaussian.shape == nominal.shape
+
+
+@pytest.mark.parametrize("nominal", [0.0, 0.3, 1.0, 3.0])
+def test_truncated_density_integrates_to_one_over_the_nonnegative_axis(nominal):
+    """The truncated density is a proper density on ``[0, +inf)``.
+
+    Purpose: A clamp at zero would leave the density integrating to less
+        than one below the point mass; a forgotten normaliser would leave it
+        integrating to ``Phi(rho / sigma)``. Quadrature catches both.
+
+    Given: A nominal range within a few standard deviations of zero
+    When: ``exp(log density)`` is integrated over ``[0, +inf)``
+    Then: The mass is one, and the density is zero below zero
+
+    Test type: unit
+    """
+    std = 1.0
+    mass, error = quad(
+        lambda z: math.exp(float(truncated_normal_log_density(z, nominal, std))), 0.0, np.inf
+    )
+    assert mass == pytest.approx(1.0, abs=max(1e-8, 10 * error))
+    assert np.isneginf(truncated_normal_log_density(-1e-9, nominal, std))
+
+
+def test_truncated_log_density_matches_the_hand_written_formula():
+    """``log phi((z-rho)/sigma) - log sigma - log Phi(rho/sigma)``, by hand.
+
+    Purpose: The implementation must be checked against the formula, not
+        against itself.
+
+    Test type: unit
+    """
+    z, nominal, std = 0.8, 0.5, 0.7
+    residual = (z - nominal) / std
+    log_phi = -0.5 * residual**2 - 0.5 * math.log(2 * math.pi)
+    big_phi = 0.5 * (1.0 + math.erf(nominal / std / math.sqrt(2)))
+    expected = log_phi - math.log(std) - math.log(big_phi)
+    assert float(truncated_normal_log_density(z, nominal, std)) == pytest.approx(expected)
+    assert float(
+        range_log_density(z, nominal, std, RangeNoiseModel.TRUNCATED_NORMAL)
+    ) == pytest.approx(expected)
+    assert float(range_log_density(z, nominal, std, RangeNoiseModel.GAUSSIAN)) == pytest.approx(
+        log_phi - math.log(std)
+    )
+
+
+@pytest.mark.parametrize("std", [0.35, 1.0, 2.0])
+def test_truncated_log_density_matches_scipy_across_the_supported_noise_range(std):
+    """Agreement with SciPy's ``truncnorm`` for small and large ``rho / sigma``.
+
+    Purpose: ``log Phi(rho/sigma)`` must be computed with ``log_ndtr`` so it
+        stays exact where ``log(ndtr(x))`` would lose digits; comparing over
+        nominal ranges from zero to ten standard deviations covers both ends.
+
+    Test type: unit
+    """
+    nominal = np.array([0.0, 0.2, 1.0, 3.5])
+    values = np.linspace(0.0, 6.0, 25)[:, None]
+    ours = truncated_normal_log_density(values, nominal[None, :], std)
+    reference = np.stack(
+        [_reference(rho, std).logpdf(values[:, 0]) for rho in nominal], axis=1
+    )
+    np.testing.assert_allclose(ours, reference, rtol=1e-10, atol=1e-10)
+
+
+def test_the_normaliser_depends_on_the_nominal_range():
+    """Two beams with different nominal ranges get different normalisers.
+
+    Purpose: The normaliser is what makes the truncated law differ from the
+        Gaussian for particle weighting. It must be a per-beam quantity, larger
+        (a bigger correction) for a nominal range closer to zero, and vanish
+        once the nominal range is far from zero.
+
+    Test type: unit
+    """
+    std = 1.0
+    near, far, remote = 0.3, 2.0, 12.0
+    z = 1.0
+    correction = {
+        rho: float(
+            truncated_normal_log_density(z, rho, std) - gaussian_log_density(z, rho, std)
+        )
+        for rho in (near, far, remote)
+    }
+    assert correction[near] == pytest.approx(-float(log_ndtr(near / std)))
+    assert correction[far] == pytest.approx(-float(log_ndtr(far / std)))
+    assert correction[near] > correction[far] > correction[remote] >= 0.0
+    assert correction[remote] == pytest.approx(0.0, abs=1e-15)
+
+
+def test_a_negative_reading_is_impossible_only_under_the_truncated_law():
+    """Test type: unit"""
+    nominal = np.array([0.5, 2.0])
+    values = np.array([-0.1, 1.0])
+    truncated = range_log_density(values, nominal, 1.0, RangeNoiseModel.TRUNCATED_NORMAL)
+    gaussian = range_log_density(values, nominal, 1.0, RangeNoiseModel.GAUSSIAN)
+    assert np.isneginf(truncated[0]) and np.isfinite(truncated[1])
+    assert np.all(np.isfinite(gaussian))
+    # Zero itself is inside the support.
+    assert np.isfinite(truncated_normal_log_density(0.0, 0.5, 1.0))
+
+
+@pytest.mark.parametrize("ratio", [0.2, 1.0, 3.0, 10.0])
+def test_the_quantile_function_inverts_the_truncated_upper_tail(ratio):
+    """``sf(quantile(u)) == u`` against SciPy, over the whole tail.
+
+    Purpose: Exact inversion is what makes sampling unbiased and the
+        quadrature transform exact; a quantile that is off in either tail
+        would bias every draw there.
+
+    Given: Nominal ranges from a fifth of a standard deviation to ten
+    When: Upper-tail probabilities from ``1e-9`` to ``1`` are mapped to ranges
+    Then: SciPy's survival function returns the input probability, every
+        range is non-negative, and ``u = 1`` lands exactly on zero
+
+    Test type: unit
+    """
+    std = 0.7
+    nominal = ratio * std
+    upper_tail = np.concatenate([np.logspace(-9, -1, 17), np.linspace(0.1, 1.0, 19)])
+    ranges = truncated_normal_from_upper_tail(upper_tail, nominal, std)
+    assert np.all(ranges >= 0.0)
+    assert ranges[-1] == 0.0
+    assert np.all(np.diff(ranges) <= 0.0)
+    interior = upper_tail < 1.0
+    np.testing.assert_allclose(
+        _reference(nominal, std).sf(ranges[interior]), upper_tail[interior], rtol=1e-7
+    )
+
+
+@pytest.mark.parametrize(
+    ("nominal", "std"),
+    [(0.5, 1.0), (1.0, 1.5), (3.5, 2.0), (2.0, 0.35)],
+)
+def test_truncated_samples_follow_the_truncated_distribution(nominal, std):
+    """Sample moments and the empirical CDF match the truncated normal.
+
+    Purpose: Non-negativity alone would also be satisfied by a clamp or by
+        rejection with a dropped tail. Matching the mean, the standard
+        deviation and the whole empirical CDF at noise levels where the
+        truncation removes a large share of the mass is what shows the draws
+        come from the right law.
+
+    Given: Noise standard deviations up to twice the nominal range
+    When: Two hundred thousand ranges are drawn
+    Then: Mean and standard deviation agree with SciPy within three standard
+        errors, and a Kolmogorov-Smirnov test does not reject the law
+
+    Test type: unit
+    """
+    count = 200000
+    np.random.seed(int(nominal * 100 + std * 10))
+    draws = sample_ranges(np.full(count, nominal), std, RangeNoiseModel.TRUNCATED_NORMAL)
+    reference = _reference(nominal, std)
+    assert draws.min() >= 0.0
+    mean_tolerance = 3 * reference.std() / math.sqrt(count)
+    assert draws.mean() == pytest.approx(reference.mean(), abs=mean_tolerance)
+    assert draws.std() == pytest.approx(reference.std(), rel=0.02)
+    assert kstest(draws, reference.cdf).pvalue > 0.01
+
+
+def test_gaussian_sampling_is_bit_identical_to_the_original_direct_draw():
+    """Selecting the Gaussian law reproduces the pre-option draw exactly.
+
+    Purpose: Existing seeded results must still reproduce, so the Gaussian
+        branch must consume the global stream exactly as ``nominal +
+        normal(0, sigma)`` did.
+
+    Test type: unit
+    """
+    nominal = np.array([1.0, 2.5, 3.5, 0.0])
+    np.random.seed(21)
+    sampled = sample_ranges(nominal, 0.35, RangeNoiseModel.GAUSSIAN)
+    np.random.seed(21)
+    np.testing.assert_array_equal(sampled, nominal + np.random.normal(0.0, 0.35, 4))
+
+
+def test_quadrature_points_reduce_to_gaussian_far_from_zero_and_stay_antithetic():
+    """The reward quadrature is exact where truncation cannot bite and
+    stays a paired rule where it does.
+
+    Purpose: The expected-reward points must represent the selected law. Far
+        from zero the two laws coincide, so the transformed points must equal
+        the Gaussian ones; near zero they must all be non-negative and the
+        antithetic pairing must survive in upper-tail probability, or the
+        rule would lose its variance cancellation.
+
+    Test type: unit
+    """
+    points = np.random.RandomState(0).normal(size=(4, 3))
+    points = np.concatenate([points, -points])
+    std = 0.35
+    # Ten or more standard deviations above zero: ``Phi(rho / sigma)`` is 1.0
+    # in double precision, so the two laws must agree exactly, not just closely.
+    far = np.array([3.5, 4.0, 10.0])
+    np.testing.assert_allclose(
+        quadrature_ranges(far, points, std, RangeNoiseModel.TRUNCATED_NORMAL),
+        quadrature_ranges(far, points, std, RangeNoiseModel.GAUSSIAN),
+        rtol=0.0,
+        atol=1e-12,
+    )
+    np.testing.assert_array_equal(
+        quadrature_ranges(far, points, std, RangeNoiseModel.GAUSSIAN), far + std * points
+    )
+    near = np.array([0.1, 0.3, 0.5])
+    mapped = quadrature_ranges(near, points, 1.0, RangeNoiseModel.TRUNCATED_NORMAL)
+    assert mapped.shape == points.shape
+    assert np.all(mapped >= 0.0)
+    assert not np.allclose(mapped, near + points)
+    for beam, rho in enumerate(near):
+        tails = _reference(rho, 1.0).sf(mapped[:, beam])
+        np.testing.assert_allclose(tails[:4] + tails[4:], 1.0, rtol=1e-9)
+
+
+def test_scan_log_density_keeps_the_original_gaussian_arithmetic():
+    """The whole-scan Gaussian score is the pre-option pooled formula, bit for bit.
+
+    Purpose: The particle filter's weights under the default law must not move
+        by even an ulp, or every seeded Gaussian result -- the golden
+        visualization included -- silently changes. The truncated score is the
+        per-beam sum, because its normaliser is per beam.
+
+    Test type: unit
+    """
+    rng = np.random.RandomState(3)
+    nominal = rng.uniform(0.5, 3.5, size=(5, 24))
+    values = nominal + rng.normal(0.0, 0.35, size=(5, 24))
+    std = 0.35
+    residual = (values - nominal) / std
+    pooled = -0.5 * np.sum(residual**2, axis=1) - 24 * np.log(std * np.sqrt(2 * np.pi))
+    np.testing.assert_array_equal(
+        scan_log_density(values, nominal, std, RangeNoiseModel.GAUSSIAN), pooled
+    )
+    np.testing.assert_array_equal(
+        scan_log_density(values, nominal, std, RangeNoiseModel.TRUNCATED_NORMAL),
+        np.sum(truncated_normal_log_density(values, nominal, std), axis=1),
+    )
+    assert scan_log_density(values[0], nominal[0], std, RangeNoiseModel.GAUSSIAN) == pooled[0]
+
+
+def test_resolve_range_noise_model_accepts_strings_and_rejects_typos():
+    """Test type: unit"""
+    assert resolve_range_noise_model("truncated_normal") is RangeNoiseModel.TRUNCATED_NORMAL
+    assert resolve_range_noise_model("gaussian") is RangeNoiseModel.GAUSSIAN
+    assert resolve_range_noise_model(RangeNoiseModel.GAUSSIAN) is RangeNoiseModel.GAUSSIAN
+    with pytest.raises(ValueError, match="truncated_normal"):
+        resolve_range_noise_model("truncated")
+    with pytest.raises(ValueError, match="unknown range noise model"):
+        range_log_density(np.zeros(1), np.zeros(1), 1.0, "gaussian")  # type: ignore[arg-type]

--- a/POMDPPlanners/tests/test_utils/env_pinned_kwargs.py
+++ b/POMDPPlanners/tests/test_utils/env_pinned_kwargs.py
@@ -44,6 +44,9 @@ from POMDPPlanners.environments.light_dark_pomdp.continuous_light_dark_pomdp imp
 from POMDPPlanners.environments.light_dark_pomdp.discrete_light_dark_pomdp import (
     ObservationModelType as DiscreteLightDarkObservationModelType,
 )
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sensor import (
+    RangeNoiseModel as OccupancyGridRangeNoiseModel,
+)
 from POMDPPlanners.environments.pacman_pomdp.pacman_pomdp import (
     RewardModelType as PacManRewardModelType,
 )
@@ -462,6 +465,7 @@ def occupancy_grid_mapping_pinned_kwargs(**overrides: Any) -> Dict[str, Any]:
         "field_of_view_degrees": 360.0,
         "max_range_cells": 3.5,
         "range_noise_std_cells": 0.35,
+        "range_noise_model": OccupancyGridRangeNoiseModel.GAUSSIAN,
         "hit_probability": 0.85,
         "miss_probability": 0.15,
         "log_odds_clamp": 6.0,

--- a/docs/environments/occupancy_grid_mapping.rst
+++ b/docs/environments/occupancy_grid_mapping.rst
@@ -24,15 +24,53 @@ State and observation contract
 The state contains the step, row, column, heading, hidden true occupancy,
 observation-derived map log-odds, and last noisy scan. Its length is
 ``4 + 2 * num_cells + num_beams``. The hidden map constrains motion and produces
-nominal ranges. Gaussian noise is drawn once in the transition, then the same
+nominal ranges. Range noise is drawn once in the transition, then the same
 scan is stored, used for mapping, and revealed by the observation.
 
 Observations contain ``[row, column, heading, ranges...]``. Pose is exact and
 integer. Repeated observation calls on one successor reveal the same stored
-scan. Gaussian ranges are unbounded; they are never clipped in the sampler.
-The augmented observation kernel is a point mass. The predictive density
-``p(observation | prior state, action)`` combines Gaussian ranges with the
-probability of the observed motion outcome.
+scan. The augmented observation kernel is a point mass. The predictive density
+``p(observation | prior state, action)`` combines the per-beam range density
+with the probability of the observed motion outcome.
+
+Range noise model
+-----------------
+
+``range_noise_model`` selects the per-beam range law that
+``range_noise_std_cells`` parametrises. Both laws are centred on the noise-free
+range ``rho`` and neither truncates above the maximum range.
+
+``gaussian`` (the default) is the unbounded normal ``N(rho, sigma^2)``. It is
+what every result produced before the option existed used, and its seeded
+draws are unchanged, so earlier runs still reproduce. A reading below zero is
+possible under it; the inverse model treats such a reading as a hit in the
+first ray cell.
+
+``truncated_normal`` is the same normal conditioned on ``z >= 0``:
+
+.. math::
+
+   p(z \mid \rho, \sigma) = \frac{\phi((z - \rho) / \sigma)}{\sigma \, \Phi(\rho / \sigma)}
+   \quad \text{for } z \ge 0, \qquad 0 \text{ otherwise.}
+
+It is a renormalised density, not a clamp: no probability mass is moved onto
+zero. The normaliser ``Phi(rho / sigma)`` depends on the nominal range, so two
+map particles that predict different ranges for one beam are normalised
+differently, and both filters carry that term per beam and per particle. A
+negative reading has zero likelihood under this law. Sampling inverts the
+truncated distribution exactly, with one uniform per beam, so no tail is
+dropped and no draw is rejected. With the default ``sigma = 0.35`` a beam at
+full range sits ten standard deviations above zero and the two laws agree to
+machine precision; they differ where an obstacle is within a few standard
+deviations of the robot.
+
+.. code-block:: python
+
+   env = OccupancyGridMappingPOMDP(range_noise_model="truncated_normal")
+
+The mode is part of ``config_id`` and of both filters' identities, so results
+cached under one law are never reused for the other. The sensor contract
+version is 3 from this option onwards.
 
 The initial observation contains known pose and zero range placeholders.
 It is a sentinel before any scan and is never applied to the map.
@@ -50,7 +88,7 @@ The robot's observed cell also receives free evidence. Log-odds are clamped.
 
 A true hit exactly at maximum range and a miss have identical range laws.
 They therefore produce identical updates for the same reading. Without an
-observed hit flag, this ambiguity cannot be removed. Gaussian noise can place
+observed hit flag, this ambiguity cannot be removed. Range noise can place
 an apparent hit beyond a real obstacle or before it; the mapper follows the
 measurement, not hidden truth.
 
@@ -58,9 +96,10 @@ Simulation reward is the realised decrease in the observed inverse map's
 summed binary entropy, minus ``step_cost``. The environment declares
 ``reward_requires_next_state=True`` so the runner supplies that realised map.
 When a planner requests reward without a successor, the explicit fallback uses
-eight fixed antithetic Gaussian samples per motion outcome to approximate the
-expected decrease. This deterministic integration consumes no simulation RNG,
-but has integration error. It updates each hypothetical map with the same
+eight fixed antithetic unit-normal points per motion outcome, mapped through
+the selected range law, to approximate the expected decrease. This
+deterministic integration consumes no simulation RNG, but has integration
+error. It updates each hypothetical map with the same
 observation-based rule as the actual map.
 
 This is an exploration surrogate inspired by entropy-reduction objectives,
@@ -81,8 +120,9 @@ Use one of the environment's two whole-map filters with PFT_DPW. Ordinary
 stored continuous scan correctly. No core planner changes are needed.
 
 Both filters install the observed scan and its map update in every
-particle. They weight whole-map hypotheses by the predictive Gaussian density
-and exact motion probability, with no epsilon floor for impossible poses.
+particle. They weight whole-map hypotheses by the predictive range density
+of the selected law and exact motion probability, with no epsilon floor for
+impossible poses.
 Routine resampling is disabled to retain low-weight hypotheses. If every
 particle contradicts observed motion, bounded prior replay tests up to 4096
 fresh maps against the entire observation history and resamples surviving
@@ -132,5 +172,7 @@ hidden true map for review. Panels depict the state before the captioned action;
 the caption's reward is the realised inverse-map entropy reduction.
 
 There is no torch vectorized or C++ model. VOPP is unsupported. Scalar PFT_DPW
-uses the environment and the whole-map filters shown above. Sensor contract version 2
-changes cache identity; old results and GIFs describe the earlier behavior.
+uses the environment and the whole-map filters shown above. Sensor contract
+versions 2 and 3 each changed cache identity; old results and GIFs describe
+the earlier behavior. The golden GIF is rendered in the default Gaussian mode
+and is unchanged by the truncated option.


### PR DESCRIPTION
`occupancy-truncated-normal-20260911` → `develop` · head f891dd00 · 15 files · +1190 / −74 · adds a selectable range law that cannot produce a negative reading; the default Gaussian path is bit-identical.

The occupancy-grid sensor drew unbounded Gaussian ranges, so a beam near a wall could report a negative distance, which no range finder produces. This adds `range_noise_model="truncated_normal"`: the same normal conditioned on `z >= 0` and renormalised, with its per-beam normaliser `Phi(rho / sigma)` carried through every likelihood, the batched updater, and the expected-reward quadrature. Not a clamp, so no point mass sits on zero.

## The changes

1. `range_noise_model` constructor option on `OccupancyGridMappingPOMDP`, `gaussian` (default) or `truncated_normal`, string or enum. — **behaviour-changing** only when selected
2. Sensor helpers: truncated density, normaliser, exact quantile by upper tail, sampler (one uniform per beam), quadrature transform. — additive
3. Scalar sampling, predictive likelihood, transition density under the selected law. — Gaussian path **identical**
4. Vectorized updater: same, with the normaliser per beam and per particle; `range_noise_model` in its identity. — Gaussian path **identical**
5. Expected-reward quadrature maps its fixed unit-normal points through the selected law. — Gaussian path **identical**
6. Mode in `config_id`, pinned kwargs, updater `config_id`; `sensor_contract_version` 2 → 3. — **breaking** for existing caches of this environment, on purpose
7. 35 tests and a second conformance registry entry `OccupancyGridMappingPOMDP[truncated_normal]` at sigma 1.0.
8. Docs page section "Range noise model"; docstrings no longer say Gaussian unconditionally.

Deliberately untouched: the stored scan `z`, the log-odds map, the observed pose, rewards and termination, `range_noise_std_cells` and its positive check, readings above max range. Removing `z` is a separate design task. The default stays `gaussian` until a default is chosen.

## What moves and what does not

| # | Change | Value before | Value after | Moved? |
| --- | --- | --- | --- | --- |
| 1, 3 | Seeded scan, default mode | `nominal + normal(0, σ)` | same bytes | identical |
| 1, 3 | Min reading, truncated mode, σ = 1.5, nominal 2, 4000 draws | −2.7 (Gaussian) | ≥ 0 | moves |
| 3 | Predictive log density, truncated, reading −0.2 | finite | `-inf` | moves |
| 3 | Filter weight ratio, nominal 1 vs 2, σ = 1.5, reading 1.5 | Gaussian ratio | × `Phi(2/1.5) / Phi(1/1.5)` | moves |
| 4 | Batched vs scalar likelihood, both modes | agree 1e-12 | agree 1e-12 | identical |
| 5 | Quadrature points, ten σ from zero | `nominal + σ·point` | same, exactly | identical |
| 6 | `config_id`, gaussian vs truncated | one id | two ids | moves |
| 3, 4 | Golden episode belief log-weights, default mode | base | same | identical (would have moved by 1e-13 without the pooled Gaussian arithmetic; that flipped the golden GIF hash) |
| — | Golden GIF hash, CI Docker image | pinned | pinned | identical |

## Before / after

### 3. Scalar likelihood

Why: the normaliser differs between particles whose maps predict different ranges, so it cannot be pooled into one constant under truncation. Under the Gaussian law the pooled arithmetic is kept verbatim, because the per-beam sum moved weights by rounding and changed the golden hash.

Before, `occupancy_grid_mapping_pomdp.py`:
```python
residual = (observation[3:] - self.nominal_scan(moved)) / self.range_noise_std_cells
log_density = -0.5 * np.sum(residual**2) - self.num_beams * np.log(
    self.range_noise_std_cells * np.sqrt(2 * np.pi)
)
```
After:
```python
log_density = float(
    scan_log_density(
        observation[3:], self.nominal_scan(moved),
        self.range_noise_std_cells, self.range_noise_model,
    )
)
```
`scan_log_density`, `occupancy_grid_sensor.py`:
```python
if model is RangeNoiseModel.GAUSSIAN:
    residual = (values - nominal) / std
    num_beams = np.broadcast_shapes(values.shape, nominal.shape)[-1]
    return -0.5 * np.sum(residual**2, axis=-1) - num_beams * np.log(std * np.sqrt(2 * np.pi))
if model is RangeNoiseModel.TRUNCATED_NORMAL:
    return np.sum(truncated_normal_log_density(values, nominal, std), axis=-1)
```

### 2. Sampling

Why: exact inversion in the upper tail, where `Phi(nominal/std)` is the factor close to 1, so at the default σ a full-range beam reduces to the untruncated quantile and nothing is rejected or dropped.

`occupancy_grid_sensor.py`:
```python
values = nominal - std * ndtri(upper_tail * ndtr(nominal / std))
return np.where(upper_tail >= 1.0, 0.0, np.maximum(values, 0.0))
```
Draws feed `upper_tail = 1.0 - np.random.random_sample(nominal.shape)`; the Gaussian branch keeps `nominal + np.random.normal(0.0, std, nominal.shape)`.

### 5. Reward quadrature

Why: the eight fixed antithetic points must represent the selected law, or the expected reward averages over scans the law cannot produce.

Before, `occupancy_grid_mapping_pomdp.py`:
```python
observation = np.r_[moved[1:4], nominal + self.range_noise_std_cells * noise]
```
After:
```python
observation = np.r_[
    moved[1:4],
    quadrature_ranges(nominal, noise, self.range_noise_std_cells, self.range_noise_model),
]
```
Truncated branch: `truncated_normal_from_upper_tail(ndtr(-standard_points), nominal, std)`; `Phi(-x) + Phi(x) = 1` keeps the pairing antithetic.

### 6. Identity

`occupancy_grid_mapping_vectorized_updater.py`:
```python
"range_noise_std_cells": self.range_noise_std_cells,
"range_noise_model": self.range_noise_model.value,
```
and `self.sensor_contract_version = 3` in the environment.

## How this was verified

On ubuntu64 (staged copy, shared venv, Python 3.12):

- black 25.9.0, pylint `--errors-only`, pyright: clean, 0 errors.
- Focused pytest (occupancy package, conformance, golden, coverage matrix, metric consistency): 688 passed, 56 skipped, 12 xfailed. Doctests: 2 passed.
- Golden GIF in `pomdpplanners-test:latest`: byte-identical. Golden episode dump (states, observations, rewards, particles, weights) equals base 39cb096b exactly.
- QA in truncated mode via `LocalSimulationsAPI`, PFT-DPW vs uniform random, 10 episodes each, 1 s/decision, 40 steps, 30 particles, vectorized belief, σ = 0.35: PFT-DPW 9/10 completed, random 0/10; mean final entropy 23.56 vs 52.12 bits; zero negative readings; every stored scan equals its observation; every transition reconstructs from its predecessor plus the observation.
- Own review: fixed a docstring and the Gaussian rounding drift. Codex second opinion: no actionable defects.

Known limits: the truncated quantile loses relative precision in the deepest lower tail for large `rho/sigma` (below ~1e-7 of the mass); the default is unchanged pending a decision; 30 particles still collapse to one map as in the Gaussian QA.

https://claude.ai/code/session_01MCJKbgioXLR23wMBYukt7h
