### PR TITLE
Make the occupancy-grid map update rule pluggable

### DIFF
--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/__init__.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/__init__.py
@@ -12,6 +12,10 @@ Exports:
     OccupancyGridMappingVectorizedUpdater: The batched kernels behind it.
     create_occupancy_grid_mapping_belief: Factory choosing between the two filters.
     RangeNoiseModel: The selectable per-beam range noise laws.
+    OccupancyUpdateRule: Abstract map update rule, written on log-odds.
+    ProbabilityOccupancyUpdateRule: Abstract map update rule, written on
+        occupancy probabilities.
+    NearestCellLogOddsUpdateRule: The original rule, and the default.
 """
 
 from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_pomdp import (
@@ -32,6 +36,12 @@ from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_maps
     OccupancyGridInitialStateDistribution,
     sample_occupancy_map,
 )
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_update_rules import (
+    NearestCellLogOddsUpdateRule,
+    OccupancyUpdateRule,
+    ProbabilityOccupancyUpdateRule,
+    default_update_rule,
+)
 from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sensor import (
     HEADING_LABELS,
     HEADING_STEPS,
@@ -39,37 +49,47 @@ from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sens
     RangeNoiseModel,
     build_ray_templates,
     cast_scan,
+    batch_observed_scan_evidence_counts,
     grid_entropy_bits,
     log_odds_from_probability,
+    observed_scan_evidence_counts,
+    observed_scan_log_odds_delta,
     scan_log_odds_delta,
 )
 
 __all__ = [
-    "OccupancyGridMappingBelief",
-    "OccupancyGridMappingVectorizedBelief",
-    "OccupancyGridMappingVectorizedUpdater",
-    "create_occupancy_grid_mapping_belief",
     "COL_INDEX",
     "HEADING_INDEX",
     "HEADING_LABELS",
     "HEADING_STEPS",
     "NUM_HEADINGS",
-    "POSE_WIDTH",
-    "RESOLVED_LOG_ODDS",
-    "ROW_INDEX",
-    "STEP_INDEX",
+    "NearestCellLogOddsUpdateRule",
     "OccupancyGridAction",
     "OccupancyGridInitialStateDistribution",
+    "OccupancyGridMappingBelief",
     "OccupancyGridMappingMetrics",
     "OccupancyGridMappingPOMDP",
+    "OccupancyGridMappingVectorizedBelief",
+    "OccupancyGridMappingVectorizedUpdater",
     "OccupancyGridState",
     "OccupancyGridStepChannel",
+    "OccupancyUpdateRule",
+    "POSE_WIDTH",
+    "ProbabilityOccupancyUpdateRule",
+    "RESOLVED_LOG_ODDS",
+    "ROW_INDEX",
     "RangeNoiseModel",
+    "STEP_INDEX",
+    "batch_observed_scan_evidence_counts",
     "build_ray_templates",
     "cast_scan",
+    "create_occupancy_grid_mapping_belief",
     "create_occupancy_grid_state",
+    "default_update_rule",
     "grid_entropy_bits",
     "log_odds_from_probability",
+    "observed_scan_evidence_counts",
+    "observed_scan_log_odds_delta",
     "sample_occupancy_map",
     "scan_log_odds_delta",
 ]

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/occupancy_grid_mapping_vectorized_updater.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/occupancy_grid_mapping_vectorized_updater.py
@@ -34,19 +34,23 @@ Classes:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import numpy as np
 
 from POMDPPlanners.core.belief.vectorized_particle_belief_updater import (
     VectorizedParticleBeliefUpdater,
 )
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_update_rules import (
+    OccupancyUpdateRule,
+    default_update_rule,
+    non_default_update_rule_id,
+)
 from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sensor import (
     HEADING_STEPS,
     NUM_HEADINGS,
     RangeNoiseModel,
     build_ray_templates,
-    observed_scan_log_odds_delta,
     quadrature_ranges,
     resolve_range_noise_model,
     sample_ranges,
@@ -84,6 +88,7 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
         range_noise_std_cells: Per-beam range noise standard deviation.
         range_noise_model: Which per-beam range law that deviation parametrises.
         move_failure_probability: Chance an otherwise-valid forward move fails.
+        update_rule: How an observed scan changes a particle's map.
 
     Example:
         >>> import numpy as np
@@ -117,6 +122,7 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
         move_failure_probability: float,
         sensor_contract_version: int = 2,
         range_noise_model: Union[RangeNoiseModel, str] = RangeNoiseModel.GAUSSIAN,
+        update_rule: Optional[OccupancyUpdateRule] = None,
     ):
         """Initialize the updater from the environment's sensor and motion settings.
 
@@ -138,6 +144,12 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
                 parametrises. Defaults to the unbounded Gaussian, the law every
                 updater built before the option existed used. Accepts the
                 member or its string value.
+            update_rule: How an observed scan changes a particle's map.
+                Defaults to ``None``, which rebuilds the environment's original
+                rule from ``free_log_odds``, ``occupied_log_odds`` and
+                ``log_odds_clamp``. Pass the environment's own rule so the
+                batched kernels and the scalar transition cannot disagree;
+                :meth:`from_environment` does exactly that.
 
         Raises:
             ValueError: If ``range_noise_std_cells`` is not positive, or
@@ -157,6 +169,11 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
         self.log_odds_clamp = float(log_odds_clamp)
         self.move_failure_probability = float(move_failure_probability)
         self.sensor_contract_version = int(sensor_contract_version)
+        self.update_rule = (
+            default_update_rule(self.free_log_odds, self.occupied_log_odds, self.log_odds_clamp)
+            if update_rule is None
+            else update_rule
+        )
 
         self.num_cells = self.num_rows * self.num_cols
         self.map_offset = _POSE_WIDTH
@@ -194,6 +211,7 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
             move_failure_probability=env.move_failure_probability,
             sensor_contract_version=env.sensor_contract_version,
             range_noise_model=env.range_noise_model,
+            update_rule=env.update_rule,
         )
 
     # ------------------------------------------------------------------
@@ -281,21 +299,19 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
         ):
             raise ValueError("observation pose must be an in-grid integer pose")
         row, col, heading = int(row), int(col), int(heading)
