### PR TITLE
Fix the RockSample rock-check sensor accuracy law

### DIFF
--- a/POMDPPlanners/environments/rock_sample_pomdp/_cpp/rock_sample.cpp
+++ b/POMDPPlanners/environments/rock_sample_pomdp/_cpp/rock_sample.cpp
@@ -5,7 +5,10 @@
 // The RockSample transition is deterministic (no RNG) and the observation is
 // a 3-way categorical over {none=0, good=1, bad=2} with a Bernoulli flip
 // whose probability depends on the Euclidean distance between the robot and
-// the queried rock via ``exp(-distance / sensor_efficiency)``. The state is
+// the queried rock via Smith & Simmons (2004),
+// ``(1 + 2^(-distance / sensor_efficiency)) / 2``, which decays from 1 at
+// distance 0 to 0.5 in the limit: a far check is uninformative, never wrong.
+// The state is
 // ``[robot_row, robot_col, rock_0, ..., rock_{R-1}]`` with terminal sentinel
 // ``[-1, -1, ...]``.
 //
@@ -49,7 +52,9 @@ constexpr int kObsBad = 2;
 // (log-pdf) paths agree on the same floored value (~ -690.776) for
 // impossible events. ``std::log`` is not constexpr in C++17 so the log
 // constant is a hard-coded ``static const double`` matching
-// ``std::log(kProbFloor)``.
+// ``std::log(kProbFloor)``. Since ``check_sensor_accuracy`` is bounded in
+// [0.5, 1], neither check branch can underflow any more; the floor is kept
+// only for the deterministic "none" branches, which are genuinely zero.
 constexpr double kProbFloor = 1e-300;
 static const double kLogProbFloor = -690.7755278982137;  // == std::log(kProbFloor)
 
@@ -63,6 +68,18 @@ static const double kLogProbFloor = -690.7755278982137;  // == std::log(kProbFlo
 //   Anything else is silently treated as a "check on nonexistent rock":
 //   no state change, observation is deterministic "none". This mirrors the
 //   Python per-particle fallback branch.
+
+// Rock-check sensor accuracy, Smith & Simmons (2004) "Heuristic Search Value
+// Iteration for POMDPs": accuracy(d) = (1 + 2^(-d / d0)) / 2, so accuracy is
+// 1 at the rock, 0.75 at d == d0, and tends to 0.5 as d grows. It is never
+// below 0.5, so a distant check is uninformative rather than misleading.
+//
+// Every caller goes through this one function, and it takes the half-life
+// itself (not a precomputed reciprocal), so the scalar and batched paths are
+// bit-identical instead of agreeing only to within a rounding step.
+inline double check_sensor_accuracy(double distance, double half_life) {
+    return 0.5 * (1.0 + std::exp2(-distance / half_life));
+}
 
 struct EnvParams {
     int map_rows;
@@ -753,7 +770,7 @@ class RockSampleObservationCpp {
 
         const std::int32_t rock_r = env_.rock_rows[static_cast<std::size_t>(rock_idx)];
         const std::int32_t rock_c = env_.rock_cols[static_cast<std::size_t>(rock_idx)];
-        const double inv_sigma = 1.0 / env_.sensor_efficiency;
+        const double half_life = env_.sensor_efficiency;
         const std::size_t rock_offset = static_cast<std::size_t>(2 + rock_idx);
 
         const double *data = next_particles.data();
@@ -768,7 +785,7 @@ class RockSampleObservationCpp {
             const double dr = robot_row - static_cast<double>(rock_r);
             const double dc = robot_col - static_cast<double>(rock_c);
             const double distance = std::sqrt(dr * dr + dc * dc);
-            const double efficiency = std::exp(-distance * inv_sigma);
+            const double efficiency = check_sensor_accuracy(distance, half_life);
             const bool rock_good = row[rock_offset] > 0.5;
             double prob;
             if (observation == kObsGood) {
@@ -808,7 +825,7 @@ class RockSampleObservationCpp {
         const double dr = state[0] - static_cast<double>(rock_r);
         const double dc = state[1] - static_cast<double>(rock_c);
         const double distance = std::sqrt(dr * dr + dc * dc);
-        return std::exp(-distance / env_.sensor_efficiency);
+        return check_sensor_accuracy(distance, env_.sensor_efficiency);
     }
 
     EnvParams env_;

--- a/POMDPPlanners/environments/rock_sample_pomdp/_native.pyi
+++ b/POMDPPlanners/environments/rock_sample_pomdp/_native.pyi
@@ -127,7 +127,9 @@ class RockSampleObservationCpp:
     Observation codes: ``0=none``, ``1=good``, ``2=bad``. Movement / sample
     actions deterministically produce ``none``; check actions produce a
     noisy Bernoulli flip whose probability depends on Euclidean distance to
-    the queried rock via ``exp(-distance / sensor_efficiency)``.
+    the queried rock via Smith & Simmons (2004),
+    ``(1 + 2 ** (-distance / sensor_efficiency)) / 2``, which decays from 1
+    to 0.5 so a far check is uninformative rather than wrong.
     """
 
     next_state: Tuple[float, ...]

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py
@@ -151,6 +151,15 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
     must navigate a grid, use sensors to evaluate rocks, and decide which ones
     to sample while balancing exploration costs and sampling rewards.
 
+    Observation model:
+        A check action on rock *i* returns ``"good"`` or ``"bad"``, correct
+        with probability ``(1 + 2 ** (-d / sensor_efficiency)) / 2`` where
+        ``d`` is the Euclidean distance from the robot to that rock. This is
+        the accuracy of Smith & Simmons, "Heuristic Search Value Iteration
+        for POMDPs" (2004). It is 1.0 at the rock and falls towards 0.5 with
+        distance, never below it, so a check from far away is uninformative
+        rather than misleading. Every other action returns ``"none"``.
+
     Stochasticity:
         The dangerous-area penalty can be applied either deterministically
         (the default) or stochastically. When
@@ -171,7 +180,9 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         map_size: Grid dimensions as (rows, cols)
         rock_positions: List of rock positions as (row, col) tuples
         init_pos: Initial robot position
-        sensor_efficiency: Sensor noise parameter (higher = less noise)
+        sensor_efficiency: Distance at which the check sensor is 75% accurate
+            (Smith & Simmons' ``d0``); larger means accuracy holds up further
+            from the rock
         bad_rock_penalty: Penalty for sampling a bad rock
         good_rock_reward: Reward for sampling a good rock
         step_penalty: Cost for each action
@@ -198,7 +209,7 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         False
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-statements
         self,
         map_size: Tuple[int, int] = (5, 5),
         rock_positions: Optional[List[Tuple[int, int]]] = None,
@@ -228,7 +239,11 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
             map_size: Grid dimensions (rows, cols). Defaults to (5, 5).
             rock_positions: Rock locations. Defaults to [(0,0), (2,2), (3,3)].
             init_pos: Initial robot position. Defaults to (0, 0).
-            sensor_efficiency: Sensor parameter. Defaults to 20.0.
+            sensor_efficiency: Half-life of the check sensor's informative
+                part, in grid cells: accuracy is
+                ``(1 + 2 ** (-d / sensor_efficiency)) / 2``, so 1.0 at the
+                rock, 0.75 at ``d == sensor_efficiency``, and it approaches
+                0.5 as ``d`` grows. Defaults to 10.0.
             bad_rock_penalty: Bad rock penalty. Defaults to -10.0.
             good_rock_reward: Good rock reward. Defaults to 10.0.
             step_penalty: Action cost. Defaults to 0.0.
@@ -330,6 +345,13 @@ class RockSamplePOMDP(DiscreteActionsEnvironment):  # pylint: disable=too-many-p
         )
         self.init_pos = init_pos
         self.sensor_efficiency = sensor_efficiency
+        # Version 1 was the rock-check accuracy ``exp(-d / sensor_efficiency)``,
+        # which fell below 0.5 and made a far check reliably wrong. Version 2 is
+        # Smith & Simmons (2004), ``(1 + 2^(-d / sensor_efficiency)) / 2``.
+        # ``config_id`` hashes every public attribute, so bumping this is what
+        # stops a cached episode from the old observation law being reused for
+        # the new one — the constructor arguments are identical across the fix.
+        self.sensor_contract_version = 2
         self.bad_rock_penalty = bad_rock_penalty
         self.good_rock_reward = good_rock_reward
         self.step_penalty = step_penalty

--- a/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_beliefs/rocksample_vectorized_updater.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_beliefs/rocksample_vectorized_updater.py
@@ -50,7 +50,10 @@ class RockSampleVectorizedUpdater(VectorizedParticleBeliefUpdater):
         map_cols: Number of grid columns.
         num_rocks: Number of rocks in the environment.
         rock_positions: Array of shape (R, 2) with rock (row, col) positions.
-        sensor_efficiency: Sensor noise parameter (higher = less noise).
+        sensor_efficiency: Distance at which the check sensor is 75%
+            accurate (Smith & Simmons' ``d0``).
+        sensor_contract_version: The environment's observation-law version,
+            carried so a belief cached under an older law is a cache miss.
     """
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -60,6 +63,7 @@ class RockSampleVectorizedUpdater(VectorizedParticleBeliefUpdater):
         num_rocks: int,
         rock_positions: np.ndarray,
         sensor_efficiency: float,
+        sensor_contract_version: int = 2,
         dangerous_areas_arr: Optional[np.ndarray] = None,
         dangerous_area_radius: float = 1.0,
         dangerous_area_hit_probability: float = 1.0,
@@ -72,6 +76,7 @@ class RockSampleVectorizedUpdater(VectorizedParticleBeliefUpdater):
         self.num_rocks = num_rocks
         self.rock_positions = np.asarray(rock_positions, dtype=np.int32)
         self.sensor_efficiency = sensor_efficiency
+        self.sensor_contract_version = int(sensor_contract_version)
         # Hazard-terminal parameters (only consumed when the flag is enabled;
         # the flag-off path builds the legacy 7-arg native kernel).
         self._dangerous_areas_arr = (
@@ -95,6 +100,7 @@ class RockSampleVectorizedUpdater(VectorizedParticleBeliefUpdater):
             num_rocks=len(env.rock_positions),
             rock_positions=rock_pos,
             sensor_efficiency=env.sensor_efficiency,
+            sensor_contract_version=env.sensor_contract_version,
             dangerous_areas_arr=env._dangerous_areas_arr,  # pylint: disable=protected-access
             dangerous_area_radius=env.dangerous_area_radius,
             dangerous_area_hit_probability=env.dangerous_area_hit_probability,
@@ -189,6 +195,7 @@ class RockSampleVectorizedUpdater(VectorizedParticleBeliefUpdater):
             "num_rocks": self.num_rocks,
             "rock_positions": self.rock_positions.tolist(),
             "sensor_efficiency": self.sensor_efficiency,
+            "sensor_contract_version": self.sensor_contract_version,
             "is_dangerous_area_hit_terminal": self._is_dangerous_area_hit_terminal,
         }
         if self._is_dangerous_area_hit_terminal:

--- a/POMDPPlanners/environments/rock_sample_pomdp/rocksample_vectorized_model.py
+++ b/POMDPPlanners/environments/rock_sample_pomdp/rocksample_vectorized_model.py
@@ -141,7 +141,6 @@ class RockSampleVectorizedModel:
         self._rock_rows = self._to_tensor(rocks[:, 0])
         self._rock_cols = self._to_tensor(rocks[:, 1])
         self._sensor_efficiency = float(env.sensor_efficiency)
-        self._inv_sigma = 1.0 / self._sensor_efficiency
 
     def _build_reward(self, env: RockSamplePOMDP) -> None:
         self._step_penalty = float(env.step_penalty)
@@ -240,12 +239,17 @@ class RockSampleVectorizedModel:
     ) -> Tuple[Tensor, Tensor]:
         rock_idx = torch.clamp(actions - _NUM_MOVE_ACTIONS, min=0)
         if self._num_rocks == 0:
-            zeros = torch.zeros(next_states.shape[0], dtype=self.dtype, device=self.device)
-            return zeros, zeros > 0.5
+            # No rock means no check action exists, so this accuracy is never
+            # consumed; return the uninformative 0.5 rather than a value the
+            # sensor law cannot produce.
+            half = torch.full((next_states.shape[0],), 0.5, dtype=self.dtype, device=self.device)
+            return half, half > 0.5
         rock_r = self._rock_rows[rock_idx]
         rock_c = self._rock_cols[rock_idx]
         dist = torch.sqrt((next_states[:, 0] - rock_r) ** 2 + (next_states[:, 1] - rock_c) ** 2)
-        efficiency = torch.exp(-dist * self._inv_sigma)
+        # Smith & Simmons (2004): accuracy decays from 1 to 0.5, never below,
+        # so a distant check is uninformative instead of reliably wrong.
+        efficiency = 0.5 * (1.0 + torch.exp2(-dist / self._sensor_efficiency))
         quality = next_states.gather(1, (rock_idx + 2).unsqueeze(1)).squeeze(1)
         return efficiency, quality > 0.5
 

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_env_api_parity.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_env_api_parity.py
@@ -251,7 +251,7 @@ def test_check_action_sample_frequency_matches_log_probability() -> None:
         same Bernoulli(p) it reports via ``observation_log_probability``.
 
     Given: A bad rock at distance sqrt(2) with sensor_efficiency=2.0; the
-        analytic P(obs='bad' | bad rock) = exp(-sqrt(2)/2) ≈ 0.493.
+        analytic P(obs='bad' | bad rock) = (1 + 2 ** (-sqrt(2)/2)) / 2 ≈ 0.806.
     When: 5_000 observations are drawn under check action 5.
     Then: Empirical frequency of 'bad' is within 3/sqrt(5000) ≈ 0.0424 of
         analytic, matching Wilson-style sample tolerance.

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_native_equivalence.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_native_equivalence.py
@@ -14,8 +14,9 @@ RockSample's discrete-action, categorical-observation contract:
 * Observations are categorical over ``{none, good, bad}``. The C++
   boundary uses integer codes; the env-API translates to strings.
   We assert the per-check Bernoulli probability matches the closed-form
-  ``exp(-distance / sensor_efficiency)`` expression and that 200K-sample
-  empirical frequencies match the analytic efficiency within 5e-3.
+  Smith & Simmons (2004) accuracy
+  ``(1 + 2 ** (-distance / sensor_efficiency)) / 2`` and that 200K-sample
+  empirical frequencies match that analytic accuracy within 5e-3.
 * The batch equivalence tests compare the native batch entry points
   against a per-particle loop over the public ``env.sample_next_state``
   / ``env.observation_log_probability`` env-API.
@@ -52,6 +53,16 @@ _INIT_POS: Tuple[int, int] = (0, 0)
 _SENSOR_EFFICIENCY: float = 10.0
 _NUM_ROCKS: int = len(_ROCK_POSITIONS)
 _STATE_DIM: int = 2 + _NUM_ROCKS
+
+
+def _accuracy(distance: float, half_life: float = _SENSOR_EFFICIENCY) -> float:
+    """Smith & Simmons (2004) check accuracy, written out independently here.
+
+    Deliberately not a call into the environment: the point of the tests
+    below is to pin the environment's law against an expression written from
+    the paper, so this must stay a separate implementation.
+    """
+    return 0.5 * (1.0 + 2.0 ** (-float(distance) / half_life))
 
 
 def _make_env() -> RockSamplePOMDP:
@@ -156,8 +167,8 @@ def test_observation_movement_returns_none(env: RockSamplePOMDP) -> None:
     [
         ((1, 1), True, 1.0),  # distance 0 -> efficiency 1.0
         ((1, 1), False, 1.0),
-        ((5, 5), True, float(np.exp(-np.sqrt(32.0) / _SENSOR_EFFICIENCY))),  # distance to (1,1)
-        ((5, 5), False, float(np.exp(-np.sqrt(32.0) / _SENSOR_EFFICIENCY))),
+        ((5, 5), True, _accuracy(np.sqrt(32.0))),  # distance to (1,1)
+        ((5, 5), False, _accuracy(np.sqrt(32.0))),
     ],
 )
 def test_observation_check_probability_matches_python_formula(
@@ -167,7 +178,8 @@ def test_observation_check_probability_matches_python_formula(
     expected_efficiency_close: float,
 ) -> None:
     """Purpose: Validates the check-action Bernoulli probability matches
-    the analytic expression ``exp(-d / sensor_efficiency)``.
+    the analytic Smith & Simmons accuracy
+    ``(1 + 2 ** (-d / sensor_efficiency)) / 2``.
 
     Given: A next_state with known robot position and rock 0 quality.
     When: env.observation_log_probability for ["good", "bad", "none"] is
@@ -212,7 +224,7 @@ def test_observation_check_sample_empirical_matches_probability(
     rocks = (True, False, True, False)  # rock 0 good
     next_state = _state(5, 5, rocks)
 
-    expected_efficiency = float(np.exp(-np.sqrt(32.0) / _SENSOR_EFFICIENCY))
+    expected_efficiency = _accuracy(np.sqrt(32.0))
 
     _native.set_seed(12345)
     samples = env.sample_observation(next_state=next_state, action=5, n_samples=200_000)

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_pomdp.py
@@ -661,7 +661,7 @@ class TestObservationModel:
 
         Given: Robot far from rock with check action and very low sensor efficiency
         When: Observation probabilities are calculated via env.observation_log_probability
-        Then: Observation probabilities are closer to random
+        Then: The reading still favours the truth, but by less than at the rock
 
         Test type: unit
         """
@@ -677,10 +677,10 @@ class TestObservationModel:
         log_probs = pomdp.observation_log_probability(state, 6, ["good", "bad", "none"])
         probs = np.exp(log_probs)
         # Distance = sqrt((0-1)^2 + (0-2)^2) = sqrt(5) ≈ 2.24
-        # Efficiency = exp(-2.24/2.0) ≈ 0.33
-        # For bad rock: P(good) = 1-0.33 = 0.67, P(bad) = 0.33
-        assert 0.6 < probs[0] < 0.8  # P(good|bad_rock) should be high due to low efficiency
-        assert 0.2 < probs[1] < 0.4  # P(bad|bad_rock) should be low
+        # Accuracy = (1 + 2^(-2.24/2.0)) / 2 ≈ 0.73
+        # For a bad rock: P(bad) = 0.73, P(good) = 1 - 0.73 = 0.27
+        assert 0.2 < probs[0] < 0.35  # P(good|bad_rock) is the error rate, below half
+        assert 0.65 < probs[1] < 0.8  # P(bad|bad_rock) is the accuracy, above half
         assert probs[2] < 1e-200  # Effectively zero probability of "none"
 
     def test_observation_check_invalid_rock(self):

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_sensor_accuracy.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_sensor_accuracy.py
@@ -1,0 +1,325 @@
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for the RockSample rock-check sensor accuracy law.
+
+RockSample's check sensor used to report a rock's quality correctly with
+probability ``exp(-d / sensor_efficiency)``. That expression decays to 0, so it
+crosses 0.5 at ``d = sensor_efficiency * ln 2`` — about 6.9 cells at the default
+``sensor_efficiency = 10.0`` — and past that point the sensor is *anti*-
+informative: a check that returns "bad" is evidence the rock is good, and the
+inversion tightens towards certainty as the robot moves further away. On an
+11x11 map most rocks sit past that crossover, so a planner could farm reward
+from a sensor that is reliably wrong.
+
+Smith & Simmons, "Heuristic Search Value Iteration for POMDPs" (2004), define
+the accuracy as ``(1 + 2 ** (-d / d0)) / 2``, which decays from 1 to 0.5 and is
+never below 0.5: a far check is uninformative, never misleading.
+
+Every test here computes the expected accuracy from the paper's expression
+written out locally, not by calling the environment, so the environment is
+pinned against the literature rather than against itself. Both the C++ kernels
+and the torch vectorized model are checked, because the law is implemented
+separately in each and they must not drift apart.
+"""
+
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+import torch
+
+from POMDPPlanners.environments.rock_sample_pomdp import _native
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp import (
+    RockSamplePOMDP,
+    create_rock_sample_state,
+)
+from POMDPPlanners.environments.rock_sample_pomdp.rock_sample_pomdp_beliefs.rocksample_vectorized_updater import (  # pylint: disable=line-too-long
+    OBS_BAD,
+    OBS_GOOD,
+    RockSampleVectorizedUpdater,
+)
+from POMDPPlanners.environments.rock_sample_pomdp.rocksample_vectorized_model import (
+    RockSampleVectorizedModel,
+)
+from POMDPPlanners.tests.test_utils.env_pinned_kwargs import rock_sample_pinned_kwargs
+
+_DEFAULT_EFFICIENCY: float = 10.0
+
+# The old law's crossover, sensor_efficiency * ln 2. Distances past this are
+# where the old formula inverted the evidence.
+_OLD_CROSSOVER: float = _DEFAULT_EFFICIENCY * float(np.log(2.0))
+
+
+def _paper_accuracy(distance: float, half_life: float = _DEFAULT_EFFICIENCY) -> float:
+    """Smith & Simmons (2004) accuracy, transcribed from the paper."""
+    return 0.5 * (1.0 + 2.0 ** (-float(distance) / half_life))
+
+
+def _make_env(
+    rock_positions: List[Tuple[int, int]],
+    map_size: Tuple[int, int] = (20, 20),
+    sensor_efficiency: float = _DEFAULT_EFFICIENCY,
+) -> RockSamplePOMDP:
+    return RockSamplePOMDP(
+        discount_factor=0.95,
+        **rock_sample_pinned_kwargs(
+            map_size=map_size,
+            rock_positions=list(rock_positions),
+            init_pos=(0, 0),
+            sensor_efficiency=sensor_efficiency,
+        ),
+    )
+
+
+def _p_correct(env: RockSamplePOMDP, robot: Tuple[int, int], rock_good: bool) -> float:
+    """P(the check on rock 0 reports the truth) from the env's own likelihoods."""
+    state = create_rock_sample_state(robot, (rock_good,))
+    log_probs = env.observation_log_probability(state, 5, ["good", "bad"])
+    probs = np.exp(np.asarray(log_probs, dtype=np.float64))
+    return float(probs[0] if rock_good else probs[1])
+
+
+# ---------------------------------------------------------------------------
+# The limits of the law
+# ---------------------------------------------------------------------------
+
+
+def test_accuracy_is_one_at_the_rock_and_decays_to_one_half() -> None:
+    """Purpose: Validates the two endpoints of the corrected accuracy law.
+
+    Given: A rock at (0, 0) on a large map, default sensor_efficiency.
+    When: The check is evaluated with the robot standing on the rock and
+        again from 200 cells away.
+    Then: Accuracy is exactly 1.0 at the rock, and from 200 cells it is
+        above 0.5 but within 1e-6 of it — the sensor becomes uninformative,
+        not wrong.
+
+    Test type: unit
+    """
+    env = _make_env([(0, 0)], map_size=(220, 220))
+
+    assert _p_correct(env, (0, 0), True) == pytest.approx(1.0, abs=1e-12)
+    assert _p_correct(env, (0, 0), False) == pytest.approx(1.0, abs=1e-12)
+
+    far = _p_correct(env, (200, 0), True)
+    assert far > 0.5
+    assert far - 0.5 < 1e-6
+
+
+def test_accuracy_decreases_monotonically_and_never_drops_below_one_half() -> None:
+    """Purpose: Validates monotone decay with a hard floor at 0.5.
+
+    Given: A rock at (0, 0) and the robot stepping out along the row from
+        distance 0 to 60 cells.
+    When: P(the check reports the truth) is read at every distance.
+    Then: The sequence is strictly decreasing and every value is >= 0.5.
+
+    Test type: unit
+    """
+    env = _make_env([(0, 0)], map_size=(80, 80))
+    values = [_p_correct(env, (d, 0), True) for d in range(0, 61)]
+
+    assert all(v >= 0.5 for v in values), min(values)
+    assert all(later < earlier for earlier, later in zip(values, values[1:]))
+
+
+@pytest.mark.parametrize("distance", [8, 9, 11, 15])
+def test_far_check_still_favours_the_truth(distance: int) -> None:
+    """Purpose: This is the test that would have caught the shipped bug.
+
+    Beyond the old law's crossover at ``sensor_efficiency * ln 2`` (~6.9 cells
+    at the default) the old ``exp(-d / sensor_efficiency)`` accuracy fell below
+    0.5, so ``P(z = "good" | rock good)`` was below a coin flip and a far check
+    was evidence *against* the truth. Under the corrected law it must stay
+    strictly above 0.5 at every distance.
+
+    Given: A good rock and a robot 8 to 15 cells away, default efficiency.
+    When: P(z = "good" | rock good) is evaluated.
+    Then: It is strictly greater than 0.5, and it equals the paper's accuracy.
+
+    Test type: unit
+    """
+    assert distance > _OLD_CROSSOVER, "distance must be past the old crossover"
+
+    env = _make_env([(0, 0)], map_size=(distance + 5, distance + 5))
+    p_good = _p_correct(env, (distance, 0), True)
+
+    assert p_good > 0.5
+    assert p_good == pytest.approx(_paper_accuracy(distance), abs=1e-12)
+    # The old law's value at this distance, for contrast: below a coin flip.
+    assert float(np.exp(-distance / _DEFAULT_EFFICIENCY)) < 0.5
+
+
+# ---------------------------------------------------------------------------
+# Closed form
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("half_life", [1.0, 2.0, 10.0, 50.0])
+@pytest.mark.parametrize("robot", [(0, 0), (1, 1), (3, 4), (12, 5), (19, 19)])
+def test_likelihood_matches_the_paper_closed_form(half_life: float, robot: Tuple[int, int]) -> None:
+    """Purpose: Validates the env likelihood against the paper's expression.
+
+    Given: A rock at (0, 0) and a robot at one of several positions, for four
+        sensor_efficiency settings.
+    When: P(z = "good" | rock good) and P(z = "bad" | rock good) are read.
+    Then: They equal ``(1 + 2 ** (-d / d0)) / 2`` and its complement, to
+        1e-12, with ``d`` the Euclidean distance.
+
+    Test type: unit
+    """
+    env = _make_env([(0, 0)], sensor_efficiency=half_life)
+    distance = float(np.hypot(robot[0], robot[1]))
+    expected = _paper_accuracy(distance, half_life)
+
+    state = create_rock_sample_state(robot, (True,))
+    probs = np.exp(np.asarray(env.observation_log_probability(state, 5, ["good", "bad"])))
+
+    np.testing.assert_allclose(probs[0], expected, atol=1e-12)
+    np.testing.assert_allclose(probs[1], 1.0 - expected, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# The three implementations agree
+# ---------------------------------------------------------------------------
+
+
+def test_scalar_batched_and_torch_paths_agree() -> None:
+    """Purpose: Validates the three copies of the sensor law do not drift.
+
+    The accuracy is written once in the C++ scalar helper, once in the C++
+    batched log-likelihood loop, and once in the torch model; nothing else
+    forces them to match.
+
+    Given: A batch of states spanning distances 0 to ~27 cells and both rock
+        qualities, and both check observations.
+    When: The env-API scalar likelihood, the native batched likelihood used by
+        the vectorized belief, and the torch model's likelihood are evaluated.
+    Then: All three agree with each other and with the paper's accuracy.
+
+    Test type: integration
+    """
+    env = _make_env([(0, 0)])
+    model = RockSampleVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+    updater = RockSampleVectorizedUpdater.from_environment(env)
+
+    states = np.array(
+        [[float(r), float(c), float(q)] for r in (0, 3, 7, 19) for c in (0, 5, 19) for q in (1, 0)],
+        dtype=np.float64,
+    )
+
+    for obs_str, obs_code in (("good", OBS_GOOD), ("bad", OBS_BAD)):
+        scalar = np.array(
+            [float(env.observation_log_probability(row, 5, [obs_str])[0]) for row in states]
+        )
+        batched = np.asarray(
+            updater.batch_observation_log_likelihood(states, np.asarray(5), np.asarray(obs_code))
+        )
+        torch_logp = (
+            model.observation_log_probs(
+                torch.as_tensor(states, dtype=torch.float64),
+                torch.full((states.shape[0],), 5, dtype=torch.int64),
+                torch.full((states.shape[0], 1), float(obs_code), dtype=torch.float64),
+            )
+            .numpy()
+            .astype(np.float64)
+        )
+
+        np.testing.assert_allclose(batched, scalar, atol=1e-12)
+        np.testing.assert_allclose(torch_logp, scalar, atol=1e-12)
+
+        expected = np.array(
+            [
+                (
+                    _paper_accuracy(float(np.hypot(row[0], row[1])))
+                    if (row[2] > 0.5) == (obs_code == OBS_GOOD)
+                    else 1.0 - _paper_accuracy(float(np.hypot(row[0], row[1])))
+                )
+                for row in states
+            ]
+        )
+        np.testing.assert_allclose(np.exp(scalar), expected, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# The sampler matches the law it reports
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("distance", [1, 12])
+def test_sampling_frequency_matches_the_accuracy(distance: int) -> None:
+    """Purpose: Validates the C++ Bernoulli sampler uses the corrected law.
+
+    A likelihood fixed without fixing the sampler would leave the belief
+    update and the episode disagreeing, which no likelihood test can see.
+
+    Given: A good rock, the robot 1 cell away and then 12 cells away (past
+        the old crossover), default efficiency, seeded RNG.
+    When: 200_000 observations are sampled under the check action.
+    Then: The fraction reported "good" matches the paper's accuracy to 5e-3,
+        and at 12 cells that fraction is above 0.5.
+
+    Test type: integration
+    """
+    env = _make_env([(0, 0)], map_size=(distance + 5, distance + 5))
+    state = create_rock_sample_state((distance, 0), (True,))
+
+    _native.set_seed(20260912)
+    samples = env.sample_observation(next_state=state, action=5, n_samples=200_000)
+    fraction_good = sum(1 for s in samples if s == "good") / len(samples)
+
+    np.testing.assert_allclose(fraction_good, _paper_accuracy(distance), atol=5e-3)
+    assert fraction_good > 0.5
+
+
+def test_torch_sampling_frequency_matches_the_accuracy() -> None:
+    """Purpose: Validates the torch sampler uses the corrected law too.
+
+    Given: A good rock 12 cells away — past the old crossover — and 200_000
+        parallel checks in the torch model.
+    When: The fraction of "good" observations is measured.
+    Then: It matches the paper's accuracy to 5e-3 and is above 0.5.
+
+    Test type: integration
+    """
+    torch.manual_seed(20260912)
+    env = _make_env([(0, 0)], map_size=(20, 20))
+    model = RockSampleVectorizedModel(env, device=torch.device("cpu"), dtype=torch.float64)
+
+    states = torch.tile(torch.tensor([[12.0, 0.0, 1.0]], dtype=torch.float64), (200_000, 1))
+    actions = torch.full((200_000,), 5, dtype=torch.int64)
+    observations = model.sample_observations(states, actions)
+    fraction_good = float((observations[:, 0] == OBS_GOOD).to(torch.float64).mean())
+
+    np.testing.assert_allclose(fraction_good, _paper_accuracy(12.0), atol=5e-3)
+    assert fraction_good > 0.5
+
+
+# ---------------------------------------------------------------------------
+# Cache identity
+# ---------------------------------------------------------------------------
+
+
+def test_sensor_contract_version_participates_in_the_identities() -> None:
+    """Purpose: Validates the observation-law change is visible to the caches.
+
+    The constructor arguments are identical across this fix, so without a
+    contract version every cached RockSample episode from before it would be
+    silently reused under the new law.
+
+    Given: A default environment and the updater built from it.
+    When: The version is bumped by hand and both identities are re-read.
+    Then: Both change, and the environment reports version 2.
+
+    Test type: unit
+    """
+    env = _make_env([(0, 0), (2, 2), (3, 3)], map_size=(5, 5))
+    assert env.sensor_contract_version == 2
+
+    env_id_before = env.config_id
+    updater_id_before = RockSampleVectorizedUpdater.from_environment(env).config_id
+
+    env.sensor_contract_version += 1
+
+    assert env.config_id != env_id_before
+    assert RockSampleVectorizedUpdater.from_environment(env).config_id != updater_id_before

--- a/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_vectorized_model.py
+++ b/POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rocksample_vectorized_model.py
@@ -198,13 +198,13 @@ def test_terminal_mask_matches_native(case: _Case) -> None:
 
 
 def test_observation_sampling_reproduces_sensor_efficiency() -> None:
-    """Check-action sampling reproduces the exp(-dist/eff) sensor accuracy.
+    """Check-action sampling reproduces the Smith & Simmons sensor accuracy.
 
     Purpose: Validates the stochastic Bernoulli sensor in expectation
 
     Given: A robot one cell from a good rock, checked many times
     When: The empirical fraction of correct ("good") observations is measured
-    Then: It matches exp(-distance / sensor_efficiency) within 0.02
+    Then: It matches (1 + 2 ** (-distance / sensor_efficiency)) / 2 within 0.02
 
     Test type: unit
     """
@@ -215,7 +215,7 @@ def test_observation_sampling_reproduces_sensor_efficiency() -> None:
     batch = np.tile(next_state, (40000, 1))
     observations = model.sample_observations(_tensor(batch), _action_col(5, 40000))
     frac_good = float((observations[:, 0] == 1).to(torch.float64).mean())
-    expected = float(np.exp(-1.0 / 3.0))
+    expected = 0.5 * (1.0 + 2.0 ** (-1.0 / 3.0))
     assert abs(frac_good - expected) < 0.02
 
 

--- a/docs/environments/rock_sample.rst
+++ b/docs/environments/rock_sample.rst
@@ -8,7 +8,10 @@ RockSample
 A robot on a grid must sample the good rocks and skip the bad ones, then leave
 by walking east off the right-hand edge. Whether a rock is good is hidden; a
 long-range sensor answers, but its accuracy decays with distance as
-``exp(-distance / sensor_efficiency)``.
+``(1 + 2 ** (-distance / sensor_efficiency)) / 2`` — the accuracy of Smith &
+Simmons, "Heuristic Search Value Iteration for POMDPs" (2004). It is ``1.0`` at
+the rock and falls towards ``0.5``, never below, so a check from far away tells
+you nothing rather than telling you the opposite of the truth.
 
 This is the standard long-horizon information-gathering benchmark. Getting a
 good score means walking *towards* a rock to make its reading trustworthy, which
@@ -62,8 +65,8 @@ Key settings
      - Number and placement of rocks. This sets the action-space size.
    * - ``sensor_efficiency``
      - ``10.0``
-     - Larger means the sensor stays accurate further away, so the problem gets
-       easier. (The docstring says 20.0; the code says 10.0.)
+     - Distance in cells at which a check is 75% accurate. Larger means the
+       sensor stays accurate further away, so the problem gets easier.
    * - ``dangerous_areas``
      - ``None``
      - Hazard cells. Adds a safety dimension on top of the information problem.


### PR DESCRIPTION
## Bug

RockSample's rock-check sensor reported a rock's quality correctly with
probability

    accuracy(d) = exp(-d / sensor_efficiency)

where `d` is the Euclidean distance from the robot to the queried rock.

That expression decays to **0**, so it crosses 0.5 at
`d = sensor_efficiency * ln 2` — about **6.9 cells** at the default
`sensor_efficiency = 10.0`. Past that distance the sensor was
*anti-informative*: `P(z = "good" | rock good) < 0.5`, so a far check that
returned "bad" was evidence the rock was **good**, and the inversion tightened
towards certainty as the robot moved further away. At 20 cells the sensor was
wrong 86% of the time.

On an 11x11 map most rocks sit past that crossover, so a planner could — and a
good one would — farm reward from a sensor that was reliably wrong. The C++
probability floor kept the log-likelihood finite but did nothing about the
direction of the evidence.

Nothing caught it because all three implementations of the law agreed with each
other, and every test that pinned a number computed it from the same wrong
formula. One test asserted the inversion outright: it required a bad rock
checked from 2.24 cells to report "good" about 70% of the time.

## Fix

Use the accuracy of Smith & Simmons, "Heuristic Search Value Iteration for
POMDPs" (2004):

    accuracy(d) = (1 + 2 ** (-d / sensor_efficiency)) / 2

It is 1.0 at the rock, 0.75 at `d = sensor_efficiency`, and decays to 0.5 —
never below. A distant check is uninformative, never misleading.

`sensor_efficiency` keeps its name and its `10.0` default. Its meaning becomes
the paper's `d0`: the distance at which accuracy is 0.75. The default value is
deliberately unchanged here.

The law lived in three places, and all three now route through a single
expression so they cannot drift apart: the C++ scalar helper and the C++ batched
log-likelihood loop share one `check_sensor_accuracy(distance, half_life)` that
takes the half-life rather than a precomputed reciprocal, which makes the two
paths bit-identical instead of agreeing only to a rounding step.

Since accuracy is bounded in `[0.5, 1]`, neither check branch can underflow any
more. The probability floor stays in place but is now inert for checks; it
remains load-bearing only for the deterministic "none" branches.

**The dangerous-zone penalty `exp(-min_dist / penalty_decay)` is untouched.**
That is a different and correct model.

## Before / after

Default environment, `sensor_efficiency = 10.0`, a good rock checked from
distance `d`, reading `P(z = "good")`:

| d (cells) | before | after |
| --- | --- | --- |
| 0 | 1.000 | 1.000 |
| 5 | 0.607 | 0.854 |
| 6.93 | 0.500 | 0.809 |
| 10 | 0.368 | 0.750 |
| 20 | 0.135 | 0.625 |
| 200 | 2e-9 | 0.500 |

Before, every row past 6.93 is a sensor that lies more often than it tells the
truth.

## Cache identity

RockSample has no `config_id` or contract version of its own, so its identity is
a hash of its public settings — and this change alters the observation law while
leaving every constructor argument identical. Without a version marker, every
cached RockSample episode and pinned identity from before this fix would be
silently reused under the new law.

Following the pattern the occupancy-grid environment uses, `RockSamplePOMDP` now
carries `sensor_contract_version = 2` (version 1 being the old law), and the
vectorized belief updater carries it into its own `config_id`.

Default environment (`RockSamplePOMDP(discount_factor=0.95)`):

| Identity | Old | New |
| --- | --- | --- |
| `RockSamplePOMDP.config_id` | `fefce17f4d54e357c692d041ec4b5ae6976a1c9eb1cfd75cbaf39e722bd303a4` | `a253d97f6b7a9458de63ba44bc2965a5ba44c4a9e46accec7eebdb67a9be0855` |
| `RockSampleVectorizedUpdater.config_id` | `ce4f5dd34d30c22a47a4c3ca5744a65d203372c232dbce8cbcd53e5c9ad97967` | `20f2d7c74f0adc2f75143e17f62ef50af6b11611cd9106f4cc8a201251909377` |

**Every earlier RockSample result is invalidated by this fix** — the planners
were solving a different POMDP. The identity change makes them cache misses
rather than silent reuse, but any RockSample number already reported or written
into a paper has to be re-measured.

## Files changed

Environment:

- `POMDPPlanners/environments/rock_sample_pomdp/_cpp/rock_sample.cpp` — the
  shared accuracy function, used by the scalar helper and the batched
  log-likelihood loop; module and floor comments.
- `POMDPPlanners/environments/rock_sample_pomdp/rocksample_vectorized_model.py`
  — the torch copy of the law.
- `POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp.py` —
  `sensor_contract_version`, an observation-model docstring section, and the
  `sensor_efficiency` docs (the constructor docstring claimed a default of 20.0
  while the signature said 10.0).
- `POMDPPlanners/environments/rock_sample_pomdp/rock_sample_pomdp_beliefs/rocksample_vectorized_updater.py`
  — carries the contract version into the belief identity.
- `POMDPPlanners/environments/rock_sample_pomdp/_native.pyi` — stub docstring.

Docs:

- `docs/environments/rock_sample.rst` — observation model and the
  `sensor_efficiency` table row.

Tests:

- `POMDPPlanners/tests/test_environments/test_rock_sample_pomdp/test_rock_sample_sensor_accuracy.py`
  (new)
- `test_rock_sample_native_equivalence.py`, `test_rocksample_vectorized_model.py`,
  `test_rock_sample_pomdp.py`, `test_rock_sample_env_api_parity.py` — re-pinned.

## Tests

New file `test_rock_sample_sensor_accuracy.py`, 31 tests. Every expected value
is computed from the paper's expression written out in the test file, not by
calling the environment, so the environment is pinned against the literature
rather than against itself:

- **Distance limits** — accuracy is exactly 1.0 at the rock; from 200 cells it
  is above 0.5 and within 1e-6 of it.
- **Monotone decay with a floor** — strictly decreasing over 0…60 cells, every
  value `>= 0.5`.
- **The regression itself** — at 8, 9, 11 and 15 cells (all past the old
  crossover) `P(z = "good" | rock good) > 0.5` strictly. Its docstring says this
  is the test that would have caught the bug.
- **Closed form** — 20 distance/`d0` combinations match
  `(1 + 2 ** (-d / d0)) / 2` to 1e-12.
- **Cross-implementation agreement** — the C++ scalar likelihood, the native
  batched likelihood used by the vectorized belief, and the torch model agree
  to 1e-12 on 24 states across both rock qualities and both check observations,
  and all three match the paper.
- **Sampling matches the law** — 200k seeded native samples at 1 cell and at 12
  cells (past the old crossover) match the accuracy to 5e-3, and 200k torch
  samples at 12 cells likewise.
- **Cache identity** — the contract version is 2, and bumping it changes both
  the environment and the updater identity.

Verified the new tests are load-bearing: with the old formula restored in both
the C++ kernel and the torch model, 26 of the 31 fail, including the named
regression test. Restored and re-passing.

### Re-pinned numbers

Four existing tests had values computed from the wrong formula.

- `test_rock_sample_pomdp.py::test_observation_check_action_far_distance` — a
  **bad** rock at distance `sqrt(5)` with `sensor_efficiency=2.0`. It asserted
  `0.6 < P("good") < 0.8` and `0.2 < P("bad") < 0.4`: it required the sensor to
  report the *opposite* of the truth most of the time. Now
  `P("bad") = 0.730` and `P("good") = 0.270` — accuracy above half, error rate
  below it. This is the assertion the bug was hiding behind.
- `test_rock_sample_native_equivalence.py` — the parametrized closed-form value
  and the 200k-sample expectation at distance `sqrt(32)` now come from a local
  `_accuracy()` helper transcribing the paper, so the file no longer hard-codes
  a single formula in two places.
- `test_rocksample_vectorized_model.py::test_observation_sampling_reproduces_sensor_efficiency`
  — expected fraction at distance 1 with `d0=3` moves from `exp(-1/3) = 0.717`
  to `0.5 * (1 + 2**(-1/3)) = 0.897`, matching the corrected sampler.
- `test_rock_sample_env_api_parity.py` — docstring only; the test already read
  its analytic value from the environment, so only the quoted number
  (`0.493` → `0.806`) was stale.

### Suites run

Local `.venv` (macOS arm64), against the exact committed content:

- All RockSample suites: **269 passed**.
- Wider sweep — `test_environments`, `test_core/test_belief`, `test_configs`,
  `test_utils`, the hash-action contract, ARDESPOT correctness: **5115 passed**,
  94 skipped, 12 xfailed.
- Black: 8 changed files, all unchanged. Pylint **10.00/10** on the touched
  modules.

## What was verified in the CI image, and what was not

Read this before trusting anything above. The `pomdp-ci-tests` Linux AMD64
Docker gate was run twice from a clean worktree and **did not complete either
time**, so it is not being reported as a pass.

Verified in the image, pinned to image id
`sha256:56125c5298bae385f3267cf2bac291cc41f71616df6a0861fd09ee8611da9362`
rather than the `:latest` tag:

| Stage | Result |
| --- | --- |
| Pyright over `POMDPPlanners/` | **0 errors**, 297 warnings |
| RockSample suites + env API conformance + environment serialization + vectorized config contract + core belief | **1047 passed**, 47 skipped, 12 xfailed |
| Doctests for `environments/rock_sample_pomdp/` | **2 passed** |
| All 31 tests in the new `test_rock_sample_sensor_accuracy.py` | **passed** (also seen passing inside the full-suite stage before it stalled) |
| Pylint | 9.97/10, advisory (`--exit-zero`), pre-existing findings only |

Not verified:

- **The full non-slow pytest stage aborted at 89% with no summary line**, in both
  gate runs, at exactly the same test:
  `test_simulations/test_simulations_deployment/test_task_managers.py::test_joblib_task_manager_run_tasks`.
  Run in isolation in the same image, that file **hangs past 600s**. Another job
  on the same machine, building from different source, stalled at the same 89%
  point. So this is a hanging test in the deployment suite, not a consequence of
  this change — but it does mean the remaining ~11% of the suite (most of
  `test_simulations`) was never executed locally. **GitHub CI is the authority
  for that remainder.**
- **The gate's Black stage is vacuous** — it prints `No Python files are present
  to be formatted. Nothing to do`, because the repo's Black configuration matches
  no filename under the paths CI passes it. The Black evidence for this change is
  the local run listed above, not the gate.
- Notebook smoke tests and the Sphinx docs build never ran; GitHub CI treats both
  as optional anyway.

## Pre-existing failure, not from this change

`test_planners/test_mcts_planners/test_constrained_pft_dpw.py::test_minimal_cost_clamp_preserves_real_vectors`
fails. It reproduces identically on a clean `develop` worktree at `e4f2e039`
with no part of this change applied, and it exercises ConstrainedPFT-DPW on
ContinuousLightDark — nothing to do with the RockSample sensor. Left alone
deliberately; please do not attribute it to this PR.

Codex reviewed the uncommitted diff and found no actionable defects.

https://claude.ai/code/session_013837wDGTwaUaAD2eiguUa6