-        delta = observed_scan_log_odds_delta(
-            observation[3:],
-            self._ray_templates[heading],
+        end = self.log_odds_offset + self.num_cells
+        updated = self.update_rule.shared_update_log_odds(
+            particles[:, self.log_odds_offset : end],
             row,
             col,
+            heading,
+            observation[3:],
+            self._ray_templates,
             self.num_rows,
             self.num_cols,
             self.max_range_cells,
-            self.free_log_odds,
-            self.occupied_log_odds,
         )
-        delta[row * self.num_cols + col] += self.free_log_odds
-        return self._install(
-            particles, observation[None, :3], observation[None, 3:], delta[None, :]
-        )
+        return self._install(particles, observation[None, :3], observation[None, 3:], updated)
 
     def batch_expected_reward(
         self,
@@ -346,16 +362,12 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
                 self.range_noise_std_cells,
                 self.range_noise_model,
             ).reshape(num_points * len(live), self.num_beams)
-            deltas = self._scan_deltas(
+            updated = self._updated_log_odds(
+                np.tile(log_odds[live], (num_points, 1)),
                 ranges,
                 np.tile(rows[live], num_points),
                 np.tile(cols[live], num_points),
                 np.tile(headings[live], num_points),
-            )
-            updated = np.clip(
-                np.tile(log_odds[live], (num_points, 1)) + deltas,
-                -self.log_odds_clamp,
-                self.log_odds_clamp,
             )
             entropies = self.entropy_bits_rows(updated).reshape(num_points, len(live))
             after[live] += probabilities[live] * entropies.sum(axis=0)
@@ -413,8 +425,11 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
         nominal = self._nominal_scans(self._maps(particles), rows, cols, headings)
         ranges = sample_ranges(nominal, self.range_noise_std_cells, self.range_noise_model)
         poses = np.stack([rows, cols, headings], axis=1).astype(np.float64)
-        delta = self._scan_deltas(ranges, rows, cols, headings)
-        return self._install(particles, poses, ranges, delta)
+        end = self.log_odds_offset + self.num_cells
+        updated = self._updated_log_odds(
+            particles[:, self.log_odds_offset : end], ranges, rows, cols, headings
+        )
+        return self._install(particles, poses, ranges, updated)
 
     def batch_observation_log_likelihood(
         self, next_particles: np.ndarray, action: Any, observation: np.ndarray
@@ -450,7 +465,10 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
 
     @property
     def config_id(self) -> str:
-        """Deterministic identifier of the sensor and motion settings."""
+        """Deterministic identifier of the sensor, motion and mapping settings."""
+        rule_id = non_default_update_rule_id(
+            self.update_rule, self.free_log_odds, self.occupied_log_odds, self.log_odds_clamp
+        )
         return config_to_id(
             {
                 "class": type(self).__name__,
@@ -466,6 +484,10 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
                 "log_odds_clamp": self.log_odds_clamp,
                 "move_failure_probability": self.move_failure_probability,
                 "sensor_contract_version": self.sensor_contract_version,
+                # Absent for the original rule, which the three log-odds
+                # settings above already describe in full, so every belief
+                # cached before rules became pluggable still matches.
+                **({} if rule_id is None else {"update_rule": rule_id}),
             }
         )
 
@@ -583,72 +605,56 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
             ranges[index] = np.where(hit, hit_ranges, self.max_range_cells)
         return ranges
 
-    def _scan_deltas(
-        self, observed_ranges: np.ndarray, rows: np.ndarray, cols: np.ndarray, headings: np.ndarray
+    def _updated_log_odds(
+        self,
+        log_odds: np.ndarray,
+        observed_ranges: np.ndarray,
+        rows: np.ndarray,
+        cols: np.ndarray,
+        headings: np.ndarray,
     ) -> np.ndarray:
-        """Per-particle inverse-sensor increments for per-particle readings.
+        """Apply the map update rule to one scan per particle.
 
-        The batched form of ``observed_scan_log_odds_delta`` plus the free
-        evidence on the robot's own cell, used by the generative transition
-        where every particle has its own scan.
+        Used by the generative transition and by the expected-reward integral,
+        where every particle has its own reading. Delegates to the environment's
+        rule, so the batched path cannot drift from the scalar one.
+
+        Args:
+            log_odds: ``(N, num_cells)`` previous log-odds.
+            observed_ranges: ``(N, num_beams)`` measured ranges.
+            rows: ``(N,)`` robot rows.
+            cols: ``(N,)`` robot columns.
+            headings: ``(N,)`` heading indices.
+
+        Returns:
+            ``(N, num_cells)`` next log-odds.
         """
-        count = observed_ranges.shape[0]
-        deltas = np.zeros((count, self.num_cells), dtype=np.float64)
-        slot_offsets = np.arange(count) * self.num_cells
-        for heading in np.unique(headings):
-            index = np.flatnonzero(headings == heading)
-            offsets, distances = self._ray_templates[int(heading)]
-            length = distances.shape[1]
-            ray_rows = offsets[None, :, :, 0] + rows[index, None, None]
-            ray_cols = offsets[None, :, :, 1] + cols[index, None, None]
-            valid = (
-                (ray_rows >= 0)
-                & (ray_rows < self.num_rows)
-                & (ray_cols >= 0)
-                & (ray_cols < self.num_cols)
-                & np.isfinite(distances)[None]
-            )
-            valid = np.logical_and.accumulate(valid, axis=2)
-            has_cell = valid.any(axis=2)
-            gaps = np.abs(distances[None] - observed_ranges[index][:, :, None])
-            nearest = np.argmin(np.where(valid, gaps, np.inf), axis=2)
-            hit = (observed_ranges[index] < self.max_range_cells) & has_cell
-            slots = np.arange(length)[None, None, :]
-            free = valid & ((slots < nearest[:, :, None]) | ~hit[:, :, None])
-            occupied = valid & (slots == nearest[:, :, None]) & hit[:, :, None]
-            flat = ray_rows * self.num_cols + ray_cols + slot_offsets[index][:, None, None]
-            deltas += (
-                np.bincount(flat[free], minlength=count * self.num_cells).reshape(
-                    count, self.num_cells
-                )
-                * self.free_log_odds
-            )
-            deltas += (
-                np.bincount(flat[occupied], minlength=count * self.num_cells).reshape(
-                    count, self.num_cells
-                )
-                * self.occupied_log_odds
-            )
-        deltas[np.arange(count), rows * self.num_cols + cols] += self.free_log_odds
-        return deltas
+        return self.update_rule.batch_update_log_odds(
+            log_odds,
+            rows,
+            cols,
+            headings,
+            observed_ranges,
+            self._ray_templates,
+            self.num_rows,
+            self.num_cols,
+            self.max_range_cells,
+        )
 
     def _install(
-        self, particles: np.ndarray, poses: np.ndarray, ranges: np.ndarray, deltas: np.ndarray
+        self, particles: np.ndarray, poses: np.ndarray, ranges: np.ndarray, log_odds: np.ndarray
     ) -> np.ndarray:
-        """Advance the step, write pose and scan, and accumulate clamped log-odds.
+        """Advance the step and write the pose, the scan and the updated map.
 
-        ``poses``, ``ranges`` and ``deltas`` broadcast over the particle axis,
-        so one observation shared by every particle and one per particle both
-        go through here.
+        The map arrives already updated and clamped, because the clamp belongs
+        to the update rule rather than to this bookkeeping. ``poses`` and
+        ``ranges`` broadcast over the particle axis, so one observation shared
+        by every particle and one per particle both go through here.
         """
         successors = particles.copy()
         successors[:, _STEP_INDEX] += 1
         successors[:, _ROW_INDEX : _ROW_INDEX + 3] = poses
         successors[:, self.scan_offset :] = ranges
         end = self.log_odds_offset + self.num_cells
-        successors[:, self.log_odds_offset : end] = np.clip(
-            successors[:, self.log_odds_offset : end] + deltas,
-            -self.log_odds_clamp,
-            self.log_odds_clamp,
-        )
+        successors[:, self.log_odds_offset : end] = log_odds
         return successors

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/occupancy_grid_mapping_vectorized_updater.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_beliefs/occupancy_grid_mapping_vectorized_updater.py
@@ -174,6 +174,10 @@ class OccupancyGridMappingVectorizedUpdater(VectorizedParticleBeliefUpdater):
             if update_rule is None
             else update_rule
         )
+        # Read-only from here on, for the same reason as in the environment:
+        # ``config_id`` below takes the rule's identifier once per call, but a
+        # belief cached under it would outlive an in-place parameter change.
+        self.update_rule.freeze()
 
         self.num_cells = self.num_rows * self.num_cols
         self.map_offset = _POSE_WIDTH

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_pomdp.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_pomdp.py
@@ -58,6 +58,11 @@ from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_maps
     optional_int,
     resolve_keep_free,
 )
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_update_rules import (
+    OccupancyUpdateRule,
+    default_update_rule,
+    non_default_update_rule_id,
+)
 from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sensor import (
     HEADING_STEPS,
     NUM_HEADINGS,
@@ -66,7 +71,6 @@ from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sens
     cast_scan,
     grid_entropy_bits,
     log_odds_from_probability,
-    observed_scan_log_odds_delta,
     quadrature_ranges,
     resolve_range_noise_model,
     sample_ranges,
@@ -158,6 +162,7 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
         hit_probability: float = 0.85,
         miss_probability: float = 0.15,
         log_odds_clamp: float = 6.0,
+        update_rule: Optional[OccupancyUpdateRule] = None,
         num_obstacles: int = 3,
         max_obstacle_size: int = 2,
         has_boundary_wall: bool = True,
@@ -216,6 +221,17 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
             log_odds_clamp: Symmetric bound on accumulated log-odds. Defaults to
                 6.0 (``p ~= 0.9975``). Clamping is what stops a cell swept by
                 many beams from becoming unrevisable.
+            update_rule: How an observed scan changes the map. Defaults to
+                ``None``, which builds the original rule
+                (``NearestCellLogOddsUpdateRule``) from ``hit_probability``,
+                ``miss_probability`` and ``log_odds_clamp`` -- so every result
+                and every cached episode from before this argument existed is
+                reproduced exactly. Supply an ``OccupancyUpdateRule`` to map
+                with a different law; the scalar transition, the batched
+                particle kernels and both rewards all use the one you supply.
+                A rule other than the default changes the environment's
+                ``config_id``, so its results cannot be served from a cache
+                filled under another rule.
             num_obstacles: Rectangular blocks placed per episode. Defaults to 3.
             max_obstacle_size: Largest block side length. Defaults to 2.
             has_boundary_wall: Whether the outer ring is occupied. Defaults to
@@ -367,6 +383,29 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
                 f"got {self.miss_probability}"
             )
 
+        # Underscored so the rule object itself stays out of ``config_id`` and
+        # ``__eq__``: the *default* rule is nothing but the three settings
+        # above restated, so letting it into the identity would change every
+        # existing config_id for no change in behaviour. What does go into the
+        # identity is the line below -- an attribute that exists only when the
+        # rule is not the default one, so a non-default rule can never be
+        # served a cached result produced under the original update.
+        self._update_rule = (
+            default_update_rule(self.free_log_odds, self.occupied_log_odds, self.log_odds_clamp)
+            if update_rule is None
+            else update_rule
+        )
+        if not isinstance(self._update_rule, OccupancyUpdateRule):
+            raise TypeError(
+                "update_rule must be an OccupancyUpdateRule, got "
+                f"{type(self._update_rule).__name__}"
+            )
+        rule_id = non_default_update_rule_id(
+            self._update_rule, self.free_log_odds, self.occupied_log_odds, self.log_odds_clamp
+        )
+        if rule_id is not None:
+            self.update_rule_config_id = rule_id
+
         # Derived read-only ray geometry. Underscored so it stays out of
         # ``config_id`` and ``__eq__``: it is a pure function of num_beams,
         # field_of_view_degrees and max_range_cells, all of which are already in
@@ -377,6 +416,11 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
             field_of_view_degrees=self.field_of_view_degrees,
             max_range_cells=self.max_range_cells,
         )
+
+    @property
+    def update_rule(self) -> OccupancyUpdateRule:
+        """The rule that turns an observed scan into the next map."""
+        return self._update_rule
 
     # -- state accessors ------------------------------------------------
 
@@ -503,23 +547,17 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
         next_state[STEP_INDEX] += 1
         next_state[1:4] = observation[:3]
         next_state[self.scan_offset :] = observation[3:]
-        delta = observed_scan_log_odds_delta(
-            observation[3:],
-            self._ray_templates[heading],
+        end = self.log_odds_offset + self.num_cells
+        next_state[self.log_odds_offset : end] = self._update_rule.update_log_odds(
+            next_state[self.log_odds_offset : end],
             row,
             col,
+            heading,
+            observation[3:],
+            self._ray_templates[heading],
             self.num_rows,
             self.num_cols,
             self.max_range_cells,
-            self.free_log_odds,
-            self.occupied_log_odds,
-        )
-        delta[row * self.num_cols + col] += self.free_log_odds
-        end = self.log_odds_offset + self.num_cells
-        next_state[self.log_odds_offset : end] = np.clip(
-            next_state[self.log_odds_offset : end] + delta,
-            -self.log_odds_clamp,
-            self.log_odds_clamp,
         )
         return next_state
 
@@ -761,6 +799,7 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
             self.log_odds_clamp,
             self.move_failure_probability,
             self.sensor_contract_version,
+            self._update_rule.config_id,
         )
         cached = vars(self).get("_batched_kernels_cache")
         if cached is None or cached[0] != key:

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_pomdp.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_mapping_pomdp.py
@@ -405,6 +405,11 @@ class OccupancyGridMappingPOMDP(DiscreteActionsEnvironment):
         )
         if rule_id is not None:
             self.update_rule_config_id = rule_id
+        # The identifier above is a string taken once, not a live view of the
+        # rule. Freezing the rule is what stops a later
+        # ``env.update_rule.occupied_log_odds = 0.5`` from mapping under a
+        # different law while the cache still answers to the old identity.
+        self._update_rule.freeze()
 
         # Derived read-only ray geometry. Underscored so it stays out of
         # ``config_id`` and ``__eq__``: it is a pure function of num_beams,

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_sensor.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_grid_sensor.py
@@ -38,6 +38,10 @@ Functions:
     build_ray_templates: Precompute the cells each beam crosses, per heading.
     cast_scan: Cast one scan against a true occupancy grid.
     scan_log_odds_delta: Inverse sensor model for one scan.
+    observed_scan_evidence_counts: Classify one measured scan into per-cell
+        free and occupied sighting counts.
+    batch_observed_scan_evidence_counts: The same for one scan per particle.
+    observed_scan_log_odds_delta: Log-odds increments of one measured scan.
     log_odds_from_probability: Convert a probability to log-odds.
     grid_entropy_bits: Binary entropy of an occupancy grid, in bits.
     gaussian_log_density: Per-beam log density of the unbounded range law.
@@ -362,7 +366,7 @@ def scan_log_odds_delta(
     return delta
 
 
-def observed_scan_log_odds_delta(
+def observed_scan_evidence_counts(
     observed_ranges,
     template,
     row,
@@ -370,16 +374,36 @@ def observed_scan_log_odds_delta(
     num_rows,
     num_cols,
     max_range_cells,
-    free_log_odds,
-    occupied_log_odds,
 ):
-    """Map measured ranges without consulting occupancy or hidden hit flags.
+    """Classify measured ranges into per-cell free and occupied sighting counts.
+
+    This is the geometric half of the inverse sensor model, split out from the
+    arithmetic half so that a rule written on probabilities and the built-in
+    log-odds rule classify a scan in exactly one place. It consults neither the
+    hidden occupancy nor a hidden hit flag.
 
     A reading below maximum selects the nearest valid ray-cell centre; ties
     select the nearer cell. A reading at/above maximum frees the full ray.
     Out-of-grid cells and padded template slots never receive evidence.
     Gaussian tails remain in the observation; only this inverse interpretation
     selects grid cells. Negative readings select the first valid cell.
+
+    The robot's own cell is not counted here. It takes one free sighting of its
+    own, which every caller adds, because it is evidence from the robot being
+    there rather than from any beam.
+
+    Args:
+        observed_ranges: ``(num_beams,)`` measured ranges.
+        template: The heading's ``(offsets, distances)`` pair.
+        row: Robot row.
+        col: Robot column.
+        num_rows: Grid rows.
+        num_cols: Grid columns.
+        max_range_cells: Sensor range in cell widths.
+
+    Returns:
+        A ``(free_counts, occupied_counts)`` pair of ``(num_rows * num_cols,)``
+        integer arrays in row-major order, each counting one entry per beam.
     """
     offsets, distances = template
     rows = offsets[:, :, 0] + row
@@ -399,9 +423,98 @@ def observed_scan_log_odds_delta(
     occupied = valid & (slots == nearest[:, None]) & hit[:, None]
     flat = rows * num_cols + cols
     return (
-        np.bincount(flat[free], minlength=num_rows * num_cols) * free_log_odds
-        + np.bincount(flat[occupied], minlength=num_rows * num_cols) * occupied_log_odds
+        np.bincount(flat[free], minlength=num_rows * num_cols),
+        np.bincount(flat[occupied], minlength=num_rows * num_cols),
     )
+
+
+def batch_observed_scan_evidence_counts(
+    observed_ranges,
+    ray_templates,
+    rows,
+    cols,
+    headings,
+    num_rows,
+    num_cols,
+    max_range_cells,
+):
+    """Batched :func:`observed_scan_evidence_counts`: one scan per particle.
+
+    Particles are grouped by heading so that one array pass covers every
+    particle that shares a ray template. Rows of the two count arrays are
+    disjoint between groups, so the per-group accumulation below gives each
+    particle exactly the counts its own scan implies.
+
+    Args:
+        observed_ranges: ``(N, num_beams)`` measured ranges, one row per particle.
+        ray_templates: The per-heading ``(offsets, distances)`` pairs.
+        rows: ``(N,)`` robot rows.
+        cols: ``(N,)`` robot columns.
+        headings: ``(N,)`` heading indices.
+        num_rows: Grid rows.
+        num_cols: Grid columns.
+        max_range_cells: Sensor range in cell widths.
+
+    Returns:
+        A ``(free_counts, occupied_counts)`` pair of ``(N, num_rows * num_cols)``
+        integer arrays.
+    """
+    count = observed_ranges.shape[0]
+    num_cells = int(num_rows) * int(num_cols)
+    free_counts = np.zeros((count, num_cells), dtype=np.int64)
+    occupied_counts = np.zeros((count, num_cells), dtype=np.int64)
+    slot_offsets = np.arange(count) * num_cells
+    for heading in np.unique(headings):
+        index = np.flatnonzero(headings == heading)
+        offsets, distances = ray_templates[int(heading)]
+        length = distances.shape[1]
+        ray_rows = offsets[None, :, :, 0] + rows[index, None, None]
+        ray_cols = offsets[None, :, :, 1] + cols[index, None, None]
+        valid = (
+            (ray_rows >= 0)
+            & (ray_rows < num_rows)
+            & (ray_cols >= 0)
+            & (ray_cols < num_cols)
+            & np.isfinite(distances)[None]
+        )
+        valid = np.logical_and.accumulate(valid, axis=2)
+        has_cell = valid.any(axis=2)
+        gaps = np.abs(distances[None] - observed_ranges[index][:, :, None])
+        nearest = np.argmin(np.where(valid, gaps, np.inf), axis=2)
+        hit = (observed_ranges[index] < max_range_cells) & has_cell
+        slots = np.arange(length)[None, None, :]
+        free = valid & ((slots < nearest[:, :, None]) | ~hit[:, :, None])
+        occupied = valid & (slots == nearest[:, :, None]) & hit[:, :, None]
+        flat = ray_rows * num_cols + ray_cols + slot_offsets[index][:, None, None]
+        free_counts += np.bincount(flat[free], minlength=count * num_cells).reshape(
+            count, num_cells
+        )
+        occupied_counts += np.bincount(flat[occupied], minlength=count * num_cells).reshape(
+            count, num_cells
+        )
+    return free_counts, occupied_counts
+
+
+def observed_scan_log_odds_delta(
+    observed_ranges,
+    template,
+    row,
+    col,
+    num_rows,
+    num_cols,
+    max_range_cells,
+    free_log_odds,
+    occupied_log_odds,
+):
+    """Map measured ranges without consulting occupancy or hidden hit flags.
+
+    Classification is :func:`observed_scan_evidence_counts`; this function only
+    turns its two counts into the log-odds increment each cell accumulates.
+    """
+    free_counts, occupied_counts = observed_scan_evidence_counts(
+        observed_ranges, template, row, col, num_rows, num_cols, max_range_cells
+    )
+    return free_counts * free_log_odds + occupied_counts * occupied_log_odds
 
 
 def gaussian_log_density(values: ArrayLike, nominal: ArrayLike, std: float) -> np.ndarray:
@@ -449,9 +562,7 @@ def truncated_normal_log_norm(nominal: ArrayLike, std: float) -> np.ndarray:
     return log_ndtr(np.asarray(nominal, dtype=np.float64) / std)
 
 
-def truncated_normal_log_density(
-    values: ArrayLike, nominal: ArrayLike, std: float
-) -> np.ndarray:
+def truncated_normal_log_density(values: ArrayLike, nominal: ArrayLike, std: float) -> np.ndarray:
     """Per-beam log density of a normal truncated to ``[0, +inf)``.
 
     ``f(z | rho, sigma) = phi((z - rho)/sigma) / (sigma * Phi(rho/sigma))`` for

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_update_rules.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_update_rules.py
@@ -1,0 +1,665 @@
+# SPDX-License-Identifier: MIT
+
+"""Pluggable map update rules for occupancy-grid mapping.
+
+The environment's transition draws a noisy scan and then folds it into a
+per-cell occupancy estimate. *How* it folds it in is a modelling choice, not a
+property of the world: the rule shipped here is the one every earlier result
+used, but it is one of many, and comparing two of them is a research question
+this package should not force a fork to answer.
+
+So the rule is an object. One rule instance serves the scalar transition, the
+batched particle kernels and both rewards, which is what stops the three from
+drifting apart -- they used to hold three copies of the same arithmetic.
+
+Two base classes:
+
+* :class:`OccupancyUpdateRule` -- the update written on log-odds ``L``. This is
+  the general interface; everything else is a convenience on top of it.
+* :class:`ProbabilityOccupancyUpdateRule` -- the update written on occupancy
+  probabilities ``p``, with the ``L -> p -> L`` conversion and the clamp done
+  for you. The textbook statement of an inverse sensor model is in ``p``, so an
+  author porting one from a paper should not have to touch a logit.
+
+:class:`NearestCellLogOddsUpdateRule` is the concrete default and holds the
+environment's original arithmetic, unchanged.
+
+A rule is part of what the environment *is*: two rules must never share a
+cache entry. :meth:`OccupancyUpdateRule.parameters` is the rule's contribution
+to that identity, and it doubles as the constructor keyword arguments used to
+rebuild the rule from a serialized config, so a subclass must accept every key
+it reports.
+
+Classes:
+    OccupancyUpdateRule: Abstract log-odds update rule.
+    ProbabilityOccupancyUpdateRule: Abstract update rule written on probabilities.
+    NearestCellLogOddsUpdateRule: The environment's original rule, the default.
+
+Functions:
+    default_update_rule: Build the default rule from the environment's settings.
+    non_default_update_rule_id: The identity a non-default rule contributes.
+"""
+
+import importlib
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+import numpy as np
+
+from POMDPPlanners.core.serialization import (
+    deserialize_value,
+    register_deserializer,
+    register_serializer,
+    serialize_value,
+)
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sensor import (
+    batch_observed_scan_evidence_counts,
+    observed_scan_evidence_counts,
+    observed_scan_log_odds_delta,
+)
+from POMDPPlanners.utils.config_to_id import config_to_id
+
+#: Marker written by the serializer below, so a serialized rule is recognisable
+#: in a config file without importing anything.
+_SERIALIZED_TYPE = "OccupancyUpdateRule"
+
+
+# Defined before the classes: ``__init_subclass__`` registers this the moment a
+# subclass body is executed, which happens while this module is still loading.
+def _serialize_update_rule(rule: "OccupancyUpdateRule") -> Dict[str, Any]:
+    """Serialize a rule as its class path plus its parameters."""
+    return {
+        "__type__": _SERIALIZED_TYPE,
+        "class": f"{type(rule).__module__}.{type(rule).__qualname__}",
+        "params": {key: serialize_value(value) for key, value in rule.parameters().items()},
+    }
+
+
+def _deserialize_update_rule(data: Any) -> Any:
+    """Rebuild a rule from :func:`_serialize_update_rule`'s output.
+
+    Anything that is not such a payload is handed back untouched, so a ``None``
+    ``update_rule`` in an old config still deserializes to ``None``.
+    """
+    if not isinstance(data, dict) or data.get("__type__") != _SERIALIZED_TYPE:
+        return data
+    module_path, _, class_name = data["class"].rpartition(".")
+    rule_class = getattr(importlib.import_module(module_path), class_name)
+    params = {key: deserialize_value(value) for key, value in data.get("params", {}).items()}
+    return rule_class(**params)
+
+
+class OccupancyUpdateRule(ABC):
+    """How one observed scan turns a previous occupancy map into the next one.
+
+    A rule reads only the previous log-odds, the *observed* pose and the
+    *measured* ranges. It is never given the hidden true map or a hit flag;
+    a rule that needed either would be describing an oracle, not a mapper.
+
+    Subclasses must implement :meth:`update_log_odds` and :meth:`parameters`.
+    The two batched entry points have working defaults, so a rule is usable as
+    soon as its scalar form exists; override them when the loop is too slow.
+
+    Example:
+        >>> import numpy as np
+        >>> from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
+        ...     NearestCellLogOddsUpdateRule,
+        ...     OccupancyGridMappingPOMDP,
+        ... )
+        >>> rule = NearestCellLogOddsUpdateRule(
+        ...     free_log_odds=-1.0, occupied_log_odds=1.0, log_odds_clamp=6.0
+        ... )
+        >>> env = OccupancyGridMappingPOMDP(update_rule=rule)
+        >>> env.config_id != OccupancyGridMappingPOMDP().config_id
+        True
+    """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Teach the serializer about every concrete rule, including a user's.
+
+        The registry matches on the exact type, so registering the base class
+        would miss every subclass. Doing it here means a rule defined in a
+        user's own module serializes into an environment config without that
+        user registering anything.
+        """
+        super().__init_subclass__(**kwargs)
+        register_serializer(cls, _serialize_update_rule)
+
+    # -- the update -----------------------------------------------------
+
+    @abstractmethod
+    def update_log_odds(
+        self,
+        log_odds: np.ndarray,
+        row: int,
+        col: int,
+        heading: int,
+        observed_ranges: np.ndarray,
+        template: Tuple[np.ndarray, np.ndarray],
+        num_rows: int,
+        num_cols: int,
+        max_range_cells: float,
+    ) -> np.ndarray:
+        """Fold one observed scan into one map.
+
+        Args:
+            log_odds: ``(num_cells,)`` previous log-odds, row-major.
+            row: Observed robot row.
+            col: Observed robot column.
+            heading: Observed heading index.
+            observed_ranges: ``(num_beams,)`` measured ranges.
+            template: The heading's ``(offsets, distances)`` ray template.
+            num_rows: Grid rows.
+            num_cols: Grid columns.
+            max_range_cells: Sensor range in cell widths. A reading at or above
+                it is a miss.
+
+        Returns:
+            ``(num_cells,)`` next log-odds. Must not modify ``log_odds``.
+        """
+
+    def batch_update_log_odds(
+        self,
+        log_odds: np.ndarray,
+        rows: np.ndarray,
+        cols: np.ndarray,
+        headings: np.ndarray,
+        observed_ranges: np.ndarray,
+        ray_templates: Sequence[Tuple[np.ndarray, np.ndarray]],
+        num_rows: int,
+        num_cols: int,
+        max_range_cells: float,
+    ) -> np.ndarray:
+        """Fold one scan per particle into one map per particle.
+
+        The default loops over :meth:`update_log_odds`, which is correct for
+        any rule and fast enough for a few hundred particles. A rule used
+        inside a planner's belief update should override it.
+
+        Args:
+            log_odds: ``(N, num_cells)`` previous log-odds.
+            rows: ``(N,)`` observed robot rows.
+            cols: ``(N,)`` observed robot columns.
+            headings: ``(N,)`` observed heading indices.
+            observed_ranges: ``(N, num_beams)`` measured ranges.
+            ray_templates: The per-heading ray templates.
+            num_rows: Grid rows.
+            num_cols: Grid columns.
+            max_range_cells: Sensor range in cell widths.
+
+        Returns:
+            ``(N, num_cells)`` next log-odds.
+        """
+        return np.stack(
+            [
+                self.update_log_odds(
+                    log_odds[index],
+                    int(rows[index]),
+                    int(cols[index]),
+                    int(headings[index]),
+                    observed_ranges[index],
+                    ray_templates[int(headings[index])],
+                    num_rows,
+                    num_cols,
+                    max_range_cells,
+                )
+                for index in range(log_odds.shape[0])
+            ]
+        )
+
+    def shared_update_log_odds(
+        self,
+        log_odds: np.ndarray,
+        row: int,
+        col: int,
+        heading: int,
+        observed_ranges: np.ndarray,
+        ray_templates: Sequence[Tuple[np.ndarray, np.ndarray]],
+        num_rows: int,
+        num_cols: int,
+        max_range_cells: float,
+    ) -> np.ndarray:
+        """Fold *one* scan into every particle's map.
+
+        This is the filter's hot path: conditioning on a real observation gives
+        every whole-map particle the same observed pose and the same measured
+        ranges, and only the previous maps differ. The default broadcasts the
+        one scan into ``N`` rows and defers to :meth:`batch_update_log_odds`;
+        a rule whose scan classification does not depend on the previous map
+        can override this to classify once.
+
+        Args:
+            log_odds: ``(N, num_cells)`` previous log-odds.
+            row: The observed robot row, shared by every particle.
+            col: The observed robot column.
+            heading: The observed heading index.
+            observed_ranges: ``(num_beams,)`` measured ranges.
+            ray_templates: The per-heading ray templates.
+            num_rows: Grid rows.
+            num_cols: Grid columns.
+            max_range_cells: Sensor range in cell widths.
+
+        Returns:
+            ``(N, num_cells)`` next log-odds.
+        """
+        count = log_odds.shape[0]
+        return self.batch_update_log_odds(
+            log_odds,
+            np.full(count, int(row), dtype=np.int64),
+            np.full(count, int(col), dtype=np.int64),
+            np.full(count, int(heading), dtype=np.int64),
+            np.broadcast_to(observed_ranges, (count, observed_ranges.shape[-1])),
+            ray_templates,
+            num_rows,
+            num_cols,
+            max_range_cells,
+        )
+
+    # -- identity -------------------------------------------------------
+
+    @abstractmethod
+    def parameters(self) -> Dict[str, Any]:
+        """The rule's parameters, as constructor keyword arguments.
+
+        Used for two things at once, deliberately: it is the rule's
+        contribution to the environment's ``config_id``, and it is what a
+        serialized config is rebuilt from. A subclass must therefore accept
+        every key it returns as a keyword argument, and must report every
+        parameter that changes the update -- a parameter left out here is a
+        parameter under which two different rules would silently share a cache
+        entry.
+
+        Returns:
+            A JSON-serializable dict of parameter names to values.
+        """
+
+    @property
+    def config_id(self) -> str:
+        """Deterministic identifier of this rule, class included."""
+        return config_to_id(
+            {
+                "class": f"{type(self).__module__}.{type(self).__qualname__}",
+                "parameters": dict(sorted(self.parameters().items())),
+            }
+        )
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, OccupancyUpdateRule):
+            return NotImplemented
+        return type(self) is type(other) and self.config_id == other.config_id
+
+    def __hash__(self) -> int:
+        return hash(self.config_id)
+
+    def __repr__(self) -> str:
+        arguments = ", ".join(
+            f"{key}={value!r}" for key, value in sorted(self.parameters().items())
+        )
+        return f"{type(self).__name__}({arguments})"
+
+
+class ProbabilityOccupancyUpdateRule(OccupancyUpdateRule):
+    """An update rule written on occupancy probabilities instead of log-odds.
+
+    Implement :meth:`update_probabilities`; this class classifies the scan,
+    converts ``L -> p`` before your method and ``p -> L`` after it, and applies
+    the clamp. The classification is the environment's: a reading below the
+    maximum range marks the cells before the nearest ray-cell centre free and
+    that cell occupied, a reading at or above it marks the whole in-grid ray
+    free, and the robot's own cell takes one free sighting.
+
+    A rule that needs a different *classification*, not just different
+    arithmetic on the counts, should subclass :class:`OccupancyUpdateRule`
+    directly.
+
+    Attributes:
+        log_odds_clamp: Symmetric bound applied to the resulting log-odds,
+            which is the same thing as clipping ``p`` to
+            ``[sigmoid(-clamp), sigmoid(clamp)]``.
+    """
+
+    def __init__(self, log_odds_clamp: float = 6.0):
+        """Initialize the rule.
+
+        Args:
+            log_odds_clamp: Symmetric bound on the resulting log-odds. Must be
+                positive; without it a cell swept by many beams becomes
+                unrevisable.
+
+        Raises:
+            ValueError: If ``log_odds_clamp`` is not positive.
+        """
+        if float(log_odds_clamp) <= 0.0:
+            raise ValueError(f"log_odds_clamp must be positive, got {log_odds_clamp}")
+        self.log_odds_clamp = float(log_odds_clamp)
+
+    @abstractmethod
+    def update_probabilities(
+        self,
+        probabilities: np.ndarray,
+        free_counts: np.ndarray,
+        occupied_counts: np.ndarray,
+    ) -> np.ndarray:
+        """Return the next occupancy probabilities.
+
+        Called once for a scalar update and once for a whole batch, so write it
+        with array operations and it serves both.
+
+        Args:
+            probabilities: Previous occupancy probabilities in ``(0, 1)``,
+                shaped ``(num_cells,)`` or ``(N, num_cells)``.
+            free_counts: How many free sightings this scan gave each cell,
+                same shape, including the robot's own cell.
+            occupied_counts: How many occupied sightings this scan gave each
+                cell, same shape.
+
+        Returns:
+            The next probabilities, same shape. A cell with no evidence should
+            be returned unchanged.
+        """
+
+    def update_log_odds(
+        self,
+        log_odds,
+        row,
+        col,
+        heading,
+        observed_ranges,
+        template,
+        num_rows,
+        num_cols,
+        max_range_cells,
+    ):
+        """Classify the scan, hand ``p`` to :meth:`update_probabilities`, clamp."""
+        free_counts, occupied_counts = observed_scan_evidence_counts(
+            observed_ranges, template, row, col, num_rows, num_cols, max_range_cells
+        )
+        free_counts = free_counts.copy()
+        free_counts[int(row) * int(num_cols) + int(col)] += 1
+        return self._apply(log_odds, free_counts, occupied_counts)
+
+    def batch_update_log_odds(
+        self,
+        log_odds,
+        rows,
+        cols,
+        headings,
+        observed_ranges,
+        ray_templates,
+        num_rows,
+        num_cols,
+        max_range_cells,
+    ):
+        """The batched twin of :meth:`update_log_odds`, in one array pass."""
+        free_counts, occupied_counts = batch_observed_scan_evidence_counts(
+            observed_ranges,
+            ray_templates,
+            rows,
+            cols,
+            headings,
+            num_rows,
+            num_cols,
+            max_range_cells,
+        )
+        free_counts[np.arange(free_counts.shape[0]), rows * int(num_cols) + cols] += 1
+        return self._apply(log_odds, free_counts, occupied_counts)
+
+    def _apply(
+        self, log_odds: np.ndarray, free_counts: np.ndarray, occupied_counts: np.ndarray
+    ) -> np.ndarray:
+        """Convert to ``p``, run the author's rule, convert back and clamp.
+
+        The previous log-odds are already clamped, so ``p`` never reaches 0 or
+        1 going in. It can come back as either -- a rule is allowed to say
+        "certainly occupied" -- so the logit is taken under ``errstate`` and the
+        resulting infinity is what the clamp is there to absorb.
+        """
+        probabilities = 1.0 / (1.0 + np.exp(-np.asarray(log_odds, dtype=np.float64)))
+        updated = np.asarray(
+            self.update_probabilities(probabilities, free_counts, occupied_counts),
+            dtype=np.float64,
+        )
+        if updated.shape != probabilities.shape:
+            raise ValueError(
+                "update_probabilities must return the shape it was given, got "
+                f"{updated.shape} for {probabilities.shape}"
+            )
+        with np.errstate(divide="ignore", invalid="ignore"):
+            next_log_odds = np.log(updated) - np.log1p(-updated)
+        # A NaN would come from p outside [0, 1], which is an author error the
+        # clamp cannot fix and which would otherwise poison the map silently.
+        if np.any(np.isnan(next_log_odds)):
+            raise ValueError("update_probabilities returned a value outside [0, 1]")
+        return np.clip(next_log_odds, -self.log_odds_clamp, self.log_odds_clamp)
+
+    def parameters(self) -> Dict[str, Any]:
+        """The clamp. A subclass with its own parameters extends this dict."""
+        return {"log_odds_clamp": self.log_odds_clamp}
+
+
+class NearestCellLogOddsUpdateRule(OccupancyUpdateRule):
+    """The environment's original rule: constant evidence at the nearest cell.
+
+    Per beam, a reading below the maximum range selects the nearest valid
+    ray-cell centre as the hit cell, gives every valid cell before it
+    ``free_log_odds`` and that cell ``occupied_log_odds``, and leaves the cells
+    behind it alone. A reading at or above the maximum range frees the whole
+    in-grid ray and marks nothing occupied. The robot's own cell takes one
+    further ``free_log_odds``. All terms are summed and the total is clamped
+    once -- never per term, which would make the order of the beams matter.
+
+    This is the rule every result produced before rules became pluggable used,
+    and it stays the default. Its arithmetic is fixed: a golden episode hash in
+    the test suite separates maps that differ by 1e-13.
+
+    Attributes:
+        free_log_odds: Increment for a cell a beam passed through. Negative.
+        occupied_log_odds: Increment for the cell a beam stopped in. Positive.
+        log_odds_clamp: Symmetric bound on the accumulated log-odds.
+    """
+
+    def __init__(self, free_log_odds: float, occupied_log_odds: float, log_odds_clamp: float):
+        """Initialize the rule.
+
+        Args:
+            free_log_odds: Increment for a cell a beam passed through. Must be
+                negative, or free space would be evidence of occupancy.
+            occupied_log_odds: Increment for the cell a beam stopped in. Must
+                be positive.
+            log_odds_clamp: Symmetric bound on the accumulated log-odds. Must
+                be positive.
+
+        Raises:
+            ValueError: If any of the three is on the wrong side of zero.
+        """
+        if float(free_log_odds) >= 0.0:
+            raise ValueError(f"free_log_odds must be negative, got {free_log_odds}")
+        if float(occupied_log_odds) <= 0.0:
+            raise ValueError(f"occupied_log_odds must be positive, got {occupied_log_odds}")
+        if float(log_odds_clamp) <= 0.0:
+            raise ValueError(f"log_odds_clamp must be positive, got {log_odds_clamp}")
+        self.free_log_odds = float(free_log_odds)
+        self.occupied_log_odds = float(occupied_log_odds)
+        self.log_odds_clamp = float(log_odds_clamp)
+
+    def update_log_odds(
+        self,
+        log_odds,
+        row,
+        col,
+        heading,
+        observed_ranges,
+        template,
+        num_rows,
+        num_cols,
+        max_range_cells,
+    ):
+        """Sum every beam's constant evidence, add the robot's cell, clamp once."""
+        delta = observed_scan_log_odds_delta(
+            observed_ranges,
+            template,
+            row,
+            col,
+            num_rows,
+            num_cols,
+            max_range_cells,
+            self.free_log_odds,
+            self.occupied_log_odds,
+        )
+        delta[row * num_cols + col] += self.free_log_odds
+        return np.clip(log_odds + delta, -self.log_odds_clamp, self.log_odds_clamp)
+
+    def batch_update_log_odds(
+        self,
+        log_odds,
+        rows,
+        cols,
+        headings,
+        observed_ranges,
+        ray_templates,
+        num_rows,
+        num_cols,
+        max_range_cells,
+    ):
+        """One array pass over every particle, grouped by heading."""
+        return np.clip(
+            log_odds
+            + self._deltas(
+                observed_ranges,
+                ray_templates,
+                rows,
+                cols,
+                headings,
+                num_rows,
+                num_cols,
+                max_range_cells,
+            ),
+            -self.log_odds_clamp,
+            self.log_odds_clamp,
+        )
+
+    def shared_update_log_odds(
+        self,
+        log_odds,
+        row,
+        col,
+        heading,
+        observed_ranges,
+        ray_templates,
+        num_rows,
+        num_cols,
+        max_range_cells,
+    ):
+        """Classify the one shared scan once, then broadcast its increment.
+
+        The increment does not depend on the previous map, so a filter with a
+        thousand map particles classifies one scan rather than a thousand
+        identical ones.
+        """
+        delta = observed_scan_log_odds_delta(
+            observed_ranges,
+            ray_templates[int(heading)],
+            row,
+            col,
+            num_rows,
+            num_cols,
+            max_range_cells,
+            self.free_log_odds,
+            self.occupied_log_odds,
+        )
+        delta[int(row) * int(num_cols) + int(col)] += self.free_log_odds
+        return np.clip(log_odds + delta[None, :], -self.log_odds_clamp, self.log_odds_clamp)
+
+    def _deltas(
+        self,
+        observed_ranges,
+        ray_templates,
+        rows,
+        cols,
+        headings,
+        num_rows,
+        num_cols,
+        max_range_cells,
+    ) -> np.ndarray:
+        """Per-particle log-odds increments, before the clamp."""
+        free_counts, occupied_counts = batch_observed_scan_evidence_counts(
+            observed_ranges,
+            ray_templates,
+            rows,
+            cols,
+            headings,
+            num_rows,
+            num_cols,
+            max_range_cells,
+        )
+        deltas = free_counts * self.free_log_odds + occupied_counts * self.occupied_log_odds
+        deltas[np.arange(deltas.shape[0]), rows * int(num_cols) + cols] += self.free_log_odds
+        return deltas
+
+    def parameters(self) -> Dict[str, Any]:
+        """The three constants that define the update."""
+        return {
+            "free_log_odds": self.free_log_odds,
+            "occupied_log_odds": self.occupied_log_odds,
+            "log_odds_clamp": self.log_odds_clamp,
+        }
+
+
+def default_update_rule(
+    free_log_odds: float, occupied_log_odds: float, log_odds_clamp: float
+) -> NearestCellLogOddsUpdateRule:
+    """The rule an environment uses when it is given none.
+
+    Args:
+        free_log_odds: The environment's ``miss_probability`` in log-odds.
+        occupied_log_odds: The environment's ``hit_probability`` in log-odds.
+        log_odds_clamp: The environment's clamp.
+
+    Returns:
+        The default rule built from those three.
+    """
+    return NearestCellLogOddsUpdateRule(
+        free_log_odds=free_log_odds,
+        occupied_log_odds=occupied_log_odds,
+        log_odds_clamp=log_odds_clamp,
+    )
+
+
+def non_default_update_rule_id(
+    rule: OccupancyUpdateRule,
+    free_log_odds: float,
+    occupied_log_odds: float,
+    log_odds_clamp: float,
+) -> Optional[str]:
+    """The identity ``rule`` adds to a config, or ``None`` when it adds nothing.
+
+    The default rule is fully described by ``hit_probability``,
+    ``miss_probability`` and ``log_odds_clamp``, which a configuration already
+    carries. Returning ``None`` for it is what keeps every cached result and
+    every pinned ``config_id`` from before this option existed valid. Any other
+    rule -- including the default class with different constants -- returns an
+    identifier, so it can never collide with them.
+
+    Args:
+        rule: The environment's or updater's rule.
+        free_log_odds: The configuration's free-space log-odds.
+        occupied_log_odds: The configuration's occupied log-odds.
+        log_odds_clamp: The configuration's clamp.
+
+    Returns:
+        ``rule.config_id``, or ``None`` if ``rule`` is the default one.
+    """
+    default = default_update_rule(free_log_odds, occupied_log_odds, log_odds_clamp)
+    if rule.config_id == default.config_id:
+        return None
+    return rule.config_id
+
+
+# Registered under both spellings because the registry is keyed on the exact
+# annotation the caller hands it, and ``Environment.from_dict`` reads the
+# constructor's ``Optional[OccupancyUpdateRule]`` rather than the bare class.
+register_deserializer(OccupancyUpdateRule, _deserialize_update_rule)
+register_deserializer(
+    Optional[OccupancyUpdateRule],  # type: ignore[arg-type]
+    _deserialize_update_rule,
+)

--- a/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_update_rules.py
+++ b/POMDPPlanners/environments/occupancy_grid_mapping_pomdp/occupancy_update_rules.py
@@ -114,6 +114,40 @@ class OccupancyUpdateRule(ABC):
         True
     """
 
+    #: Class-level default so ``__setattr__`` below works before ``__init__``
+    #: has run. :meth:`freeze` shadows it with an instance attribute, which is
+    #: what makes the frozen state survive pickling.
+    _frozen = False
+
+    def freeze(self) -> "OccupancyUpdateRule":
+        """Make this rule read-only, and return it.
+
+        An environment calls this on the rule it adopts. The rule's parameters
+        were folded into that environment's ``config_id`` at that moment, and
+        the identifier is a string, not a live view -- so a later
+        ``rule.occupied_log_odds = 0.5`` would map under a different law while
+        the cache still answered to the old identity. Refusing the assignment
+        is cheaper than making every identifier live.
+
+        Freezing is idempotent, so one rule shared by two environments is fine.
+
+        Returns:
+            ``self``, so the call can be chained onto construction.
+        """
+        object.__setattr__(self, "_frozen", True)
+        return self
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Assign, unless the rule has been attached to an environment."""
+        if self._frozen:
+            raise AttributeError(
+                f"{type(self).__name__} is attached to an environment and is read-only. "
+                "Its parameters are already part of that environment's config_id, so "
+                f"setting {name!r} here would change the mapping law without changing "
+                "the identity its results are cached under. Build a new rule instead."
+            )
+        object.__setattr__(self, name, value)
+
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Teach the serializer about every concrete rule, including a user's.
 
@@ -190,6 +224,10 @@ class OccupancyUpdateRule(ABC):
         Returns:
             ``(N, num_cells)`` next log-odds.
         """
+        if log_odds.shape[0] == 0:
+            # np.stack refuses an empty list, and an empty particle array is a
+            # real state for a filter whose motion outcomes left a branch dead.
+            return np.zeros_like(log_odds)
         return np.stack(
             [
                 self.update_log_odds(

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_update_rules.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_update_rules.py
@@ -31,6 +31,9 @@ from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
 from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_beliefs import (
     OccupancyGridMappingVectorizedUpdater,
 )
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_sensor import (
+    observed_scan_evidence_counts,
+)
 from POMDPPlanners.tests.test_environments.test_occupancy_grid_mapping_pomdp.test_occupancy_grid_mapping_beliefs.test_occupancy_grid_mapping_vectorized_updater import (  # noqa: E501
     diverse_particles,
     make_env,
@@ -559,10 +562,6 @@ def test_a_probability_rule_returning_an_impossible_value_is_rejected():
             """Return an impossible probability."""
             return probabilities + 2.0
 
-        def parameters(self):
-            """No parameters beyond the clamp."""
-            return super().parameters()
-
     # Driven with the default rule: the broken one raises on the first
     # transition, which would fail the test before it reached its assertion.
     default_env = make_env()
@@ -571,3 +570,176 @@ def test_a_probability_rule_returning_an_impossible_value_is_rejected():
     env = make_env(update_rule=OutOfRangeRule())
     with pytest.raises(ValueError, match="outside"):
         env.state_from_observation(particle, observation)
+
+
+# ----------------------------------------------------------------------
+# The base class's own batched fallback.
+# ----------------------------------------------------------------------
+
+
+class ScalarOnlyDecayRule(OccupancyUpdateRule):
+    """A rule with no batched override, so the base class's loop is exercised.
+
+    It halves the prior before folding the scan in, which makes the result
+    depend on both the previous map and the scan -- a fallback that silently
+    dropped either would not survive the comparison below.
+    """
+
+    def update_log_odds(
+        self,
+        log_odds,
+        row,
+        col,
+        heading,
+        observed_ranges,
+        template,
+        num_rows,
+        num_cols,
+        max_range_cells,
+    ):
+        """Halve the prior, add one unit of evidence per sighting, clamp at 6."""
+        free_counts, occupied_counts = observed_scan_evidence_counts(
+            observed_ranges, template, row, col, num_rows, num_cols, max_range_cells
+        )
+        delta = occupied_counts - free_counts
+        return np.clip(0.5 * np.asarray(log_odds, dtype=np.float64) + delta, -6.0, 6.0)
+
+    def parameters(self):
+        """No parameters."""
+        return {}
+
+
+def test_the_default_batched_form_equals_looping_the_scalar_one():
+    """Purpose: a rule that implements only the scalar form must still be usable.
+
+    Given: A rule with no batched override, and one scan per particle.
+    When: ``batch_update_log_odds`` and an explicit loop over
+        ``update_log_odds`` are both applied.
+    Then: The results are equal element by element, so the fallback is not a
+        second, subtly different implementation of the rule.
+
+    Test type: unit
+    """
+    env = make_env(update_rule=ScalarOnlyDecayRule())
+    rng = np.random.RandomState(29)
+    count = 10
+    rows = rng.randint(1, env.num_rows - 1, count)
+    cols = rng.randint(1, env.num_cols - 1, count)
+    headings = rng.randint(0, 4, count)
+    ranges = rng.uniform(-0.5, env.max_range_cells + 1.0, (count, env.num_beams))
+    log_odds = rng.normal(0.0, 3.0, (count, env.num_cells))
+    templates = env._ray_templates  # pylint: disable=protected-access
+
+    batched = env.update_rule.batch_update_log_odds(
+        log_odds,
+        rows,
+        cols,
+        headings,
+        ranges,
+        templates,
+        env.num_rows,
+        env.num_cols,
+        env.max_range_cells,
+    )
+    expected = np.stack(
+        [
+            env.update_rule.update_log_odds(
+                log_odds[index],
+                int(rows[index]),
+                int(cols[index]),
+                int(headings[index]),
+                ranges[index],
+                templates[int(headings[index])],
+                env.num_rows,
+                env.num_cols,
+                env.max_range_cells,
+            )
+            for index in range(count)
+        ]
+    )
+    assert np.array_equal(batched, expected)
+
+
+def test_the_default_batched_form_accepts_an_empty_particle_array():
+    """Purpose: an empty particle set is a real state, not an error.
+
+    Given: No particles at all, which a filter reaches when every motion
+        outcome of a branch was pruned.
+    When: The base class's batched form and the default rule's own are called.
+    Then: Both return an empty map array of the right shape rather than
+        raising, which ``np.stack`` of an empty list would.
+
+    Test type: unit
+    """
+    env = make_env()
+    empty_maps = np.zeros((0, env.num_cells))
+    empty_int = np.zeros(0, dtype=np.int64)
+    empty_ranges = np.zeros((0, env.num_beams))
+    templates = env._ray_templates  # pylint: disable=protected-access
+
+    for rule in (ScalarOnlyDecayRule(), env.update_rule):
+        result = rule.batch_update_log_odds(
+            empty_maps,
+            empty_int,
+            empty_int,
+            empty_int,
+            empty_ranges,
+            templates,
+            env.num_rows,
+            env.num_cols,
+            env.max_range_cells,
+        )
+        assert result.shape == (0, env.num_cells)
+
+
+def test_an_attached_rule_cannot_be_mutated_behind_the_identity():
+    """Purpose: a rule's parameters must not change after they were hashed.
+
+    Given: An environment built with a custom rule, whose ``config_id`` already
+        carries that rule's parameters.
+    When: One of those parameters is assigned on the rule object afterwards.
+    Then: The assignment is refused, because the identifier is a string taken
+        once rather than a live view, so the change would map under a different
+        law while the cache still answered to the old identity.
+
+    Test type: unit
+    """
+    rule = OddsProductProbabilityRule()
+    env = make_env(update_rule=rule)
+    assert env.update_rule is rule
+    with pytest.raises(AttributeError, match="read-only"):
+        rule.hit_probability = 0.5
+    # Through the environment's own handle too: ``setattr`` rather than a dotted
+    # assignment because the property is typed as the abstract base, which has
+    # no such attribute.
+    with pytest.raises(AttributeError, match="read-only"):
+        setattr(env.update_rule, "hit_probability", 0.5)
+    assert rule.hit_probability == 0.85
+
+
+def test_a_rule_is_mutable_until_an_environment_adopts_it():
+    """Purpose: freezing must not make a rule awkward to build.
+
+    Given: A freshly constructed rule.
+    When: Its parameters are set, as a subclass constructor does.
+    Then: The assignments succeed, and the environment built from it is
+        identified by the values in force at that moment.
+
+    Test type: unit
+    """
+    rule = OddsProductProbabilityRule()
+    rule.hit_probability = 0.9
+    assert (
+        make_env(update_rule=rule).config_id
+        == make_env(update_rule=OddsProductProbabilityRule(hit_probability=0.9)).config_id
+    )
+
+
+def test_a_frozen_rule_stays_frozen_through_pickling():
+    """Purpose: the environment reaches a worker by pickle, rules included.
+
+    Test type: unit
+    """
+    env = pickle.loads(pickle.dumps(make_env(update_rule=OddsProductProbabilityRule())))
+    with pytest.raises(AttributeError, match="read-only"):
+        setattr(env.update_rule, "hit_probability", 0.5)

--- a/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_update_rules.py
+++ b/POMDPPlanners/tests/test_environments/test_occupancy_grid_mapping_pomdp/test_occupancy_update_rules.py
@@ -1,0 +1,573 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the pluggable occupancy-grid map update rule.
+
+Two things have to hold at once. The default rule must reproduce the update the
+environment performed before the rule became an object -- every cached result
+and the pinned golden visualization were produced under it, and a golden hash
+separates maps that differ by 1e-13, so "close" is not good enough. And a rule
+supplied by a user must reach every path: the scalar transition, the batched
+particle kernels and both rewards, with an identity that cannot collide with
+the default's in a cache.
+
+The legacy arithmetic is written out here rather than imported, so that these
+tests still fail if someone rewrites the shipped rule into something that is
+only algebraically the same.
+"""
+
+import pickle
+
+import numpy as np
+import pytest
+
+from POMDPPlanners.core.environment import Environment
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
+    NearestCellLogOddsUpdateRule,
+    OccupancyGridMappingPOMDP,
+    OccupancyUpdateRule,
+    ProbabilityOccupancyUpdateRule,
+    create_occupancy_grid_state,
+)
+from POMDPPlanners.environments.occupancy_grid_mapping_pomdp.occupancy_grid_mapping_beliefs import (
+    OccupancyGridMappingVectorizedUpdater,
+)
+from POMDPPlanners.tests.test_environments.test_occupancy_grid_mapping_pomdp.test_occupancy_grid_mapping_beliefs.test_occupancy_grid_mapping_vectorized_updater import (  # noqa: E501
+    diverse_particles,
+    make_env,
+)
+
+ACTIONS = (0, 1, 2)
+
+
+# ----------------------------------------------------------------------
+# The update as it was written before the rule became an object.
+# ----------------------------------------------------------------------
+
+
+def legacy_scalar_delta(env, row, col, heading, ranges):
+    """The pre-refactor scalar increment, transcribed from ``develop`` 6adbd45b."""
+    offsets, distances = env._ray_templates[heading]  # pylint: disable=protected-access
+    rows = offsets[:, :, 0] + row
+    cols = offsets[:, :, 1] + col
+    valid = (
+        (rows >= 0)
+        & (rows < env.num_rows)
+        & (cols >= 0)
+        & (cols < env.num_cols)
+        & np.isfinite(distances)
+    )
+    valid = np.logical_and.accumulate(valid, axis=1)
+    has_cell = valid.any(axis=1)
+    nearest = np.argmin(np.where(valid, np.abs(distances - ranges[:, None]), np.inf), axis=1)
+    hit = (ranges < env.max_range_cells) & has_cell
+    slots = np.arange(distances.shape[1])[None, :]
+    free = valid & ((slots < nearest[:, None]) | ~hit[:, None])
+    occupied = valid & (slots == nearest[:, None]) & hit[:, None]
+    flat = rows * env.num_cols + cols
+    delta = (
+        np.bincount(flat[free], minlength=env.num_cells) * env.free_log_odds
+        + np.bincount(flat[occupied], minlength=env.num_cells) * env.occupied_log_odds
+    )
+    delta[row * env.num_cols + col] += env.free_log_odds
+    return delta
+
+
+def legacy_state_from_observation(env, state, observation):
+    """The pre-refactor ``state_from_observation``."""
+    row, col, heading = (int(value) for value in observation[:3])
+    next_state = np.array(state, dtype=float, copy=True)
+    next_state[0] += 1
+    next_state[1:4] = observation[:3]
+    next_state[env.scan_offset :] = observation[3:]
+    delta = legacy_scalar_delta(env, row, col, heading, observation[3:])
+    end = env.log_odds_offset + env.num_cells
+    next_state[env.log_odds_offset : end] = np.clip(
+        next_state[env.log_odds_offset : end] + delta, -env.log_odds_clamp, env.log_odds_clamp
+    )
+    return next_state
+
+
+def legacy_batch_deltas(env, ranges, rows, cols, headings):
+    """The pre-refactor ``_scan_deltas``, transcribed from ``develop`` 6adbd45b."""
+    count = ranges.shape[0]
+    deltas = np.zeros((count, env.num_cells), dtype=np.float64)
+    slot_offsets = np.arange(count) * env.num_cells
+    for heading in np.unique(headings):
+        index = np.flatnonzero(headings == heading)
+        offsets, distances = env._ray_templates[int(heading)]  # pylint: disable=protected-access
+        length = distances.shape[1]
+        ray_rows = offsets[None, :, :, 0] + rows[index, None, None]
+        ray_cols = offsets[None, :, :, 1] + cols[index, None, None]
+        valid = (
+            (ray_rows >= 0)
+            & (ray_rows < env.num_rows)
+            & (ray_cols >= 0)
+            & (ray_cols < env.num_cols)
+            & np.isfinite(distances)[None]
+        )
+        valid = np.logical_and.accumulate(valid, axis=2)
+        has_cell = valid.any(axis=2)
+        gaps = np.abs(distances[None] - ranges[index][:, :, None])
+        nearest = np.argmin(np.where(valid, gaps, np.inf), axis=2)
+        hit = (ranges[index] < env.max_range_cells) & has_cell
+        slots = np.arange(length)[None, None, :]
+        free = valid & ((slots < nearest[:, :, None]) | ~hit[:, :, None])
+        occupied = valid & (slots == nearest[:, :, None]) & hit[:, :, None]
+        flat = ray_rows * env.num_cols + ray_cols + slot_offsets[index][:, None, None]
+        deltas += (
+            np.bincount(flat[free], minlength=count * env.num_cells).reshape(count, env.num_cells)
+            * env.free_log_odds
+        )
+        deltas += (
+            np.bincount(flat[occupied], minlength=count * env.num_cells).reshape(
+                count, env.num_cells
+            )
+            * env.occupied_log_odds
+        )
+    deltas[np.arange(count), rows * env.num_cols + cols] += env.free_log_odds
+    return deltas
+
+
+# ----------------------------------------------------------------------
+# A test-only rule, written on probabilities.
+# ----------------------------------------------------------------------
+
+
+class OddsProductProbabilityRule(ProbabilityOccupancyUpdateRule):
+    """The same inverse sensor model, stated on ``p`` instead of on ``L``.
+
+    Defined at module level rather than inside a test because it has to survive
+    pickling to a worker and a rebuild from a serialized config, and neither
+    works for a class defined in a function body.
+
+    Attributes:
+        hit_probability: Probability a cell is occupied given one occupied sighting.
+        miss_probability: The same for one free sighting.
+    """
+
+    def __init__(self, hit_probability=0.85, miss_probability=0.15, log_odds_clamp=6.0):
+        """Initialize the rule.
+
+        Args:
+            hit_probability: Inverse sensor probability for an occupied sighting.
+            miss_probability: Inverse sensor probability for a free sighting.
+            log_odds_clamp: Symmetric bound on the resulting log-odds.
+        """
+        super().__init__(log_odds_clamp=log_odds_clamp)
+        self.hit_probability = float(hit_probability)
+        self.miss_probability = float(miss_probability)
+
+    def update_probabilities(self, probabilities, free_counts, occupied_counts):
+        """Multiply the prior odds by one likelihood ratio per sighting."""
+        ratio = (self.miss_probability / (1.0 - self.miss_probability)) ** free_counts * (
+            self.hit_probability / (1.0 - self.hit_probability)
+        ) ** occupied_counts
+        scaled = probabilities * ratio
+        return scaled / (1.0 - probabilities + scaled)
+
+    def parameters(self):
+        """Both probabilities and the clamp."""
+        return {
+            "hit_probability": self.hit_probability,
+            "miss_probability": self.miss_probability,
+            **super().parameters(),
+        }
+
+
+class ForgetfulRule(OccupancyUpdateRule):
+    """A rule that throws the scan away, so a wired-up path is unmistakable."""
+
+    def update_log_odds(
+        self,
+        log_odds,
+        row,
+        col,
+        heading,
+        observed_ranges,
+        template,
+        num_rows,
+        num_cols,
+        max_range_cells,
+    ):
+        """Return the prior map untouched."""
+        return np.array(log_odds, dtype=np.float64, copy=True)
+
+    def parameters(self):
+        """No parameters."""
+        return {}
+
+
+# ----------------------------------------------------------------------
+# The default rule reproduces the previous update exactly.
+# ----------------------------------------------------------------------
+
+
+def random_observations(env, count=8, seed=3):
+    """Readings spanning misses, in-range hits and negative draws."""
+    rng = np.random.RandomState(seed)
+    observations = []
+    for _ in range(count):
+        ranges = rng.uniform(-0.5, env.max_range_cells + 1.0, env.num_beams)
+        observations.append(
+            np.r_[
+                float(rng.randint(1, env.num_rows - 1)),
+                float(rng.randint(1, env.num_cols - 1)),
+                float(rng.randint(0, 4)),
+                ranges,
+            ]
+        )
+    return observations
+
+
+def random_log_odds(env, count=8, seed=5):
+    """Partly resolved maps, including cells already at the clamp."""
+    rng = np.random.RandomState(seed)
+    return rng.normal(0.0, 3.0, size=(count, env.num_cells))
+
+
+def test_default_rule_reproduces_the_previous_scalar_update_exactly():
+    """Purpose: the shipped default must be the pre-refactor update, bit for bit.
+
+    Given: Partly resolved maps and scans covering misses, hits and negative
+        readings.
+    When: ``state_from_observation`` and the transcribed pre-refactor update are
+        both applied.
+    Then: Every successor is equal element by element, not merely close --
+        a pinned golden visualization hash separates maps differing by 1e-13.
+
+    Test type: unit
+    """
+    env = make_env()
+    maps = random_log_odds(env)
+    for observation in random_observations(env):
+        for log_odds in maps:
+            state = create_occupancy_grid_state(
+                env, np.zeros(env.num_cells), log_odds=log_odds, step=2
+            )
+            assert np.array_equal(
+                env.state_from_observation(state, observation),
+                legacy_state_from_observation(env, state, observation),
+            )
+
+
+def test_default_rule_reproduces_the_previous_batched_update_exactly():
+    """Purpose: the batched kernel must also be the pre-refactor arithmetic.
+
+    Given: One scan per particle at mixed poses and headings.
+    When: The rule's batched form and the transcribed pre-refactor
+        ``_scan_deltas`` plus clamp are both applied.
+    Then: The resulting maps are equal element by element.
+
+    Test type: unit
+    """
+    env = make_env()
+    rng = np.random.RandomState(17)
+    count = 16
+    rows = rng.randint(1, env.num_rows - 1, count)
+    cols = rng.randint(1, env.num_cols - 1, count)
+    headings = rng.randint(0, 4, count)
+    ranges = rng.uniform(-0.5, env.max_range_cells + 1.0, (count, env.num_beams))
+    log_odds = rng.normal(0.0, 3.0, (count, env.num_cells))
+
+    updated = env.update_rule.batch_update_log_odds(
+        log_odds,
+        rows,
+        cols,
+        headings,
+        ranges,
+        env._ray_templates,  # pylint: disable=protected-access
+        env.num_rows,
+        env.num_cols,
+        env.max_range_cells,
+    )
+    expected = np.clip(
+        log_odds + legacy_batch_deltas(env, ranges, rows, cols, headings),
+        -env.log_odds_clamp,
+        env.log_odds_clamp,
+    )
+    assert np.array_equal(updated, expected)
+
+
+def test_default_rule_batched_transition_matches_the_previous_update_exactly():
+    """Purpose: the belief's generative transition must be unchanged too.
+
+    Given: Diverse particles and one observation.
+    When: ``batch_state_from_observation`` and the scalar
+        ``state_from_observation`` are both applied.
+    Then: Every particle's successor is equal element by element.
+
+    Test type: unit
+    """
+    env = make_env()
+    updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+    particles = diverse_particles(env)
+    for observation in random_observations(env, count=3):
+        batched = updater.batch_state_from_observation(particles, observation)
+        scalar = np.asarray(
+            [env.state_from_observation(particle, observation) for particle in particles]
+        )
+        assert np.array_equal(batched, scalar)
+        assert np.array_equal(
+            batched,
+            np.asarray(
+                [
+                    legacy_state_from_observation(env, particle, observation)
+                    for particle in particles
+                ]
+            ),
+        )
+
+
+# ----------------------------------------------------------------------
+# A custom rule reaches every path.
+# ----------------------------------------------------------------------
+
+
+def test_probability_rule_is_accepted_and_reaches_every_path():
+    """Purpose: a rule written on ``p`` must drive all four entry points alike.
+
+    Given: An environment built with a probability-space rule.
+    When: ``state_from_observation``, ``batch_state_from_observation``,
+        ``reward`` and ``reward_batch`` are evaluated on the same particles.
+    Then: The two map paths agree exactly and the two reward paths agree to
+        floating-point precision, so no path kept the built-in rule.
+
+    Test type: unit
+    """
+    env = make_env(update_rule=OddsProductProbabilityRule())
+    updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+    particles = diverse_particles(env)
+
+    for observation in random_observations(env, count=3):
+        scalar = np.asarray(
+            [env.state_from_observation(particle, observation) for particle in particles]
+        )
+        assert np.array_equal(updater.batch_state_from_observation(particles, observation), scalar)
+
+    for action in ACTIONS:
+        np.testing.assert_allclose(
+            env.reward_batch(particles, action),
+            [env.reward(particle, action) for particle in particles],
+            rtol=1e-12,
+            atol=1e-9,
+        )
+
+
+def test_probability_rule_restating_the_default_agrees_with_it():
+    """Purpose: ``L`` and ``p`` must be two ways of writing one update.
+
+    Given: The default rule's constants restated as an odds product on ``p``.
+    When: Both rules map the same partly resolved maps and scans.
+    Then: The resulting maps agree to floating-point precision, which is what
+        makes the probability base class usable for porting a published rule.
+
+    Test type: unit
+    """
+    default_env = make_env()
+    probability_env = make_env(update_rule=OddsProductProbabilityRule())
+    maps = random_log_odds(default_env, count=4)
+    for observation in random_observations(default_env, count=4):
+        for log_odds in maps:
+            state = create_occupancy_grid_state(
+                default_env, np.zeros(default_env.num_cells), log_odds=log_odds
+            )
+            np.testing.assert_allclose(
+                probability_env.state_from_observation(state, observation),
+                default_env.state_from_observation(state, observation),
+                rtol=0,
+                atol=1e-9,
+            )
+
+
+def test_a_rule_that_ignores_the_scan_leaves_every_path_unchanged():
+    """Purpose: no path may quietly fall back to the built-in update.
+
+    Given: A rule that returns the prior map untouched.
+    When: The scalar transition and the batched kernel run.
+    Then: The maps are unchanged and the expected reward is exactly the step
+        cost, because no scan can reduce entropy.
+
+    Test type: unit
+    """
+    env = make_env(update_rule=ForgetfulRule(), step_cost=0.25)
+    updater = OccupancyGridMappingVectorizedUpdater.from_environment(env)
+    particles = diverse_particles(env)
+    observation = random_observations(env, count=1)[0]
+    end = env.log_odds_offset + env.num_cells
+
+    successors = updater.batch_state_from_observation(particles, observation)
+    assert np.array_equal(
+        successors[:, env.log_odds_offset : end], particles[:, env.log_odds_offset : end]
+    )
+    scalar = env.state_from_observation(particles[0], observation)
+    assert np.array_equal(
+        scalar[env.log_odds_offset : end], particles[0][env.log_odds_offset : end]
+    )
+    np.testing.assert_allclose(env.reward_batch(particles, 0), -0.25, atol=1e-12)
+
+
+def test_batched_kernels_follow_the_rule_rather_than_a_cached_default():
+    """Purpose: the lazily built kernels must be keyed on the rule.
+
+    Given: Two environments identical but for their update rule.
+    When: Their batched kernels are built.
+    Then: The kernels carry the environment's own rule and different identifiers.
+
+    Test type: unit
+    """
+    default_env = make_env()
+    custom_env = make_env(update_rule=OddsProductProbabilityRule())
+    default_kernels = default_env._batched_kernels  # pylint: disable=protected-access
+    custom_kernels = custom_env._batched_kernels  # pylint: disable=protected-access
+    assert isinstance(default_kernels.update_rule, NearestCellLogOddsUpdateRule)
+    assert isinstance(custom_kernels.update_rule, OddsProductProbabilityRule)
+    assert default_kernels.config_id != custom_kernels.config_id
+
+
+# ----------------------------------------------------------------------
+# Identity, pickling and the config round trip.
+# ----------------------------------------------------------------------
+
+
+def test_the_default_rule_leaves_the_environment_identity_alone():
+    """Purpose: adding this knob must not invalidate results already cached.
+
+    Given: The default environment, and the same environment handed the default
+        rule explicitly.
+    When: Their ``config_id`` values are compared.
+    Then: They are equal, because the default rule is nothing but the
+        environment's own hit/miss probabilities and clamp restated.
+
+    Test type: unit
+    """
+    env = make_env()
+    explicit = make_env(
+        update_rule=NearestCellLogOddsUpdateRule(
+            free_log_odds=env.free_log_odds,
+            occupied_log_odds=env.occupied_log_odds,
+            log_odds_clamp=env.log_odds_clamp,
+        )
+    )
+    assert explicit.config_id == env.config_id
+    assert explicit == env
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        OddsProductProbabilityRule(),
+        OddsProductProbabilityRule(hit_probability=0.9),
+        ForgetfulRule(),
+        NearestCellLogOddsUpdateRule(free_log_odds=-0.5, occupied_log_odds=0.5, log_odds_clamp=6.0),
+    ],
+)
+def test_a_non_default_rule_changes_the_environment_identity(rule):
+    """Purpose: two rules must never share a cache entry.
+
+    Given: A rule that is not the environment's default.
+    When: The environment's ``config_id`` is taken.
+    Then: It differs from the default environment's, and the two environments
+        are not equal.
+
+    Test type: unit
+    """
+    env = make_env()
+    custom = make_env(update_rule=rule)
+    assert custom.config_id != env.config_id
+    assert custom != env
+
+
+def test_rules_that_differ_only_in_a_parameter_have_different_identities():
+    """Purpose: a parameter left out of ``parameters`` would be a silent collision.
+
+    Test type: unit
+    """
+    first = OddsProductProbabilityRule(hit_probability=0.85)
+    second = OddsProductProbabilityRule(hit_probability=0.80)
+    assert first.config_id != second.config_id
+    assert first != second
+    assert first == OddsProductProbabilityRule(hit_probability=0.85)
+
+
+def test_a_rule_survives_pickling():
+    """Purpose: the environment is pickled to every parallel worker.
+
+    Given: An environment with a custom rule.
+    When: It is pickled and restored.
+    Then: The rule, the identity and the update all come back unchanged.
+
+    Test type: unit
+    """
+    env = make_env(update_rule=OddsProductProbabilityRule(hit_probability=0.8))
+    restored = pickle.loads(pickle.dumps(env))
+    assert restored.config_id == env.config_id
+    assert restored.update_rule == env.update_rule
+    particle = diverse_particles(env)[0]
+    observation = random_observations(env, count=1)[0]
+    assert np.array_equal(
+        restored.state_from_observation(particle, observation),
+        env.state_from_observation(particle, observation),
+    )
+
+
+def test_a_rule_survives_the_config_round_trip():
+    """Purpose: a study's saved config must rebuild the environment it ran.
+
+    Given: An environment with a custom rule.
+    When: It is serialized with ``to_dict`` and rebuilt with ``from_dict``.
+    Then: The rebuilt environment carries the same rule and the same identity.
+
+    Test type: unit
+    """
+    env = make_env(update_rule=OddsProductProbabilityRule(miss_probability=0.2))
+    rebuilt = Environment.from_dict(env.to_dict())
+    assert isinstance(rebuilt, OccupancyGridMappingPOMDP)
+    assert isinstance(rebuilt.update_rule, OddsProductProbabilityRule)
+    assert rebuilt.update_rule == env.update_rule
+    assert rebuilt.config_id == env.config_id
+
+
+def test_the_default_environment_round_trips_to_the_same_identity():
+    """Purpose: serializing the default must not promote the rule into the identity.
+
+    Test type: unit
+    """
+    env = make_env()
+    rebuilt = Environment.from_dict(env.to_dict())
+    assert rebuilt.config_id == env.config_id
+
+
+def test_a_non_rule_is_rejected_at_construction():
+    """Purpose: a typo in a config should fail loudly, not map with the default.
+
+    Test type: unit
+    """
+    with pytest.raises(TypeError, match="update_rule"):
+        make_env(update_rule="nearest-cell")
+
+
+def test_a_probability_rule_returning_an_impossible_value_is_rejected():
+    """Purpose: a probability outside [0, 1] is an author error the clamp hides.
+
+    Test type: unit
+    """
+
+    class OutOfRangeRule(ProbabilityOccupancyUpdateRule):
+        """Returns a probability above one."""
+
+        def update_probabilities(self, probabilities, free_counts, occupied_counts):
+            """Return an impossible probability."""
+            return probabilities + 2.0
+
+        def parameters(self):
+            """No parameters beyond the clamp."""
+            return super().parameters()
+
+    # Driven with the default rule: the broken one raises on the first
+    # transition, which would fail the test before it reached its assertion.
+    default_env = make_env()
+    particle = diverse_particles(default_env)[0]
+    observation = random_observations(default_env, count=1)[0]
+    env = make_env(update_rule=OutOfRangeRule())
+    with pytest.raises(ValueError, match="outside"):
+        env.state_from_observation(particle, observation)

--- a/docs/environments/occupancy_grid_mapping.rst
+++ b/docs/environments/occupancy_grid_mapping.rst
@@ -122,6 +122,12 @@ a scan is classified rather than only the arithmetic on the counts; implement
 its batched method as well if the rule runs inside a planner's belief update,
 since the default loops over the scalar one.
 
+A rule becomes read-only the moment an environment or an updater adopts it.
+Its parameters are hashed into that object's ``config_id`` once, so allowing
+``env.update_rule.occupied_log_odds = 0.5`` afterwards would map under a
+different law while the cache still answered to the old identity. Build a new
+rule and a new environment instead.
+
 ``parameters()`` is both the rule's contribution to the environment's
 ``config_id`` and the keyword arguments it is rebuilt from, so a subclass must
 accept every key it reports and report every parameter that changes the update.

--- a/docs/environments/occupancy_grid_mapping.rst
+++ b/docs/environments/occupancy_grid_mapping.rst
@@ -86,6 +86,51 @@ Negative readings select the first valid cell. Ties select the nearer cell.
 A reading at or above maximum range marks the full in-grid ray free.
 The robot's observed cell also receives free evidence. Log-odds are clamped.
 
+That rule is the default, not a fixed property of the environment. It is
+``NearestCellLogOddsUpdateRule``, built from ``hit_probability``,
+``miss_probability`` and ``log_odds_clamp``, and it is what every result
+produced before the rule became pluggable used. The ``update_rule`` constructor
+argument replaces it, and one rule object serves the scalar transition, the
+batched particle kernels and both rewards, so the three cannot disagree::
+
+    from POMDPPlanners.environments.occupancy_grid_mapping_pomdp import (
+        OccupancyGridMappingPOMDP,
+        ProbabilityOccupancyUpdateRule,
+    )
+
+
+    class DampedOddsRule(ProbabilityOccupancyUpdateRule):
+        """Half the usual confidence per sighting."""
+
+        def update_probabilities(self, probabilities, free_counts, occupied_counts):
+            ratio = 0.4**free_counts * 2.5**occupied_counts
+            scaled = probabilities * ratio
+            return scaled / (1.0 - probabilities + scaled)
+
+        def parameters(self):
+            return super().parameters()
+
+
+    env = OccupancyGridMappingPOMDP(update_rule=DampedOddsRule())
+
+Subclass ``ProbabilityOccupancyUpdateRule`` to write the update on occupancy
+probabilities, as the literature states it: the base class classifies the scan
+into per-cell free and occupied sighting counts, converts ``L`` to ``p`` before
+your method and back after it, and applies the clamp. Subclass
+``OccupancyUpdateRule`` instead to work directly on log-odds, or to change how
+a scan is classified rather than only the arithmetic on the counts; implement
+its batched method as well if the rule runs inside a planner's belief update,
+since the default loops over the scalar one.
+
+``parameters()`` is both the rule's contribution to the environment's
+``config_id`` and the keyword arguments it is rebuilt from, so a subclass must
+accept every key it reports and report every parameter that changes the update.
+The default rule contributes nothing, because the three settings that define it
+are already in the configuration -- so a default environment's ``config_id`` is
+what it always was, and every cached episode stays valid. Any other rule does
+contribute, so its results can never be served from a cache filled under a
+different rule.
+
 A true hit exactly at maximum range and a miss have identical range laws.
 They therefore produce identical updates for the same reading. Without an
 observed hit flag, this ambiguity cannot be removed. Range noise can place


### PR DESCRIPTION
## What

The occupancy-grid map update is now a pluggable rule object instead of arithmetic copied into three places. `OccupancyGridMappingPOMDP(update_rule=...)` accepts any `OccupancyUpdateRule`; the scalar transition, the batched particle kernels and both rewards call that one object.

- `OccupancyUpdateRule`: abstract rule written on log-odds `L`. Scalar method required; batched and shared-scan methods have loop fallbacks.
- `ProbabilityOccupancyUpdateRule`: abstract rule written on occupancy probabilities `p`. The framework classifies the scan into free and occupied sighting counts per cell, converts `L` to `p` and back, and clamps.
- `NearestCellLogOddsUpdateRule`: the original rule, moved unchanged. It is the default.
- A rule is frozen when an environment or updater adopts it, so its parameters cannot drift from the config identity that was computed from them.
- Rules serialize into environment configs by class path and parameters, so a user-defined rule round-trips without registration.

## Why

The current rule is one modelling choice among several, and comparing rules is a research question. Before this change a comparison needed a fork, and the three copies of the update could drift apart.

## Compatibility

- Default behaviour is bit-identical. `config_id` of the environment and of the vectorized updater with the default rule are unchanged from develop, so cached results and the golden GIF stay valid.
- A non-default rule, including the default class with different constants, changes `config_id`.
- Sensor contract version unchanged.

## Verification

- Full `POMDPPlanners/tests/test_environments` locally: 4195 passed, 91 skipped, 12 xfailed.
- Docker CI image: occupancy and golden-file suites 200 passed, package doctests 3 passed, pyright 0 errors, black clean.
- Cross-review by Codex: one finding (mutable rule parameters after adoption), fixed in the second commit with tests.
- Ran on the MacBook; ubuntu64 was unreachable.

Not verified: the full non-slow suite in Docker was stopped at 86% inside a slow unrelated VOPP runner test. A local full run failed only in Dask task-manager tests because spawned workers import the main checkout instead of the worktree.

https://claude.ai/code/session_013837wDGTwaUaAD2eiguUa6
